### PR TITLE
integrate langfuse for observablity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,15 @@ STRICT_LLM=true
 # OPENAI_PROJECT_ID=your_openai_project_id_here
 # OPENAI_ORG_ID=your_openai_org_id_here
 
+# Optional Langfuse observability for generation traces and structured LLM calls.
+# LANGFUSE_PUBLIC_KEY=pk-lf-your_public_key_here
+# LANGFUSE_SECRET_KEY=sk-lf-your_secret_key_here
+# LANGFUSE_BASE_URL=https://cloud.langfuse.com
+# LANGFUSE_TRACING_ENVIRONMENT=local
+# LANGFUSE_TRACING_RELEASE=dev
+# LANGFUSE_MAX_FIELD_CHARS=20000
+# LANGFUSE_ENABLED=false
+
 # Optional generated product image output.
 IMAGE_OUTPUT_ENABLED=false
 IMAGE_PROVIDER=openai

--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ __pycache__/
 .env.production.local
 supabase/.temp/
 
+# Runtime logs
+.logs/
+*.log
+
 # IDE & OS files
 .DS_Store
 .idea/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This repository is an **MVP and research prototype** focused on **low-voltage ma
 - View a lightweight **3D mechanical layout** (Three.js / React Three Fiber)
 - Generate an optional **product concept image** with an image model
 - Persist generated projects to **Supabase** through the Supabase client when configured, with an automatic **SQLite fallback** and `BLUEPRINT_DEV_MODE` for SQLite-only local work
+- Trace generation runs and structured LLM calls with **Langfuse** when project keys are configured
 - Let external agents integrate over **REST long-polling, WebSocket, optional TCP JSONL sockets, or MCP-style JSON-RPC tools**
 
 ## How it works
@@ -117,6 +118,11 @@ Environment variables (recommended via a repo-root `.env`; see `.env.example`):
 - `OPENAI_REASONING_EFFORT`: Optional reasoning effort for GPT-5/o-series models, for example `low`.
 - `OPENAI_TEMPERATURE`: Optional first-party OpenAI sampling temperature. Omitted by default so models that only support their default temperature can run.
 - `OPENAI_PROJECT_ID` / `OPENAI_ORG_ID`: Optional OpenAI project and organization routing headers.
+- `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY`: Optional Langfuse project keys. When both are set, the backend traces each generation request and structured LLM call.
+- `LANGFUSE_BASE_URL`: Optional Langfuse host (default `https://cloud.langfuse.com`).
+- `LANGFUSE_TRACING_ENVIRONMENT` / `LANGFUSE_TRACING_RELEASE`: Optional Langfuse trace attributes.
+- `LANGFUSE_MAX_FIELD_CHARS`: Optional traced payload preview cap (default `20000`).
+- `LANGFUSE_ENABLED`: Optional explicit on/off switch. Set to `false` to disable tracing even when keys are present.
 - `IMAGE_OUTPUT_ENABLED`: Optional global default for generated product images. The UI and API can opt in per job with `generate_image=true`.
 - `IMAGE_PROVIDER`: Image provider. Supports `openai`, `openai-compatible`, or `none`.
 - `OPENAI_IMAGE_MODEL`: OpenAI image model ID. The example default is `gpt-image-2`.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,6 +21,15 @@ STRICT_LLM=true
 # OPENAI_PROJECT_ID=your_openai_project_id_here
 # OPENAI_ORG_ID=your_openai_org_id_here
 
+# Optional Langfuse observability for generation traces and structured LLM calls.
+# LANGFUSE_PUBLIC_KEY=pk-lf-your_public_key_here
+# LANGFUSE_SECRET_KEY=sk-lf-your_secret_key_here
+# LANGFUSE_BASE_URL=https://cloud.langfuse.com
+# LANGFUSE_TRACING_ENVIRONMENT=local
+# LANGFUSE_TRACING_RELEASE=dev
+# LANGFUSE_MAX_FIELD_CHARS=20000
+# LANGFUSE_ENABLED=false
+
 # Optional generated product image output.
 IMAGE_OUTPUT_ENABLED=false
 IMAGE_PROVIDER=openai

