### PR TITLE
fix: unify workspace typography

### DIFF
--- a/frontend/app/blueprint-workspace/workspace-frame.tsx
+++ b/frontend/app/blueprint-workspace/workspace-frame.tsx
@@ -19,7 +19,7 @@ export default function WorkspaceFrame({
     <div
       className={
         homeMobileTopPadding
-          ? "h-[100dvh] w-full overflow-hidden bg-[#141519] font-sans text-slate-100"
+          ? "h-[100dvh] w-full overflow-hidden bg-[#141519] text-slate-100"
           : "h-[100dvh] w-full overflow-hidden bg-[#141519] text-slate-200"
       }
     >


### PR DESCRIPTION
## Summary
- remove the home-only sans-serif override from the shared workspace frame
- keep chat and generated-project views on the global monospace typography

## Verification
- `npm run build` from `frontend/`

Build passes with the existing `@next/next/no-img-element` warnings.