### PR TITLE
Fix production LLM allowlist rendering

### DIFF
--- a/frontend/lib/active-llms.ts
+++ b/frontend/lib/active-llms.ts
@@ -56,6 +56,15 @@ function parseLlmSelector(value: string | null) {
   };
 }
 
+function parseProviderAllowlist(value: string | null) {
+  if (!value) return null;
+  const providers = value
+    .split(",")
+    .map((provider) => provider.trim().toLowerCase())
+    .filter(Boolean);
+  return providers.length ? new Set(providers) : null;
+}
+
 function firstDefaultModelForProvider(defaultLlms: GenerationLlmOption[], provider: string) {
   return defaultLlms.find((option) => option.provider === provider)?.model || "";
 }
@@ -85,8 +94,10 @@ export function activeLlmsFromIntegrations(
   const byId = new Map(integrations.map((integration) => [integration.id, integration]));
   const options: GenerationLlmOption[] = [];
   const runtime = byId.get("runtime");
+  const allowedProviders = parseProviderAllowlist(integrationFieldValue(runtime, "allowed_providers"));
+  const providerIsAllowed = (provider: string) => !allowedProviders || allowedProviders.has(provider.toLowerCase());
   const preferred = parseLlmSelector(integrationFieldValue(runtime, "llm_selector"));
-  if (preferred) {
+  if (preferred && providerIsAllowed(preferred.provider)) {
     const providerIntegration = byId.get(preferred.provider);
     if (integrationIsAvailable(providerIntegration)) {
       options.push({
@@ -98,7 +109,7 @@ export function activeLlmsFromIntegrations(
   }
 
   integrations.forEach((integration) => {
-    if (!LLM_PROVIDER_IDS.has(integration.id) || !integrationIsAvailable(integration)) return;
+    if (!LLM_PROVIDER_IDS.has(integration.id) || !providerIsAllowed(integration.id) || !integrationIsAvailable(integration)) return;
     const model = integrationFieldValue(integration, "model") || firstDefaultModelForProvider(defaultLlms, integration.id);
     if (!model) return;
     options.push({

--- a/frontend/test/active-llms.test.ts
+++ b/frontend/test/active-llms.test.ts
@@ -112,6 +112,51 @@ test("an environment provider remains active when its saved BYOK entry is off", 
   ]);
 });
 
+test("the runtime provider allowlist hides unrelated configured environment providers", () => {
+  const payload: IntegrationsPayload = {
+    integrations: [
+      {
+        id: "runtime",
+        enabled: true,
+        configured: true,
+        fields: [{ id: "allowed_providers", value: "nebius", configured: true }],
+      },
+      {
+        id: "baseten",
+        enabled: true,
+        configured: true,
+        environment_configured: true,
+        available: true,
+        fields: [{ id: "model", value: "zai-org/GLM-5.2", configured: true }],
+      },
+      {
+        id: "nvidia",
+        enabled: true,
+        configured: true,
+        environment_configured: true,
+        available: true,
+        fields: [{ id: "model", value: "qwen/qwen2.5-coder-32b-instruct", configured: true }],
+      },
+      {
+        id: "nebius",
+        enabled: true,
+        configured: true,
+        environment_configured: true,
+        available: true,
+        fields: [{ id: "model", value: "nvidia/nemotron-3-super-120b-a12b", configured: true }],
+      },
+    ],
+  };
+
+  assert.deepEqual(activeLlmsFromIntegrations(payload, defaults, label), [
+    {
+      provider: "nebius",
+      model: "nvidia/nemotron-3-super-120b-a12b",
+      label: "nebius nvidia/nemotron-3-super-120b-a12b",
+    },
+  ]);
+});
+
 test("configured Nebius falls back to its catalog default when no model is saved", () => {
   const payload: IntegrationsPayload = {
     integrations: [


### PR DESCRIPTION
## Summary

- make the signed-in model selector respect the runtime LLM provider allowlist
- keep configured but disallowed platform providers out of the production selector
- add a regression test for a Nebius-only runtime using nvidia/nemotron-3-super-120b-a12b

## Production configuration

The production Nebius model allowlist was corrected to match the configured Nemotron model. The live runtime now reports Nebius as the only allowed LLM provider and OpenAI gpt-image-2 as request-capable.

## Validation

- TypeScript typecheck
- targeted frontend lint
- active LLM tests: 5 passed