--- a/backend/a2a.py
+++ b/backend/a2a.py
@@ -22,6 +22,13 @@ from backend.database import update_generated_project_hardware_ir
 from backend.image_providers import build_image_provider, build_project_visual_spec, get_image_output_debug_config
 from backend.job_store import JOB_STORE
 from backend.models import ComponentInstance, ConnectionNet
+from backend.observability import (
+    get_langfuse_debug_config,
+    propagate_observation_attributes,
+    serialize_for_langfuse,
+    start_observation,
+    update_observation,
+)
 from backend.runtime_config import (
     ALPHA_GENERATION_UNAVAILABLE_MESSAGE,
     AlphaGenerationUnavailableError,
@@ -189,6 +196,7 @@ def get_a2a_capabilities() -> Dict[str, Any]:
         "job_metadata": JOB_STORE.get_config(),
         "image_output": get_image_output_debug_config(),
         "image_storage": get_image_storage_config(),
+        "observability": get_langfuse_debug_config(),
         "workflows": list_workflows(),
         "actions": [
             "blueprint.generate_project",
@@ -401,46 +409,92 @@ def build_generation_response(
     if deployment_runtime_config(llm_config)["alpha_generation_gate_active"]:
         raise AlphaGenerationUnavailableError(ALPHA_GENERATION_UNAVAILABLE_MESSAGE)
 
-    ir = generate_project_with_workflow(
-        workflow_id,
-        prompt_text,
-        image_bytes=image_bytes,
-        image_mime_type=image_mime_type,
-    )
-    ir.assembly_metadata = {
-        **(ir.assembly_metadata or {}),
+    trace_metadata = {
         "workflow": workflow_id,
+        "has_reference_image": bool(image_data),
+        "image_mime_type": image_mime_type,
+        "generate_image": generate_image,
     }
+    with start_observation(
+        name="blueprint.generate_project",
+        as_type="span",
+        input={
+            "prompt": prompt_text,
+            "workflow": workflow_id,
+            "has_reference_image": bool(image_data),
+            "generate_image": generate_image,
+        },
+        metadata=trace_metadata,
+    ) as root_observation:
+        with propagate_observation_attributes(
+            trace_name="blueprint.generate_project",
+            metadata=trace_metadata,
+            tags=["blueprint", f"workflow:{workflow_id}"],
+        ):
+            ir = generate_project_with_workflow(
+                workflow_id,
+                prompt_text,
+                image_bytes=image_bytes,
+                image_mime_type=image_mime_type,
+            )
+            ir.assembly_metadata = {
+                **(ir.assembly_metadata or {}),
+                "workflow": workflow_id,
+            }
 
-    if image_data:
-        metadata = ir.assembly_metadata or {}
-        storage_metadata = _attach_stored_image_metadata(
-            ir,
-            image_data=image_data,
-            metadata_prefix="reference_image",
-            object_prefix="reference",
-            fallback_content_type=image_mime_type or "image/png",
-        )
-        reference_metadata: Dict[str, Any] = {
-            **storage_metadata,
-            "image_features": metadata.get("image_features") or ir.constraints[:12],
-            "input_mode": "prompt_image",
-        }
-        if not storage_metadata.get("reference_image_url"):
-            reference_metadata["reference_image_data"] = image_data
-        ir.assembly_metadata = {
-            **metadata,
-            **reference_metadata,
-        }
+            if image_data:
+                metadata = ir.assembly_metadata or {}
+                storage_metadata = _attach_stored_image_metadata(
+                    ir,
+                    image_data=image_data,
+                    metadata_prefix="reference_image",
+                    object_prefix="reference",
+                    fallback_content_type=image_mime_type or "image/png",
+                )
+                reference_metadata: Dict[str, Any] = {
+                    **storage_metadata,
+                    "image_features": metadata.get("image_features") or ir.constraints[:12],
+                    "input_mode": "prompt_image",
+                }
+                if not storage_metadata.get("reference_image_url"):
+                    reference_metadata["reference_image_data"] = image_data
+                ir.assembly_metadata = {
+                    **metadata,
+                    **reference_metadata,
+                }
 
-    _attach_product_image(prompt_text, ir, generate_image=generate_image)
-    _persist_updated_project_ir(ir)
+            _attach_product_image(prompt_text, ir, generate_image=generate_image)
+            _persist_updated_project_ir(ir)
 
-    return {
-        "project_ir": ir.model_dump(),
-        "mermaid_code": generate_mermaid_chart(ir),
-        "svg_schematic": generate_svg_schematic(ir),
-    }
+            response = {
+                "project_ir": ir.model_dump(),
+                "mermaid_code": generate_mermaid_chart(ir),
+                "svg_schematic": generate_svg_schematic(ir),
+            }
+            update_observation(
+                root_observation,
+                output={
+                    "project_id": (ir.assembly_metadata or {}).get("project_id"),
+                    "title": ir.overview.title if ir.overview else None,
+                    "is_valid": ir.is_valid,
+                    "component_count": len(ir.components),
+                    "net_count": len(ir.nets),
+                    "workflow": workflow_id,
+                },
+                metadata={
+                    **trace_metadata,
+                    "project_id": (ir.assembly_metadata or {}).get("project_id"),
+                    "llm_provider": (ir.assembly_metadata or {}).get("llm_provider"),
+                    "model_name": (ir.assembly_metadata or {}).get("model_name"),
+                    "response_summary": serialize_for_langfuse(
+                        {
+                            "has_mermaid": bool(response["mermaid_code"]),
+                            "has_svg_schematic": bool(response["svg_schematic"]),
+                        }
+                    ),
+                },
+            )
+            return response
 
 
 async def call_blueprint_action(action: str, payload: Dict[str, Any]) -> Dict[str, Any]:
@@ -461,6 +515,7 @@ async def call_blueprint_action(action: str, payload: Dict[str, Any]) -> Dict[st
             **orchestrator.get_debug_config(),
             "image_output": get_image_output_debug_config(),
             "image_storage": get_image_storage_config(),
+            "observability": get_langfuse_debug_config(),
             "workflows": list_workflows(),
         }
 

--- a/backend/agents/orchestrator.py
+++ b/backend/agents/orchestrator.py
@@ -14,6 +14,7 @@ from backend.database import (
     save_generated_project,
 )
 from backend.llm_providers import LLMProviderConfigError, LLMProviderValidation, build_llm_provider
+from backend.observability import serialize_for_langfuse, start_observation, update_observation
 from backend.runtime_config import (
     ALPHA_GENERATION_UNAVAILABLE_MESSAGE,
     AlphaGenerationUnavailableError,
@@ -421,13 +422,42 @@ class HardwarePipelineOrchestrator:
         if self.use_simulation:
             raise RuntimeError("Simulation mode is active; should use simulated generator instead.")
 
-        try:
-            result = self.llm_provider.generate_structured(prompt, schema_class, image_bytes, image_mime_type)
-            self.model_name = self.llm_provider.model_name
-            return result
-        except Exception as e:
-            logger.error(f"LLM structured call failed via {self.llm_provider.provider_name}: {e}")
-            raise
+        schema_name = getattr(schema_class, "__name__", "StructuredResponse")
+        metadata = {
+            "workflow": "default",
+            "llm_provider": self.llm_provider.provider_name,
+            "response_schema": schema_name,
+            "has_reference_image": bool(image_bytes),
+            "image_mime_type": image_mime_type,
+        }
+        with start_observation(
+            name=f"blueprint.default.{schema_name}",
+            as_type="generation",
+            model=self.llm_provider.model_name,
+            input={
+                "prompt": prompt,
+                "schema": schema_name,
+                "has_reference_image": bool(image_bytes),
+                "image_mime_type": image_mime_type,
+            },
+            metadata=metadata,
+        ) as observation:
+            try:
+                result = self.llm_provider.generate_structured(prompt, schema_class, image_bytes, image_mime_type)
+                self.model_name = self.llm_provider.model_name
+                update_observation(
+                    observation,
+                    output=serialize_for_langfuse(result),
+                    metadata={**metadata, "actual_model": self.model_name},
+                )
+                return result
+            except Exception as e:
+                update_observation(
+                    observation,
+                    metadata={**metadata, "error_type": e.__class__.__name__, "error": str(e)[:1000]},
+                )
+                logger.error(f"LLM structured call failed via {self.llm_provider.provider_name}: {e}")
+                raise
 
     def generate_project(self, user_prompt: str, image_bytes: Optional[bytes] = None, image_mime_type: Optional[str] = None) -> HardwareIR:
         """Orchestrates the 7-agent hardware compilation pipeline with verification loop."""

--- a/backend/agents/web_research_workflow.py
+++ b/backend/agents/web_research_workflow.py
@@ -29,6 +29,7 @@ from backend.models import (
     ProjectOverview,
     ValidationIssue,
 )
+from backend.observability import serialize_for_langfuse, start_observation, update_observation
 from backend.runtime_config import (
     ALPHA_GENERATION_UNAVAILABLE_MESSAGE,
     AlphaGenerationUnavailableError,
@@ -109,9 +110,41 @@ class WebResearchHardwarePipeline:
         if self.use_simulation:
             raise RuntimeError("Simulation mode is active; web research workflow needs a live structured LLM provider.")
 
-        result = self.llm_provider.generate_structured(prompt, schema_class, image_bytes, image_mime_type)
-        self.model_name = self.llm_provider.model_name
-        return result
+        schema_name = getattr(schema_class, "__name__", "StructuredResponse")
+        metadata = {
+            "workflow": self.workflow_id,
+            "llm_provider": self.llm_provider.provider_name,
+            "response_schema": schema_name,
+            "has_reference_image": bool(image_bytes),
+            "image_mime_type": image_mime_type,
+        }
+        with start_observation(
+            name=f"blueprint.{self.workflow_id}.{schema_name}",
+            as_type="generation",
+            model=self.llm_provider.model_name,
+            input={
+                "prompt": prompt,
+                "schema": schema_name,
+                "has_reference_image": bool(image_bytes),
+                "image_mime_type": image_mime_type,
+            },
+            metadata=metadata,
+        ) as observation:
+            try:
+                result = self.llm_provider.generate_structured(prompt, schema_class, image_bytes, image_mime_type)
+                self.model_name = self.llm_provider.model_name
+                update_observation(
+                    observation,
+                    output=serialize_for_langfuse(result),
+                    metadata={**metadata, "actual_model": self.model_name},
+                )
+                return result
+            except Exception as exc:
+                update_observation(
+                    observation,
+                    metadata={**metadata, "error_type": exc.__class__.__name__, "error": str(exc)[:1000]},
+                )
+                raise
 
     def generate_project(
         self,

--- a/backend/main.py
+++ b/backend/main.py
@@ -65,6 +65,7 @@ from backend.a2a import (
 )
 from backend.image_providers import get_image_output_debug_config
 from backend.job_store import JOB_STORE
+from backend.observability import flush_langfuse, get_langfuse_debug_config
 from backend.runtime_config import (
     ALPHA_GENERATION_UNAVAILABLE_MESSAGE,
     AlphaGenerationUnavailableError,
@@ -164,6 +165,7 @@ async def startup_event():
 @app.on_event("shutdown")
 async def shutdown_event():
     await stop_a2a_tcp_server()
+    flush_langfuse()
 
 @app.get("/")
 def read_root():
@@ -189,6 +191,7 @@ def debug_config_endpoint():
             "job_metadata": JOB_STORE.get_config(),
             "image_output": get_image_output_debug_config(),
             "image_storage": get_image_storage_config(),
+            "observability": get_langfuse_debug_config(),
             "video_generation": GMICloudProvider().get_debug_config(),
             "video_storage": get_video_storage_config(),
             "workflows": list_workflows(),

--- a/backend/observability.py
+++ b/backend/observability.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from contextlib import contextmanager
+from typing import Any, Dict, Iterator, List, Optional
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+logger = logging.getLogger(__name__)
+
+try:
+    from langfuse import get_client, propagate_attributes
+except ImportError as exc:  # pragma: no cover - exercised when optional dep is absent
+    get_client = None
+    propagate_attributes = None
+    _LANGFUSE_IMPORT_ERROR = str(exc)
+else:
+    _LANGFUSE_IMPORT_ERROR = None
+
+
+DEFAULT_MAX_FIELD_CHARS = 20000
+
+
+class NoopObservation:
+    def update(self, **_: Any) -> None:
+        return None
+
+
+def _env(name: str, default: Optional[str] = None) -> Optional[str]:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    stripped = value.strip()
+    return stripped if stripped else default
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _max_field_chars() -> int:
+    raw_value = _env("LANGFUSE_MAX_FIELD_CHARS")
+    if raw_value is None:
+        return DEFAULT_MAX_FIELD_CHARS
+    try:
+        return max(1000, int(raw_value))
+    except ValueError:
+        logger.warning("Invalid LANGFUSE_MAX_FIELD_CHARS=%r; using %s.", raw_value, DEFAULT_MAX_FIELD_CHARS)
+        return DEFAULT_MAX_FIELD_CHARS
+
+
+def _keys_configured() -> bool:
+    return bool(_env("LANGFUSE_PUBLIC_KEY") and _env("LANGFUSE_SECRET_KEY"))
+
+
+def langfuse_enabled() -> bool:
+    if os.getenv("LANGFUSE_ENABLED") is not None:
+        return _env_bool("LANGFUSE_ENABLED")
+    return _keys_configured()
+
+
+def get_langfuse_debug_config() -> Dict[str, Any]:
+    enabled = langfuse_enabled()
+    reason = None
+    if os.getenv("LANGFUSE_ENABLED") is not None and not enabled:
+        reason = "LANGFUSE_ENABLED is false."
+    elif not enabled:
+        reason = "Set LANGFUSE_PUBLIC_KEY and LANGFUSE_SECRET_KEY to enable tracing."
+    elif get_client is None:
+        reason = f"Langfuse SDK import failed: {_LANGFUSE_IMPORT_ERROR}"
+    elif not _keys_configured():
+        reason = "LANGFUSE_ENABLED is true, but Langfuse project keys are missing."
+
+    return {
+        "enabled": bool(enabled and get_client is not None and _keys_configured()),
+        "installed": get_client is not None,
+        "public_key_configured": bool(_env("LANGFUSE_PUBLIC_KEY")),
+        "secret_key_configured": bool(_env("LANGFUSE_SECRET_KEY")),
+        "base_url": _env("LANGFUSE_BASE_URL", "https://cloud.langfuse.com"),
+        "environment": _env("LANGFUSE_TRACING_ENVIRONMENT"),
+        "release": _env("LANGFUSE_TRACING_RELEASE"),
+        "max_field_chars": _max_field_chars(),
+        "reason": reason,
+    }
+
+
+def serialize_for_langfuse(value: Any) -> Any:
+    if value is None:
+        return None
+    if hasattr(value, "model_dump"):
+        value = value.model_dump()
+
+    try:
+        serialized = json.dumps(value, default=str)
+    except TypeError:
+        serialized = str(value)
+
+    max_chars = _max_field_chars()
+    if len(serialized) <= max_chars:
+        try:
+            return json.loads(serialized)
+        except json.JSONDecodeError:
+            return serialized
+
+    return {
+        "truncated": True,
+        "chars": len(serialized),
+        "preview": serialized[:max_chars],
+    }
+
+
+def _client_enabled() -> bool:
+    return bool(langfuse_enabled() and get_client is not None and _keys_configured())
+
+
+@contextmanager
+def start_observation(
+    *,
+    name: str,
+    as_type: str = "span",
+    input: Any = None,
+    model: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
+) -> Iterator[Any]:
+    if not _client_enabled():
+        yield NoopObservation()
+        return
+
+    try:
+        client = get_client()
+        kwargs: Dict[str, Any] = {
+            "as_type": as_type,
+            "name": name,
+        }
+        serialized_input = serialize_for_langfuse(input)
+        if serialized_input is not None:
+            kwargs["input"] = serialized_input
+        if model:
+            kwargs["model"] = model
+        if metadata:
+            kwargs["metadata"] = serialize_for_langfuse(metadata)
+
+        manager = client.start_as_current_observation(**kwargs)
+        observation = manager.__enter__()
+    except Exception as exc:  # pragma: no cover - defensive against SDK/env failures
+        logger.warning("Langfuse observation %s could not start: %s", name, exc)
+        yield NoopObservation()
+        return
+
+    exc_info = (None, None, None)
+    try:
+        yield observation
+    except BaseException:
+        exc_info = sys.exc_info()
+        try:
+            observation.update(
+                metadata=serialize_for_langfuse(
+                    {
+                        "error_type": exc_info[0].__name__ if exc_info[0] else "Error",
+                        "error": str(exc_info[1])[:1000] if exc_info[1] else "",
+                    }
+                )
+            )
+        except Exception:
+            logger.debug("Langfuse observation error update failed.", exc_info=True)
+        raise
+    finally:
+        try:
+            manager.__exit__(*exc_info)
+        except Exception as exc:  # pragma: no cover - defensive against SDK/env failures
+            logger.warning("Langfuse observation %s could not close: %s", name, exc)
+
+
+@contextmanager
+def propagate_observation_attributes(
+    *,
+    trace_name: str,
+    metadata: Optional[Dict[str, Any]] = None,
+    tags: Optional[List[str]] = None,
+) -> Iterator[None]:
+    if not _client_enabled() or propagate_attributes is None:
+        yield
+        return
+
+    try:
+        manager = propagate_attributes(
+            trace_name=trace_name,
+            metadata=serialize_for_langfuse(metadata or {}),
+            tags=tags or [],
+        )
+        manager.__enter__()
+    except Exception as exc:  # pragma: no cover - defensive against SDK/env failures
+        logger.warning("Langfuse attribute propagation failed: %s", exc)
+        yield
+        return
+
+    exc_info = (None, None, None)
+    try:
+        yield
+    except BaseException:
+        exc_info = sys.exc_info()
+        raise
+    finally:
+        try:
+            manager.__exit__(*exc_info)
+        except Exception as exc:  # pragma: no cover - defensive against SDK/env failures
+            logger.warning("Langfuse attribute propagation could not close: %s", exc)
+
+
+def update_observation(observation: Any, **kwargs: Any) -> None:
+    if observation is None:
+        return
+
+    payload = {
+        key: serialize_for_langfuse(value)
+        for key, value in kwargs.items()
+        if value is not None
+    }
+    if not payload:
+        return
+
+    try:
+        observation.update(**payload)
+    except Exception:  # pragma: no cover - defensive against SDK/env failures
+        logger.debug("Langfuse observation update failed.", exc_info=True)
+
+
+def flush_langfuse() -> None:
+    if not _client_enabled():
+        return
+
+    try:
+        get_client().flush()
+    except Exception as exc:  # pragma: no cover - defensive against SDK/env failures
+        logger.warning("Langfuse flush failed: %s", exc)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,3 +8,4 @@ sqlalchemy==2.0.31
 supabase==2.31.0
 boto3==1.35.99
 python-dotenv==1.0.1
+langfuse>=4.0.0

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -8,6 +8,7 @@ The backend is a **FastAPI** service that orchestrates agents, validates netlist
 - `backend/a2a.py` – A2A broker, REST/WebSocket/TCP/MCP handlers
 - `backend/llm_providers.py` – provider-agnostic structured LLM adapters
 - `backend/image_providers.py` – optional generated product image adapters
+- `backend/observability.py` – optional Langfuse tracing helpers
 - `backend/storage.py` – Supabase Storage image uploads, disabled in development mode
 - `backend/validation.py` – rule-based electrical checks
 - `backend/models.py` – Pydantic IR schemas
@@ -51,6 +52,11 @@ LLM configuration behavior:
 - `OPENAI_REASONING_EFFORT`: optional reasoning effort for GPT-5/o-series models, for example `low`
 - `OPENAI_TEMPERATURE`: optional first-party OpenAI sampling temperature. Omitted by default so models that only support their default temperature can run
 - `OPENAI_PROJECT_ID` / `OPENAI_ORG_ID`: optional OpenAI project and organization routing headers
+- `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY`: optional Langfuse project keys. When both are set, Blueprint traces each generation request and structured LLM step.
+- `LANGFUSE_BASE_URL`: optional Langfuse host, defaulting to `https://cloud.langfuse.com`.
+- `LANGFUSE_TRACING_ENVIRONMENT` / `LANGFUSE_TRACING_RELEASE`: optional trace attributes for environment and release filtering.
+- `LANGFUSE_MAX_FIELD_CHARS`: optional per-field payload cap for traced prompt/output previews, defaulting to `20000`.
+- `LANGFUSE_ENABLED=false`: explicit opt-out when project keys are present in the runtime environment.
 - `IMAGE_OUTPUT_ENABLED=true`: make product concept image generation the default. Requests can opt in per job with `generate_image=true`
 - `IMAGE_PROVIDER`: `openai`, `openai-compatible`, or `none`
 - `OPENAI_IMAGE_MODEL`: first-party OpenAI image model, for example `gpt-image-2`

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -77,6 +77,15 @@ STRICT_LLM=true
 # OPENAI_PROJECT_ID=your_openai_project_id_here
 # OPENAI_ORG_ID=your_openai_org_id_here
 
+# Optional Langfuse observability
+# LANGFUSE_PUBLIC_KEY=pk-lf-your_public_key_here
+# LANGFUSE_SECRET_KEY=sk-lf-your_secret_key_here
+# LANGFUSE_BASE_URL=https://cloud.langfuse.com
+# LANGFUSE_TRACING_ENVIRONMENT=local
+# LANGFUSE_TRACING_RELEASE=dev
+# LANGFUSE_MAX_FIELD_CHARS=20000
+# LANGFUSE_ENABLED=false
+
 # Optional generated product image output
 IMAGE_OUTPUT_ENABLED=false
 IMAGE_PROVIDER=openai
@@ -131,6 +140,7 @@ Notes:
 - `OPENAI_REASONING_EFFORT` can lower latency for GPT-5/o-series reasoning models, for example `low`.
 - `OPENAI_TEMPERATURE` is optional and omitted by default for first-party OpenAI so models that only support their default temperature can run.
 - `OPENAI_PROJECT_ID` and `OPENAI_ORG_ID` are optional routing headers for accounts that need explicit project or organization selection.
+- Set `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` to enable Langfuse tracing for full generation requests and every structured LLM step. `GET /api/debug/config` reports whether tracing is active without exposing secrets. Set `LANGFUSE_ENABLED=false` to disable tracing even when keys are present.
 - `IMAGE_OUTPUT_ENABLED=true` makes generated product concept images the default. Leave it `false` and use the UI checkbox or `generate_image=true` API flag to opt in per job.
 - `IMAGE_PROVIDER` can be `openai`, `openai-compatible`, or `none`.
 - `OPENAI_IMAGE_MODEL` selects the image model. The example default is `gpt-image-2`.

--- a/frontend/app/blueprint-workspace.tsx
+++ b/frontend/app/blueprint-workspace.tsx
@@ -1406,12 +1406,17 @@ export function BlueprintWorkspace({ routeProjectId = null }: HomeProps = {}) {
       }
 
       console.warn("Using local simulation fallback", error);
-      const mockRes = await runMockCompilation(promptText, imageData);
-      setProjectIR(mockRes.project_ir);
-      setMermaidCode(mockRes.mermaid_code);
-      setSvgSchematic(mockRes.svg_schematic);
-      buildReactFlowGraph(mockRes.project_ir);
-      generatedProject = true;
+      try {
+        const mockRes = await runMockCompilation(promptText, imageData);
+        setProjectIR(mockRes.project_ir);
+        setMermaidCode(mockRes.mermaid_code);
+        setSvgSchematic(mockRes.svg_schematic);
+        buildReactFlowGraph(mockRes.project_ir);
+        generatedProject = true;
+      } catch (fallbackError) {
+        const message = fallbackError instanceof Error ? fallbackError.message : "Local example fallback failed.";
+        setGenerationInputNotice(`Generation failed and local fallback was unavailable: ${message}`);
+      }
     } finally {
       if (generatedProject) {
         setSelectedImage(null);
@@ -1551,6 +1556,9 @@ export function BlueprintWorkspace({ routeProjectId = null }: HomeProps = {}) {
     }
 
     const res = await fetch(`/examples/${file}`);
+    if (!res.ok) {
+      throw new Error(`Could not load local example ${file}.`);
+    }
     const ir = await res.json();
     ir.assembly_metadata = {
       ...(ir.assembly_metadata || {}),


### PR DESCRIPTION
# Add Langfuse Observability for Blueprint Generation Pipeline

## Summary

This PR adds optional Langfuse tracing for Blueprint’s generation workflows. When Langfuse keys are configured, each generation request emits a top-level `blueprint.generate_project` trace with child observations for each structured LLM step in both the default catalog workflow and the web research workflow.

## Changes

- Added `backend/observability.py` as a small Langfuse adapter with:
  - no-op behavior when Langfuse is not configured
  - payload serialization/truncation via `LANGFUSE_MAX_FIELD_CHARS`
  - debug config reporting
  - graceful failure handling so tracing does not break generation
  - flush on backend shutdown

- Added tracing around:
  - top-level generation response building in `backend/a2a.py`
  - default workflow structured LLM calls
  - web research workflow structured LLM calls

- Exposed observability status through:
  - `GET /debug/config`
  - A2A capabilities/debug config

- Added `langfuse>=4.0.0` to backend requirements.

- Documented Langfuse env vars in:
  - `README.md`
  - `docs/setup.md`
  - `docs/backend.md`
  - `.env.example`
  - `backend/.env.example`

- Added `LANGFUSE_ENABLED=false` opt-out support.

- Added `.logs/` and `*.log` to `.gitignore`.

- Fixed frontend fallback handling so failed live generation plus failed local example fallback shows an in-app message instead of a Next.js runtime overlay.

## Testing

- Ran `python3 -m compileall backend`
- Ran `.venv/bin/python -m compileall backend`
- Verified FastAPI app import with `LANGFUSE_ENABLED=false`
- Verified `/debug/config` reports observability status
- Checked Langfuse SDK v4 signatures against `langfuse 4.13.0`
- Ran `npm run lint -- --file app/blueprint-workspace.tsx`

Lint passed with existing warnings about `useEffect` deps and `<img>` usage.