### PR TITLE
Fix generation failure fallback behavior

### DIFF
--- a/blueprint_core/agents/orchestrator.py
+++ b/blueprint_core/agents/orchestrator.py
@@ -978,8 +978,8 @@ class HardwarePipelineOrchestrator:
             if _generation_fallback_disabled():
                 logger.error("Pipeline execution failed and fallback is disabled: %s", e)
                 raise
-            logger.error(f"Pipeline execution encountered an error: {e}. Falling back to simulation.")
-            return self._generate_simulated_project(user_prompt, has_image=bool(image_bytes))
+            logger.error("Pipeline execution encountered an error: %s", e)
+            return self._generate_failed_project(e)
 
     def _request_parti_base_seed(
         self,
@@ -1463,6 +1463,29 @@ class HardwarePipelineOrchestrator:
             return self._load_simulated_thermostat_project(prompt)
         else:
             return self._load_simulated_smart_lock_project(prompt)
+
+    def _generate_failed_project(self, error: Exception) -> HardwareIR:
+        """Return an empty, invalid project that preserves a pipeline failure for callers."""
+        error_type = error.__class__.__name__
+        error_message = str(error).strip() or error_type
+        issue = ValidationIssue(
+            severity="CRITICAL",
+            category="Generation Failure",
+            description=error_message,
+            troubleshooting="Retry generation or review the configured provider and model logs.",
+        )
+        return HardwareIR(
+            assembly_metadata={
+                "status": "failed",
+                "generation_error": {
+                    "type": error_type,
+                    "message": error_message,
+                },
+                "fallback_mode": False,
+            },
+            validation=ValidationSummary(critical=[issue]),
+            is_valid=False,
+        )
 
     def _load_simulated_mp3_player_project(self, prompt: str) -> HardwareIR:
         """Reference-style Forma project used for prompt+image MP3 player examples."""

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -87,6 +87,40 @@ class PipelineMetadataTests(unittest.TestCase):
 
         orchestrator._generate_simulated_project.assert_not_called()
 
+    def test_failed_live_pipeline_returns_empty_project_with_error(self) -> None:
+        orchestrator = HardwarePipelineOrchestrator.__new__(HardwarePipelineOrchestrator)
+        orchestrator._active_generation_metadata = {}
+        orchestrator.use_simulation = False
+        orchestrator.llm_provider = SimpleNamespace(provider_name="anthropic", model_name="claude-sonnet-5")
+        orchestrator.runtime_config = SimpleNamespace(
+            provider="anthropic",
+            model="claude-sonnet-5",
+            requested_provider="anthropic",
+            requested_model="claude-sonnet-5",
+            provider_overridden=False,
+            model_overridden=False,
+        )
+        orchestrator.validate_configured_model = Mock(
+            return_value=SimpleNamespace(provider="anthropic", actual_model="claude-sonnet-5")
+        )
+        orchestrator._call_llm_structured = Mock(side_effect=RuntimeError("provider timed out"))
+        orchestrator._generate_simulated_project = Mock()
+
+        project = orchestrator.generate_project("environment monitor")
+
+        self.assertIsNone(project.overview)
+        self.assertIsNone(project.requirements)
+        self.assertEqual([], project.components)
+        self.assertEqual([], project.nets)
+        self.assertFalse(project.is_valid)
+        self.assertEqual("failed", project.assembly_metadata["status"])
+        self.assertEqual(
+            {"type": "RuntimeError", "message": "provider timed out"},
+            project.assembly_metadata["generation_error"],
+        )
+        self.assertEqual("provider timed out", project.validation.critical[0].description)
+        orchestrator._generate_simulated_project.assert_not_called()
+
     def test_unknown_workflow_falls_back_to_default(self) -> None:
         self.assertEqual("default", pipeline_workflow_id("does-not-exist"))
 


### PR DESCRIPTION
## Summary
- stop falling back to simulated project data after unexpected live pipeline failures
- return an empty, invalid HardwareIR with structured error metadata and a critical validation issue
- add regression coverage ensuring simulation is not invoked

## Testing
- `.venv/bin/python -m unittest discover -s tests -p "test_pipeline.py" -v` (9 passed)