### PR TITLE
chore: consolidate performance and quality evals

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ You can contribute by:
 * Adding supported LLM or image providers
 * Improving project iteration and self-correction
 * Improving observability, persistence, or deployment support
-* Adding examples or benchmarks
+* Adding examples or evaluations
 * Reviewing issues and pull requests
 
 Small, focused contributions are welcome.
@@ -216,7 +216,7 @@ backend/          FastAPI application and service integrations
 blueprint_core/   Reusable generation, validation, provider, and project logic
 frontend/         Next.js frontend
 tests/            Offline Python unit tests
-benchmarks/       Model and pipeline benchmarks
+evals/            Performance benchmarks, quality evaluations, datasets, and reports
 docs/             Architecture and development documentation
 scripts/          Development, testing, verification, and operational scripts
 supabase/         Supabase schema and migration resources

--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ curl -X POST http://127.0.0.1:8000/projects/<project-id>/iterate -H 'Content-Typ
 
 Generation and project iteration logic lives in the reusable `blueprint_core` package, published as the `caid-blueprint-core` PyPI distribution. New code should import from `blueprint_core.generation`, `blueprint_core.iteration`, `blueprint_core.project_objects`, `blueprint_core.models`, `blueprint_core.validation`, `blueprint_core.llm`, `blueprint_core.images`, `blueprint_core.runtime`, and `blueprint_core.selectors`; the old backend modules are compatibility wrappers. Projects are represented as `FormaProjectObject` values with an object version plus versioned namespaces such as `product.mech`, `product.electrical`, `product.validation`, `product.assembly`, `project.docs`, and `project.history`. `ProjectIterator.iterate_project(...)` takes an existing `HardwareIR` plus a natural-language instruction, can target a namespace, returns a full revised `HardwareIR`, normalizes revision/history/object metadata, redacts bulky data URLs from LLM context, and reruns circuit validation before returning. `ProjectSelfCorrectionAgent` builds validation-driven repair instructions and applies them through the same namespace-aware iterator.
 
-Benchmarks live under `benchmarks/` and save JSON reports under `.logs/benchmarks/`:
+Performance benchmarks live under `evals/performance/` and save JSON reports under `.logs/benchmarks/`. See [`evals/README.md`](evals/README.md) for the performance/quality distinction, shared datasets, reports, and extension guidance.
 ```bash
 ./scripts/benchmark.sh
-./benchmarks/benchmark_models.py --iterations 1
-./benchmarks/benchmark_models.py --live --llm openai/gpt-5.5 --iterations 3 --concurrency 2
+./evals/performance/benchmark_models.py --iterations 1
+./evals/performance/benchmark_models.py --live --llm openai/gpt-5.5 --iterations 3 --concurrency 2
 ```
 
 `benchmark_models.py` defaults to config-only mode so it can run safely without spending provider calls. Add `--live` when you want real LLM latency measurements. Each completed provider/model attempt is also flushed immediately to per-run JSONL and CSV files named `model-job-results-*.jsonl` and `model-job-results-*.csv`, including status, round, completion time, and duration fields.
@@ -151,8 +151,8 @@ Benchmark, output, and eval artifacts can be uploaded to a Hugging Face dataset 
 export HF_TOKEN=...
 export HF_ARTIFACT_REPO_ID=username/blueprint-metrics
 
