### PR TITLE
Track catalog and web research usage in jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,9 @@ uvicorn backend.main:app --reload --port 8000
 
 The CLI uses `.venv/bin/python` when present and falls back to `python3`. `health`
 checks the root, component, and A2A jobs endpoints; `jobs --local` reads the
-SQLite job metadata store directly when the API server is not running.
+SQLite job metadata store directly when the API server is not running. Job
+tables include the generation source when known: `Catalog`, `Web Research`, or
+both.
 
 To run with OpenAI:
 ```bash

--- a/backend/agents/web_research_workflow.py
+++ b/backend/agents/web_research_workflow.py
@@ -17,6 +17,7 @@ from backend.agents.orchestrator import (
     extract_power_rails,
 )
 from backend.database import save_generated_project
+from backend.job_source_usage import source_usage_for_workflow
 from backend.llm_providers import LLMProviderConfigError, build_llm_provider
 from backend.models import (
     AssemblyStep,
@@ -171,6 +172,7 @@ class WebResearchHardwarePipeline:
             ir.assembly_metadata = {
                 **(ir.assembly_metadata or {}),
                 "workflow": self.workflow_id,
+                "source_usage": source_usage_for_workflow(self.workflow_id),
                 "workflow_fallback": "simulation",
                 "firecrawl_research": self.research_client.config.reason,
             }
@@ -242,6 +244,7 @@ class WebResearchHardwarePipeline:
                 "actual_model": model_validation.actual_model,
                 "llm_provider": model_validation.provider,
                 "workflow": self.workflow_id,
+                "source_usage": source_usage_for_workflow(self.workflow_id),
                 "pipeline": "Firecrawl MCP web research + sourced hardware agents",
                 "component_source_policy": "web-sourced components; not constrained to seed_db.py",
                 "architecture_notes": plan.architecture_notes,

--- a/backend/agents/workflows.py
+++ b/backend/agents/workflows.py
@@ -5,11 +5,13 @@ from typing import Any, Dict, List, Optional
 
 from backend.agents.orchestrator import HardwarePipelineOrchestrator
 from backend.agents.web_research_workflow import WebResearchHardwarePipeline
+from backend.job_source_usage import (
+    DEFAULT_WORKFLOW_ID,
+    WEB_RESEARCH_WORKFLOW_ID,
+    normalize_generation_workflow_id,
+    source_usage_for_workflow,
+)
 from backend.models import HardwareIR
-
-
-DEFAULT_WORKFLOW_ID = "default"
-WEB_RESEARCH_WORKFLOW_ID = "web_research"
 
 
 @dataclass(frozen=True)
@@ -17,6 +19,8 @@ class WorkflowDescriptor:
     id: str
     label: str
     description: str
+    uses_catalog: bool = False
+    uses_web_research: bool = False
     uses_firecrawl_mcp: bool = False
 
 
@@ -25,32 +29,20 @@ WORKFLOW_DESCRIPTORS = [
         id=DEFAULT_WORKFLOW_ID,
         label="Catalog",
         description="Original sequential pipeline constrained to the active component catalog.",
+        uses_catalog=True,
     ),
     WorkflowDescriptor(
         id=WEB_RESEARCH_WORKFLOW_ID,
         label="Web Research",
         description="Firecrawl MCP research pipeline that sources components from web research before validation.",
+        uses_web_research=True,
         uses_firecrawl_mcp=True,
     ),
 ]
 
 
 def normalize_workflow_id(value: Optional[str]) -> str:
-    normalized = (value or DEFAULT_WORKFLOW_ID).strip().lower().replace("-", "_")
-    aliases = {
-        "catalog": DEFAULT_WORKFLOW_ID,
-        "seed": DEFAULT_WORKFLOW_ID,
-        "seed_db": DEFAULT_WORKFLOW_ID,
-        "legacy": DEFAULT_WORKFLOW_ID,
-        "firecrawl": WEB_RESEARCH_WORKFLOW_ID,
-        "web": WEB_RESEARCH_WORKFLOW_ID,
-        "internet": WEB_RESEARCH_WORKFLOW_ID,
-    }
-    normalized = aliases.get(normalized, normalized)
-    if normalized not in {descriptor.id for descriptor in WORKFLOW_DESCRIPTORS}:
-        valid = ", ".join(descriptor.id for descriptor in WORKFLOW_DESCRIPTORS)
-        raise ValueError(f"Unsupported generation workflow '{value}'. Valid workflows: {valid}.")
-    return normalized
+    return normalize_generation_workflow_id(value, strict=True)
 
 
 def list_workflows() -> List[Dict[str, Any]]:
@@ -75,20 +67,22 @@ def generate_project_with_workflow(
     image_mime_type: Optional[str] = None,
 ) -> HardwareIR:
     normalized = normalize_workflow_id(workflow_id)
+    source_usage = source_usage_for_workflow(normalized)
     if normalized == WEB_RESEARCH_WORKFLOW_ID:
-        return WebResearchHardwarePipeline().generate_project(
+        ir = WebResearchHardwarePipeline().generate_project(
             prompt,
             image_bytes=image_bytes,
             image_mime_type=image_mime_type,
         )
-
-    ir = HardwarePipelineOrchestrator().generate_project(
-        prompt,
-        image_bytes=image_bytes,
-        image_mime_type=image_mime_type,
-    )
+    else:
+        ir = HardwarePipelineOrchestrator().generate_project(
+            prompt,
+            image_bytes=image_bytes,
+            image_mime_type=image_mime_type,
+        )
     ir.assembly_metadata = {
         **(ir.assembly_metadata or {}),
-        "workflow": DEFAULT_WORKFLOW_ID,
+        "workflow": normalized,
+        "source_usage": source_usage,
     }
     return ir

--- a/backend/cli.py
+++ b/backend/cli.py
@@ -63,6 +63,24 @@ def _format_cell(value: Any, width: int) -> str:
     return text.ljust(width)
 
 
+def _job_source_label(job: dict[str, Any]) -> str:
+    summary = job.get("result_summary") if isinstance(job.get("result_summary"), dict) else {}
+    payload = job.get("payload") if isinstance(job.get("payload"), dict) else {}
+    source_usage = job.get("source_usage") or summary.get("source_usage") or {}
+    if not isinstance(source_usage, dict):
+        source_usage = {}
+    workflow = str(source_usage.get("workflow") or summary.get("workflow") or payload.get("workflow") or "")
+    workflow = workflow.strip().lower().replace("-", "_")
+    labels = source_usage.get("source_labels")
+    if isinstance(labels, list) and labels:
+        return " + ".join(str(label) for label in labels)
+    if source_usage.get("web_research") or source_usage.get("firecrawl") or workflow in {"web_research", "firecrawl"}:
+        return "Web Research"
+    if source_usage.get("catalog") or source_usage.get("data_warehouse") or workflow in {"default", "catalog"}:
+        return "Catalog"
+    return "-"
+
+
 def _print_jobs_table(jobs: list[dict[str, Any]]) -> None:
     if not jobs:
         print("No jobs found.")
@@ -72,6 +90,7 @@ def _print_jobs_table(jobs: list[dict[str, Any]]) -> None:
         ("status", 10),
         ("sender", 12),
         ("action", 28),
+        ("source", 16),
         ("job_id", 34),
         ("updated_at", 24),
         ("error", 32),
@@ -80,7 +99,8 @@ def _print_jobs_table(jobs: list[dict[str, Any]]) -> None:
     print(header)
     print("  ".join("-" * width for _, width in columns))
     for job in jobs:
-        print("  ".join(_format_cell(job.get(name), width) for name, width in columns))
+        row = {**job, "source": _job_source_label(job)}
+        print("  ".join(_format_cell(row.get(name), width) for name, width in columns))
 
 
 def cmd_serve(args: argparse.Namespace) -> int:

--- a/backend/job_source_usage.py
+++ b/backend/job_source_usage.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+DEFAULT_WORKFLOW_ID = "default"
+WEB_RESEARCH_WORKFLOW_ID = "web_research"
+
+WORKFLOW_ALIASES = {
+    "catalog": DEFAULT_WORKFLOW_ID,
+    "seed": DEFAULT_WORKFLOW_ID,
+    "seed_db": DEFAULT_WORKFLOW_ID,
+    "legacy": DEFAULT_WORKFLOW_ID,
+    "firecrawl": WEB_RESEARCH_WORKFLOW_ID,
+    "web": WEB_RESEARCH_WORKFLOW_ID,
+    "internet": WEB_RESEARCH_WORKFLOW_ID,
+}
+
+VALID_WORKFLOW_IDS = {DEFAULT_WORKFLOW_ID, WEB_RESEARCH_WORKFLOW_ID}
+
+
+def normalize_generation_workflow_id(value: Optional[str], *, strict: bool = True) -> str:
+    normalized = (value or DEFAULT_WORKFLOW_ID).strip().lower().replace("-", "_")
+    normalized = WORKFLOW_ALIASES.get(normalized, normalized)
+    if strict and normalized not in VALID_WORKFLOW_IDS:
+        valid = ", ".join(sorted(VALID_WORKFLOW_IDS))
+        raise ValueError(f"Unsupported generation workflow '{value}'. Valid workflows: {valid}.")
+    return normalized
+
+
+def source_usage_for_workflow(workflow_id: Optional[str], *, strict: bool = False) -> Dict[str, Any]:
+    workflow = normalize_generation_workflow_id(workflow_id, strict=strict)
+    uses_catalog = workflow == DEFAULT_WORKFLOW_ID
+    uses_web_research = workflow == WEB_RESEARCH_WORKFLOW_ID
+    return _source_usage_payload(workflow, uses_catalog=uses_catalog, uses_web_research=uses_web_research)
+
+
+def infer_source_usage(
+    *,
+    action: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+    result: Optional[Dict[str, Any]] = None,
+    result_summary: Optional[Dict[str, Any]] = None,
+    current: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    payload = _as_dict(payload)
+    result = _as_dict(result)
+    result_summary = _as_dict(result_summary)
+    current = _as_dict(current)
+    project_ir = _as_dict(result.get("project_ir"))
+    metadata = _as_dict(project_ir.get("assembly_metadata"))
+
+    embedded_usage = metadata.get("source_usage")
+    workflow = (
+        metadata.get("workflow")
+        or result_summary.get("workflow")
+        or _as_dict(current.get("source_usage")).get("workflow")
+        or payload.get("workflow")
+    )
+
+    if isinstance(embedded_usage, dict):
+        return normalize_source_usage(embedded_usage, fallback_workflow=workflow)
+
+    if not workflow and _is_generation_action(action):
+        workflow = DEFAULT_WORKFLOW_ID
+
+    if not workflow:
+        existing = _as_dict(current.get("source_usage"))
+        return normalize_source_usage(existing) if existing else {}
+
+    usage = source_usage_for_workflow(str(workflow), strict=False)
+    pipeline = str(metadata.get("pipeline") or result_summary.get("pipeline") or "").lower()
+    component_source_policy = str(metadata.get("component_source_policy") or "").lower()
+    has_firecrawl_metadata = metadata.get("firecrawl_research") is not None or "firecrawl" in pipeline
+    if has_firecrawl_metadata:
+        usage = _source_usage_payload(
+            usage["workflow"],
+            uses_catalog=usage["catalog"],
+            uses_web_research=True,
+        )
+    if "not constrained to seed_db.py" in component_source_policy:
+        usage = _source_usage_payload(
+            usage["workflow"],
+            uses_catalog=False,
+            uses_web_research=usage["web_research"],
+        )
+    return usage
+
+
+def normalize_source_usage(value: Dict[str, Any], *, fallback_workflow: Optional[Any] = None) -> Dict[str, Any]:
+    source_usage = _as_dict(value)
+    workflow = source_usage.get("workflow") or fallback_workflow
+    usage = source_usage_for_workflow(str(workflow) if workflow else None, strict=False)
+
+    catalog = _optional_bool(
+        source_usage.get("catalog", source_usage.get("used_catalog", source_usage.get("data_warehouse")))
+    )
+    web_research = _optional_bool(
+        source_usage.get("web_research", source_usage.get("used_web_research", source_usage.get("firecrawl")))
+    )
+    return _source_usage_payload(
+        usage["workflow"],
+        uses_catalog=usage["catalog"] if catalog is None else catalog,
+        uses_web_research=usage["web_research"] if web_research is None else web_research,
+    )
+
+
+def _source_usage_payload(workflow: str, *, uses_catalog: bool, uses_web_research: bool) -> Dict[str, Any]:
+    sources = []
+    source_labels = []
+    if uses_catalog:
+        sources.append("catalog")
+        source_labels.append("Catalog")
+    if uses_web_research:
+        sources.append("web_research")
+        source_labels.append("Web Research")
+    return {
+        "workflow": workflow,
+        "catalog": uses_catalog,
+        "web_research": uses_web_research,
+        "data_warehouse": uses_catalog,
+        "firecrawl": uses_web_research,
+        "sources": sources,
+        "source_labels": source_labels,
+    }
+
+
+def _is_generation_action(action: Optional[str]) -> bool:
+    if not action:
+        return False
+    normalized = action.removeprefix("blueprint.")
+    return normalized == "generate_project"
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _optional_bool(value: Any) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "off"}:
+            return False
+    return bool(value)

--- a/backend/job_store.py
+++ b/backend/job_store.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, List, Optional
 
 from dotenv import load_dotenv
 
+from backend.job_source_usage import infer_source_usage
 from backend.runtime_config import blueprint_dev_mode_enabled
 
 load_dotenv()
@@ -72,6 +73,7 @@ def summarize_result(result: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any
     overview = project_ir.get("overview") or {}
     metadata = project_ir.get("assembly_metadata") or {}
     validation = project_ir.get("validation") or {}
+    source_usage = infer_source_usage(result=result)
 
     return {
         "project_id": metadata.get("project_id"),
@@ -88,6 +90,8 @@ def summarize_result(result: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any
         "has_product_image": bool(metadata.get("product_image_data") or metadata.get("product_image_url")),
         "product_image_provider": metadata.get("product_image_provider") or metadata.get("image_output_provider"),
         "product_image_model": metadata.get("product_image_model") or metadata.get("image_output_model"),
+        "workflow": metadata.get("workflow"),
+        "source_usage": source_usage,
         "pipeline": metadata.get("pipeline"),
     }
 
@@ -168,15 +172,41 @@ class JobMetadataStore:
                     completed_at TEXT,
                     payload_json TEXT,
                     result_summary_json TEXT,
+                    source_usage_json TEXT,
                     error TEXT
                 )
                 """
             )
+            self._migrate_sqlite_schema(conn)
             conn.execute("CREATE INDEX IF NOT EXISTS idx_a2a_jobs_sender ON a2a_jobs(sender)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_a2a_jobs_status ON a2a_jobs(status)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_a2a_jobs_created_at ON a2a_jobs(created_at)")
             conn.commit()
         self._initialized = True
+
+    def _migrate_sqlite_schema(self, conn: sqlite3.Connection) -> None:
+        columns = {row["name"] for row in conn.execute("PRAGMA table_info(a2a_jobs)").fetchall()}
+        if "source_usage_json" not in columns:
+            conn.execute("ALTER TABLE a2a_jobs ADD COLUMN source_usage_json TEXT")
+
+        rows = conn.execute(
+            """
+            SELECT job_id, action, payload_json, result_summary_json, source_usage_json
+            FROM a2a_jobs
+            WHERE source_usage_json IS NULL OR source_usage_json = ''
+            """
+        ).fetchall()
+        for row in rows:
+            source_usage = infer_source_usage(
+                action=row["action"],
+                payload=_json_loads(row["payload_json"]) or {},
+                result_summary=_json_loads(row["result_summary_json"]) or {},
+            )
+            if source_usage:
+                conn.execute(
+                    "UPDATE a2a_jobs SET source_usage_json = ? WHERE job_id = ?",
+                    (_json_dumps(source_usage), row["job_id"]),
+                )
 
     def create_job(
         self,
@@ -193,6 +223,7 @@ class JobMetadataStore:
     ) -> Dict[str, Any]:
         self.init_db()
         now = _utc_now()
+        source_usage = infer_source_usage(action=action, payload=payload)
         if self.backend == "supabase":
             self._client.table("a2a_jobs").upsert(
                 {
@@ -210,6 +241,7 @@ class JobMetadataStore:
                     "completed_at": None,
                     "payload_json": _redact_payload(payload),
                     "result_summary_json": None,
+                    "source_usage_json": source_usage,
                     "error": None,
                 },
                 on_conflict="job_id",
@@ -221,9 +253,9 @@ class JobMetadataStore:
                 """
                 INSERT OR REPLACE INTO a2a_jobs (
                     job_id, message_id, correlation_id, action, sender, recipient, status,
-                    server_owned, created_at, updated_at, payload_json
+                    server_owned, created_at, updated_at, payload_json, source_usage_json
                 )
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     job_id,
@@ -237,6 +269,7 @@ class JobMetadataStore:
                     now,
                     now,
                     _json_dumps(_redact_payload(payload)),
+                    _json_dumps(source_usage),
                 ),
             )
         return self.get_job(job_id) or {}
@@ -272,6 +305,14 @@ class JobMetadataStore:
         self.init_db()
         now = _utc_now()
         result_summary = summarize_result(result)
+        current = self.get_job(job_id) or {}
+        source_usage = infer_source_usage(
+            action=current.get("action"),
+            payload=current.get("payload"),
+            result=result,
+            result_summary=result_summary,
+            current=current,
+        )
         if self.backend == "supabase":
             self._client.table("a2a_jobs").update(
                 {
@@ -279,6 +320,7 @@ class JobMetadataStore:
                     "completed_at": now,
                     "updated_at": now,
                     "result_summary_json": result_summary,
+                    "source_usage_json": source_usage,
                     "error": None,
                 }
             ).eq("job_id", job_id).execute()
@@ -288,10 +330,10 @@ class JobMetadataStore:
             conn.execute(
                 """
                 UPDATE a2a_jobs
-                SET status = ?, completed_at = ?, updated_at = ?, result_summary_json = ?, error = NULL
+                SET status = ?, completed_at = ?, updated_at = ?, result_summary_json = ?, source_usage_json = ?, error = NULL
                 WHERE job_id = ?
                 """,
-                ("succeeded", now, now, _json_dumps(result_summary), job_id),
+                ("succeeded", now, now, _json_dumps(result_summary), _json_dumps(source_usage), job_id),
             )
 
     def mark_failed(self, job_id: str, error: str) -> None:
@@ -390,8 +432,17 @@ class JobMetadataStore:
     def _row_to_dict(row: Any) -> Dict[str, Any]:
         result = dict(row)
         result["server_owned"] = bool(result["server_owned"])
-        result["payload"] = _json_loads(result.pop("payload_json", None)) or {}
-        result["result_summary"] = _json_loads(result.pop("result_summary_json", None))
+        payload = _json_loads(result.pop("payload_json", None)) or {}
+        result_summary = _json_loads(result.pop("result_summary_json", None))
+        source_usage = _json_loads(result.pop("source_usage_json", None)) or {}
+        result["payload"] = payload
+        result["result_summary"] = result_summary
+        result["source_usage"] = infer_source_usage(
+            action=result.get("action"),
+            payload=payload,
+            result_summary=result_summary,
+            current={"source_usage": source_usage},
+        )
         return result
 
 

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -8,7 +8,7 @@ Blueprint exposes the same hardware generation capability through several agent-
 - **TCP JSONL socket:** optional newline-delimited JSON socket enabled with `A2A_SOCKET_ENABLED=true`
 - **MCP-style JSON-RPC:** `POST /api/mcp` or `POST /api/a2a/mcp`
 
-Job metadata is persisted through `JOB_METADATA_BACKEND` (default: `auto`). In `auto`, Blueprint stores A2A jobs in Supabase when the main app database is Supabase, otherwise in SQLite at `JOB_METADATA_DB_PATH` (default: `./blueprint_jobs.db`). `BLUEPRINT_DEV_MODE=true` always uses SQLite, even if Supabase credentials are configured. The store keeps compact metadata only: payloads have image data redacted, and results are summarized instead of storing full generated IR blobs.
+Job metadata is persisted through `JOB_METADATA_BACKEND` (default: `auto`). In `auto`, Blueprint stores A2A jobs in Supabase when the main app database is Supabase, otherwise in SQLite at `JOB_METADATA_DB_PATH` (default: `./blueprint_jobs.db`). `BLUEPRINT_DEV_MODE=true` always uses SQLite, even if Supabase credentials are configured. The store keeps compact metadata only: payloads have image data redacted, results are summarized instead of storing full generated IR blobs, and `source_usage` records whether a generation job used the Catalog/data warehouse, Web Research/Firecrawl, or both.
 
 ## Message Shape
 ```json
