### PR TITLE
fix: layer environment and BYOK provider settings

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -520,6 +520,7 @@ def generate_project_endpoint(request: GenerateProjectRequest, user: UserContext
             **response,
             "project_id": project_id,
             "chat_id": metadata.get("chat_id"),
+            "can_chat": True,
             "job_id": job_id,
             "job": job,
         }

--- a/blueprint_core/user_integrations.py
+++ b/blueprint_core/user_integrations.py
@@ -1368,6 +1368,36 @@ def _managed_environment_names() -> set[str]:
     return names
 
 
+def _capture_original_environment(env_names: Iterable[str]) -> None:
+    """Remember deployment/local env values before applying a saved BYOK overlay."""
+    for env_name in env_names:
+        if env_name not in _ORIGINAL_ENV_VALUES:
+            _ORIGINAL_ENV_VALUES[env_name] = os.environ.get(env_name)
+
+
+def _original_environment_value(env_names: Iterable[str]) -> Optional[str]:
+    for env_name in env_names:
+        value = _ORIGINAL_ENV_VALUES.get(env_name)
+        if value and value.strip():
+            return value.strip()
+    return None
+
+
+def _environment_configures_integration(definition: IntegrationDefinition) -> bool:
+    configured_fields = [
+        field_definition
+        for field_definition in definition.fields
+        if _original_environment_value(field_definition.env_names)
+    ]
+    if definition.id not in LLM_PROVIDER_INTEGRATION_IDS:
+        return bool(configured_fields)
+    if any(field_definition.secret for field_definition in configured_fields):
+        return True
+    runtime_provider = _normalize_provider_id(_ORIGINAL_ENV_VALUES.get("LLM_PROVIDER") or "")
+    generic_key = _ORIGINAL_ENV_VALUES.get("LLM_API_KEY")
+    return runtime_provider == definition.id and bool(generic_key and generic_key.strip())
+
+
 def _normalize_provider_id(value: str) -> Optional[str]:
     normalized = value.strip().lower().replace("_", "-")
     if not normalized:
@@ -1533,15 +1563,32 @@ def apply_user_integrations_to_environment(
             exc,
         )
         config = UserIntegrationConfig()
-    desired = _desired_environment(config)
     managed_env_names = _managed_environment_names()
+    _capture_original_environment(managed_env_names)
+    desired = _desired_environment(config)
+
+    # Allowlists describe availability, so BYOK entries extend platform/env
+    # entries instead of replacing them. Direct settings (keys, endpoints,
+    # selected provider/model) retain normal saved-over-environment precedence.
+    additive_env_names = {"LLM_ALLOWED_PROVIDERS", *PROVIDER_ALLOWED_MODEL_ENV.values()}
+    for env_name in additive_env_names:
+        desired_value = desired.get(env_name)
+        if not desired_value:
+            continue
+        desired[env_name] = _merge_csv_value(
+            _ORIGINAL_ENV_VALUES.get(env_name),
+            desired_value.split(","),
+        )
 
     for env_name in managed_env_names:
         if env_name in desired:
             continue
-        os.environ.pop(env_name, None)
+        original_value = _ORIGINAL_ENV_VALUES.get(env_name)
+        if original_value is None:
+            os.environ.pop(env_name, None)
+        else:
+            os.environ[env_name] = original_value
         _APPLIED_ENV_VALUES.pop(env_name, None)
-        _ORIGINAL_ENV_VALUES.pop(env_name, None)
 
     for env_name, desired_value in desired.items():
         os.environ[env_name] = desired_value
@@ -1557,14 +1604,16 @@ def _field_status_payload(
     integration_id: str,
     hosted_user_store: bool = False,
 ) -> dict[str, object]:
