### PR TITLE
fix(auth): centralize provider-neutral project access

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -1,8 +1,10 @@
 import base64
 import json
 import os
+from dataclasses import dataclass, field
 from functools import lru_cache
-from typing import Any, Dict, Optional, Set
+from types import MappingProxyType
+from typing import Any, Dict, Mapping, Optional, Set
 from urllib import request as urllib_request
 
 import jwt
@@ -10,6 +12,30 @@ from fastapi import HTTPException, Request, status
 from jwt import PyJWKClient
 
 from backend.auth_mode import clerk_auth_required
+
+
+LOCAL_USER_ID = "local-dev-user"
+
+
+def _empty_claims() -> Mapping[str, Any]:
+    return MappingProxyType({})
+
+
+@dataclass(frozen=True, slots=True)
+class UserContext:
+    """Provider-neutral identity resolved for one backend request."""
+
+    provider: str
+    subject: Optional[str]
+    owner_user_id: Optional[str]
+    is_authenticated: bool
+    is_admin: bool
+    claims: Mapping[str, Any] = field(default_factory=_empty_claims)
+
+    def __post_init__(self) -> None:
+        # Do not retain a caller-owned mutable claims mapping inside an otherwise
+        # immutable request context.
+        object.__setattr__(self, "claims", MappingProxyType(dict(self.claims)))
 
 
 def _csv_env(name: str) -> Set[str]:
@@ -193,24 +219,6 @@ def _request_bearer_token(request: Request) -> Optional[str]:
     return normalized or None
 
 
-async def require_deployed_clerk_auth(request: Request) -> Optional[Dict[str, Any]]:
-    if not deployed_auth_required():
-        return None
-    token = _request_bearer_token(request)
-    if token:
-        return verify_clerk_bearer_token(token)
-    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Sign in to use Forma generation.")
-
-
-async def optional_deployed_clerk_auth(request: Request) -> Optional[Dict[str, Any]]:
-    if not deployed_auth_required():
-        return None
-    token = _request_bearer_token(request)
-    if token:
-        return verify_clerk_bearer_token(token)
-    return None
-
-
 def clerk_user_id(auth_claims: Optional[Dict[str, Any]]) -> Optional[str]:
     if not auth_claims:
         return None
@@ -242,8 +250,89 @@ def clerk_user_is_admin(auth_claims: Optional[Dict[str, Any]]) -> bool:
             return True
 
     admin_emails = {email.lower() for email in (_csv_env("BLUEPRINT_ADMIN_EMAILS") | _csv_env("CLERK_ADMIN_EMAILS"))}
+    if not admin_emails:
+        return False
     email = clerk_user_email(user_id)
     return bool(email and email.lower() in admin_emails)
+
+
+def _local_user_context() -> UserContext:
+    return UserContext(
+        provider="local",
+        subject=LOCAL_USER_ID,
+        owner_user_id=LOCAL_USER_ID,
+        is_authenticated=True,
+        is_admin=True,
+    )
+
+
+def _anonymous_clerk_context() -> UserContext:
+    return UserContext(
+        provider="clerk",
+        subject=None,
+        owner_user_id=None,
+        is_authenticated=False,
+        is_admin=False,
+    )
+
+
+def _authenticated_clerk_context(auth_claims: Dict[str, Any]) -> UserContext:
+    subject = clerk_user_id(auth_claims)
+    return UserContext(
+        provider="clerk",
+        subject=subject,
+        owner_user_id=subject,
+        is_authenticated=subject is not None,
+        is_admin=bool(subject and clerk_user_is_admin(auth_claims)),
+        claims=auth_claims,
+    )
+
+
+async def optional_user_context(request: Request) -> UserContext:
+    """Resolve a request identity without requiring the caller to be signed in."""
+    if not deployed_auth_required():
+        return _local_user_context()
+
+    token = _request_bearer_token(request)
+    if not token:
+        return _anonymous_clerk_context()
+    return _authenticated_clerk_context(verify_clerk_bearer_token(token))
+
+
+async def require_user_context(request: Request) -> UserContext:
+    """Resolve a request identity and reject anonymous Clerk requests."""
+    context = await optional_user_context(request)
+    if context.is_authenticated:
+        return context
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Sign in to use Forma generation.")
+
+
+async def require_admin_user_context(request: Request) -> UserContext:
+    """Resolve a request identity and require administrative access."""
+    context = await require_user_context(request)
+    if context.is_admin:
+        return context
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin access is required.")
+
+
+async def require_deployed_clerk_auth(request: Request) -> Optional[Dict[str, Any]]:
+    """Compatibility wrapper for routes that still consume raw Clerk claims."""
+    if not deployed_auth_required():
+        await require_user_context(request)
+        return None
+
+    context = await optional_user_context(request)
+    if _request_bearer_token(request):
+        return dict(context.claims)
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Sign in to use Forma generation.")
+
+
+async def optional_deployed_clerk_auth(request: Request) -> Optional[Dict[str, Any]]:
+    """Compatibility wrapper for routes that still consume raw Clerk claims."""
+    context = await optional_user_context(request)
+    if context.provider == "local" or not _request_bearer_token(request):
+        return None
+    return dict(context.claims)
 
 
 async def require_deployed_admin_auth(request: Request) -> Optional[Dict[str, Any]]:

--- a/backend/main.py
+++ b/backend/main.py
@@ -41,7 +41,7 @@ from blueprint_core.debug import (
 )
 from fastapi import Body, Depends, FastAPI, HTTPException, Query, WebSocket, status
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -102,7 +102,13 @@ from blueprint_core.video_review import FireworksVideoReviewClient, FireworksVid
 from backend.logs_api import router as logs_router
 from backend.streams_api import router as streams_router
 from backend.user_integrations_api import router as user_integrations_router