@@ -21,6 +21,7 @@ Job metadata is persisted through `JOB_METADATA_BACKEND` (default: `auto`). In `
   "correlation_id": "build-001",
   "payload": {
     "prompt": "ESP32 soil moisture monitor with OLED",
+    "workflow": "default",
     "generate_image": false
   }
 }

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -23,8 +23,8 @@ The backend is a **FastAPI** service that orchestrates agents, validates netlist
 - `PUT /api/a2a/agents/{agent_id}` – register an agent listener
 - `POST /api/a2a/messages` – submit or broker an A2A message
 - `GET /api/a2a/agents/{agent_id}/events` – long-poll queued A2A events
-- `GET /api/a2a/jobs` – list persisted A2A job metadata
-- `GET /api/a2a/jobs/{job_id}` – fetch one persisted A2A job metadata record
+- `GET /api/a2a/jobs` – list persisted A2A job metadata, including generation `source_usage`
+- `GET /api/a2a/jobs/{job_id}` – fetch one persisted A2A job metadata record, including generation `source_usage`
 - `WebSocket /api/a2a/socket/{agent_id}` – bidirectional A2A event stream
 - `POST /api/mcp` and `POST /api/a2a/mcp` – MCP-style JSON-RPC tool endpoint
 - `POST /api/validate` – validate a user-supplied netlist

--- a/docs/database.md
+++ b/docs/database.md
@@ -41,7 +41,7 @@ A2A job metadata follows `JOB_METADATA_BACKEND`:
 - `BLUEPRINT_DEV_MODE=true` overrides this setting and uses SQLite.
 - SQLite path default: `./blueprint_jobs.db`
 - SQLite path override: `JOB_METADATA_DB_PATH`
-- Stored data: job ids, sender/recipient/action, lifecycle status, timestamps, redacted payload metadata, compact result summaries, and errors
+- Stored data: job ids, sender/recipient/action, lifecycle status, timestamps, redacted payload metadata, `source_usage` metadata for Catalog/data warehouse vs Web Research/Firecrawl, compact result summaries, and errors
 
 ### alpha_signups
 Alpha access leads captured when `BLUEPRINT_DEPLOYMENT=true` and live LLM generation is unavailable.

--- a/frontend/app/blueprint-workspace.tsx
+++ b/frontend/app/blueprint-workspace.tsx
@@ -59,12 +59,14 @@ type GenerationWorkflowOption = {
   id: string;
   label: string;
   description?: string;
+  uses_catalog?: boolean;
+  uses_web_research?: boolean;
   uses_firecrawl_mcp?: boolean;
 };
 
 const defaultGenerationWorkflows: GenerationWorkflowOption[] = [
-  { id: "default", label: "Catalog", description: "Catalog workflow" },
-  { id: "web_research", label: "Web Research", description: "Firecrawl MCP workflow", uses_firecrawl_mcp: true },
+  { id: "default", label: "Catalog", description: "Catalog workflow", uses_catalog: true },
+  { id: "web_research", label: "Web Research", description: "Firecrawl MCP workflow", uses_web_research: true, uses_firecrawl_mcp: true },
 ];
 
 function normalizeApiUrl(value: string) {
@@ -410,6 +412,7 @@ type A2AJob = {
   completed_at?: string | null;
   payload?: Record<string, any>;
   result_summary?: Record<string, any> | null;
+  source_usage?: Record<string, any>;
   error?: string | null;
 };
 
@@ -3649,6 +3652,9 @@ function JobRow({
   const summary = job.result_summary || {};
   const title = summary.title || job.payload?.prompt || job.action;
   const prompt = job.payload?.prompt || job.correlation_id || job.job_id;
+  const sourceUsage = getJobSourceUsage(job);
+  const sourceLabel = formatSourceUsageLabel(sourceUsage);
+  const SourceIcon = sourceUsage.web_research || sourceUsage.firecrawl ? Sparkles : Database;
   const isOpenable = Boolean(project?.project_id);
 
   return (
@@ -3660,6 +3666,12 @@ function JobRow({
               {job.status === "succeeded" ? <CheckCircle className="h-3.5 w-3.5" /> : job.status === "failed" ? <AlertTriangle className="h-3.5 w-3.5" /> : <RefreshCw className="h-3.5 w-3.5" />}
               {job.status}
             </span>
+            {sourceLabel !== "-" && (
+              <span className="inline-flex max-w-full items-center gap-1.5 truncate border border-cyan-300/25 bg-cyan-300/10 px-2 py-1 text-[11px] font-black uppercase text-cyan-200">
+                <SourceIcon className="h-3.5 w-3.5 shrink-0" />
+                <span className="truncate">{sourceLabel}</span>
+              </span>
+            )}
             <span className="min-w-0 max-w-full truncate text-[11px] font-bold text-slate-500">{job.sender} {"->"} {job.recipient}</span>
           </div>
           <h3 className="truncate text-sm font-black text-white">{title}</h3>
@@ -3678,10 +3690,11 @@ function JobRow({
       </div>
 
       {!compact && (
-        <div className="mt-4 grid gap-2 text-[11px] sm:grid-cols-6">
+        <div className="mt-4 grid gap-2 text-[11px] sm:grid-cols-7">
           <JobMetric label="Job" value={job.job_id} />
           <JobMetric label="Created" value={formatJobTime(job.created_at)} />
           <JobMetric label="Duration" value={formatJobDuration(job)} />
+          <JobMetric label="Source" value={sourceLabel} />
           <JobMetric label="Parts" value={summary.component_count ?? "-"} />
           <JobMetric label="Valid" value={summary.is_valid === undefined ? "-" : summary.is_valid ? "yes" : "no"} />
           <JobMetric label="Image" value={summary.has_product_image ? summary.product_image_model || "yes" : "-"} />
@@ -3695,6 +3708,40 @@ function JobRow({
       )}
     </article>
   );
+}
+
+function getJobSourceUsage(job: A2AJob) {
+  const summaryUsage = job.result_summary?.source_usage;
+  const workflow = job.result_summary?.workflow || job.payload?.workflow;
+  return normalizeJobSourceUsage(job.source_usage || summaryUsage || (workflow ? { workflow } : {}));
+}
+
+function normalizeJobSourceUsage(value: any) {
+  const sourceUsage = value && typeof value === "object" ? value : {};
+  const rawWorkflow = typeof sourceUsage.workflow === "string" ? sourceUsage.workflow : "";
+  const workflow = rawWorkflow.trim().toLowerCase().replace(/-/g, "_");
+  const catalog = Boolean(sourceUsage.catalog || sourceUsage.data_warehouse || sourceUsage.used_catalog || workflow === "default" || workflow === "catalog");
+  const webResearch = Boolean(sourceUsage.web_research || sourceUsage.firecrawl || sourceUsage.used_web_research || workflow === "web_research" || workflow === "firecrawl");
+  const sourceLabels = Array.isArray(sourceUsage.source_labels)
+    ? sourceUsage.source_labels.filter((label: any) => typeof label === "string" && label.trim())
+    : [];
+  const labels = sourceLabels.length ? sourceLabels : [
+    ...(catalog ? ["Catalog"] : []),
+    ...(webResearch ? ["Web Research"] : []),
+  ];
+  return {
+    ...sourceUsage,
+    workflow,
+    catalog,
+    web_research: webResearch,
+    firecrawl: Boolean(sourceUsage.firecrawl || webResearch),
+    source_labels: labels,
+  };
+}
+
+function formatSourceUsageLabel(sourceUsage: Record<string, any>) {
+  const labels = Array.isArray(sourceUsage.source_labels) ? sourceUsage.source_labels : [];
+  return labels.length ? labels.join(" + ") : "-";
 }
 
 function JobMetric({ label, value }: { label: string; value: any }) {

--- a/supabase/migrations/20260702000200_job_source_usage_metadata.sql
+++ b/supabase/migrations/20260702000200_job_source_usage_metadata.sql
@@ -1,0 +1,58 @@
+-- Track whether each A2A job used the component catalog/data warehouse,
+-- Firecrawl-backed Web Research, or both.
+
+alter table public.a2a_jobs
+  add column if not exists source_usage_json jsonb not null default '{}'::jsonb;
+
+with normalized_jobs as (
+  select
+    job_id,
+    case
+      when replace(lower(coalesce(payload_json ->> 'workflow', result_summary_json ->> 'workflow', 'default')), '-', '_')
+        in ('firecrawl', 'web', 'internet', 'web_research')
+        then 'web_research'
+      when replace(lower(coalesce(payload_json ->> 'workflow', result_summary_json ->> 'workflow', 'default')), '-', '_')
+        in ('catalog', 'seed', 'seed_db', 'legacy', 'default')
+        then 'default'
+      else replace(lower(coalesce(payload_json ->> 'workflow', result_summary_json ->> 'workflow', 'default')), '-', '_')
+    end as workflow
+  from public.a2a_jobs
+  where action = 'blueprint.generate_project'
+    and (source_usage_json is null or source_usage_json = '{}'::jsonb)
+)
+update public.a2a_jobs as jobs
+set source_usage_json = case
+  when normalized_jobs.workflow = 'web_research' then jsonb_build_object(
+    'workflow', 'web_research',
+    'catalog', false,
+    'web_research', true,
+    'data_warehouse', false,
+    'firecrawl', true,
+    'sources', jsonb_build_array('web_research'),
+    'source_labels', jsonb_build_array('Web Research')
+  )
+  when normalized_jobs.workflow = 'default' then jsonb_build_object(
+    'workflow', 'default',
+    'catalog', true,
+    'web_research', false,
+    'data_warehouse', true,
+    'firecrawl', false,
+    'sources', jsonb_build_array('catalog'),
+    'source_labels', jsonb_build_array('Catalog')
+  )
+  else jsonb_build_object(
+    'workflow', normalized_jobs.workflow,
+    'catalog', false,
+    'web_research', false,
+    'data_warehouse', false,
+    'firecrawl', false,
+    'sources', '[]'::jsonb,
+    'source_labels', '[]'::jsonb
+  )
+end
+from normalized_jobs
+where jobs.job_id = normalized_jobs.job_id;
+
+create index if not exists idx_a2a_jobs_source_usage_gin
+  on public.a2a_jobs
+  using gin (source_usage_json);


### PR DESCRIPTION
## Summary

Closes #26.

Adds first-class job metadata for whether a generation job used:

- `Catalog` / data warehouse
- `Web Research` / Firecrawl
- both, if metadata indicates both sources

## Changes

- Added shared source usage normalization in `backend/job_source_usage.py`.
- Persisted `source_usage_json` on A2A jobs for both SQLite and Supabase-backed job metadata.
- Added SQLite auto-migration/backfill for existing local job databases.
- Added Supabase migration for `a2a_jobs.source_usage_json` plus backfill/index.
- Refreshes job source metadata from the completed generated IR on success.
- Includes `source_usage` in job API responses and compact result summaries.
- Shows source usage in:
  - frontend Jobs panel
  - backend CLI jobs table
- Adds source usage metadata to workflow descriptors and generated IR assembly metadata.
- Updated README and docs for the new job metadata field.

## Verification

- `python3 -m compileall backend`
- focused SQLite migration/write/read check
- `npm run lint`
- `npm run build`
- `git diff --check`

Notes: frontend lint/build pass with existing warnings around `loadExample` hook deps and `<img>` usage.