### PR TITLE
Fix image-only and image-plus-text generation

### DIFF
--- a/blueprint_core/agents/orchestrator.py
+++ b/blueprint_core/agents/orchestrator.py
@@ -18,6 +18,7 @@ from blueprint_core.database import (
 )
 from blueprint_core.llm import (
     LLMProviderConfigError,
+    LLMProviderInputError,
     LLMProviderOutputError,
     LLMProviderValidation,
     LLMRuntimeConfig,
@@ -711,6 +712,8 @@ class HardwarePipelineOrchestrator:
 
         try:
             model_validation = self.validate_configured_model()
+            if image_bytes:
+                self.llm_provider.validate_image_input()
         except LLMProviderConfigError as e:
             if deployment_mode_enabled():
                 logger.error("LLM provider validation failed in deployment mode: %s", e)
@@ -965,6 +968,8 @@ class HardwarePipelineOrchestrator:
         except PipelineCancelledError:
             raise
         except LLMProviderConfigError:
+            raise
+        except LLMProviderInputError:
             raise
         except LLMProviderOutputError:
             raise

--- a/blueprint_core/agents/web_research_workflow.py
+++ b/blueprint_core/agents/web_research_workflow.py
@@ -253,6 +253,8 @@ class WebResearchHardwarePipeline:
         try:
             model_validation = self.llm_provider.validate_configured_model()
             self.model_name = model_validation.actual_model or self.llm_provider.model_name
+            if image_bytes:
+                self.llm_provider.validate_image_input()
         except LLMProviderConfigError as exc:
             if deployment_mode_enabled():
                 raise AlphaGenerationUnavailableError(generation_unavailable_message(self.get_debug_config())) from exc
@@ -280,13 +282,13 @@ class WebResearchHardwarePipeline:
             plan = self._plan_project(user_prompt, research_context, image_bytes, image_mime_type)
         logger.info("Invoking Web Component Sourcing Agent...")
         with agent_pipeline_step(self.workflow_id, "web_component_sourcing"):
-            selection = self._select_components(user_prompt, plan, research_context, image_bytes, image_mime_type)
+            selection = self._select_components(user_prompt, plan, research_context)
             components = selection.components
             components_json = json.dumps([component.model_dump() for component in components], indent=2)
 
         logger.info("Invoking Wiring/Netlist Agent...")
         with agent_pipeline_step(self.workflow_id, "wiring_netlist"):
-            wiring = self._wire_project(user_prompt, plan, components_json, image_bytes, image_mime_type)
+            wiring = self._wire_project(user_prompt, plan, components_json)
             nets = wiring.nets
             pin_mappings = wiring.pin_mappings
 
@@ -296,7 +298,7 @@ class WebResearchHardwarePipeline:
             is_valid = not any(issue.severity.upper() == "CRITICAL" for issue in validation_issues)
             if not is_valid:
                 logger.info("Invoking Validation + Auto-Correction Agent...")
-                corrected = self._repair_wiring(plan, components_json, nets, validation_issues, image_bytes, image_mime_type)
+                corrected = self._repair_wiring(plan, components_json, nets, validation_issues)
                 nets = corrected.nets
                 pin_mappings = corrected.pin_mappings
                 validation_issues = validate_circuit(components, nets)
@@ -307,10 +309,10 @@ class WebResearchHardwarePipeline:
 
         logger.info("Invoking Mechanical/Fabrication Agent...")
         with agent_pipeline_step(self.workflow_id, "mechanical_fabrication"):
-            mechanical = self._generate_mechanical(plan, components_json, research_context, image_bytes, image_mime_type)
+            mechanical = self._generate_mechanical(plan, components_json, research_context)
         logger.info("Invoking Assembly Instruction Agent...")
         with agent_pipeline_step(self.workflow_id, "assembly"):
-            assembly = self._generate_assembly(plan, components_json, nets, mechanical, image_bytes, image_mime_type)
+            assembly = self._generate_assembly(plan, components_json, nets, mechanical)
 
         constraints = plan.requirements.physical_constraints + [f"Operating Voltage: {plan.requirements.operating_voltage}V"]
         fab_notes = mechanical.fabrication_details if mechanical else []
@@ -442,8 +444,6 @@ class WebResearchHardwarePipeline:
         user_prompt: str,
         plan: WebProjectPlan,
         research_context: str,
-        image_bytes: Optional[bytes],
-        image_mime_type: Optional[str],
     ) -> WebComponentSelection:
         prompt = f"""
         You are a Web Component Sourcing Agent.
@@ -470,15 +470,13 @@ class WebResearchHardwarePipeline:
 
         Return WebComponentSelection.
         """