-from backend.auth import clerk_user_display_name, clerk_user_id, clerk_user_image_url, clerk_user_is_admin, deployed_auth_required, optional_deployed_clerk_auth, require_deployed_admin_auth, require_deployed_clerk_auth
+from backend.auth import (
+    UserContext,
+    deployed_auth_required,
+    optional_user_context,
+    require_admin_user_context,
+    require_user_context,
+)
 from backend.job_store import JOB_STORE, JobCancelledError
 from blueprint_core.observability import flush_langfuse, get_langfuse_debug_config
 from blueprint_core.runtime import (
@@ -224,25 +230,21 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-app.include_router(logs_router, dependencies=[Depends(require_deployed_admin_auth)])
-app.include_router(streams_router, dependencies=[Depends(require_deployed_admin_auth)])
+app.include_router(logs_router, dependencies=[Depends(require_admin_user_context)])
+app.include_router(streams_router, dependencies=[Depends(require_admin_user_context)])
 app.include_router(user_integrations_router)
-
-
-@app.middleware("http")
-async def apply_user_integrations_middleware(request: Any, call_next: Any) -> Any:
-    apply_user_integrations_to_environment()
-    return await call_next(request)
 
 
 def _deployment_runtime_config(llm_config: Dict[str, Any]) -> Dict[str, Any]:
     return deployment_runtime_config(llm_config, signup_storage=get_database_config()["client"])
 
 
-def _apply_auth_user_integrations(auth_claims: Any) -> None:
-    user_id = clerk_user_id(auth_claims)
-    if user_id:
-        apply_user_integrations_to_environment(UserIntegrationStore.for_user(user_id))
+def _apply_user_integrations(user: UserContext) -> None:
+    """Load provider settings only for operations that consume them."""
+    if user.provider == "local":
+        apply_user_integrations_to_environment()
+    elif user.owner_user_id:
+        apply_user_integrations_to_environment(UserIntegrationStore.for_user(user.owner_user_id))
 
 
 def _job_owner_user_id(job: Optional[Dict[str, Any]]) -> Optional[str]:
@@ -253,11 +255,11 @@ def _job_owner_user_id(job: Optional[Dict[str, Any]]) -> Optional[str]:
     return None
 
 
-def _require_job_reader(job: Dict[str, Any], auth_claims: Any) -> None:
-    if clerk_user_is_admin(auth_claims):
+def _require_job_reader(job: Dict[str, Any], user: UserContext) -> None:
+    if user.is_admin:
         return
     owner_user_id = _job_owner_user_id(job)
-    if owner_user_id and owner_user_id == clerk_user_id(auth_claims):
+    if owner_user_id and owner_user_id == user.owner_user_id:
         return
     raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You can only view your own jobs.")
 
@@ -336,11 +338,12 @@ def read_root():
 
 
 @app.get("/admin/session")
-def admin_session_endpoint(_auth_claims: Any = Depends(optional_deployed_clerk_auth)):
+def admin_session_endpoint(user: UserContext = Depends(optional_user_context)):
     """Reports whether the current signed-in user has Forma admin access."""
     return {
-        "is_admin": clerk_user_is_admin(_auth_claims),
-        "user_id": clerk_user_id(_auth_claims),
+        "is_admin": user.is_admin,
+        "user_id": user.owner_user_id,
+        "provider": user.provider,
     }
 
 
@@ -348,12 +351,12 @@ def admin_session_endpoint(_auth_claims: Any = Depends(optional_deployed_clerk_a
 def debug_config_endpoint(
     provider: Optional[str] = Query(None, description="Optional runtime LLM provider override to validate."),
     model: Optional[str] = Query(None, description="Optional runtime LLM model override to validate."),
-    _auth_claims: Any = Depends(optional_deployed_clerk_auth),
+    user: UserContext = Depends(optional_user_context),
 ):
     """
     Reports LLM provider and model resolution state without exposing credentials.
     """
-    _apply_auth_user_integrations(_auth_claims)
+    _apply_user_integrations(user)
     try:
         orchestrator = HardwarePipelineOrchestrator(provider_name=provider, model_name=model)
         llm_config = orchestrator.get_debug_config()
@@ -385,12 +388,12 @@ def debug_config_endpoint(
         ) from e
 
 @app.post("/generate", response_model=Dict[str, Any])
-def generate_project_endpoint(request: GenerateProjectRequest, _auth_claims: Any = Depends(require_deployed_clerk_auth)):
+def generate_project_endpoint(request: GenerateProjectRequest, user: UserContext = Depends(require_user_context)):
     """
     Submits a natural language hardware idea and optional multimodal reference image.
     Runs the 7-agent compilation workflow, circuit safety auditor, and returns a verified Hardware IR, SVG schematic, and Mermaid diagram.
     """
-    _apply_auth_user_integrations(_auth_claims)
+    _apply_user_integrations(user)
     try:
         llm_config = get_workflow_debug_config(
             request.workflow,
@@ -449,12 +452,12 @@ def generate_project_endpoint(request: GenerateProjectRequest, _auth_claims: Any
 
     job_id = request.client_job_id or f"job_frontend_{uuid4().hex}"
     message_id = f"msg_{uuid4().hex}"
-    owner_user_id = _require_authenticated_user(_auth_claims)
+    owner_user_id = _require_authenticated_user(user)
     if request.source_project_id:
         source_project = get_generated_project(request.source_project_id)
         if not source_project:
             raise HTTPException(status_code=404, detail="Source project not found.")
-        _require_project_chat_owner(source_project, _auth_claims)
+        _require_project_chat_owner(source_project, user)
     payload = {
         "prompt": request.prompt,
         "workflow": request.workflow,
@@ -711,12 +714,9 @@ def _require_non_empty(value: str | None, message: str) -> str:
     return normalized
 
 
-def _require_authenticated_user(auth_claims: Any) -> str:
-    user_id = clerk_user_id(auth_claims)
-    if user_id:
-        return user_id
-    if not deployed_auth_required():
-        return "local-dev-user"
+def _require_authenticated_user(user: UserContext) -> str:
+    if user.is_authenticated and user.owner_user_id:
+        return user.owner_user_id
     raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Sign in to manage projects and chats.")
 
 
@@ -727,32 +727,44 @@ def _project_owner_user_id(project: Any) -> Optional[str]:
     return None
 
 
+def _project_visibility(project: Any) -> str:
+    value = getattr(project, "visibility", "public")
+    normalized = str(value or "public").strip().lower()
+    return normalized if normalized in {"public", "private"} else "public"
+
+
+def _user_owns_project(project: Any, user: UserContext) -> bool:
+    return bool(user.owner_user_id and _project_owner_user_id(project) == user.owner_user_id)
+
+
+def _require_project_reader(project: Any, user: UserContext) -> None:
+    if _project_visibility(project) == "public" or _user_owns_project(project, user):
+        return
+    # Do not reveal that another user's private project exists.
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found.")
+
+
 def creator_display_name(owner_user_id: Optional[str]) -> str:
     if not owner_user_id:
         return "unknown"
     normalized = owner_user_id.strip()
     if normalized == "local-dev-user":
         return "local_dev"
-    clerk_display = clerk_user_display_name(normalized)
-    if clerk_display:
-        return clerk_display
     if len(normalized) <= 12:
         return normalized
     return f"{normalized[:6]}_{normalized[-4:]}"
 
 
-def _require_project_owner(project: Any, auth_claims: Any) -> str:
-    user_id = _require_authenticated_user(auth_claims)
-    if not deployed_auth_required():
-        return user_id
+def _require_project_owner(project: Any, user: UserContext) -> str:
+    user_id = _require_authenticated_user(user)
     owner_user_id = _project_owner_user_id(project)
     if owner_user_id != user_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You can only modify your own projects.")
     return user_id
 
 
-def _require_project_chat_owner(project: Any, auth_claims: Any) -> str:
-    user_id = _require_authenticated_user(auth_claims)
+def _require_project_chat_owner(project: Any, user: UserContext) -> str:
+    user_id = _require_authenticated_user(user)
     owner_user_id = _project_owner_user_id(project)
     if owner_user_id != user_id:
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="You can only chat with your own projects.")
@@ -852,13 +864,13 @@ def list_video_models_endpoint():
 
 
 @app.get("/video/projects/{project_id}")
-def list_project_videos_endpoint(project_id: str, _auth_claims: Any = Depends(require_deployed_clerk_auth)):
+def list_project_videos_endpoint(project_id: str, user: UserContext = Depends(require_user_context)):
     """Lists videos saved for one project from configured backend storage."""
     project_id = _require_non_empty(project_id, "projectId is required.")
     project = get_generated_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail="Project not found.")
-    _require_project_owner(project, _auth_claims)
+    _require_project_owner(project, user)
     try:
         videos = list_project_videos(project_id)
         return {
@@ -871,13 +883,13 @@ def list_project_videos_endpoint(project_id: str, _auth_claims: Any = Depends(re
 
 
 @app.post("/video/image-to-video")
-def create_image_to_video_endpoint(request: VideoImageToVideoRequest, _auth_claims: Any = Depends(require_deployed_clerk_auth)):
+def create_image_to_video_endpoint(request: VideoImageToVideoRequest, user: UserContext = Depends(require_user_context)):
     """Queues a backend-only GMI Cloud image-to-video generation request."""
     project_id = _require_non_empty(request.projectId, "projectId is required.")
     project = get_generated_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail="Project not found.")
-    _require_project_owner(project, _auth_claims)
+    _require_project_owner(project, user)
     image = _require_non_empty(request.image, "image is required.")
     prompt = _require_non_empty(request.prompt, "prompt is required.")
     model = _normalize_video_model(request.model, VIDEO_MODE_IMAGE_TO_VIDEO)
@@ -930,13 +942,13 @@ def create_image_to_video_endpoint(request: VideoImageToVideoRequest, _auth_clai
 
 
 @app.post("/video/video-to-video")
-def create_video_to_video_endpoint(request: VideoToVideoRequest, _auth_claims: Any = Depends(require_deployed_clerk_auth)):
+def create_video_to_video_endpoint(request: VideoToVideoRequest, user: UserContext = Depends(require_user_context)):
     """Queues a backend-only GMI Cloud video-to-video generation request."""
     project_id = _require_non_empty(request.projectId, "projectId is required.")
     project = get_generated_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail="Project not found.")
-    _require_project_owner(project, _auth_claims)
+    _require_project_owner(project, user)
     video = _require_non_empty(request.video, "video is required.")
     prompt = _require_non_empty(request.prompt, "prompt is required.")
     model = _normalize_video_model(request.model, VIDEO_MODE_VIDEO_TO_VIDEO)
@@ -997,7 +1009,7 @@ def get_image_to_video_status_endpoint(
     prompt: str | None = Query(None, description="Prompt used for the original video request."),
     aspectRatio: str | None = Query(None, description="Aspect ratio used for the original video request."),
     sourceUrl: str | None = Query(None, description="Source image or video URL used for the original video request."),
-    _auth_claims: Any = Depends(require_deployed_clerk_auth),
+    user: UserContext = Depends(require_user_context),
 ):
     """Polls GMI Cloud for a project-scoped video request and stores completed videos in S3."""
     request_id = _require_non_empty(request_id, "requestId is required.")
@@ -1005,7 +1017,7 @@ def get_image_to_video_status_endpoint(
     project = get_generated_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail="Project not found.")
-    _require_project_owner(project, _auth_claims)
+    _require_project_owner(project, user)
     normalized_mode = normalize_video_mode(mode)
     model = _normalize_video_model(model, normalized_mode)
     aspect_ratio = _normalize_video_request_aspect_ratio(aspectRatio) if aspectRatio else None
@@ -1090,9 +1102,9 @@ async def register_a2a_agent(agent_id: str, registration: A2AAgentRegistration):
 
 
 @app.post("/a2a/messages")
-async def send_a2a_message(message: A2AMessage, _auth_claims: Any = Depends(require_deployed_clerk_auth)):
+async def send_a2a_message(message: A2AMessage, user: UserContext = Depends(require_user_context)):
     """Submits an A2A message and queues an async result for the sender."""
-    owner_user_id = clerk_user_id(_auth_claims)
+    owner_user_id = user.owner_user_id
     if owner_user_id and message.action.startswith("blueprint."):
         message.payload = {**message.payload, "owner_user_id": owner_user_id}
     ack = await submit_a2a_message(message)
@@ -1115,29 +1127,29 @@ def list_a2a_jobs(
     sender: str | None = None,
     job_status: str | None = Query(None, alias="status"),
     limit: int = Query(50, ge=1, le=200),
-    _auth_claims: Any = Depends(require_deployed_admin_auth),
+    _user: UserContext = Depends(require_admin_user_context),
 ):
     """Lists persisted A2A job metadata."""
     return JOB_STORE.list_jobs(sender=sender, status=job_status, limit=limit)
 
 
 @app.get("/a2a/jobs/{job_id}")
-def get_a2a_job(job_id: str, _auth_claims: Any = Depends(require_deployed_clerk_auth)):
+def get_a2a_job(job_id: str, user: UserContext = Depends(require_user_context)):
     """Fetches persisted metadata for one A2A job."""
     job = JOB_STORE.get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="A2A job not found.")
-    _require_job_reader(job, _auth_claims)
+    _require_job_reader(job, user)
     return job
 
 
 @app.post("/a2a/jobs/{job_id}/cancel")
-def cancel_a2a_job(job_id: str, _auth_claims: Any = Depends(require_deployed_clerk_auth)):
+def cancel_a2a_job(job_id: str, user: UserContext = Depends(require_user_context)):
     """Stops a queued or running job owned by the current user."""
     job = JOB_STORE.get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail="A2A job not found.")
-    _require_job_reader(job, _auth_claims)
+    _require_job_reader(job, user)
     cancelled_job = JOB_STORE.mark_cancelled(job_id) or job
     if str(cancelled_job.get("status") or "").lower() in {"cancelled", "canceled"}:
         _delete_cancelled_generation_projects(job_id, cancelled_job)
@@ -1329,7 +1341,7 @@ def _example_project_object_jobs(limit: int, status: Optional[str]) -> List[Dict
 def list_example_project_object_jobs(
     job_status: str | None = Query(None, alias="status"),
     limit: int = Query(50, ge=1, le=200),
-    _auth_claims: Any = Depends(require_deployed_admin_auth),
+    _user: UserContext = Depends(require_admin_user_context),
 ):
     """Lists project-object jobs created by scripts under examples/results."""
     try:
@@ -1346,13 +1358,13 @@ async def a2a_websocket_endpoint(websocket: WebSocket, agent_id: str):
 
 
 @app.post("/mcp")
-async def mcp_endpoint(payload: Any = Body(...), _auth_claims: Any = Depends(require_deployed_admin_auth)):
+async def mcp_endpoint(payload: Any = Body(...), _user: UserContext = Depends(require_admin_user_context)):
     """MCP-style JSON-RPC endpoint exposing Forma tools."""
     return await handle_mcp_json_rpc(payload)
 
 
 @app.post("/a2a/mcp")
-async def a2a_mcp_endpoint(payload: Any = Body(...), _auth_claims: Any = Depends(require_deployed_admin_auth)):
+async def a2a_mcp_endpoint(payload: Any = Body(...), _user: UserContext = Depends(require_admin_user_context)):
     """Alias for agents that discover MCP under the A2A route prefix."""
     return await handle_mcp_json_rpc(payload)
 
@@ -1378,14 +1390,26 @@ def _project_summary_response(project: Any, current_user_id: Optional[str] = Non
         or hydrated_metadata.get("product_image_content_type")
     )
     star_count = metadata.get("star_count", metadata.get("stars", 0))
-    creator_display = creator_display_name(owner_user_id)
-    creator_image_url = clerk_user_image_url(owner_user_id) if owner_user_id else None
+    stored_creator_display = metadata.get("creator_display") or metadata.get("creator_username")
+    creator_display = (
+        stored_creator_display.strip()
+        if isinstance(stored_creator_display, str) and stored_creator_display.strip()
+        else creator_display_name(owner_user_id)
+    )
+    stored_creator_image_url = metadata.get("creator_image_url")
+    creator_image_url = (
+        stored_creator_image_url.strip()
+        if isinstance(stored_creator_image_url, str)
+        and stored_creator_image_url.strip().startswith(("http://", "https://"))
+        else None
+    )
     return {
         "project_id": project.project_id,
         "chat_id": getattr(project, "chat_id", None),
         "title": project.title,
         "prompt": project.prompt,
         "created_at": project.created_at,
+        "visibility": _project_visibility(project),
         "can_chat": bool(current_user_id and owner_user_id == current_user_id),
         "creator_display": creator_display,
         "creator_username": creator_display,
@@ -1412,7 +1436,10 @@ def _without_downloadable_project_assets(hardware_ir: Dict[str, Any]) -> Dict[st
                 sanitized_sources.append(source)
                 continue
             sanitized_source = dict(source)
-            for key in ("url", "href", "download_url", "downloadUrl", "file_url", "fileUrl", "source_url", "sourceUrl"):
+            # MechanicalSource.url is required by HardwareIR. Keep the public
+            # shape valid while removing the downloadable target itself.
+            sanitized_source["url"] = ""
+            for key in ("href", "download_url", "downloadUrl", "file_url", "fileUrl", "source_url", "sourceUrl"):
                 sanitized_source.pop(key, None)
             sanitized_sources.append(sanitized_source)
         mechanical["cad_sources"] = sanitized_sources
@@ -1435,20 +1462,19 @@ def _without_downloadable_project_assets(hardware_ir: Dict[str, Any]) -> Dict[st
 
 
 @app.get("/projects")
-def list_projects_endpoint(_auth_claims: Any = Depends(optional_deployed_clerk_auth)):
-    """Lists all previously compiled hardware projects."""
-    current_user_id = clerk_user_id(_auth_claims)
+def list_projects_endpoint(user: UserContext = Depends(optional_user_context)):
+    """Lists public compiled hardware projects."""
     try:
-        projects = list_generated_projects()
-        return [_project_summary_response(p, current_user_id=current_user_id) for p in projects]
+        projects = [project for project in list_generated_projects() if _project_visibility(project) == "public"]
+        return [_project_summary_response(p, current_user_id=user.owner_user_id) for p in projects]
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
 
 @app.get("/my/projects")
-def list_my_projects_endpoint(_auth_claims: Any = Depends(require_deployed_clerk_auth)):
+def list_my_projects_endpoint(user: UserContext = Depends(require_user_context)):
     """Lists projects owned by the signed-in user."""
-    owner_user_id = _require_authenticated_user(_auth_claims)
+    owner_user_id = _require_authenticated_user(user)
     try:
         projects = list_generated_projects(owner_user_id=owner_user_id)
         return [_project_summary_response(p, current_user_id=owner_user_id) for p in projects]
@@ -1457,31 +1483,78 @@ def list_my_projects_endpoint(_auth_claims: Any = Depends(require_deployed_clerk
 
 
 @app.get("/projects/{project_id}/image-summary")
-def get_project_image_summary_endpoint(project_id: str, _auth_claims: Any = Depends(optional_deployed_clerk_auth)):
+def get_project_image_summary_endpoint(project_id: str, user: UserContext = Depends(optional_user_context)):
     """Returns gallery-safe project metadata without validating or expanding the full hardware IR."""
     project = get_generated_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail="Project not found.")
+    _require_project_reader(project, user)
 
     try:
-        return _project_summary_response(project, current_user_id=clerk_user_id(_auth_claims))
+        return _project_summary_response(project, current_user_id=user.owner_user_id)
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error reading project image summary: {str(e)}")
 
 
 @app.get("/projects/{project_id}")
-def get_project_endpoint(project_id: str, _auth_claims: Any = Depends(optional_deployed_clerk_auth)):
+def get_project_endpoint(project_id: str, user: UserContext = Depends(optional_user_context)):
     """Retrieves a specific hardware design and its corresponding schematics."""
     project = get_generated_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail="Project not found.")
-    
+    _require_project_reader(project, user)
+
+    can_chat = _user_owns_project(project, user)
+    stored_hardware_ir = json.loads(json.dumps(project.hardware_ir or {}))
     try:
-        current_user_id = clerk_user_id(_auth_claims)
-        can_chat = bool(current_user_id and _project_owner_user_id(project) == current_user_id)
-        ir = HardwareIR(**project.hardware_ir)
+        ir = HardwareIR(**stored_hardware_ir)
+    except ValidationError as exc:
+        # Saved projects can outlive the current HardwareIR schema. They should
+        # remain inspectable, but public readers still receive a redacted copy.
+        logger.warning(
+            "Returning legacy project IR without derived artifacts: project_id=%s validation_errors=%s",
+            project.project_id,
+            len(exc.errors()),
+        )
+        metadata = stored_hardware_ir.get("assembly_metadata")
+        if isinstance(metadata, dict):
+            stored_hardware_ir["assembly_metadata"] = hydrate_image_storage_metadata(metadata, project.project_id)
+        response_payload = stored_hardware_ir if can_chat else _without_downloadable_project_assets(stored_hardware_ir)
+        response_metadata = response_payload.get("assembly_metadata")
+        return {
+            "project_id": project.project_id,
+            "chat_id": getattr(project, "chat_id", None)
+            or (response_metadata.get("chat_id") if isinstance(response_metadata, dict) else None),
+            "prompt": project.prompt,
+            "created_at": project.created_at,
+            "can_chat": can_chat,
+            "project_ir": response_payload,
+            "project_object": None,
+            "mermaid_code": None,
+            "svg_schematic": None,
+        }
+
+    try:
         ir.assembly_metadata = hydrate_image_storage_metadata(ir.assembly_metadata, project.project_id)
-        response_ir = ir if can_chat else HardwareIR(**_without_downloadable_project_assets(ir.model_dump()))
+        if can_chat:
+            response_ir = ir
+        else:
+            sanitized_payload = _without_downloadable_project_assets(ir.model_dump())
+            try:
+                response_ir = HardwareIR(**sanitized_payload)
+            except ValidationError:
+                return {
+                    "project_id": project.project_id,
+                    "chat_id": getattr(project, "chat_id", None)
+                    or (sanitized_payload.get("assembly_metadata") or {}).get("chat_id"),
+                    "prompt": project.prompt,
+                    "created_at": project.created_at,
+                    "can_chat": False,
+                    "project_ir": sanitized_payload,
+                    "project_object": None,
+                    "mermaid_code": None,
+                    "svg_schematic": None,
+                }
         mermaid_code = generate_mermaid_chart(ir)
         svg_schematic = generate_svg_schematic(ir)
         
@@ -1496,6 +1569,8 @@ def get_project_endpoint(project_id: str, _auth_claims: Any = Depends(optional_d
             "mermaid_code": mermaid_code,
             "svg_schematic": svg_schematic
         }
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Error reading project IR: {str(e)}")
 
@@ -1504,13 +1579,13 @@ def get_project_endpoint(project_id: str, _auth_claims: Any = Depends(optional_d
 def update_project_endpoint(
     project_id: str,
     request: ProjectUpdateRequest,
-    _auth_claims: Any = Depends(require_deployed_clerk_auth),
+    user: UserContext = Depends(require_user_context),
 ):
-    """Updates owner-managed project metadata. Project records remain publicly readable."""
+    """Updates owner-managed project metadata, including public/private visibility."""
     project = get_generated_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail="Project not found.")
-    owner_user_id = _require_project_owner(project, _auth_claims)
+    owner_user_id = _require_project_owner(project, user)
     saved = update_generated_project_metadata(
         project.project_id,
         owner_user_id=owner_user_id,
@@ -1524,12 +1599,12 @@ def update_project_endpoint(
 
 
 @app.delete("/projects/{project_id}")
-def delete_project_endpoint(project_id: str, _auth_claims: Any = Depends(require_deployed_clerk_auth)):
+def delete_project_endpoint(project_id: str, user: UserContext = Depends(require_user_context)):
     """Deletes a project owned by the signed-in user."""
     project = get_generated_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail="Project not found.")
-    owner_user_id = _require_project_owner(project, _auth_claims)
+    owner_user_id = _require_project_owner(project, user)
     deleted = delete_generated_project(project.project_id, owner_user_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Project not found.")
@@ -1547,16 +1622,16 @@ def _chat_response(chat: Any) -> Dict[str, Any]:
 
 
 @app.get("/chats")
-def list_chats_endpoint(_auth_claims: Any = Depends(require_deployed_clerk_auth)):
+def list_chats_endpoint(user: UserContext = Depends(require_user_context)):
     """Lists private chats for the signed-in user."""
-    owner_user_id = _require_authenticated_user(_auth_claims)
+    owner_user_id = _require_authenticated_user(user)
     return [_chat_response(chat) for chat in list_project_chats(owner_user_id)]
 
 
 @app.get("/chats/{chat_id}")
-def get_chat_endpoint(chat_id: str, _auth_claims: Any = Depends(require_deployed_clerk_auth)):
+def get_chat_endpoint(chat_id: str, user: UserContext = Depends(require_user_context)):
     """Retrieves one private chat owned by the signed-in user."""
-    owner_user_id = _require_authenticated_user(_auth_claims)
+    owner_user_id = _require_authenticated_user(user)
     chat = get_project_chat(chat_id, owner_user_id)
     if not chat:
         raise HTTPException(status_code=404, detail="Chat not found.")
@@ -1567,10 +1642,10 @@ def get_chat_endpoint(chat_id: str, _auth_claims: Any = Depends(require_deployed
 def upsert_chat_endpoint(
     chat_id: str,
     request: ProjectChatUpsertRequest,
-    _auth_claims: Any = Depends(require_deployed_clerk_auth),
+    user: UserContext = Depends(require_user_context),
 ):
     """Creates or updates a private chat owned by the signed-in user."""
-    owner_user_id = _require_authenticated_user(_auth_claims)
+    owner_user_id = _require_authenticated_user(user)
     now = datetime.utcnow().isoformat() + "Z"
     chat = upsert_project_chat(
         chat_id=chat_id,
@@ -1584,9 +1659,9 @@ def upsert_chat_endpoint(
 
 
 @app.delete("/chats/{chat_id}")
-def delete_chat_endpoint(chat_id: str, _auth_claims: Any = Depends(require_deployed_clerk_auth)):
+def delete_chat_endpoint(chat_id: str, user: UserContext = Depends(require_user_context)):
     """Deletes a private chat owned by the signed-in user."""
-    owner_user_id = _require_authenticated_user(_auth_claims)
+    owner_user_id = _require_authenticated_user(user)
     deleted = delete_project_chat(chat_id, owner_user_id)
     if not deleted:
         raise HTTPException(status_code=404, detail="Chat not found.")
@@ -1594,11 +1669,12 @@ def delete_chat_endpoint(chat_id: str, _auth_claims: Any = Depends(require_deplo
 
 
 @app.get("/projects/{project_id}/video-prompt")
-def generate_project_video_prompt_endpoint(project_id: str):
+def generate_project_video_prompt_endpoint(project_id: str, user: UserContext = Depends(optional_user_context)):
     """Builds an image-to-video prompt from Forma project namespaces."""
     project = get_generated_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail="Project not found.")
+    _require_project_reader(project, user)
 
     try:
         ir = HardwareIR(**project.hardware_ir)
@@ -1617,13 +1693,15 @@ def generate_project_video_prompt_endpoint(project_id: str):
 def iterate_project_endpoint(
     project_id: str,
     request: IterateProjectRequest,
-    _auth_claims: Any = Depends(require_deployed_clerk_auth),
+    user: UserContext = Depends(require_user_context),
 ):
     """Applies an iteration instruction to an existing project through blueprint_core."""
-    _apply_auth_user_integrations(_auth_claims)
+    _apply_user_integrations(user)
     project = get_generated_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail="Project not found.")
+    _require_project_reader(project, user)
+    save_owner_user_id = _require_project_owner(project, user) if request.save else None
 
     try:
         current_ir = HardwareIR(**project.hardware_ir)
@@ -1637,8 +1715,11 @@ def iterate_project_endpoint(
         )
         revised_ir.assembly_metadata = hydrate_image_storage_metadata(revised_ir.assembly_metadata, project.project_id)
         if request.save:
-            owner_user_id = _require_project_owner(project, _auth_claims)
-            saved = update_generated_project_hardware_ir(project.project_id, revised_ir.model_dump(mode="json"), owner_user_id=owner_user_id)
+            saved = update_generated_project_hardware_ir(
+                project.project_id,
+                revised_ir.model_dump(mode="json"),
+                owner_user_id=save_owner_user_id,
+            )
             if not saved:
                 raise HTTPException(status_code=404, detail="Project not found.")
 
@@ -1768,13 +1849,14 @@ def _resolve_stored_video_review_target(project_id: str, request: VideoSelfCorre
 def video_self_correct_project_endpoint(
     project_id: str,
     request: VideoSelfCorrectRequest,
-    _auth_claims: Any = Depends(require_deployed_clerk_auth),
+    user: UserContext = Depends(require_user_context),
 ):
     """Reviews a generated project video with a Fireworks native video model and applies a corrective iteration."""
-    _apply_auth_user_integrations(_auth_claims)
+    _apply_user_integrations(user)
     project = get_generated_project(project_id)
     if not project:
         raise HTTPException(status_code=404, detail="Project not found.")
+    owner_user_id = _require_project_owner(project, user)
 
     try:
         current_ir = HardwareIR(**project.hardware_ir)
@@ -1792,7 +1874,6 @@ def video_self_correct_project_endpoint(
         )
         revised_ir.assembly_metadata = hydrate_image_storage_metadata(revised_ir.assembly_metadata, project.project_id)
         if request.save:
-            owner_user_id = _require_project_owner(project, _auth_claims)
             saved = update_generated_project_hardware_ir(project.project_id, revised_ir.model_dump(mode="json"), owner_user_id=owner_user_id)
             if not saved:
                 raise HTTPException(status_code=404, detail="Project not found.")

--- a/backend/user_integrations_api.py
+++ b/backend/user_integrations_api.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import time
-from typing import Any, Optional
+from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
@@ -14,7 +14,7 @@ from blueprint_core.user_integrations import (
     default_integration_store,
     integration_status_payload,
 )
-from backend.auth import clerk_user_id, deployed_auth_required, require_deployed_clerk_auth
+from backend.auth import UserContext, require_user_context
 from blueprint_core.debug import api_error_detail, redact_debug_text, redact_debug_value
 from blueprint_core.images import build_image_provider
 from blueprint_core.runtime import deployment_mode_enabled
@@ -51,10 +51,10 @@ def _status_payload(store: UserIntegrationStore) -> dict[str, object]:
     return payload
 
 
-def _store_for_auth(auth_claims: Any) -> UserIntegrationStore:
-    if not deployed_auth_required():
+def _store_for_context(user_context: UserContext) -> UserIntegrationStore:
+    if user_context.provider == "local":
         return default_integration_store()
-    owner_user_id = clerk_user_id(auth_claims)
+    owner_user_id = user_context.owner_user_id
     if not owner_user_id:
         raise HTTPException(status_code=401, detail="Sign in to manage provider settings.")
     return UserIntegrationStore.for_user(owner_user_id)
@@ -68,11 +68,11 @@ def _unexpected_storage_error(
     *,
     operation: str,
     store: UserIntegrationStore,
-    auth_claims: Any,
+    user_context: UserContext,
     exc: Exception,
     integration_id: Optional[str] = None,
 ) -> HTTPException:
-    owner_user_id = clerk_user_id(auth_claims)
+    owner_user_id = user_context.owner_user_id
     logger.exception(
         "User integration %s failed: owner_user_id=%s integration_id=%s storage=%s error_type=%s",
         operation,
@@ -102,29 +102,29 @@ def _unexpected_storage_error(
 
 
 @router.get("/integrations")
-def get_user_integrations(auth_claims: Any = Depends(require_deployed_clerk_auth)) -> dict[str, object]:
-    store = _store_for_auth(auth_claims)
+def get_user_integrations(user_context: UserContext = Depends(require_user_context)) -> dict[str, object]:
+    store = _store_for_context(user_context)
     try:
         return _status_payload(store)
     except Exception as exc:
         raise _unexpected_storage_error(
             operation="load",
             store=store,
-            auth_claims=auth_claims,
+            user_context=user_context,
             exc=exc,
         ) from exc
 
 
 @router.post("/integrations/reload")
-def reload_user_integrations(auth_claims: Any = Depends(require_deployed_clerk_auth)) -> dict[str, object]:
-    store = _store_for_auth(auth_claims)
+def reload_user_integrations(user_context: UserContext = Depends(require_user_context)) -> dict[str, object]:
+    store = _store_for_context(user_context)
     try:
         return _status_payload(store)
     except Exception as exc:
         raise _unexpected_storage_error(
             operation="reload",
             store=store,
-            auth_claims=auth_claims,
+            user_context=user_context,
             exc=exc,
         ) from exc
 
@@ -133,9 +133,9 @@ def reload_user_integrations(auth_claims: Any = Depends(require_deployed_clerk_a
 def update_user_integration(
     integration_id: str,
     request: IntegrationUpdateRequest,
-    auth_claims: Any = Depends(require_deployed_clerk_auth),
+    user_context: UserContext = Depends(require_user_context),
 ) -> dict[str, object]:
-    store = _store_for_auth(auth_claims)
+    store = _store_for_context(user_context)
     try:
         store.update_integration(
             integration_id,
@@ -146,7 +146,7 @@ def update_user_integration(
     except ValueError as exc:
         logger.warning(
             "User integration update rejected: owner_user_id=%s integration_id=%s storage=%s error=%s",
-            clerk_user_id(auth_claims),
+            user_context.owner_user_id,
             integration_id,
             _storage_label(store),
             redact_debug_text(str(exc)),
@@ -155,7 +155,7 @@ def update_user_integration(
     except KeyError as exc:
         logger.warning(
             "User integration update target not found: owner_user_id=%s integration_id=%s storage=%s error=%s",
-            clerk_user_id(auth_claims),
+            user_context.owner_user_id,
             integration_id,
             _storage_label(store),
             redact_debug_text(str(exc)),
@@ -165,14 +165,14 @@ def update_user_integration(
         raise _unexpected_storage_error(
             operation="save",
             store=store,
-            auth_claims=auth_claims,
+            user_context=user_context,
             exc=exc,
             integration_id=integration_id,
         ) from exc
     logger.info(
         "User integration update persisted: owner_user_id=%s integration_id=%s storage=%s "
         "enabled=%s field_ids=%s clear_fields=%s",
-        clerk_user_id(auth_claims),
+        user_context.owner_user_id,
         integration_id,
         _storage_label(store),
         request.enabled,
@@ -185,7 +185,7 @@ def update_user_integration(
         raise _unexpected_storage_error(
             operation="post_save_reload",
             store=store,
-            auth_claims=auth_claims,
+            user_context=user_context,
             exc=exc,
             integration_id=integration_id,
         ) from exc
@@ -194,15 +194,15 @@ def update_user_integration(
 @router.delete("/integrations/{integration_id}")
 def clear_user_integration(
     integration_id: str,
-    auth_claims: Any = Depends(require_deployed_clerk_auth),
+    user_context: UserContext = Depends(require_user_context),
 ) -> dict[str, object]:
-    store = _store_for_auth(auth_claims)
+    store = _store_for_context(user_context)
     try:
         store.clear_integration(integration_id)
     except KeyError as exc:
         logger.warning(
             "User integration clear target not found: owner_user_id=%s integration_id=%s storage=%s error=%s",
-            clerk_user_id(auth_claims),
+            user_context.owner_user_id,
             integration_id,
             _storage_label(store),
             redact_debug_text(str(exc)),
@@ -212,13 +212,13 @@ def clear_user_integration(
         raise _unexpected_storage_error(
             operation="clear",
             store=store,
-            auth_claims=auth_claims,
+            user_context=user_context,
             exc=exc,
             integration_id=integration_id,
         ) from exc
     logger.info(
         "User integration clear persisted: owner_user_id=%s integration_id=%s storage=%s",
-        clerk_user_id(auth_claims),
+        user_context.owner_user_id,
         integration_id,
         _storage_label(store),
     )
@@ -228,7 +228,7 @@ def clear_user_integration(
         raise _unexpected_storage_error(
             operation="post_clear_reload",
             store=store,
-            auth_claims=auth_claims,
+            user_context=user_context,
             exc=exc,
             integration_id=integration_id,
         ) from exc
@@ -237,19 +237,19 @@ def clear_user_integration(
 @router.post("/integrations/image-model-test")
 def test_image_model(
     request: ImageModelTestRequest,
-    auth_claims: Any = Depends(require_deployed_clerk_auth),
+    user_context: UserContext = Depends(require_user_context),
 ) -> dict[str, object]:
     if not image_model_test_available():
         raise HTTPException(status_code=404, detail="Image model testing is only available locally and in preview deployments.")
 
-    store = _store_for_auth(auth_claims)
+    store = _store_for_context(user_context)
     try:
         apply_user_integrations_to_environment(store, fail_open=False)
     except Exception as exc:
         raise _unexpected_storage_error(
             operation="image_model_test_load",
             store=store,
-            auth_claims=auth_claims,
+            user_context=user_context,
             exc=exc,
         ) from exc
 
@@ -294,7 +294,7 @@ def test_image_model(
         elapsed_ms = round((time.monotonic() - started_at) * 1000)
         logger.exception(
             "Direct image model test failed: owner_user_id=%s provider=%s model=%s elapsed_ms=%s error_type=%s",
-            clerk_user_id(auth_claims),
+            user_context.owner_user_id,
             actual_provider,
             actual_model,
             elapsed_ms,

--- a/docs/database.md
+++ b/docs/database.md
@@ -32,8 +32,8 @@ Seed component library used by the Component Selection Agent.
 Archived outputs from the pipeline.
 - `project_id` (unique canonical UUID string; used directly in `/project/<uuid>` routes)
 - `chat_id` (optional private chat/thread id that created the project)
-- `owner_user_id` (optional Clerk user id that owns mutation rights)
-- `visibility` (`public` by default; public project reads are allowed through the API)
+- `owner_user_id` (provider-neutral internal user id that owns mutation rights)
+- `visibility` (`public` by default; `private` projects are readable only by their owner)
 - `title`
 - `prompt`
 - `hardware_ir` (JSON representation of the IR)
@@ -41,12 +41,12 @@ Archived outputs from the pipeline.
 
 `hardware_ir.assembly_metadata.project_id` must match `generated_projects.project_id`. Supabase Storage image keys are written under `images/<project_id>/...` so the DB row, route id, IR metadata, and object path share the same UUID.
 
-Projects are public artifacts: `GET /api/projects` and `GET /api/projects/{project_id}` do not require the project owner. Mutating a project, deleting it, or saving derived artifacts requires the signed-in Clerk user to match `owner_user_id` when deployed auth is enabled.
+`GET /api/projects` returns public artifacts only. `GET /api/projects/{project_id}` allows public projects or the owning identity; private non-owner reads return 404. Mutating, deleting, chatting with, or saving derived artifacts requires the request's provider-neutral user context to match `owner_user_id`.
 
 ### project_chats
-Private chat threads owned by a Clerk user.
+Private chat threads owned by an authenticated user.
 - `chat_id` (unique)
-- `owner_user_id` (Clerk user id; required)
+- `owner_user_id` (provider-neutral internal user id; required)
 - `title`
 - `messages` (JSON array)
 - `created_at`
@@ -56,7 +56,7 @@ Chats are not publicly readable. Sharing is intentionally deferred to a future s
 
 ### user_integration_configs
 Encrypted per-user BYOK/provider settings.
-- `owner_user_id` (Clerk user id; primary key)
+- `owner_user_id` (provider-neutral internal user id; primary key)
 - `encrypted_config` (Fernet-encrypted `UserIntegrationConfig` JSON)
 - `encryption_key_id` (non-secret fingerprint of the server key used for operations/debugging)
 - `version`

--- a/tests/test_project_access.py
+++ b/tests/test_project_access.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from backend import main
+from backend.auth import UserContext, optional_user_context
+from blueprint_core.models import (
+    FunctionalRequirements,
+    HardwareIR,
+    MechanicalNotes,
+    MechanicalSource,
+    ProjectOverview,
+)
+
+
+def _request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/projects",
+            "headers": [],
+        }
+    )
+
+
+def _user_context(owner_user_id: str) -> UserContext:
+    return UserContext(
+        provider="clerk",
+        subject=owner_user_id,
+        owner_user_id=owner_user_id,
+        is_authenticated=True,
+        is_admin=False,
+        claims={"sub": owner_user_id},
+    )
+
+
+def _anonymous_context() -> UserContext:
+    return UserContext(
+        provider="clerk",
+        subject=None,
+        owner_user_id=None,
+        is_authenticated=False,
+        is_admin=False,
+        claims={},
+    )
+
+
+def _project(
+    project_id: str,
+    *,
+    owner_user_id: str,
+    visibility: str,
+    hardware_ir: dict | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        project_id=project_id,
+        chat_id=f"chat-{project_id}",
+        owner_user_id=owner_user_id,
+        visibility=visibility,
+        title=f"Project {project_id}",
+        prompt="Build a low-voltage test fixture.",
+        created_at="2026-07-25T12:00:00Z",
+        hardware_ir=hardware_ir
+        or {
+            "components": [],
+            "assembly_metadata": {"project_id": project_id},
+        },
+    )
+
+
+class LocalProjectIdentityTests(unittest.IsolatedAsyncioTestCase):
+    async def test_local_user_context_owns_local_dev_user_projects(self) -> None:
+        with patch.dict(os.environ, {"BLUEPRINT_AUTH_MODE": "local"}, clear=False):
+            context = await optional_user_context(_request())
+
+        self.assertEqual("local", context.provider)
+        self.assertEqual("local-dev-user", context.subject)
+        self.assertEqual("local-dev-user", context.owner_user_id)
+        self.assertTrue(context.is_authenticated)
+        self.assertTrue(context.is_admin)
+
+
+class ProjectReadAccessTests(unittest.TestCase):
+    def _summary_dependencies(self) -> ExitStack:
+        stack = ExitStack()
+        stack.enter_context(
+            patch.object(
+                main,
+                "hydrate_image_storage_metadata",
+                side_effect=lambda metadata, _project_id: metadata,
+            )
+        )
+        stack.enter_context(patch.object(main, "creator_display_name", return_value="test-user"))
+        return stack
+
+    def test_public_list_includes_public_and_excludes_another_users_private_project(self) -> None:
+        public_project = _project(
+            "public-project",
+            owner_user_id="user-b",
+            visibility="public",
+        )
+        private_project = _project(
+            "private-project",
+            owner_user_id="user-b",
+            visibility="private",
+        )
+
+        with self._summary_dependencies(), patch.object(
+            main,
+            "list_generated_projects",
+            return_value=[private_project, public_project],
+        ):
+            response = main.list_projects_endpoint(_user_context("user-a"))
+
+        self.assertEqual(["public-project"], [item["project_id"] for item in response])
+
+    def test_owner_can_read_own_private_project(self) -> None:
+        private_project = _project(
+            "private-project",
+            owner_user_id="user-a",
+            visibility="private",
+        )
+
+        with self._summary_dependencies(), patch.object(
+            main,
+            "get_generated_project",
+            return_value=private_project,
+        ):
+            response = main.get_project_endpoint(
+                private_project.project_id,
+                _user_context("user-a"),
+            )
+
+        self.assertEqual(private_project.project_id, response["project_id"])
+        self.assertTrue(response["can_chat"])
+
+    def test_nonowner_private_project_read_returns_not_found(self) -> None:
+        private_project = _project(
+            "private-project",
+            owner_user_id="user-b",
+            visibility="private",
+        )
+
+        with patch.object(main, "get_generated_project", return_value=private_project):
+            with self.assertRaises(HTTPException) as raised:
+                main.get_project_endpoint(
+                    private_project.project_id,
+                    _user_context("user-a"),
+                )
+
+        self.assertEqual(404, raised.exception.status_code)
+
+    def test_public_legacy_project_read_redacts_downloadable_cad_urls(self) -> None:
+        downloadable_url = "https://downloads.example.test/private/enclosure.step"
+        legacy_ir = {
+            # This deliberately resembles a saved legacy payload rather than a
+            # current HardwareIR. Public reads must not turn schema drift into a
+            # 500 response merely to display the inspectable project artifact.
+            "overview": {"title": "Legacy enclosure"},
+            "components": [
+                {
+                    "legacy_shape": "not-a-current-component",
+                    "category": "mechanical",
+                    "name": "Printed enclosure",
+                    "url": downloadable_url,
+                    "sourcing_url": downloadable_url,
+                }
+            ],
+            "mechanical": {
+                "cad_sources": [
+                    {
+                        "name": "Enclosure CAD",
+                        "format": "STEP",
+                        "url": downloadable_url,
+                        "download_url": downloadable_url,
+                    }
+                ]
+            },
+            "assembly_metadata": {"project_id": "legacy-public-project"},
+        }
+        public_project = _project(
+            "legacy-public-project",
+            owner_user_id="user-b",
+            visibility="public",
+            hardware_ir=legacy_ir,
+        )
+
+        with self._summary_dependencies(), patch.object(
+            main,
+            "get_generated_project",
+            return_value=public_project,
+        ):
+            response = main.get_project_endpoint(
+                public_project.project_id,
+                _anonymous_context(),
+            )
+
+        self.assertEqual(public_project.project_id, response["project_id"])
+        self.assertFalse(response["can_chat"])
+        self.assertIsInstance(response["project_ir"], dict)
+        self.assertNotIn(downloadable_url, json.dumps(response, default=str))
+
+    def test_public_current_ir_keeps_required_cad_url_field_valid_while_redacting_value(self) -> None:
+        downloadable_url = "https://downloads.example.test/private/enclosure.step"
+        ir = HardwareIR(
+            overview=ProjectOverview(
+                title="Public enclosure",
+                description="A small low-voltage enclosure.",
+                difficulty="Beginner",
+                estimated_cost=12.0,
+                category="Mechanical",
+            ),
+            requirements=FunctionalRequirements(
+                requirements=["Protect the electronics"],
+                power_needs="USB 5V",
+                operating_voltage=5.0,
+            ),
+            mechanical=MechanicalNotes(
+                enclosure_type="3D Printed",
+                mounting_guidance="Fasten the board to internal standoffs.",
+                manufacturability_rating="Easy",
+                cad_sources=[
+                    MechanicalSource(
+                        name="Enclosure STEP",
+                        source_type="Vendor CAD",
+                        url=downloadable_url,
+                        file_formats=["STEP"],
+                    )
+                ],
+            ),
+            assembly_metadata={"project_id": "current-public-project"},
+        )
+        public_project = _project(
+            "current-public-project",
+            owner_user_id="user-b",
+            visibility="public",
+            hardware_ir=ir.model_dump(mode="json"),
+        )
+
+        with self._summary_dependencies(), patch.object(
+            main,
+            "get_generated_project",
+            return_value=public_project,
+        ):
+            response = main.get_project_endpoint(public_project.project_id, _anonymous_context())
+
+        self.assertFalse(response["can_chat"])
+        self.assertEqual("", response["project_ir"]["mechanical"]["cad_sources"][0]["url"])
+        self.assertNotIn(downloadable_url, json.dumps(response, default=str))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_summary.py
+++ b/tests/test_project_summary.py
@@ -5,6 +5,17 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from backend import main
+from backend.auth import UserContext
+
+
+ANONYMOUS_USER = UserContext(
+    provider="clerk",
+    subject=None,
+    owner_user_id=None,
+    is_authenticated=False,
+    is_admin=False,
+    claims={},
+)
 
 
 class ProjectSummaryTests(unittest.TestCase):
@@ -47,8 +58,8 @@ class ProjectSummaryTests(unittest.TestCase):
         }
 
         with patch.object(main, "creator_display_name", return_value="isayahc"), patch.object(
-            main, "clerk_user_image_url", return_value=None
-        ), patch.object(main, "hydrate_image_storage_metadata", return_value=hydrated):
+            main, "hydrate_image_storage_metadata", return_value=hydrated
+        ):
             summary = main._project_summary_response(project, current_user_id="user_123")
 
         self.assertTrue(summary["has_product_image"])
@@ -78,10 +89,10 @@ class ProjectSummaryTests(unittest.TestCase):
 
         with patch.object(main, "get_generated_project", return_value=project), patch.object(
             main, "creator_display_name", return_value="isayahc"
-        ), patch.object(main, "clerk_user_image_url", return_value=None), patch.object(
+        ), patch.object(
             main, "hydrate_image_storage_metadata", side_effect=lambda metadata, _project_id: metadata
         ), patch.object(main, "HardwareIR", side_effect=AssertionError("HardwareIR should not be constructed")):
-            summary = main.get_project_image_summary_endpoint(project.project_id, _auth_claims=None)
+            summary = main.get_project_image_summary_endpoint(project.project_id, ANONYMOUS_USER)
 
         self.assertEqual(project.project_id, summary["project_id"])
         self.assertEqual("https://storage.example.test/product.png", summary["product_image_url"])

--- a/tests/test_user_context.py
+++ b/tests/test_user_context.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import os
+import unittest
+from dataclasses import FrozenInstanceError
+from unittest.mock import patch
+
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from backend.auth import (
+    LOCAL_USER_ID,
+    UserContext,
+    optional_deployed_clerk_auth,
+    optional_user_context,
+    require_admin_user_context,
+    require_deployed_clerk_auth,
+    require_user_context,
+)
+
+
+def request_with_authorization(value: str | None = None) -> Request:
+    headers = [] if value is None else [(b"authorization", value.encode("utf-8"))]
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": headers,
+        }
+    )
+
+
+class UserContextTests(unittest.IsolatedAsyncioTestCase):
+    async def test_local_mode_resolves_a_stable_authenticated_admin(self) -> None:
+        request = request_with_authorization("Bearer ignored-in-local-mode")
+
+        with patch.dict(os.environ, {"BLUEPRINT_AUTH_MODE": "local"}, clear=True), patch(
+            "backend.auth.verify_clerk_bearer_token"
+        ) as verify_token:
+            optional_context = await optional_user_context(request)
+            required_context = await require_user_context(request)
+            admin_context = await require_admin_user_context(request)
+
+        for context in (optional_context, required_context, admin_context):
+            self.assertEqual("local", context.provider)
+            self.assertEqual(LOCAL_USER_ID, context.subject)
+            self.assertEqual(LOCAL_USER_ID, context.owner_user_id)
+            self.assertTrue(context.is_authenticated)
+            self.assertTrue(context.is_admin)
+            self.assertEqual({}, dict(context.claims))
+        verify_token.assert_not_called()
+
+    async def test_optional_clerk_mode_without_token_returns_anonymous_context(self) -> None:
+        with patch.dict(os.environ, {"BLUEPRINT_AUTH_MODE": "clerk"}, clear=True):
+            context = await optional_user_context(request_with_authorization())
+
+        self.assertEqual("clerk", context.provider)
+        self.assertIsNone(context.subject)
+        self.assertIsNone(context.owner_user_id)
+        self.assertFalse(context.is_authenticated)
+        self.assertFalse(context.is_admin)
+        self.assertEqual({}, dict(context.claims))
+
+    async def test_clerk_token_resolves_subject_owner_claims_and_admin(self) -> None:
+        claims = {"sub": "user_123", "public_metadata": {"role": "admin"}}
+        request = request_with_authorization("Bearer valid-token")
+
+        with patch.dict(os.environ, {"BLUEPRINT_AUTH_MODE": "clerk"}, clear=True), patch(
+            "backend.auth.verify_clerk_bearer_token", return_value=claims
+        ) as verify_token:
+            context = await optional_user_context(request)
+
+        verify_token.assert_called_once_with("valid-token")
+        self.assertEqual("clerk", context.provider)
+        self.assertEqual("user_123", context.subject)
+        self.assertEqual("user_123", context.owner_user_id)
+        self.assertTrue(context.is_authenticated)
+        self.assertTrue(context.is_admin)
+        self.assertEqual(claims, dict(context.claims))
+
+    async def test_required_context_rejects_anonymous_clerk_request(self) -> None:
+        with patch.dict(os.environ, {"BLUEPRINT_AUTH_MODE": "clerk"}, clear=True):
+            with self.assertRaises(HTTPException) as raised:
+                await require_user_context(request_with_authorization())
+
+        self.assertEqual(401, raised.exception.status_code)
+
+    async def test_admin_context_rejects_non_admin_clerk_user(self) -> None:
+        request = request_with_authorization("Bearer valid-token")
+        with patch.dict(os.environ, {"BLUEPRINT_AUTH_MODE": "clerk"}, clear=True), patch(
+            "backend.auth.verify_clerk_bearer_token", return_value={"sub": "user_123"}
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await require_admin_user_context(request)
+
+        self.assertEqual(403, raised.exception.status_code)
+
+    async def test_legacy_clerk_dependencies_keep_their_return_shapes(self) -> None:
+        local_request = request_with_authorization("Bearer ignored")
+        with patch.dict(os.environ, {"BLUEPRINT_AUTH_MODE": "local"}, clear=True):
+            self.assertIsNone(await optional_deployed_clerk_auth(local_request))
+            self.assertIsNone(await require_deployed_clerk_auth(local_request))
+
+        clerk_request = request_with_authorization("Bearer valid-token")
+        claims = {"sub": "user_123"}
+        with patch.dict(os.environ, {"BLUEPRINT_AUTH_MODE": "clerk"}, clear=True), patch(
+            "backend.auth.verify_clerk_bearer_token", return_value=claims
+        ):
+            self.assertEqual(claims, await optional_deployed_clerk_auth(clerk_request))
+            self.assertEqual(claims, await require_deployed_clerk_auth(clerk_request))
+
+    def test_user_context_is_frozen_and_copies_claims(self) -> None:
+        claims = {"sub": "user_123"}
+        context = UserContext(
+            provider="clerk",
+            subject="user_123",
+            owner_user_id="user_123",
+            is_authenticated=True,
+            is_admin=False,
+            claims=claims,
+        )
+
+        claims["sub"] = "changed"
+        self.assertEqual("user_123", context.claims["sub"])
+        with self.assertRaises(TypeError):
+            context.claims["sub"] = "changed"  # type: ignore[index]
+        with self.assertRaises(FrozenInstanceError):
+            context.subject = "changed"  # type: ignore[misc]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_user_integrations_api.py
+++ b/tests/test_user_integrations_api.py
@@ -8,18 +8,34 @@ from unittest.mock import patch
 from fastapi import HTTPException
 from fastapi.routing import APIRoute
 
-from backend.auth import require_deployed_clerk_auth
+from backend.auth import UserContext, require_user_context
 from backend.user_integrations_api import (
     ImageModelTestRequest,
     IntegrationUpdateRequest,
     get_user_integrations,
-    _store_for_auth,
+    _store_for_context,
     image_model_test_available,
     router,
     test_image_model,
     update_user_integration,
 )
 from blueprint_core.user_integrations import SupabaseUserIntegrationStore, SupabaseWorkspaceIntegrationStore
+
+
+LOCAL_CONTEXT = UserContext(
+    provider="local",
+    subject="local-dev-user",
+    owner_user_id="local-dev-user",
+    is_authenticated=True,
+    is_admin=True,
+)
+HOSTED_CONTEXT = UserContext(
+    provider="hosted-test",
+    subject="user_test",
+    owner_user_id="user_test",
+    is_authenticated=True,
+    is_admin=False,
+)
 
 
 class BrokenIntegrationStore:
@@ -39,36 +55,50 @@ class PersistThenBrokenReloadStore(BrokenIntegrationStore):
 
 
 class UserIntegrationsApiAuthTests(unittest.TestCase):
-    def test_local_mode_uses_encrypted_workspace_store_even_if_clerk_claims_are_present(self) -> None:
+    def test_local_context_uses_encrypted_workspace_store(self) -> None:
         workspace_store = SupabaseWorkspaceIntegrationStore()
-        with patch.dict(os.environ, {"BLUEPRINT_AUTH_MODE": "local"}, clear=False), patch(
+        with patch(
             "backend.user_integrations_api.default_integration_store",
             return_value=workspace_store,
         ):
-            self.assertIs(workspace_store, _store_for_auth({"sub": "user_should_be_ignored"}))
+            self.assertIs(workspace_store, _store_for_context(LOCAL_CONTEXT))
 
-    def test_clerk_mode_uses_authenticated_user_store(self) -> None:
+    def test_hosted_context_uses_authenticated_user_store(self) -> None:
         user_store = SupabaseUserIntegrationStore("user_test")
-        with patch.dict(os.environ, {"BLUEPRINT_AUTH_MODE": "clerk"}, clear=False), patch(
+        with patch(
             "backend.user_integrations_api.UserIntegrationStore.for_user",
             return_value=user_store,
         ) as for_user:
-            self.assertIs(user_store, _store_for_auth({"sub": "user_test"}))
+            self.assertIs(user_store, _store_for_context(HOSTED_CONTEXT))
         for_user.assert_called_once_with("user_test")
 
-    def test_user_integration_routes_require_deployed_auth(self) -> None:
+    def test_hosted_context_without_owner_is_rejected(self) -> None:
+        anonymous_context = UserContext(
+            provider="hosted-test",
+            subject=None,
+            owner_user_id=None,
+            is_authenticated=False,
+            is_admin=False,
+        )
+
+        with self.assertRaises(HTTPException) as raised:
+            _store_for_context(anonymous_context)
+
+        self.assertEqual(401, raised.exception.status_code)
+
+    def test_user_integration_routes_require_user_context(self) -> None:
         routes = [route for route in router.routes if isinstance(route, APIRoute)]
         self.assertGreaterEqual(len(routes), 4)
 
         for route in routes:
             dependency_calls = {dependency.call for dependency in route.dependant.dependencies}
-            self.assertIn(require_deployed_clerk_auth, dependency_calls, route.path)
+            self.assertIn(require_user_context, dependency_calls, route.path)
 
     def test_load_failure_is_logged_and_returned_as_structured_error(self) -> None:
-        with patch("backend.user_integrations_api._store_for_auth", return_value=BrokenIntegrationStore()):
+        with patch("backend.user_integrations_api._store_for_context", return_value=BrokenIntegrationStore()):
             with self.assertLogs("backend.user_integrations_api", level="ERROR") as logs:
                 with self.assertRaises(HTTPException) as raised:
-                    get_user_integrations({"sub": "user_test"})
+                    get_user_integrations(HOSTED_CONTEXT)
 
         self.assertEqual(500, raised.exception.status_code)
         self.assertEqual("user_integrations_load_failed", raised.exception.detail["code"])
@@ -78,10 +108,10 @@ class UserIntegrationsApiAuthTests(unittest.TestCase):
 
     def test_save_failure_is_logged_and_returned_as_structured_error(self) -> None:
         request = IntegrationUpdateRequest(enabled=True, fields={"api_key": "test-secret"})
-        with patch("backend.user_integrations_api._store_for_auth", return_value=BrokenIntegrationStore()):
+        with patch("backend.user_integrations_api._store_for_context", return_value=BrokenIntegrationStore()):
             with self.assertLogs("backend.user_integrations_api", level="ERROR") as logs:
                 with self.assertRaises(HTTPException) as raised:
-                    update_user_integration("anthropic", request, {"sub": "user_test"})
+                    update_user_integration("anthropic", request, HOSTED_CONTEXT)
 
         self.assertEqual(500, raised.exception.status_code)
         self.assertEqual("user_integrations_save_failed", raised.exception.detail["code"])
@@ -91,10 +121,10 @@ class UserIntegrationsApiAuthTests(unittest.TestCase):
 
     def test_post_save_reload_failure_is_distinguished_from_write_failure(self) -> None:
         request = IntegrationUpdateRequest(enabled=True, fields={"api_key": "test-secret"})
-        with patch("backend.user_integrations_api._store_for_auth", return_value=PersistThenBrokenReloadStore()):
+        with patch("backend.user_integrations_api._store_for_context", return_value=PersistThenBrokenReloadStore()):
             with self.assertLogs("backend.user_integrations_api", level="INFO") as logs:
                 with self.assertRaises(HTTPException) as raised:
-                    update_user_integration("anthropic", request, {"sub": "user_test"})
+                    update_user_integration("anthropic", request, HOSTED_CONTEXT)
 
         output = "\n".join(logs.output)
         self.assertEqual(500, raised.exception.status_code)
@@ -138,11 +168,11 @@ class UserIntegrationsApiAuthTests(unittest.TestCase):
         provider = FakeProvider()
         request = ImageModelTestRequest(provider="gmi", model="seedream-5.0-pro", prompt="  test render  ")
         with patch.dict(os.environ, {}, clear=True), patch(
-            "backend.user_integrations_api._store_for_auth", return_value=object()
+            "backend.user_integrations_api._store_for_context", return_value=object()
         ), patch("backend.user_integrations_api.apply_user_integrations_to_environment"), patch(
             "backend.user_integrations_api.build_image_provider", return_value=provider
         ):
-            response = test_image_model(request, {"sub": "user_test"})
+            response = test_image_model(request, HOSTED_CONTEXT)
 
         self.assertTrue(response["ok"])
         self.assertEqual("test render", provider.prompt)
@@ -153,7 +183,7 @@ class UserIntegrationsApiAuthTests(unittest.TestCase):
         request = ImageModelTestRequest(provider="gmi", model="seedream-5.0-pro", prompt="test render")
         with patch.dict(os.environ, {"VERCEL": "1", "VERCEL_ENV": "production"}, clear=True):
             with self.assertRaises(HTTPException) as raised:
-                test_image_model(request, {"sub": "user_test"})
+                test_image_model(request, HOSTED_CONTEXT)
 
         self.assertEqual(404, raised.exception.status_code)
 


### PR DESCRIPTION
## Summary

- Introduce a provider-neutral UserContext with local and Clerk adapters.
- Centralize project visibility, ownership, mutation, chat, and admin authorization.
- Fix public project serialization so required CAD source fields remain valid without leaking source URLs.
- Remove blocking Clerk profile lookups from project summaries.

## Tests

- 29 focused auth, access, summary, and integration API tests pass.
- git diff --check passes.