### PR TITLE
refactor: move Hugging Face artifacts under integrations

### DIFF
--- a/blueprint_core/integrations/__init__.py
+++ b/blueprint_core/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""External service integrations for Blueprint Core."""

--- a/blueprint_core/integrations/huggingface/__init__.py
+++ b/blueprint_core/integrations/huggingface/__init__.py
@@ -1,0 +1,29 @@
+"""Hugging Face integrations."""
+
+from .huggingface_artifacts import (
+    DEFAULT_HF_ARTIFACT_PREFIX,
+    DEFAULT_HF_REPO_TYPE,
+    HF_REPO_ENV_NAMES,
+    HF_TOKEN_ENV_NAMES,
+    HuggingFaceArtifact,
+    HuggingFaceUploadConfig,
+    HuggingFaceUploadResult,
+    HuggingFaceUploadedFile,
+    build_artifacts,
+    path_from_repo,
+    upload_artifacts_to_huggingface,
+)
+
+__all__ = [
+    "DEFAULT_HF_ARTIFACT_PREFIX",
+    "DEFAULT_HF_REPO_TYPE",
+    "HF_REPO_ENV_NAMES",
+    "HF_TOKEN_ENV_NAMES",
+    "HuggingFaceArtifact",
+    "HuggingFaceUploadConfig",
+    "HuggingFaceUploadResult",
+    "HuggingFaceUploadedFile",
+    "build_artifacts",
+    "path_from_repo",
+    "upload_artifacts_to_huggingface",
+]

--- a/blueprint_core/integrations/huggingface/huggingface_artifacts.py
+++ b/blueprint_core/integrations/huggingface/huggingface_artifacts.py
@@ -1,3 +1,5 @@
+"""Build and upload Forma artifacts to Hugging Face repositories."""
+
 from __future__ import annotations
 
 import hashlib
@@ -265,5 +267,6 @@ __all__ = [
     "HuggingFaceUploadResult",
     "HuggingFaceUploadedFile",
     "build_artifacts",
+    "path_from_repo",
     "upload_artifacts_to_huggingface",
 ]

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,7 @@ Forma OSS turns prompts into structured hardware projects using a sequential, va
 - The backend runs an **ADK-style sequential workflow** implemented in `blueprint_core/agents/orchestrator.py`.
 - Live structured JSON output is routed through the reusable `blueprint_core.llm` package API.
 - Shared generation, provider, validation, model, and runtime utilities live under `blueprint_core` so the backend, CLI, smoke tests, and future workers use the same implementation.
+- External service adapters live under `blueprint_core/integrations/`; Hugging Face artifact packaging and uploads are grouped under `integrations/huggingface/`.
 - Supported providers are `anthropic`, `baseten`, `gemini`, `gmi`, `huggingface`, `nebius`, `nvidia`, `openai`, `openai-compatible`, `runpod`, `runpod-serverless`, and `simulation`.
 - Generic configuration uses `LLM_PROVIDER`, `LLM_API_KEY`, `LLM_MODEL`, `STRICT_LLM`, and `LLM_FALLBACK_MODEL`.
 - `/api/generate` can override the provider and model at runtime with optional `provider` and `model` fields. Overrides are checked against `LLM_ALLOWED_PROVIDERS` and provider-specific model allowlists before generation starts.

--- a/evals/performance/benchmark_models.py
+++ b/evals/performance/benchmark_models.py
@@ -24,7 +24,7 @@ if str(ROOT_DIR) not in sys.path:
 
 from scripts import sample, sample_async
 from blueprint_core.selectors import LLMSelector
-from blueprint_core.huggingface_artifacts import (
+from blueprint_core.integrations.huggingface import (
     HuggingFaceUploadConfig,
     build_artifacts,
     upload_artifacts_to_huggingface,

--- a/evals/performance/benchmark_offline.py
+++ b/evals/performance/benchmark_offline.py
@@ -31,7 +31,7 @@ DEFAULT_SCHEDULER_SLEEP_MS = 10.0
 DEFAULT_OUTPUT_DIR = ".logs/benchmarks"
 LATEST_REPORT_NAME = "offline-latest.json"
 
-from blueprint_core.huggingface_artifacts import (
+from blueprint_core.integrations.huggingface import (
     HuggingFaceUploadConfig,
     build_artifacts,
     upload_artifacts_to_huggingface,

--- a/scripts/upload-artifacts-to-huggingface.py
+++ b/scripts/upload-artifacts-to-huggingface.py
@@ -15,7 +15,7 @@ if str(ROOT_DIR) not in sys.path:
     sys.path.insert(0, str(ROOT_DIR))
 
 
-from blueprint_core.huggingface_artifacts import (
+from blueprint_core.integrations.huggingface import (
     HuggingFaceUploadConfig,
     build_artifacts,
     path_from_repo,

--- a/tests/test_huggingface_artifacts.py
+++ b/tests/test_huggingface_artifacts.py
@@ -7,7 +7,7 @@ import tempfile
 import types
 import unittest
 
-from blueprint_core.huggingface_artifacts import (
+from blueprint_core.integrations.huggingface import (
     HuggingFaceUploadConfig,
     build_artifacts,
     upload_artifacts_to_huggingface,
@@ -34,6 +34,16 @@ class FakeHfApi:
 
 
 class HuggingFaceArtifactTests(unittest.TestCase):
+    def test_artifact_implementation_lives_in_huggingface_integration_package(self) -> None:
+        core_root = pathlib.Path(__file__).resolve().parents[1] / "blueprint_core"
+
+        self.assertFalse((core_root / "huggingface_artifacts.py").exists())
+        self.assertTrue((core_root / "integrations" / "huggingface" / "huggingface_artifacts.py").is_file())
+        self.assertEqual(
+            "blueprint_core.integrations.huggingface.huggingface_artifacts",
+            build_artifacts.__module__,
+        )
+
     def test_build_artifacts_records_checksum_size_and_repo_path(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = pathlib.Path(temp_dir)


### PR DESCRIPTION
## Summary

- Move `blueprint_core/huggingface_artifacts.py` to `blueprint_core/integrations/huggingface/huggingface_artifacts.py`.
- Add explicit `integrations` and `integrations.huggingface` packages, with the artifact API re-exported from the Hugging Face package boundary.
- Update benchmark runners, the artifact upload CLI, and tests to use the new package.
- Add regression coverage requiring the nested implementation and rejecting the retired flat module.
- Document `blueprint_core/integrations/` as the home for external-service adapters.

## Related issue

Closes #144

## Change type

- [ ] Bug fix
- [ ] Feature
- [x] Documentation
- [x] Test
- [x] Refactor
- [ ] Chore or maintenance

## Verification

```text
.venv/bin/python -m unittest tests.test_huggingface_artifacts tests.test_benchmarks -v
PASS (8 tests)

.venv/bin/python scripts/upload-artifacts-to-huggingface.py --help
PASS

.venv/bin/python -m compileall -q blueprint_core/integrations evals/performance scripts/upload-artifacts-to-huggingface.py
PASS

.venv/bin/python -m build --wheel --outdir <temporary-directory>
PASS; wheel contains the nested Hugging Face integration and no flat huggingface_artifacts module

./scripts/test.sh
329 passed, 1 skipped; 1 pre-existing error remains: tests/test_fabricator_cli.py expects the absent `fibricator` typo-shim package. The same package/test mismatch exists on dev and is unrelated to this move.
```

## Configuration or migration requirements

Update direct imports from `blueprint_core.huggingface_artifacts` to `blueprint_core.integrations.huggingface`. Environment variables and runtime configuration are unchanged.

## Visual changes

Not applicable.

## Safety and compatibility

Artifact behavior is unchanged. The old flat Python import path is intentionally removed; all repository callers are migrated. No hardware-safety logic is affected.

## AI assistance

Codex assisted with the caller inventory, package move, regression coverage, and verification. The final diff was reviewed for stale imports and clean wheel contents.

## Checklist

- [x] This pull request targets `dev` and the branch started from an up-to-date `dev`.
- [x] The change addresses one logical concern and contains no unrelated cleanup.
- [x] Temporary, fixup, and unrelated commits were cleaned up where practical.
- [x] Python code is typed and public classes and functions are documented where applicable.
- [x] Relevant deterministic tests were added or updated.
- [x] `./scripts/test.sh` passes, or failures are explained above.
- [x] Frontend lint and build checks pass when applicable.
- [x] Documentation was updated when behavior changed.
- [x] No secrets, credentials, logs, databases, build artifacts, or generated temporary files were committed.
- [x] Hardware safety implications were considered.
- [x] Breaking changes are clearly identified.