-./benchmarks/benchmark_models.py --live --iterations 3 --upload-huggingface
-./benchmarks/benchmark_offline.py --upload-huggingface
+./evals/performance/benchmark_models.py --live --iterations 3 --upload-huggingface
+./evals/performance/benchmark_offline.py --upload-huggingface
 ./scripts/upload-artifacts-to-huggingface.py --artifact-type outputs examples/results
 ./scripts/upload-artifacts-to-huggingface.py --artifact-type evals .logs/evals
 ```

--- a/benchmarks/__init__.py
+++ b/benchmarks/__init__.py
@@ -1,1 +1,0 @@
-"""Benchmark helpers for Forma core and provider integrations."""

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,54 @@
+# Forma evaluations
+
+This directory is the shared home for performance benchmarks and output-quality evaluations. Performance measures how reliably and quickly a workflow runs; quality measures whether its result is correct, complete, feasible, and faithful to the request.
+
+```text
+evals/
+├── performance/  Provider, model, pipeline, and offline timing benchmarks
+├── quality/      Correctness and output-quality evaluation suites
+├── datasets/     Reusable prompts, fixtures, rubrics, and expected outputs
+└── reports/      Optional local or curated evaluation reports
+```
+
+## Performance benchmarks
+
+Run the deterministic offline suite from the repository root:
+
+```bash
+./scripts/benchmark.sh
+./evals/performance/benchmark_offline.py --iterations 1000
+```
+
+Inspect configured provider/model pairs without making generation calls:
+
+```bash
+./evals/performance/benchmark_models.py --iterations 1
+```
+
+Add `--live` to measure real provider calls:
+
+```bash
+./evals/performance/benchmark_models.py \
+  --live \
+  --llm openai/gpt-5.5 \
+  --iterations 3 \
+  --concurrency 2
+```
+
+For compatibility with existing automation, benchmark reports still default to `.logs/benchmarks/`, and their console output, schema, filenames, and Hugging Face artifact layout are unchanged. Pass `--output-dir evals/reports/performance` when a report specifically belongs under this umbrella.
+
+## Quality evaluations
+
+Quality suites belong in `quality/` and should use reusable inputs from `datasets/`. Typical checks include BOM accuracy, component compatibility, wiring correctness, prompt adherence, schema completeness, feasibility, and unsupported-component detection.
+
+Keep evaluation logic separate from production generation code. A quality suite should document its dataset, scoring method, thresholds, and whether it can call paid or networked providers. Deterministic checks should be the default for automated tests; live evaluations must require an explicit flag.
+
+## Extending the suite
+
+1. Put reusable, non-secret inputs and expected outputs in `datasets/`.
+2. Add the runner under `performance/` or `quality/` according to what it measures.
+3. Write generated output to `.logs/` by default, or to `reports/` when explicitly requested.
+4. Add offline regression coverage under `tests/`.
+5. Document live-provider requirements, costs, and report fields.
+
+Do not commit credentials, proprietary prompts, or generated reports containing secrets or user data.

--- a/evals/__init__.py
+++ b/evals/__init__.py
@@ -1,0 +1,1 @@
+"""Performance and quality evaluations for Forma."""

--- a/evals/datasets/README.md
+++ b/evals/datasets/README.md
@@ -1,0 +1,5 @@
+# Evaluation datasets
+
+Store reusable evaluation prompts, fixtures, rubrics, and expected outputs here. Prefer small, reviewable, versioned files that multiple performance or quality suites can share.
+
+Document provenance and licensing alongside imported data. Do not include credentials, private customer inputs, or artifacts containing user data.

--- a/evals/performance/__init__.py
+++ b/evals/performance/__init__.py
@@ -1,0 +1,1 @@
+"""Performance benchmark runners for Forma."""

--- a/evals/performance/benchmark_models.py
+++ b/evals/performance/benchmark_models.py
@@ -17,7 +17,7 @@ from statistics import mean, median
 from typing import Any
 
 
-ROOT_DIR = Path(__file__).resolve().parents[1]
+ROOT_DIR = Path(__file__).resolve().parents[2]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
@@ -327,7 +327,7 @@ def build_report(
     summary = summarize_candidate_runs(candidates, measured_rounds)
     return {
         "schema_version": 1,
-        "tool": "benchmarks/benchmark_models.py",
+        "tool": "evals/performance/benchmark_models.py",
         "started_at": sample.format_utc(started_at),
         "completed_at": sample.format_utc(completed_at),
         "duration_seconds": round((completed_at - started_at).total_seconds(), 3),

--- a/evals/performance/benchmark_offline.py
+++ b/evals/performance/benchmark_offline.py
@@ -19,7 +19,7 @@ from statistics import mean
 from typing import Any, Callable, Iterator
 
 
-ROOT_DIR = Path(__file__).resolve().parents[1]
+ROOT_DIR = Path(__file__).resolve().parents[2]
 if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
@@ -404,7 +404,7 @@ def build_report(args: argparse.Namespace, results: list[BenchmarkResult], start
     payload_results = [result.as_dict() for result in results]
     return {
         "schema_version": 1,
-        "tool": "benchmarks/benchmark_offline.py",
+        "tool": "evals/performance/benchmark_offline.py",
         "started_at": format_utc(started_at),
         "completed_at": format_utc(completed_at),
         "duration_seconds": round((completed_at - started_at).total_seconds(), 3),

--- a/evals/quality/README.md
+++ b/evals/quality/README.md
@@ -1,0 +1,5 @@
+# Quality evaluations
+
+This directory is reserved for suites that score generated hardware output rather than runtime performance. Candidate dimensions include BOM accuracy, component compatibility, wiring correctness, prompt adherence, schema completeness, hardware feasibility, and hallucinated or unsupported components.
+
+Each suite should identify its dataset and rubric, emit machine-readable results, and distinguish deterministic checks from opt-in live-provider runs.

--- a/evals/reports/.gitignore
+++ b/evals/reports/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+!README.md

--- a/evals/reports/README.md
+++ b/evals/reports/README.md
@@ -1,0 +1,5 @@
+# Evaluation reports
+
+This directory is available for explicitly requested local or curated performance and quality reports. Existing benchmark runners continue to write to `.logs/benchmarks/` by default so current automation and artifact consumers remain compatible.
+
+Use `--output-dir evals/reports/performance` to place benchmark output here intentionally. Generated reports are ignored by default; only this documentation and the ignore rules are tracked.

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -10,4 +10,4 @@ fi
 
 cd "$ROOT_DIR"
 
-"$PYTHON_BIN" benchmarks/benchmark_offline.py "$@"
+"$PYTHON_BIN" evals/performance/benchmark_offline.py "$@"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -10,6 +10,6 @@ fi
 
 cd "$ROOT_DIR"
 
-"$PYTHON_BIN" -m compileall -q blueprint_core backend benchmarks scripts tests
-"$PYTHON_BIN" -m py_compile scripts/sample.py scripts/sample_async.py benchmarks/benchmark_offline.py benchmarks/benchmark_models.py
+"$PYTHON_BIN" -m compileall -q blueprint_core backend evals scripts tests
+"$PYTHON_BIN" -m py_compile scripts/sample.py scripts/sample_async.py evals/performance/benchmark_offline.py evals/performance/benchmark_models.py
 "$PYTHON_BIN" -m unittest discover -s tests -v

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -10,8 +10,8 @@ import unittest
 
 
 ROOT_DIR = pathlib.Path(__file__).resolve().parents[1]
-OFFLINE_BENCHMARK_SCRIPT = ROOT_DIR / "benchmarks" / "benchmark_offline.py"
-MODEL_BENCHMARK_SCRIPT = ROOT_DIR / "benchmarks" / "benchmark_models.py"
+OFFLINE_BENCHMARK_SCRIPT = ROOT_DIR / "evals" / "performance" / "benchmark_offline.py"
+MODEL_BENCHMARK_SCRIPT = ROOT_DIR / "evals" / "performance" / "benchmark_models.py"
 
 
 def load_module(name: str, path: pathlib.Path):
@@ -25,10 +25,20 @@ def load_module(name: str, path: pathlib.Path):
 
 
 class BenchmarkScriptTests(unittest.TestCase):
+    def test_evaluation_layout_separates_performance_quality_and_data(self) -> None:
+        self.assertFalse((ROOT_DIR / "benchmarks" / "benchmark_offline.py").exists())
+        self.assertFalse((ROOT_DIR / "benchmarks" / "benchmark_models.py").exists())
+        self.assertTrue(OFFLINE_BENCHMARK_SCRIPT.is_file())
+        self.assertTrue(MODEL_BENCHMARK_SCRIPT.is_file())
+        for directory in ("quality", "datasets", "reports"):
+            self.assertTrue((ROOT_DIR / "evals" / directory / "README.md").is_file())
+
     def test_offline_sample_circuit_validates_without_critical_issues(self) -> None:
         module = load_module("blueprint_benchmark_offline", OFFLINE_BENCHMARK_SCRIPT)
         from blueprint_core.validation import validate_circuit
 
+        self.assertEqual(ROOT_DIR, module.ROOT_DIR)
+        self.assertEqual(".logs/benchmarks", module.DEFAULT_OUTPUT_DIR)
         components, nets = module.make_sample_circuit()
         issues = validate_circuit(components, nets)
 
@@ -46,6 +56,8 @@ class BenchmarkScriptTests(unittest.TestCase):
 
     def test_model_benchmark_summary_groups_by_candidate(self) -> None:
         module = load_module("blueprint_benchmark_models", MODEL_BENCHMARK_SCRIPT)
+        self.assertEqual(ROOT_DIR, module.ROOT_DIR)
+        self.assertEqual(".logs/benchmarks", module.DEFAULT_OUTPUT_DIR)
         candidate = module.LLMSelector("openai", "gpt-5.5")
         rounds = [
             {


### PR DESCRIPTION
Closes #145.

## Summary

- replace the root-level `benchmarks/` source directory with the broader `evals/` umbrella
- move both existing runners to `evals/performance/`
- add documented `evals/quality/`, `evals/datasets/`, and `evals/reports/` areas
- update repository docs, test/benchmark wrappers, compile checks, and unit-test paths
- add regression coverage for the new layout and relocated repository-root resolution

## Compatibility

The runners moved one directory deeper, so their repository-root calculation was updated accordingly. Existing benchmark behavior is otherwise preserved:

- reports still default to `.logs/benchmarks/`
- report filenames and console output are unchanged
- Hugging Face benchmark artifact taxonomy/layout is unchanged
- `scripts/benchmark.sh` remains the stable wrapper command
- both runners work as executable files and as `python -m evals.performance...` modules

Generated files under `evals/reports/` are ignored by default; the directory can be selected explicitly with `--output-dir`.

## Validation

- benchmark unit suite: 5 passed
- offline wrapper smoke run: passed
- direct executable and module-entry smoke runs: passed
- Python compile and shell syntax checks: passed
- full suite: 326 passed, 1 skipped
- two pre-existing failures remain: missing `fibricator` shim and root requirements missing `PyJWT`
