### PR TITLE
Rename public projects to Community

### DIFF
--- a/frontend/app/blueprint-workspace.tsx
+++ b/frontend/app/blueprint-workspace.tsx
@@ -4160,12 +4160,13 @@ export function FormaWorkspace({
             <>
               <WorkspacePageHeading
                 icon={Layers}
-                title="Projects"
-                description="Saved generated projects, grouped from the chat and project history."
+                title="Community"
+                description="Explore public projects shared by the Forma community."
               />
               <ProjectGallery
                 sectionRef={projectsSectionRef}
                 items={projectGalleryItems}
+                title="Community"
                 loading={projectsPageLoading}
                 onOpenProjectPage={(projectId) => router.push(projectRoute(projectId))}
                 onVisibleProjectIdsChange={handleVisibleProjectGalleryIdsChange}
@@ -4182,6 +4183,7 @@ export function FormaWorkspace({
               <ProjectGallery
                 sectionRef={projectsSectionRef}
                 items={myProjectGalleryItems}
+                title="My Projects"
                 loading={myProjectsPageLoading}
                 onOpenProjectPage={(projectId) => router.push(projectRoute(projectId))}
                 onVisibleProjectIdsChange={handleVisibleProjectGalleryIdsChange}

--- a/frontend/app/blueprint-workspace/project-gallery.tsx
+++ b/frontend/app/blueprint-workspace/project-gallery.tsx
@@ -213,6 +213,7 @@ export function buildProjectGalleryItems(
 export function ProjectGallery({
   sectionRef,
   items,
+  title = "Projects",
   loading = false,
   onOpenProjectPage,
   onVisibleProjectIdsChange,
@@ -220,6 +221,7 @@ export function ProjectGallery({
 }: {
   sectionRef: React.RefObject<HTMLElement>;
   items: ProjectGalleryItem[];
+  title?: string;
   loading?: boolean;
   onOpenProjectPage: (projectId: string) => void;
   onVisibleProjectIdsChange?: (projectIds: string[]) => void;
@@ -268,7 +270,7 @@ export function ProjectGallery({
             <span className="flex h-9 w-9 items-center justify-center border border-[#2c2f37] bg-black text-white">
               <Cpu className="h-4 w-4" />
             </span>
-            <h2 className="text-2xl font-black uppercase tracking-[0.22em] text-white">Projects</h2>
+            <h2 className="text-2xl font-black uppercase tracking-[0.22em] text-white">{title}</h2>
           </div>
           <p className="mt-4 text-sm leading-6 text-slate-500">
             {loading ? "Loading projects..." : `${items.length} saved projects.`}

--- a/frontend/app/blueprint-workspace/sidebar.tsx
+++ b/frontend/app/blueprint-workspace/sidebar.tsx
@@ -397,10 +397,10 @@ export function ChatSidebar({
             href="/projects"
             onClick={onNavigate}
             className={`flex h-10 items-center gap-3 px-2 text-sm font-semibold text-slate-100 hover:bg-[#17181d] hover:text-white ${compact ? "justify-center" : ""}`}
-            title="Projects"
+            title="Community"
           >
             <Layers className="h-5 w-5 text-slate-500" />
-            {!compact && <span className="truncate">Projects</span>}
+            {!compact && <span className="truncate">Community</span>}
           </Link>
           {showJobs ? (
             <Link


### PR DESCRIPTION
Closes #110

## Summary
- rename the public Projects sidebar item to Community
- update the public gallery heading and accessibility title
- clarify that the Community page contains public Forma projects
- preserve My Projects terminology for the signed-in user gallery

## Validation
- `npx tsc --noEmit`
- `npm run build`