-    saved_value = integration.field_value(field_definition.id) if integration else None
+    stored_value = integration.field_value(field_definition.id) if integration else None
+    saved_value = stored_value if integration and integration.enabled else None
+    environment_value = _original_environment_value(field_definition.env_names)
     policy = _active_hosted_byok_policy(integration_id) if hosted_user_store else None
     blocked_by_policy = bool(policy and field_definition.id in policy.blocked_secret_fields)
     conditional_by_policy = bool(policy and field_definition.id in policy.conditional_secret_fields)
     if blocked_by_policy:
         saved_value = None
-    active_value = saved_value
-    source = "saved" if saved_value else "unset"
+    active_value = saved_value or environment_value
+    source = "saved" if saved_value else "environment" if environment_value else "unset"
     payload: dict[str, object] = {
         "id": field_definition.id,
         "label": field_definition.label,
@@ -1573,7 +1622,7 @@ def _field_status_payload(
         "placeholder": field_definition.placeholder,
         "help": field_definition.help,
         "configured": bool(active_value),
-        "saved": bool(saved_value),
+        "saved": bool(stored_value),
         "source": source,
         "editable": not blocked_by_policy,
         "policy_status": policy.hosted_byok if policy else "enabled",
@@ -1599,6 +1648,7 @@ def integration_status_payload(store: Optional[UserIntegrationStore] = None) -> 
     integrations: list[dict[str, object]] = []
     for definition in INTEGRATION_DEFINITIONS:
         stored = config.integration_by_id(definition.id)
+        environment_configured = _environment_configures_integration(definition)
         configured_fields = [
             _field_status_payload(
                 stored,
@@ -1608,6 +1658,12 @@ def integration_status_payload(store: Optional[UserIntegrationStore] = None) -> 
             )
             for field_definition in definition.fields
         ]
+        enabled = stored.enabled if stored else True
+        saved_configured = bool(
+            stored
+            and any(stored.field_value(field_definition.id) for field_definition in definition.fields)
+        )
+        configured = environment_configured or saved_configured
         policy = _active_hosted_byok_policy(definition.id) if hosted_user_store else None
         integrations.append(
             {
@@ -1616,10 +1672,12 @@ def integration_status_payload(store: Optional[UserIntegrationStore] = None) -> 
                 "description": definition.description,
                 "policy_status": policy.hosted_byok if policy else "enabled",
                 "policy_notice": policy.note if policy else "",
-                "enabled": stored.enabled if stored else True,
+                "enabled": enabled,
+                "environment_configured": environment_configured,
+                "available": environment_configured or (enabled and saved_configured),
                 "saved": stored is not None,
                 "updated_at": stored.updated_at if stored else None,
-                "configured": any(bool(field_payload["configured"]) for field_payload in configured_fields),
+                "configured": configured,
                 "fields": configured_fields,
             }
         )

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -141,6 +141,7 @@ Notes:
 - If Supabase client variables are missing, the backend falls back to `SQLITE_DATABASE_URL` or `sqlite:///./blueprint.db`.
 - `DATABASE_BACKEND` can be `supabase` or `sqlite`.
 - Image storage and encrypted integration stores follow `DATABASE_BACKEND`. Supabase credentials alone do not activate them when `DATABASE_BACKEND=sqlite`; use `BLUEPRINT_IMAGE_STORAGE_BACKEND=supabase` or the workspace/user integration backend overrides for an intentional exception.
+- Provider availability is `environment configured OR (BYOK enabled AND BYOK configured)`. Environment variables remain workspace/platform defaults, saved BYOK values overlay matching fields, and clearing or disabling BYOK reveals the environment fallback. Generated provider/model allowlists include both sources, so either source can make a provider available without suppressing the other.
 - `BLUEPRINT_DEPLOYMENT=true` requires a configured deployment provider or signed-in user's BYOK provider for generation. The frontend keeps the composer visible and directs users without an active provider to Settings.
 - `LLM_PROVIDER` can be `anthropic`, `baseten`, `gemini`, `gmi`, `huggingface`, `nebius`, `nvidia`, `openai`, `openai-compatible`, `runpod`, `runpod-serverless`, or `simulation`. Use `runpod` for Runpod OpenAI-compatible/vLLM endpoints and `runpod-serverless` for queue-style `/runsync` workers.
 - `/api/generate` accepts optional `provider` and `model` fields for runtime switching, for example `{"provider":"openai","model":"gpt-4o-mini"}`.

--- a/frontend/app/blueprint-workspace.tsx
+++ b/frontend/app/blueprint-workspace.tsx
@@ -1409,7 +1409,7 @@ function withProjectResponseMetadata(ir: any, response: any) {
       ...(ir.assembly_metadata || {}),
       project_id: ir.assembly_metadata?.project_id || response?.project_id,
       chat_id: ir.assembly_metadata?.chat_id || response?.chat_id,
-      can_chat: Boolean(ir.assembly_metadata?.can_chat ?? ir.assembly_metadata?.canChat ?? response?.can_chat ?? response?.canChat),
+      can_chat: Boolean(response?.can_chat ?? response?.canChat ?? ir.assembly_metadata?.can_chat ?? ir.assembly_metadata?.canChat),
       frontend_job_id: ir.assembly_metadata?.frontend_job_id || response?.job_id,
       source_prompt: ir.assembly_metadata?.source_prompt || response?.prompt,
       ...timingMetadata,
@@ -3107,6 +3107,7 @@ export function FormaWorkspace({
         mockRes.project_ir.assembly_metadata = {
           ...(mockRes.project_ir.assembly_metadata || {}),
           chat_id: requestChatId,
+          can_chat: true,
         };
         setProjectIR(mockRes.project_ir);
         const fallbackProjectId = projectIdFromIR(mockRes.project_ir);

--- a/frontend/app/blueprint-workspace.tsx
+++ b/frontend/app/blueprint-workspace.tsx
@@ -2060,25 +2060,19 @@ export function FormaWorkspace({
     }, 300);
   };
 
-  const goHome = () => {
-    setChatRouteTransition(null);
-    setProjectIR(null);
-    setActiveTab("chat");
-    router.push("/");
-  };
-
-  const startNewProjectChat = () => {
+  const currentProjectChatHasStarted = () => {
     const guardChatId = projectIR ? (chatIdFromIR(projectIR) || projectIdFromIR(projectIR) || activeChatId) : activeChatId;
     const guardMessages = projectIR && guardChatId ? chatThreads[guardChatId] || [] : chatMessages;
     const guardItem = chatListItems.find((item) => item.chatId === guardChatId);
-    const currentChatStarted = Boolean(
+    return Boolean(
       projectIR ||
       chatHasStarted(guardMessages) ||
       guardItem?.projectId ||
       guardItem?.projectCount
     );
-    if (!currentChatStarted) return;
+  };
 
+  const resetToNewProjectChat = () => {
     const nextChatId = newBuildChatId();
     setActiveChatId(nextChatId);
     rememberChatItem({
@@ -2097,6 +2091,22 @@ export function FormaWorkspace({
     setChatRouteTransition(null);
     setProjectIR(null);
     setActiveTab("chat");
+  };
+
+  const goHome = () => {
+    if (currentProjectChatHasStarted()) {
+      resetToNewProjectChat();
+    } else {
+      setChatRouteTransition(null);
+      setProjectIR(null);
+      setActiveTab("chat");
+    }
+    router.push("/");
+  };
+
+  const startNewProjectChat = () => {
+    if (!currentProjectChatHasStarted()) return;
+    resetToNewProjectChat();
     router.push("/");
   };
 

--- a/frontend/app/user/user-integrations-page.tsx
+++ b/frontend/app/user/user-integrations-page.tsx
@@ -1373,6 +1373,10 @@ export default function UserIntegrationsPage() {
       if (clearFieldSet.has(field.id)) return;
       const value = form.fields[field.id] || "";
       if (field.secret && !value.trim()) return;
+      // Environment-backed values are visible defaults, not implicit BYOK
+      // values. Persist them only when the user actually changes the field.
+      if (field.source === "environment" && value === (field.value || "")) return;
+      if (field.source === "unset" && !value.trim()) return;
       fields[field.id] = value;
     });
 

--- a/frontend/lib/active-llms.ts
+++ b/frontend/lib/active-llms.ts
@@ -14,6 +14,8 @@ export type IntegrationStatus = {
   id: string;
   enabled: boolean;
   configured: boolean;
+  environment_configured?: boolean;
+  available?: boolean;
   fields: IntegrationFieldStatus[];
 };
 
@@ -68,6 +70,12 @@ function uniqueGenerationLlms(options: GenerationLlmOption[]) {
   });
 }
 
+function integrationIsAvailable(integration: IntegrationStatus | undefined) {
+  if (!integration) return false;
+  if (typeof integration.available === "boolean") return integration.available;
+  return Boolean(integration.environment_configured || (integration.enabled && integration.configured));
+}
+
 export function activeLlmsFromIntegrations(
   payload: IntegrationsPayload | null | undefined,
   defaultLlms: GenerationLlmOption[],
@@ -80,7 +88,7 @@ export function activeLlmsFromIntegrations(
   const preferred = parseLlmSelector(integrationFieldValue(runtime, "llm_selector"));
   if (preferred) {
     const providerIntegration = byId.get(preferred.provider);
-    if (providerIntegration?.enabled && providerIntegration.configured) {
+    if (integrationIsAvailable(providerIntegration)) {
       options.push({
         provider: preferred.provider,
         model: preferred.model,
@@ -90,7 +98,7 @@ export function activeLlmsFromIntegrations(
   }
 
   integrations.forEach((integration) => {
-    if (!LLM_PROVIDER_IDS.has(integration.id) || !integration.enabled || !integration.configured) return;
+    if (!LLM_PROVIDER_IDS.has(integration.id) || !integrationIsAvailable(integration)) return;
     const model = integrationFieldValue(integration, "model") || firstDefaultModelForProvider(defaultLlms, integration.id);
     if (!model) return;
     options.push({

--- a/frontend/test/active-llms.test.ts
+++ b/frontend/test/active-llms.test.ts
@@ -89,6 +89,29 @@ test("no static fallback models appear when every provider is off", () => {
   assert.deepEqual(activeLlmsFromIntegrations(payload, defaults, label), []);
 });
 
+test("an environment provider remains active when its saved BYOK entry is off", () => {
+  const payload: IntegrationsPayload = {
+    integrations: [
+      {
+        id: "baseten",
+        enabled: false,
+        configured: true,
+        environment_configured: true,
+        available: true,
+        fields: [{ id: "model", value: "platform/model", configured: true }],
+      },
+    ],
+  };
+
+  assert.deepEqual(activeLlmsFromIntegrations(payload, defaults, label), [
+    {
+      provider: "baseten",
+      model: "platform/model",
+      label: "baseten platform/model",
+    },
+  ]);
+});
+
 test("configured Nebius falls back to its catalog default when no model is saved", () => {
   const payload: IntegrationsPayload = {
     integrations: [

--- a/tests/test_project_access.py
+++ b/tests/test_project_access.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import json
 import os
 import unittest
-from contextlib import ExitStack
+from contextlib import ExitStack, nullcontext
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from fastapi import HTTPException
 from starlette.requests import Request
@@ -14,6 +14,7 @@ from backend import main
 from backend.auth import UserContext, optional_user_context
 from blueprint_core.models import (
     FunctionalRequirements,
+    GenerateProjectRequest,
     HardwareIR,
     MechanicalNotes,
     MechanicalSource,
@@ -256,6 +257,40 @@ class ProjectReadAccessTests(unittest.TestCase):
         self.assertFalse(response["can_chat"])
         self.assertEqual("", response["project_ir"]["mechanical"]["cad_sources"][0]["url"])
         self.assertNotIn(downloadable_url, json.dumps(response, default=str))
+
+
+class ProjectGenerationAccessTests(unittest.TestCase):
+    def test_generation_response_marks_new_project_as_owner_chat_capable(self) -> None:
+        job_store = MagicMock()
+        job_store.is_cancelled.return_value = False
+        job_store.get_job.return_value = {"status": "succeeded"}
+        generated_response = {
+            "project_ir": {
+                "assembly_metadata": {
+                    "project_id": "generated-project",
+                    "chat_id": "generated-chat",
+                }
+            }
+        }
+
+        with (
+            patch.object(main, "_apply_user_integrations"),
+            patch.object(main, "get_workflow_debug_config", return_value={}),
+            patch.object(main, "_deployment_runtime_config", return_value={"alpha_generation_gate_active": False}),
+            patch.object(main, "JOB_STORE", job_store),
+            patch.object(main, "observe_agent_pipeline", return_value=nullcontext()),
+            patch.object(main, "build_generation_response", return_value=generated_response),
+            patch.object(main, "_attach_generation_timing_metadata", side_effect=lambda response, _job: response),
+            patch.object(main, "update_generated_project_hardware_ir"),
+        ):
+            response = main.generate_project_endpoint(
+                GenerateProjectRequest(prompt="Build a sensor", chat_id="generated-chat"),
+                _user_context("user-a"),
+            )
+
+        self.assertTrue(response["can_chat"])
+        self.assertEqual("generated-project", response["project_id"])
+        self.assertEqual("generated-chat", response["chat_id"])
 
 
 if __name__ == "__main__":

--- a/tests/test_user_integrations.py
+++ b/tests/test_user_integrations.py
@@ -30,6 +30,14 @@ TEST_ENV_KEYS = (
     "OPENAI_STREAM_MODEL",
     "OPENAI_ALLOWED_MODELS",
     "BASETEN_API_KEY",
+    "BASETEN_BASE_URL",
+    "BASETEN_MODEL",
+    "BASETEN_STREAM_MODEL",
+    "BASETEN_TIMEOUT_SECONDS",
+    "BASETEN_STREAM_TIMEOUT_SECONDS",
+    "BASETEN_MAX_TOKENS",
+    "BASETEN_STREAM_MAX_OUTPUT_TOKENS",
+    "BASETEN_ALLOWED_MODELS",
     "NVIDIA_API_KEY",
     "NVIDIA_MODEL",
     "NEBIUS_ALLOWED_MODELS",
@@ -38,6 +46,7 @@ TEST_ENV_KEYS = (
     "NEBIUS_MODEL",
     "LLM_PROVIDER",
     "LLM_MODEL",
+    "LLM_ALLOWED_PROVIDERS",
     "BLUEPRINT_WORKSPACE_INTEGRATIONS_BACKEND",
     "BLUEPRINT_USER_INTEGRATIONS_BACKEND",
     "BLUEPRINT_INTEGRATIONS_BACKEND",
@@ -197,7 +206,7 @@ class UserIntegrationTests(unittest.TestCase):
             self.assertNotIn("sk-testsecret123456", str(payload))
             self.assertEqual(stat.S_IMODE(store.path.stat().st_mode), 0o600)
 
-    def test_apply_sets_runtime_environment_and_clears_previous_env_values(self) -> None:
+    def test_apply_overlays_saved_values_and_restores_environment_fallback(self) -> None:
         with isolated_integration_env(), tempfile.TemporaryDirectory() as tmpdir:
             os.environ["OPENAI_API_KEY"] = "sk-env-original"
             os.environ["IMAGE_PROVIDER"] = "openai"
@@ -219,14 +228,14 @@ class UserIntegrationTests(unittest.TestCase):
 
             store.clear_integration("openai")
             apply_user_integrations_to_environment(store)
-            self.assertNotIn("OPENAI_API_KEY", os.environ)
-            self.assertNotIn("IMAGE_PROVIDER", os.environ)
-            self.assertNotIn("OPENAI_IMAGE_MODEL", os.environ)
+            self.assertEqual("sk-env-original", os.environ["OPENAI_API_KEY"])
+            self.assertEqual("openai", os.environ["IMAGE_PROVIDER"])
+            self.assertEqual("gpt-image-2", os.environ["OPENAI_IMAGE_MODEL"])
             self.assertNotIn("OPENAI_IMAGE_API_KEY", os.environ)
             self.assertNotIn("OPENAI_MODEL", os.environ)
             self.assertNotIn("OPENAI_STREAM_MODEL", os.environ)
 
-    def test_status_payload_does_not_treat_environment_as_configured(self) -> None:
+    def test_status_payload_reports_environment_as_configured_fallback(self) -> None:
         with isolated_integration_env(), tempfile.TemporaryDirectory() as tmpdir:
             os.environ["OPENAI_API_KEY"] = "sk-env-original"
             os.environ["IMAGE_PROVIDER"] = "openai"
@@ -237,11 +246,46 @@ class UserIntegrationTests(unittest.TestCase):
             openai = integration_by_id(payload, "openai")
             runtime = integration_by_id(payload, "runtime")
 
-            self.assertFalse(openai["configured"])
-            self.assertEqual("unset", field_by_id(openai, "api_key")["source"])
-            self.assertFalse(field_by_id(openai, "api_key")["configured"])
-            self.assertEqual("unset", field_by_id(runtime, "image_provider")["source"])
-            self.assertFalse(field_by_id(runtime, "image_provider")["configured"])
+            self.assertTrue(openai["configured"])
+            self.assertEqual("environment", field_by_id(openai, "api_key")["source"])
+            self.assertTrue(field_by_id(openai, "api_key")["configured"])
+            self.assertEqual("environment", field_by_id(runtime, "image_provider")["source"])
+            self.assertTrue(field_by_id(runtime, "image_provider")["configured"])
+
+    def test_saved_byok_overrides_environment_without_hiding_other_env_providers(self) -> None:
+        with isolated_integration_env(), tempfile.TemporaryDirectory() as tmpdir:
+            os.environ["OPENAI_API_KEY"] = "sk-platform"
+            os.environ["OPENAI_MODEL"] = "gpt-platform"
+            os.environ["LLM_ALLOWED_PROVIDERS"] = "openai"
+            os.environ["OPENAI_ALLOWED_MODELS"] = "gpt-platform"
+            store = UserIntegrationStore(Path(tmpdir) / "integrations.json")
+            store.update_integration(
+                "openai",
+                field_values={"api_key": "sk-user", "model": "gpt-user"},
+            )
+            store.update_integration(
+                "baseten",
+                field_values={"api_key": "baseten-user", "model": "byok/model"},
+            )
+
+            payload = integration_status_payload(store)
+
+            self.assertEqual("sk-user", os.environ["OPENAI_API_KEY"])
+            self.assertEqual("gpt-user", os.environ["OPENAI_MODEL"])
+            self.assertEqual("openai,baseten", os.environ["LLM_ALLOWED_PROVIDERS"])
+            self.assertEqual("gpt-platform,gpt-user", os.environ["OPENAI_ALLOWED_MODELS"])
+            openai = integration_by_id(payload, "openai")
+            self.assertEqual("saved", field_by_id(openai, "api_key")["source"])
+            self.assertEqual("saved", field_by_id(openai, "model")["source"])
+
+            store.clear_integration("openai")
+            payload = integration_status_payload(store)
+            openai = integration_by_id(payload, "openai")
+
+            self.assertEqual("sk-platform", os.environ["OPENAI_API_KEY"])
+            self.assertEqual("gpt-platform", os.environ["OPENAI_MODEL"])
+            self.assertEqual("environment", field_by_id(openai, "api_key")["source"])
+            self.assertEqual("environment", field_by_id(openai, "model")["source"])
 
     def test_disabled_integration_is_saved_but_not_applied(self) -> None:
         with isolated_integration_env(), tempfile.TemporaryDirectory() as tmpdir:
@@ -257,7 +301,30 @@ class UserIntegrationTests(unittest.TestCase):
 
             self.assertFalse(baseten["enabled"])
             self.assertTrue(baseten["configured"])
+            self.assertFalse(baseten["available"])
             self.assertNotIn("BASETEN_API_KEY", os.environ)
+
+    def test_environment_provider_remains_available_when_saved_byok_is_disabled(self) -> None:
+        with isolated_integration_env(), tempfile.TemporaryDirectory() as tmpdir:
+            os.environ["BASETEN_API_KEY"] = "baseten-platform"
+            os.environ["BASETEN_MODEL"] = "platform/model"
+            store = UserIntegrationStore(Path(tmpdir) / "integrations.json")
+            store.update_integration(
+                "baseten",
+                enabled=False,
+                field_values={"api_key": "baseten-user", "model": "user/model"},
+            )
+
+            payload = integration_status_payload(store)
+            baseten = integration_by_id(payload, "baseten")
+
+            self.assertFalse(baseten["enabled"])
+            self.assertTrue(baseten["environment_configured"])
+            self.assertTrue(baseten["available"])
+            self.assertEqual("environment", field_by_id(baseten, "api_key")["source"])
+            self.assertEqual("environment", field_by_id(baseten, "model")["source"])
+            self.assertEqual("baseten-platform", os.environ["BASETEN_API_KEY"])
+            self.assertEqual("platform/model", os.environ["BASETEN_MODEL"])
 
     def test_runtime_defaults_apply_to_llm_selector(self) -> None:
         with isolated_integration_env(), tempfile.TemporaryDirectory() as tmpdir:
@@ -291,7 +358,7 @@ class UserIntegrationTests(unittest.TestCase):
             self.assertEqual("gpt-5.5", os.environ["OPENAI_MODEL"])
             self.assertEqual("gpt-5.5", os.environ["OPENAI_ALLOWED_MODELS"])
 
-    def test_saved_provider_config_overrides_stale_llm_allowed_providers(self) -> None:
+    def test_saved_provider_config_extends_environment_llm_allowed_providers(self) -> None:
         with isolated_integration_env(), tempfile.TemporaryDirectory() as tmpdir:
             os.environ["LLM_ALLOWED_PROVIDERS"] = "openai,simulation"
             store = UserIntegrationStore(Path(tmpdir) / "integrations.json")
@@ -308,7 +375,7 @@ class UserIntegrationTests(unittest.TestCase):
             apply_user_integrations_to_environment(store)
             runtime = resolve_llm_runtime_config("baseten", "deepseek-ai/DeepSeek-V4-Pro")
 
-            self.assertEqual(["baseten"], runtime.allowed_providers)
+            self.assertEqual(["baseten", "openai", "simulation"], runtime.allowed_providers)
             self.assertEqual("baseten", runtime.provider)
             self.assertEqual("deepseek-ai/DeepSeek-V4-Pro", runtime.model)
 


### PR DESCRIPTION
## Summary
- preserve environment-backed provider settings as the platform/workspace baseline
- overlay enabled BYOK values while restoring environment fallbacks when BYOK is cleared or disabled
- compute picker availability as environment configured OR enabled-and-configured BYOK
- keep environment-derived form values from being saved as BYOK unless the user changes them
- merge environment and BYOK provider/model allowlists

## Verification
- 62 focused Python integration/API tests
- frontend TypeScript type-check
- 4 active-LLM picker tests

Vercel launch environment changes are intentionally not part of this PR.