-        return self._call_llm_structured(prompt, WebComponentSelection, image_bytes, image_mime_type, pipeline_step_id="web_component_sourcing")
+        return self._call_llm_structured(prompt, WebComponentSelection, pipeline_step_id="web_component_sourcing")
 
     def _wire_project(
         self,
         user_prompt: str,
         plan: WebProjectPlan,
         components_json: str,
-        image_bytes: Optional[bytes],
-        image_mime_type: Optional[str],
     ) -> WiringWrapper:
         prompt = f"""
         You are a Wiring/Netlist Agent for sourced web components.
@@ -504,7 +502,7 @@ class WebResearchHardwarePipeline:
 
         Return WiringWrapper.
         """
-        return self._call_llm_structured(prompt, WiringWrapper, image_bytes, image_mime_type, pipeline_step_id="wiring_netlist")
+        return self._call_llm_structured(prompt, WiringWrapper, pipeline_step_id="wiring_netlist")
 
     def _repair_wiring(
         self,
@@ -512,8 +510,6 @@ class WebResearchHardwarePipeline:
         components_json: str,
         nets: List[ConnectionNet],
         issues: List[ValidationIssue],
-        image_bytes: Optional[bytes],
-        image_mime_type: Optional[str],
     ) -> WiringWrapper:
         prompt = f"""
         You are a Wiring/Netlist Auto-Correction Agent.
@@ -533,15 +529,13 @@ class WebResearchHardwarePipeline:
 
         Return corrected WiringWrapper.
         """
-        return self._call_llm_structured(prompt, WiringWrapper, image_bytes, image_mime_type, pipeline_step_id="validation_repair")
+        return self._call_llm_structured(prompt, WiringWrapper, pipeline_step_id="validation_repair")
 
     def _generate_mechanical(
         self,
         plan: WebProjectPlan,
         components_json: str,
         research_context: str,
-        image_bytes: Optional[bytes],
-        image_mime_type: Optional[str],
     ) -> MechanicalNotes:
         prompt = f"""
         You are a Mechanical/Fabrication and CAD Sourcing Agent.
@@ -559,7 +553,7 @@ class WebResearchHardwarePipeline:
         Use CAD/enclosure URLs only when present in research or well-known source data. If no source exists, keep cad_sources empty.
         Return MechanicalNotes.
         """
-        return self._call_llm_structured(prompt, MechanicalNotes, image_bytes, image_mime_type, pipeline_step_id="mechanical_fabrication")
+        return self._call_llm_structured(prompt, MechanicalNotes, pipeline_step_id="mechanical_fabrication")
 
     def _generate_assembly(
         self,
@@ -567,8 +561,6 @@ class WebResearchHardwarePipeline:
         components_json: str,
         nets: List[ConnectionNet],
         mechanical: MechanicalNotes,
-        image_bytes: Optional[bytes],
-        image_mime_type: Optional[str],
     ) -> List[AssemblyStep]:
         prompt = f"""
         You are an Assembly Instruction Agent.
@@ -589,7 +581,7 @@ class WebResearchHardwarePipeline:
         Mention safety flags for batteries, motors, relays, soldering, heat, moving parts, and polarity.
         Return AssemblyWrapper.
         """
