### PR TITLE
Simplify issue template requirements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,43 +34,35 @@ body:
         - Developer tooling or deployment
         - Documentation
         - Other
-    validations:
-      required: true
 
   - type: textarea
     id: reproduction
     attributes:
       label: Steps to reproduce
-      description: Provide the smallest reliable sequence that triggers the problem.
+      description: If possible, provide the smallest reliable sequence that triggers the problem.
       placeholder: |
         1. Start Forma with...
         2. Open...
         3. Submit...
         4. Observe...
-    validations:
-      required: true
 
   - type: textarea
     id: expected
     attributes:
       label: Expected behavior
       placeholder: I expected Forma to...
-    validations:
-      required: true
 
   - type: textarea
     id: actual
     attributes:
       label: Actual behavior
       placeholder: Instead, Forma...
-    validations:
-      required: true
 
   - type: textarea
     id: environment
     attributes:
       label: Environment
-      description: Include every relevant value. Write "not applicable" where appropriate.
+      description: Share any details that may help reproduce the problem.
       placeholder: |
         Forma commit/version:
         Deployment: local / Docker / Vercel / other
@@ -80,8 +72,6 @@ body:
         Browser:
         Database backend:
         Provider and model:
-    validations:
-      required: true
 
   - type: textarea
     id: logs
@@ -98,8 +88,6 @@ body:
         - No known safety impact
         - Safety impact is possible or unknown
         - Yes, this affects safety-related behavior
-    validations:
-      required: true
 
   - type: checkboxes
     id: checks
@@ -107,8 +95,5 @@ body:
       label: Submission checklist
       options:
         - label: I searched existing issues for duplicates.
-          required: true
         - label: I included the commit or version where this occurs.
-          required: true
         - label: I removed API keys, tokens, project secrets, personal data, and other sensitive information.
-          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -23,16 +23,12 @@ body:
     attributes:
       label: Affected workflow
       description: Describe the current workflow and where it falls short.
-    validations:
-      required: true
 
   - type: textarea
     id: behavior
     attributes:
       label: Proposed behavior
       description: Explain the observable outcome rather than only an implementation detail.
-    validations:
-      required: true
 
   - type: dropdown
     id: area
@@ -50,16 +46,12 @@ body:
         - Developer tooling or deployment
         - Documentation
         - Other
-    validations:
-      required: true
 
   - type: textarea
     id: alternatives
     attributes:
       label: Current alternatives
       description: Explain existing workarounds and why they are insufficient.
-    validations:
-      required: true
 
   - type: textarea
     id: compatibility
@@ -67,8 +59,6 @@ body:
       label: Safety and compatibility considerations
       description: Note hardware-safety, API, schema, database, deployment, provider, or backward-compatibility concerns.
       placeholder: No known concerns, or...
-    validations:
-      required: true
 
   - type: textarea
     id: implementation
@@ -82,8 +72,5 @@ body:
       label: Submission checklist
       options:
         - label: I searched existing issues and discussions for similar requests.
-          required: true
         - label: This request describes one focused problem.
-          required: true
         - label: I considered Forma's low-voltage hardware safety boundaries.
-          required: true


### PR DESCRIPTION
## Summary
- reduce bug reports from ten required responses to one core problem summary
- reduce feature requests from nine required responses to one core user problem
- keep reproduction, environment, safety, compatibility, and checklist prompts available as optional context
- soften the environment and reproduction guidance so partial reports are welcome

## Validation
- parsed all issue-template YAML files with js-yaml
- git diff --check