### PR TITLE
fix: merge redundant Info and Image tabs

### DIFF
--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -52,7 +52,6 @@ import {
 import {
   AssemblyPanel,
   BomPanel,
-  ChatNamespaceSummaryPanel,
   MechanicalPanel,
   OverviewPanel,
 } from "./blueprint-workspace/project-detail-panels";
@@ -1369,8 +1368,7 @@ type ImageGenerationConfig = {
 };
 
 const workspaceTabs = [
-  { id: "chat", label: "INFO", icon: Info },
-  { id: "overview", label: "IMAGE", icon: Eye },
+  { id: "overview", label: "INFO", icon: Info },
   { id: "bom", label: "BOM", icon: ShoppingBag },
   { id: "mechanical", label: "MECH", icon: Box },
   { id: "schematic", label: "WIRE", icon: Cpu },
@@ -1379,8 +1377,7 @@ const workspaceTabs = [
 ];
 
 const workspaceTabNamespaces: Record<string, string> = {
-  overview: "product.visuals",
-  chat: "project.chat",
+  overview: "product.overview",
   bom: "product.bom",
   mechanical: "product.mech",
   schematic: "product.electrical",
@@ -1393,6 +1390,9 @@ const workspaceTabNamespaces: Record<string, string> = {
 function normalizeTab(tab: string | null) {
   if (!tab) return null;
   const aliases: Record<string, string> = {
+    chat: "overview",
+    concept: "overview",
+    info: "overview",
     image: "overview",
     mech: "mechanical",
     wire: "schematic",
@@ -1404,7 +1404,7 @@ function normalizeTab(tab: string | null) {
 
 function workspaceTabMeta(tab: string | null) {
   const normalized = normalizeTab(tab);
-  return workspaceTabs.find((item) => item.id === normalized) || workspaceTabs.find((item) => item.id === "chat") || workspaceTabs[0];
+  return workspaceTabs.find((item) => item.id === normalized) || workspaceTabs[0];
 }
 
 function workspaceNamespaceForTab(tab: string | null) {
@@ -1462,21 +1462,6 @@ function formatDurationSeconds(value: any) {
   if (hours) return `${hours}h ${minutes}m ${remainingSeconds}s`;
   if (minutes) return `${minutes}m ${remainingSeconds}s`;
   return `${remainingSeconds}s`;
-}
-
-function formatTotalGenerationTime(metadata: Record<string, any> = {}) {
-  const explicitSeconds =
-    metadata.total_generation_time_seconds ??
-    metadata.total_generation_duration_seconds ??
-    metadata.generation_duration_seconds ??
-    metadata.duration_seconds;
-  const formatted = formatDurationSeconds(explicitSeconds);
-  if (formatted !== "-") return formatted;
-  const derivedSeconds = durationSecondsBetween(
-    metadata.total_generation_started_at || metadata.generation_started_at || metadata.started_at,
-    metadata.total_generation_completed_at || metadata.generation_completed_at || metadata.completed_at
-  );
-  return formatDurationSeconds(derivedSeconds);
 }
 
 function projectIdFromIR(ir: any) {
@@ -1559,7 +1544,7 @@ export function FormaWorkspace({
   const [projectChatInput, setProjectChatInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [activeGeneration, setActiveGeneration] = useState<ActiveGenerationState | null>(null);
-  const [activeTab, setActiveTab] = useState("chat");
+  const [activeTab, setActiveTab] = useState("overview");
   const [projectIR, setProjectIR] = useState<any>(null);
   const [projectHistory, setProjectHistory] = useState<any[]>([]);
   const [myProjectHistory, setMyProjectHistory] = useState<any[]>([]);
@@ -2107,7 +2092,7 @@ export function FormaWorkspace({
     setSelectedImage(null);
     setChatRouteTransition(null);
     setProjectIR(null);
-    setActiveTab("chat");
+    setActiveTab("overview");
   };
 
   const goHome = () => {
@@ -2116,7 +2101,7 @@ export function FormaWorkspace({
     } else {
       setChatRouteTransition(null);
       setProjectIR(null);
-      setActiveTab("chat");
+      setActiveTab("overview");
     }
     router.push("/");
   };
@@ -2133,7 +2118,7 @@ export function FormaWorkspace({
       return;
     }
     setActiveChatId(item.chatId);
-    setActiveTab("chat");
+    setActiveTab("overview");
     const storedMessages = readStoredChatThread(item.chatId, null, chatStorageScope);
     if (storedMessages.length) {
       setChatThreads((current) => ({ ...current, [item.chatId]: storedMessages }));
@@ -2160,7 +2145,7 @@ export function FormaWorkspace({
       return;
     }
     setActiveChatId(chatId);
-    setActiveTab("chat");
+    setActiveTab("overview");
     setChatRouteTransition({
       chatId,
       title: "Opening chat",
@@ -2588,7 +2573,7 @@ export function FormaWorkspace({
 
 
   useEffect(() => {
-    if (!normalizeTab(activeTab)) setActiveTab("chat");
+    if (!normalizeTab(activeTab)) setActiveTab("overview");
   }, [activeTab]);
 
 
@@ -3215,7 +3200,7 @@ export function FormaWorkspace({
       if (progressPollId !== null) window.clearInterval(progressPollId);
       if (generatedProject) {
         setSelectedImage(null);
-        setActiveTab("chat");
+        setActiveTab("overview");
       }
       if (generatedProjectId) {
         refreshProjectAndChatLists();
@@ -3243,7 +3228,7 @@ export function FormaWorkspace({
 
     const sourceProjectId = currentProjectId;
     const sourceChatId = currentProjectChatId || activeChatId || newBuildChatId();
-    const targetNamespace = activeTab === "chat" ? null : workspaceNamespaceForTab(activeTab);
+    const targetNamespace = activeTab === "overview" ? null : workspaceNamespaceForTab(activeTab);
     const generationRun = beginGenerationRun("project-chat", sourceChatId);
     setActiveChatId(sourceChatId);
     rememberChatItem({
@@ -3444,7 +3429,7 @@ export function FormaWorkspace({
       if (options.hydrateChat && canChatWithProjectIR(ir)) {
         ensureChatThread(projectId, ir, data.prompt);
       }
-      setActiveTab(normalizeTab(options.tab || "") || "chat");
+      setActiveTab(normalizeTab(options.tab || "") || "overview");
       if (shouldSyncRoute) syncProjectRoute(projectId);
       return true;
     } catch (error) {
@@ -3485,7 +3470,7 @@ export function FormaWorkspace({
         if (canChatWithProjectIR(ir)) {
           ensureChatThread(inlineChatProjectId, ir, data.prompt);
         }
-        setActiveTab("chat");
+        setActiveTab("overview");
       } catch (error) {
         if (controller.signal.aborted) return;
         if (attempt < 4) {
@@ -3555,7 +3540,7 @@ export function FormaWorkspace({
       ? readStoredChatThread(chatId, null, chatStorageScope)
       : [];
     setActiveChatId(chatId);
-    setActiveTab("chat");
+    setActiveTab("overview");
     setRouteProjectError(null);
     if (storedMessages.length) {
       setChatThreads((current) => ({ ...current, [chatId]: storedMessages }));
@@ -3627,7 +3612,7 @@ export function FormaWorkspace({
         return;
       }
       setProjectIR(null);
-      setActiveTab("chat");
+      setActiveTab("overview");
       const nextMessages = messagesWithoutMissingProject(
         storedMessages.length ? storedMessages : initialChatMessages(),
         routedChatProjectId
@@ -3868,9 +3853,7 @@ export function FormaWorkspace({
   );
   const activeWorkspaceTab = workspaceTabMeta(activeTab);
   const activeWorkspaceNamespace = workspaceNamespaceForTab(activeTab);
-  const displayedWorkspaceNamespace = routedProjectId && activeWorkspaceTab.id === "chat"
-    ? "project.overview"
-    : activeWorkspaceNamespace;
+  const displayedWorkspaceNamespace = activeWorkspaceNamespace;
   const projectNamespaceContent = (() => {
     switch (activeWorkspaceTab.id) {
       case "overview":
@@ -3954,20 +3937,8 @@ export function FormaWorkspace({
             pollIntervalMs={LOG_POLL_INTERVAL_MS}
           />
         ) : null;
-      case "chat":
       default:
-        return (
-          <ChatNamespaceSummaryPanel
-            projectId={currentProjectId}
-            title={projectTitle}
-            description={projectDescription}
-            namespace={displayedWorkspaceNamespace}
-            totalGenerationTime={formatTotalGenerationTime(projectIR?.assembly_metadata || {})}
-            components={components}
-            metrics={metrics}
-            issues={issues}
-          />
-        );
+        return null;
     }
   })();
 

--- a/apps/web/app/blueprint-workspace/project-detail-panels.tsx
+++ b/apps/web/app/blueprint-workspace/project-detail-panels.tsx
@@ -13,7 +13,6 @@ import {
   Download,
   ExternalLink,
   Eye,
-  Info,
   Monitor,
   Printer,
   RefreshCw,
@@ -23,7 +22,6 @@ import {
   Wrench,
 } from "lucide-react";
 
-import { JobMetric } from "./admin-panels";
 import { type ProjectImageCandidate } from "./project-gallery";
 
 const RUNPOD_PARTI_BASE_MODEL = "caid-technologies/parti-base";
@@ -596,94 +594,6 @@ export function AssemblyPanel({
           )}
         </div>
       </div>
-    </div>
-  );
-}
-
-export function ChatNamespaceSummaryPanel({
-  projectId,
-  title,
-  description,
-  namespace,
-  totalGenerationTime,
-  components,
-  metrics,
-  issues,
-}: {
-  projectId: string | null;
-  title: string;
-  description: string;
-  namespace: string;
-  totalGenerationTime: string;
-  components: any[];
-  metrics: ReturnType<typeof emptyMetrics>;
-  issues: any[];
-}) {
-  const topComponents = components.slice(0, 8);
-  return (
-    <div className="h-full min-w-0 overflow-y-auto overflow-x-hidden bg-[#141519] p-4 sm:p-6">
-      <section className="border border-[#2a2c33] bg-[#17181d] p-4 sm:p-5">
-        <div className="flex flex-col gap-3 border-b border-[#2a2c33] pb-4 sm:flex-row sm:items-start sm:justify-between">
-          <div className="min-w-0">
-            <div className="flex items-center gap-2">
-              <Info className="h-4 w-4 text-cyan-300" />
-              <h2 className="truncate text-sm font-black uppercase tracking-[0.16em] text-white">Info</h2>
-            </div>
-            <p className="mt-2 break-words text-sm leading-6 text-slate-400">{description}</p>
-          </div>
-          <div className="shrink-0 border border-cyan-300/30 bg-cyan-300/10 px-3 py-2 font-mono text-[11px] text-cyan-100">
-            {namespace}
-          </div>
-        </div>
-
-        <div className="mt-4 grid gap-2 text-[11px] sm:grid-cols-2 xl:grid-cols-5">
-          <JobMetric label="Project" value={projectId || "-"} />
-          <JobMetric label="Title" value={title} />
-          <JobMetric label="Parts" value={metrics.totalParts} />
-          <JobMetric label="Total Generation Time" value={totalGenerationTime} />
-          <JobMetric label="Validation" value={issues.length ? `${issues.length} issues` : "approved"} />
-        </div>
-
-        <div className="mt-5 border border-[#2a2c33] bg-[#141519] p-4">
-          <div className="text-[10px] font-black uppercase tracking-[0.16em] text-slate-500">Project Components</div>
-          {topComponents.length ? (
-            <div className="mt-3 grid gap-2 sm:grid-cols-2">
-              {topComponents.map((component, index) => {
-                const tone = categoryTone[component.category?.toLowerCase()] || categoryTone.default;
-                const Icon = iconForCategory(component.category);
-                return (
-                  <div key={`${component.ref_des || component.name}-${index}`} className="flex min-w-0 items-center gap-2 border border-[#25272e] bg-black/20 px-3 py-2">
-                    <Icon className={`h-4 w-4 shrink-0 ${tone.text}`} />
-                    <span className="truncate text-xs font-bold text-slate-300">{component.ref_des ? `${component.ref_des} ` : ""}{component.name || component.part_number || "Component"}</span>
-                  </div>
-                );
-              })}
-            </div>
-          ) : (
-            <div className="mt-3 border border-[#25272e] bg-black/20 p-3 text-xs leading-5 text-slate-500">
-              No components attached to this project yet.
-            </div>
-          )}
-        </div>
-
-        <div className="mt-5 grid gap-3 sm:grid-cols-3">
-          <div className="border border-[#2a2c33] bg-[#141519] p-4">
-            <div className="text-[10px] font-black uppercase tracking-[0.16em] text-slate-500">Electrical</div>
-            <div className="mt-2 text-xl font-black text-white">{metrics.electricalParts}</div>
-            <div className="mt-1 text-xs text-slate-500">~${metrics.electricalCost.toFixed(2)}</div>
-          </div>
-          <div className="border border-[#2a2c33] bg-[#141519] p-4">
-            <div className="text-[10px] font-black uppercase tracking-[0.16em] text-slate-500">Mechanical</div>
-            <div className="mt-2 text-xl font-black text-white">{metrics.mechanicalParts}</div>
-            <div className="mt-1 text-xs text-slate-500">~${metrics.mechanicalCost.toFixed(2)}</div>
-          </div>
-          <div className="border border-[#2a2c33] bg-[#141519] p-4">
-            <div className="text-[10px] font-black uppercase tracking-[0.16em] text-slate-500">Total Cost</div>
-            <div className="mt-2 text-xl font-black text-white">~${metrics.totalCost.toFixed(2)}</div>
-            <div className="mt-1 text-xs text-slate-500">{metrics.totalParts} parts</div>
-          </div>
-        </div>
-      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- merge the redundant Info and Image tabs into one Info workspace view
- reuse the existing image overview so both exterior and interior images, descriptions, features, and cost summaries remain available
- keep legacy `chat`, `info`, `image`, and `concept` tab links compatible
- preserve general project chat behavior from the merged overview

## Verification

- `npm run lint` (passes with existing image-element warnings)
- `npx tsc --noEmit`
- `npm run build`
- `.venv/bin/python -m unittest tests.providers.test_image_providers tests.projects.test_project_output tests.api.test_project_summary` (20 tests)

Fixes #153