-        wrapper: AssemblyWrapper = self._call_llm_structured(prompt, AssemblyWrapper, image_bytes, image_mime_type, pipeline_step_id="assembly")
+        wrapper: AssemblyWrapper = self._call_llm_structured(prompt, AssemblyWrapper, pipeline_step_id="assembly")
         return wrapper.steps
 
     def _audit_output(

--- a/blueprint_core/llm_providers.py
+++ b/blueprint_core/llm_providers.py
@@ -1949,13 +1949,51 @@ class OpenAICompatibleProvider(StructuredLLMProvider):
             if not choices:
                 raise RuntimeError(f"{self.provider_name} response did not include any choices.")
 
-            finish_reason = choices[0].get("finish_reason")
-            message = choices[0].get("message") or {}
+            choice = choices[0]
+            finish_reason = choice.get("finish_reason")
+            message = choice.get("message") or {}
             content = message.get("content")
             if isinstance(content, list):
                 content = "".join(part.get("text", "") for part in content if isinstance(part, dict))
             if not isinstance(content, str) or not content.strip():
-                raise RuntimeError(f"{self.provider_name} response did not include text content.")
+                choice_text = choice.get("text")
+                if isinstance(choice_text, str) and choice_text.strip():
+                    content = choice_text
+            if not isinstance(content, str) or not content.strip():
+                refusal = message.get("refusal")
+                if isinstance(refusal, str) and refusal.strip():
+                    raise LLMProviderOutputError(
+                        f"{self.provider_name} refused to produce structured output for {_schema_name(schema_class)}."
+                    )
+
+                usage = response.get("usage") if isinstance(response.get("usage"), dict) else {}
+                completion_tokens = usage.get("completion_tokens")
+                reasoning_content = message.get("reasoning_content")
+                has_reasoning_content = isinstance(reasoning_content, str) and bool(reasoning_content.strip())
+                last_error = LLMProviderOutputError(
+                    f"{self.provider_name} response did not include text content "
+                    f"(finish_reason={finish_reason}, max_tokens={budget}, "
+                    f"completion_tokens={completion_tokens}, reasoning_content={has_reasoning_content})."
+                )
+                if attempt == 0:
+                    budget = min(
+                        max(budget * 2, STRUCTURED_MAX_TOKENS_FLOOR),
+                        STRUCTURED_MAX_TOKENS_CEILING,
+                    )
+                    if self.provider_name == "nebius" and has_reasoning_content and not self.reasoning_effort:
+                        payload["reasoning_effort"] = "low"
+                    logger.warning(
+                        "%s returned no visible %s content (finish_reason=%s, completion_tokens=%s, "
+                        "reasoning_content=%s); retrying once with max_tokens=%d.",
+                        self.provider_name,
+                        _schema_name(schema_class),
+                        finish_reason,
+                        completion_tokens,
+                        has_reasoning_content,
+                        budget,
+                    )
+                    continue
+                break
 
             try:
                 result = _validate_structured_json(content, schema_class)

--- a/blueprint_core/llm_providers.py
+++ b/blueprint_core/llm_providers.py
@@ -71,6 +71,56 @@ class LLMProviderOutputError(RuntimeError):
     """Raised when a live provider returns unusable structured output."""
 
 
+class LLMProviderInputError(ValueError):
+    """Raised when the selected provider/model cannot consume the supplied input."""
+
+
+def model_image_input_support(provider_name: str, model_name: str) -> Optional[bool]:
+    """Return known image-input support, or ``None`` when it is not known.
+
+    OpenAI-compatible model catalogs do not expose capabilities consistently, so
+    unknown models are allowed through and provider errors are normalized later.
+    The explicit text-only markers prevent known-incompatible requests from
+    starting expensive workflow steps such as web research.
+    """
+    provider = normalize_llm_provider_name(provider_name) or provider_name.strip().lower()
+    model = _normalize_model_name(model_name).lower()
+
+    if provider in {"gemini", "anthropic"}:
+        return True
+    if any(marker in model for marker in ("-vl", "_vl", "/vl", "vision", "llava")):
+        return True
+    if provider == "openai" and model.startswith(("gpt-4o", "gpt-4.1", "gpt-5")):
+        return True
+    if any(marker in model for marker in ("nemotron", "gpt-oss", "coder")):
+        return False
+    return None
+
+
+def _image_input_error_message(provider_name: str, model_name: str) -> str:
+    return (
+        f"The selected model '{provider_name}/{model_name}' cannot read reference images. "
+        "Choose a vision-capable model or remove the image attachment."
+    )
+
+
+def _is_image_input_unsupported_error(exc: Exception) -> bool:
+    message = str(exc).lower()
+    return any(
+        marker in message
+        for marker in (
+            "unknown modality: image",
+            "image input is not supported",
+            "image inputs are not supported",
+            "does not support image input",
+            "doesn't support image input",
+            "unsupported image input",
+            "multimodal input is not supported",
+            "only supports text input",
+        )
+    )
+
+
 SUPPORTED_LLM_PROVIDERS = {
     "anthropic",
     "baseten",
@@ -134,6 +184,7 @@ class LLMProviderValidation:
     live_generation_enabled: bool = True
 
     def as_debug_dict(self) -> Dict[str, Any]:
+        image_support_model = self.actual_model or self.requested_model
         return {
             "provider": self.provider,
             "requested_model": self.requested_model,
@@ -145,6 +196,7 @@ class LLMProviderValidation:
             "fallback_model": self.fallback_model,
             "validation_error": self.validation_error,
             "live_generation_enabled": self.live_generation_enabled,
+            "supports_image_input": model_image_input_support(self.provider, image_support_model),
         }
 
 
@@ -797,6 +849,10 @@ class StructuredLLMProvider:
 
     def get_debug_config(self) -> Dict[str, Any]:
         return self.validate_configured_model(raise_on_strict=False).as_debug_dict()
+
+    def validate_image_input(self) -> None:
+        if model_image_input_support(self.provider_name, self.model_name) is False:
+            raise LLMProviderInputError(_image_input_error_message(self.provider_name, self.model_name))
 
     def generate_structured(
         self,
@@ -1881,7 +1937,14 @@ class OpenAICompatibleProvider(StructuredLLMProvider):
         finish_reason: Optional[str] = None
         for attempt in range(2):
             payload[tokens_key] = budget
-            response = self._request_json("chat/completions", method="POST", payload=payload)
+            try:
+                response = self._request_json("chat/completions", method="POST", payload=payload)
+            except RuntimeError as exc:
+                if image_bytes and _is_image_input_unsupported_error(exc):
+                    raise LLMProviderInputError(
+                        _image_input_error_message(self.provider_name, self.model_name)
+                    ) from exc
+                raise
             choices = response.get("choices") or []
             if not choices:
                 raise RuntimeError(f"{self.provider_name} response did not include any choices.")

--- a/frontend/app/blueprint-workspace.tsx
+++ b/frontend/app/blueprint-workspace.tsx
@@ -5,6 +5,7 @@ import dynamic from "next/dynamic";
 import { usePathname, useRouter } from "next/navigation";
 import {
   activeLlmsFromIntegrations,
+  generationLlmImageSupport,
   generationLlmKey,
   type GenerationLlmOption,
   type IntegrationsPayload,
@@ -211,6 +212,7 @@ const BASETEN_GLM_MODEL = "zai-org/GLM-5.2";
 const BASETEN_DEEPSEEK_MODEL = "deepseek-ai/DeepSeek-V4-Pro";
 const ANTHROPIC_SONNET_MODEL = "claude-sonnet-5";
 const NEBIUS_QWEN_MODEL = "Qwen/Qwen3.5-397B-A17B";
+const NEBIUS_QWEN_VISION_MODEL = "Qwen/Qwen2-VL-72B-Instruct";
 const NVIDIA_GLM_MODEL = "nvidia/z-ai/glm-5.2";
 const NVIDIA_QWEN_CODER_32B_MODEL = "qwen/qwen2.5-coder-32b-instruct";
 const NVIDIA_LLAMA_8B_MODEL = "meta/llama-3.1-8b-instruct";
@@ -230,6 +232,7 @@ const defaultGenerationLlms: GenerationLlmOption[] = [
   ...localOnlyGenerationLlms,
   { provider: "gmi", model: "anthropic/claude-fable-5", label: "GMI Claude Fable 5" },
   { provider: "nebius", model: NEBIUS_QWEN_MODEL, label: "Nebius Qwen 3.5 397B A17B" },
+  { provider: "nebius", model: NEBIUS_QWEN_VISION_MODEL, label: "Nebius Qwen2 VL 72B (Vision)" },
   { provider: "nvidia", model: NVIDIA_GLM_MODEL, label: "NVIDIA GLM 5.2" },
   { provider: "nvidia", model: NVIDIA_QWEN_CODER_32B_MODEL, label: "NVIDIA Qwen2.5 Coder 32B" },
   { provider: "nvidia", model: NVIDIA_LLAMA_8B_MODEL, label: "NVIDIA Llama 3.1 8B" },
@@ -2849,6 +2852,16 @@ export function FormaWorkspace({
     if (!(await requireSignedInForGeneration())) return;
     if (!selectedGenerationLlm) {
       setGenerationInputNotice("Turn on at least one model provider in Settings before building.");
+      return;
+    }
+    if (selectedImage && generationLlmImageSupport(selectedGenerationLlm) === false) {
+      const message = `${selectedGenerationLlm.label} cannot read reference images. Choose a vision-capable model or remove the image.`;
+      setGenerationInputNotice(message);
+      appendChatMessage({
+        role: "assistant",
+        content: message,
+        status: "error",
+      });
       return;
     }
     const contextCheckpoint = pendingHumanContext;

--- a/frontend/lib/active-llms.ts
+++ b/frontend/lib/active-llms.ts
@@ -4,6 +4,17 @@ export type GenerationLlmOption = {
   label: string;
 };
 
+export function generationLlmImageSupport(option: Pick<GenerationLlmOption, "provider" | "model">): boolean | null {
+  const provider = option.provider.trim().toLowerCase();
+  const model = option.model.trim().toLowerCase().replace(/^models\//, "");
+
+  if (provider === "gemini" || provider === "anthropic") return true;
+  if (["-vl", "_vl", "/vl", "vision", "llava"].some((marker) => model.includes(marker))) return true;
+  if (provider === "openai" && ["gpt-4o", "gpt-4.1", "gpt-5"].some((prefix) => model.startsWith(prefix))) return true;
+  if (["nemotron", "gpt-oss", "coder"].some((marker) => model.includes(marker))) return false;
+  return null;
+}
+
 export type IntegrationFieldStatus = {
   id: string;
   value: string | null;
@@ -117,6 +128,9 @@ export function activeLlmsFromIntegrations(
       model,
       label: labelFor(integration.id, model),
     });
+    defaultLlms
+      .filter((option) => option.provider === integration.id && generationLlmImageSupport(option) === true)
+      .forEach((option) => options.push(option));
   });
 
   return uniqueGenerationLlms(options);

--- a/frontend/test/active-llms.test.ts
+++ b/frontend/test/active-llms.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { activeLlmsFromIntegrations, type GenerationLlmOption, type IntegrationsPayload } from "../lib/active-llms";
+import {
+  activeLlmsFromIntegrations,
+  generationLlmImageSupport,
+  type GenerationLlmOption,
+  type IntegrationsPayload,
+} from "../lib/active-llms";
 
 const defaults: GenerationLlmOption[] = [
   { provider: "openai", model: "gpt-5.5", label: "OpenAI GPT-5.5" },
@@ -9,8 +14,15 @@ const defaults: GenerationLlmOption[] = [
   { provider: "huggingface", model: "Qwen/Qwen2.5-Coder-3B-Instruct:nscale", label: "Hugging Face Qwen2.5 Coder" },
   { provider: "baseten", model: "zai-org/GLM-5.2", label: "GLM 5.2" },
   { provider: "nebius", model: "Qwen/Qwen3.5-397B-A17B", label: "Nebius Qwen 3.5 397B A17B" },
+  { provider: "nebius", model: "Qwen/Qwen2-VL-72B-Instruct", label: "Nebius Qwen2 VL 72B (Vision)" },
   { provider: "nvidia", model: "nvidia/z-ai/glm-5.2", label: "NVIDIA GLM 5.2" },
 ];
+
+test("image support distinguishes vision, text-only, and unknown models", () => {
+  assert.equal(generationLlmImageSupport({ provider: "nebius", model: "Qwen/Qwen2-VL-72B-Instruct" }), true);
+  assert.equal(generationLlmImageSupport({ provider: "nebius", model: "nvidia/nemotron-3-super-120b-a12b" }), false);
+  assert.equal(generationLlmImageSupport({ provider: "nebius", model: "some-new-model" }), null);
+});
 
 function label(provider: string, model: string) {
   const known = defaults.find((option) => option.provider === provider && option.model === model);
@@ -154,6 +166,11 @@ test("the runtime provider allowlist hides unrelated configured environment prov
       model: "nvidia/nemotron-3-super-120b-a12b",
       label: "nebius nvidia/nemotron-3-super-120b-a12b",
     },
+    {
+      provider: "nebius",
+      model: "Qwen/Qwen2-VL-72B-Instruct",
+      label: "Nebius Qwen2 VL 72B (Vision)",
+    },
   ]);
 });
 
@@ -177,6 +194,11 @@ test("configured Nebius falls back to its catalog default when no model is saved
       provider: "nebius",
       model: "Qwen/Qwen3.5-397B-A17B",
       label: "Nebius Qwen 3.5 397B A17B",
+    },
+    {
+      provider: "nebius",
+      model: "Qwen/Qwen2-VL-72B-Instruct",
+      label: "Nebius Qwen2 VL 72B (Vision)",
     },
   ]);
 });

