### PR TITLE
Allow users to delete their own projects

### DIFF
--- a/frontend/app/blueprint-workspace.tsx
+++ b/frontend/app/blueprint-workspace.tsx
@@ -45,6 +45,7 @@ import {
   buildProjectGalleryItems,
   previewableImageSrc,
   resolveProjectImageCandidates,
+  type ProjectGalleryItem,
   type ProjectImageCandidate,
 } from "./blueprint-workspace/project-gallery";
 import {
@@ -1918,6 +1919,37 @@ export function FormaWorkspace({
       writeStoredChatIndex(nextItems, chatStorageScope);
       return nextItems;
     });
+  };
+
+  const deleteOwnedProject = async (item: ProjectGalleryItem) => {
+    const response = await fetch(`${API_URL}/projects/${encodeURIComponent(item.projectId)}`, {
+      method: "DELETE",
+      headers: await generationRequestHeaders(),
+    });
+    if (!response.ok) {
+      throw new Error(await readApiErrorMessage(response));
+    }
+
+    const removeProject = (projects: any[]) => (
+      projects.filter((project: any) => String(project?.project_id || "") !== item.projectId)
+    );
+    setProjectHistory(removeProject);
+    setMyProjectHistory(removeProject);
+    setProjectGalleryImages((current) => {
+      if (!(item.projectId in current)) return current;
+      const next = { ...current };
+      delete next[item.projectId];
+      return next;
+    });
+    if (item.chatId) {
+      detachMissingProjectFromChat(item.chatId, item.projectId, item.title);
+    }
+    if (projectIdFromIR(projectIR) === item.projectId) {
+      setProjectIR(null);
+    }
+    if (currentRouteProjectId && safeDecodeProjectId(currentRouteProjectId) === item.projectId) {
+      router.replace("/my-projects");
+    }
   };
 
   const updateHumanContextAnswer = (questionId: string, value: string) => {
@@ -4157,6 +4189,7 @@ export function FormaWorkspace({
                 items={projectGalleryItems}
                 loading={projectsPageLoading}
                 onOpenProjectPage={(projectId) => router.push(projectRoute(projectId))}
+                onDeleteProject={deleteOwnedProject}
                 onVisibleProjectIdsChange={handleVisibleProjectGalleryIdsChange}
                 standalone
               />
@@ -4173,6 +4206,7 @@ export function FormaWorkspace({
                 items={myProjectGalleryItems}
                 loading={myProjectsPageLoading}
                 onOpenProjectPage={(projectId) => router.push(projectRoute(projectId))}
+                onDeleteProject={deleteOwnedProject}
                 onVisibleProjectIdsChange={handleVisibleProjectGalleryIdsChange}
                 standalone
               />

--- a/frontend/app/blueprint-workspace/project-gallery.tsx
+++ b/frontend/app/blueprint-workspace/project-gallery.tsx
@@ -8,6 +8,7 @@ import {
   Cpu,
   MessageSquare,
   Star,
+  Trash2,
 } from "lucide-react";
 
 export type ProjectGalleryItem = {
@@ -215,6 +216,7 @@ export function ProjectGallery({
   items,
   loading = false,
   onOpenProjectPage,
+  onDeleteProject,
   onVisibleProjectIdsChange,
   standalone = false,
 }: {
@@ -222,11 +224,15 @@ export function ProjectGallery({
   items: ProjectGalleryItem[];
   loading?: boolean;
   onOpenProjectPage: (projectId: string) => void;
+  onDeleteProject?: (item: ProjectGalleryItem) => Promise<void>;
   onVisibleProjectIdsChange?: (projectIds: string[]) => void;
   standalone?: boolean;
 }) {
   const pageSize = PROJECT_GALLERY_PAGE_SIZE;
   const [currentPage, setCurrentPage] = useState(0);
+  const [projectPendingDeletion, setProjectPendingDeletion] = useState<ProjectGalleryItem | null>(null);
+  const [deletingProjectId, setDeletingProjectId] = useState<string | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const pageCount = Math.max(1, Math.ceil(items.length / pageSize));
   const safePage = Math.min(currentPage, pageCount - 1);
   const firstVisibleItem = safePage * pageSize;
@@ -256,8 +262,34 @@ export function ProjectGallery({
     onVisibleProjectIdsChange?.(visibleProjectIds);
   }, [onVisibleProjectIdsChange, visibleProjectIds]);
 
+  useEffect(() => {
+    if (!projectPendingDeletion) return;
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !deletingProjectId) {
+        setDeleteError(null);
+        setProjectPendingDeletion(null);
+      }
+    };
+    window.addEventListener("keydown", closeOnEscape);
+    return () => window.removeEventListener("keydown", closeOnEscape);
+  }, [deletingProjectId, projectPendingDeletion]);
+
   const goToPage = (page: number) => {
     setCurrentPage(Math.min(Math.max(page, 0), pageCount - 1));
+  };
+
+  const confirmProjectDeletion = async () => {
+    if (!projectPendingDeletion || !onDeleteProject) return;
+    setDeleteError(null);
+    setDeletingProjectId(projectPendingDeletion.projectId);
+    try {
+      await onDeleteProject(projectPendingDeletion);
+      setProjectPendingDeletion(null);
+    } catch (error) {
+      setDeleteError(error instanceof Error ? error.message : "Project deletion failed.");
+    } finally {
+      setDeletingProjectId(null);
+    }
   };
 
   return (
@@ -286,6 +318,12 @@ export function ProjectGallery({
                 key={item.key}
                 item={item}
                 onOpen={() => onOpenProjectPage(item.projectId)}
+                onDeleteRequest={item.canChat && onDeleteProject
+                  ? () => {
+                      setDeleteError(null);
+                      setProjectPendingDeletion(item);
+                    }
+                  : undefined}
               />
             ))}
           </div>
@@ -354,6 +392,70 @@ export function ProjectGallery({
       ) : (
         <div className="border border-[#2c2f37] bg-[#17181d] p-8 text-sm leading-6 text-slate-500">
           No saved projects yet.
+        </div>
+      )}
+
+      {projectPendingDeletion && (
+        <div
+          className="fixed inset-0 z-[70] flex items-center justify-center bg-black/80 p-4"
+          role="presentation"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget && !deletingProjectId) {
+              setDeleteError(null);
+              setProjectPendingDeletion(null);
+            }
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="delete-project-title"
+            aria-describedby="delete-project-description"
+            className="w-full max-w-md border border-rose-400/40 bg-[#17181d] p-5 shadow-2xl"
+          >
+            <div className="flex items-start gap-3">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center border border-rose-400/40 bg-rose-950/30 text-rose-300">
+                <Trash2 className="h-4 w-4" />
+              </span>
+              <div className="min-w-0">
+                <h3 id="delete-project-title" className="text-sm font-black uppercase tracking-[0.16em] text-white">
+                  Delete project?
+                </h3>
+                <p id="delete-project-description" className="mt-2 text-sm leading-6 text-slate-400">
+                  <span className="font-bold text-slate-200">{projectPendingDeletion.title}</span> will be permanently removed. This cannot be undone.
+                </p>
+              </div>
+            </div>
+
+            {deleteError && (
+              <div role="alert" className="mt-4 border border-rose-400/35 bg-rose-950/25 px-3 py-2 text-sm text-rose-200">
+                {deleteError}
+              </div>
+            )}
+
+            <div className="mt-5 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setDeleteError(null);
+                  setProjectPendingDeletion(null);
+                }}
+                disabled={Boolean(deletingProjectId)}
+                className="h-10 border border-[#343740] px-4 text-xs font-black uppercase tracking-[0.12em] text-slate-300 transition hover:bg-white hover:text-black disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void confirmProjectDeletion()}
+                disabled={Boolean(deletingProjectId)}
+                className="inline-flex h-10 items-center gap-2 border border-rose-400/50 bg-rose-950/30 px-4 text-xs font-black uppercase tracking-[0.12em] text-rose-100 transition hover:bg-rose-400 hover:text-black disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                <Trash2 className="h-4 w-4" />
+                {deletingProjectId ? "Deleting..." : "Delete permanently"}
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </section>
@@ -431,9 +533,11 @@ function ProjectImageLoadingPanel() {
 function ProjectGalleryCard({
   item,
   onOpen,
+  onDeleteRequest,
 }: {
   item: ProjectGalleryItem;
   onOpen: () => void;
+  onDeleteRequest?: () => void;
 }) {
   const ageLabel = formatProjectAge(item.createdAt);
   return (
@@ -497,10 +601,28 @@ function ProjectGalleryCard({
             <span className="truncate">{item.creatorDisplay}</span>
           </div>
           {item.canChat && (
-            <span className="inline-flex h-9 shrink-0 items-center justify-center gap-2 border border-cyan-300/35 px-3 text-xs font-black uppercase text-cyan-100 transition group-hover:bg-cyan-300 group-hover:text-black">
-              <MessageSquare className="h-4 w-4 shrink-0" />
-              <span className="truncate">Your project</span>
-            </span>
+            <div className="flex shrink-0 items-center gap-2">
+              <span className="inline-flex h-9 items-center justify-center gap-2 border border-cyan-300/35 px-3 text-xs font-black uppercase text-cyan-100 transition group-hover:bg-cyan-300 group-hover:text-black">
+                <MessageSquare className="h-4 w-4 shrink-0" />
+                <span className="hidden truncate sm:inline">Your project</span>
+              </span>
+              {onDeleteRequest && (
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onDeleteRequest();
+                  }}
+                  onKeyDown={(event) => event.stopPropagation()}
+                  className="inline-flex h-9 w-9 items-center justify-center border border-rose-400/35 text-rose-300 transition hover:bg-rose-400 hover:text-black"
+                  aria-label={`Delete project ${item.title}`}
+                  title="Delete project"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              )}
+            </div>
           )}
         </div>
       </div>

--- a/tests/test_project_access.py
+++ b/tests/test_project_access.py
@@ -272,6 +272,53 @@ class ProjectReadAccessTests(unittest.TestCase):
         self.assertNotIn(downloadable_url, json.dumps(response, default=str))
 
 
+class ProjectDeleteAccessTests(unittest.TestCase):
+    def test_owner_can_delete_own_project(self) -> None:
+        project = _project("owned-project", owner_user_id="user-a", visibility="private")
+
+        with (
+            patch.object(main, "get_generated_project", return_value=project),
+            patch.object(main, "delete_generated_project", return_value=True) as delete_project,
+        ):
+            response = main.delete_project_endpoint(project.project_id, _user_context("user-a"))
+
+        self.assertEqual({"ok": True, "project_id": project.project_id}, response)
+        delete_project.assert_called_once_with(project.project_id, "user-a")
+
+    def test_nonowner_cannot_delete_project(self) -> None:
+        project = _project("another-project", owner_user_id="user-b", visibility="public")
+
+        with (
+            patch.object(main, "get_generated_project", return_value=project),
+            patch.object(main, "delete_generated_project") as delete_project,
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                main.delete_project_endpoint(project.project_id, _user_context("user-a"))
+
+        self.assertEqual(403, raised.exception.status_code)
+        delete_project.assert_not_called()
+
+    def test_anonymous_user_cannot_delete_project(self) -> None:
+        project = _project("owned-project", owner_user_id="user-a", visibility="public")
+
+        with (
+            patch.object(main, "get_generated_project", return_value=project),
+            patch.object(main, "delete_generated_project") as delete_project,
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                main.delete_project_endpoint(project.project_id, _anonymous_context())
+
+        self.assertEqual(401, raised.exception.status_code)
+        delete_project.assert_not_called()
+
+    def test_missing_project_returns_not_found(self) -> None:
+        with patch.object(main, "get_generated_project", return_value=None):
+            with self.assertRaises(HTTPException) as raised:
+                main.delete_project_endpoint("missing-project", _user_context("user-a"))
+
+        self.assertEqual(404, raised.exception.status_code)
+
+
 class ProjectChatAccessTests(unittest.TestCase):
     def test_chat_lookup_is_scoped_to_the_signed_in_owner(self) -> None:
         owned_chat = SimpleNamespace(


### PR DESCRIPTION
Closes #130

## Summary
- add an owner-only delete action to project cards
- require confirmation before permanently deleting a project
- remove deleted projects from public and personal gallery state
- surface API deletion errors without dismissing the confirmation dialog
- cover owner, non-owner, anonymous, and missing-project authorization cases

## Testing
- `.venv/bin/python -m unittest tests.test_project_access tests.test_persistence -q` — 19 passed
- `npm run build` in `frontend` — passed (existing image optimization warnings only)