### PR TITLE
Fix chat ordering when selecting conversations

### DIFF
--- a/frontend/app/blueprint-workspace.tsx
+++ b/frontend/app/blueprint-workspace.tsx
@@ -2128,7 +2128,6 @@ export function FormaWorkspace({
         : null
     );
     if (!item.projectId) setProjectIR(null);
-    rememberChatItem(item);
     router.push(chatRoute(item.chatId));
   };
 


### PR DESCRIPTION
## Summary
- stop persisting a chat when it is only selected
- preserve sidebar ordering until the conversation receives a message update
- keep active-chat navigation and loading behavior unchanged

## Validation
- `npm run lint` (passes with existing `next/image` warnings)
- `npx tsc --noEmit`
- `npm run build`