--- a/tests/test_llm_runtime.py
+++ b/tests/test_llm_runtime.py
@@ -12,6 +12,7 @@ from blueprint_core.agents.web_research_workflow import WebResearchHardwarePipel
 from blueprint_core.llm import (
     LLMProviderConfigError,
     LLMProviderInputError,
+    LLMProviderOutputError,
     build_llm_provider,
     model_image_input_support,
     resolve_llm_runtime_config,
@@ -470,6 +471,91 @@ class LLMRuntimeTests(unittest.TestCase):
                 image_bytes=b"fake-image",
                 image_mime_type="image/png",
             )
+
+    def test_nebius_retries_when_reasoning_uses_budget_before_visible_content(self) -> None:
+        with isolated_llm_env(
+            LLM_PROVIDER="nebius",
+            LLM_ALLOWED_PROVIDERS="nebius,simulation",
+            NEBIUS_API_KEY="nebius_test",
+            NEBIUS_MODEL="nvidia/nemotron-3-super-120b-a12b",
+            NEBIUS_MAX_TOKENS="7000",
+            NEBIUS_VALIDATE_MODELS="false",
+        ):
+            runtime = resolve_llm_runtime_config("nebius", "nvidia/nemotron-3-super-120b-a12b")
+            provider = build_llm_provider(runtime_config=runtime)
+
+        payloads = []
+        responses = iter(
+            [
+                {
+                    "choices": [
+                        {
+                            "message": {"content": None, "reasoning_content": "internal reasoning"},
+                            "finish_reason": "length",
+                        }
+                    ],
+                    "usage": {"completion_tokens": 7000},
+                },
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": json.dumps(
+                                    {
+                                        "title": "Recovered Project",
+                                        "description": "A valid response after retry.",
+                                        "difficulty": "Beginner",
+                                        "estimated_cost": 5.0,
+                                        "category": "IoT",
+                                    }
+                                )
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ]
+                },
+            ]
+        )
+
+        def fake_request(_path, method="GET", payload=None):
+            payloads.append(copy.deepcopy(payload or {}))
+            return next(responses)
+
+        provider._request_json = fake_request
+        result = provider.generate_structured("Return a project overview.", ProjectOverview)
+
+        self.assertEqual("Recovered Project", result.title)
+        self.assertEqual(7000, payloads[0]["max_tokens"])
+        self.assertEqual(14000, payloads[1]["max_tokens"])
+        self.assertNotIn("reasoning_effort", payloads[0])
+        self.assertEqual("low", payloads[1]["reasoning_effort"])
+
+    def test_nebius_empty_retry_reports_safe_response_metadata(self) -> None:
+        with isolated_llm_env(
+            LLM_PROVIDER="nebius",
+            LLM_ALLOWED_PROVIDERS="nebius,simulation",
+            NEBIUS_API_KEY="nebius_test",
+            NEBIUS_MODEL="some-new-model",
+            NEBIUS_VALIDATE_MODELS="false",
+        ):
+            runtime = resolve_llm_runtime_config("nebius", "some-new-model")
+            provider = build_llm_provider(runtime_config=runtime)
+
+        provider._request_json = lambda *_args, **_kwargs: {
+            "choices": [
+                {
+                    "message": {"content": None, "reasoning_content": "internal reasoning"},
+                    "finish_reason": "length",
+                }
+            ],
+            "usage": {"completion_tokens": 8192},
+        }
+
+        with self.assertRaisesRegex(
+            LLMProviderOutputError,
+            r"finish_reason=length.*completion_tokens=8192.*reasoning_content=True",
+        ):
+            provider.generate_structured("Return a project overview.", ProjectOverview)
 
     def test_nvidia_runtime_allows_qwen_coder_32b_instruct_override(self) -> None:
         with isolated_llm_env(

--- a/tests/test_llm_runtime.py
+++ b/tests/test_llm_runtime.py
@@ -6,8 +6,16 @@ import json
 import unittest
 from contextlib import contextmanager
 from typing import Iterator
+from unittest.mock import patch
 
-from blueprint_core.llm import LLMProviderConfigError, build_llm_provider, resolve_llm_runtime_config
+from blueprint_core.agents.web_research_workflow import WebResearchHardwarePipeline
+from blueprint_core.llm import (
+    LLMProviderConfigError,
+    LLMProviderInputError,
+    build_llm_provider,
+    model_image_input_support,
+    resolve_llm_runtime_config,
+)
 from blueprint_core.models import ProjectOverview
 from blueprint_core.selectors import parse_llm_selector, split_llm_selector
 
@@ -156,6 +164,12 @@ def isolated_llm_env(**overrides: str) -> Iterator[None]:
 
 
 class LLMRuntimeTests(unittest.TestCase):
+    def test_image_input_capability_identifies_known_model_types(self) -> None:
+        self.assertFalse(model_image_input_support("nebius", "nvidia/nemotron-3-super-120b-a12b"))
+        self.assertTrue(model_image_input_support("nebius", "Qwen/Qwen2-VL-72B-Instruct"))
+        self.assertTrue(model_image_input_support("openai", "gpt-5.5"))
+        self.assertIsNone(model_image_input_support("nebius", "some-new-model"))
+
     def test_parse_provider_model_selector(self) -> None:
         selector = parse_llm_selector("runpod/caid-technologies/parti-base")
 
@@ -398,6 +412,64 @@ class LLMRuntimeTests(unittest.TestCase):
         self.assertEqual("json_schema", payloads[0]["response_format"]["type"])
         self.assertEqual(321, payloads[0]["max_tokens"])
         self.assertNotIn("max_completion_tokens", payloads[0])
+
+    def test_known_text_only_model_rejects_image_before_request(self) -> None:
+        with isolated_llm_env(
+            LLM_PROVIDER="nebius",
+            LLM_ALLOWED_PROVIDERS="nebius,simulation",
+            NEBIUS_API_KEY="nebius_test",
+            NEBIUS_MODEL="nvidia/nemotron-3-super-120b-a12b",
+        ):
+            runtime = resolve_llm_runtime_config("nebius", "nvidia/nemotron-3-super-120b-a12b")
+            provider = build_llm_provider(runtime_config=runtime)
+
+        with self.assertRaisesRegex(LLMProviderInputError, "vision-capable model"):
+            provider.validate_image_input()
+
+    def test_web_research_rejects_text_only_image_input_before_research(self) -> None:
+        with isolated_llm_env(
+            LLM_PROVIDER="nebius",
+            LLM_ALLOWED_PROVIDERS="nebius,simulation",
+            NEBIUS_API_KEY="nebius_test",
+            NEBIUS_MODEL="nvidia/nemotron-3-super-120b-a12b",
+            NEBIUS_VALIDATE_MODELS="false",
+        ):
+            pipeline = WebResearchHardwarePipeline(
+                provider_name="nebius",
+                model_name="nvidia/nemotron-3-super-120b-a12b",
+            )
+            with patch.object(pipeline, "_research") as research:
+                with self.assertRaises(LLMProviderInputError):
+                    pipeline.generate_project(
+                        "Build the safe low-voltage circuit shown in this image.",
+                        image_bytes=b"fake-image",
+                        image_mime_type="image/png",
+                    )
+
+        research.assert_not_called()
+
+    def test_provider_normalizes_unknown_image_modality_error(self) -> None:
+        with isolated_llm_env(
+            LLM_PROVIDER="nebius",
+            LLM_ALLOWED_PROVIDERS="nebius,simulation",
+            NEBIUS_API_KEY="nebius_test",
+            NEBIUS_MODEL="some-new-model",
+            NEBIUS_VALIDATE_MODELS="false",
+        ):
+            runtime = resolve_llm_runtime_config("nebius", "some-new-model")
+            provider = build_llm_provider(runtime_config=runtime)
+
+        def reject_image(*_args, **_kwargs):
+            raise RuntimeError('nebius request failed with HTTP 400: {"detail":"Unknown modality: image"}')
+
+        provider._request_json = reject_image
+        with self.assertRaisesRegex(LLMProviderInputError, "cannot read reference images"):
+            provider.generate_structured(
+                "Infer the hardware project.",
+                ProjectOverview,
+                image_bytes=b"fake-image",
+                image_mime_type="image/png",
+            )
 
     def test_nvidia_runtime_allows_qwen_coder_32b_instruct_override(self) -> None:
         with isolated_llm_env(


### PR DESCRIPTION
Closes #127

## Summary
- add the documented Nebius Qwen2 VL vision model to the generation picker
- reject known text-only models before starting external research
- normalize provider image-modality failures into actionable validation errors
- send the reference image only to the web architecture stage, then use the extracted plan downstream
- retry Nebius responses that spend their completion budget on reasoning before emitting visible content
- record safe response metadata in Jobs when an empty response persists

Nebius references:
- vision input: https://docs.tokenfactory.nebius.com/api-reference/examples/vision-capabilities
- reasoning and completion budgets: https://docs.tokenfactory.nebius.com/api-reference/inference/create-chat-completion

## Testing
- `.venv/bin/python -m unittest tests.test_llm_runtime -q` — 28 passed
- `.venv/bin/python -m unittest tests.test_structured_repair tests.test_api_error_visibility -q` — 10 passed
- `npm run build` in `frontend` — passed
- full backend suite: 292 tests run; two unrelated existing failures remain in the root requirements parity check and legacy `fibricator` shim