### PR TITLE
fix: replace Wi-Fi icon with connection status dot

### DIFF
--- a/apps/web/app/blueprint-workspace/sidebar.tsx
+++ b/apps/web/app/blueprint-workspace/sidebar.tsx
@@ -16,12 +16,11 @@ import {
   RefreshCw,
   Settings,
   Terminal,
-  Wifi,
-  WifiOff,
   X,
 } from "lucide-react";
 
 import { FormaUserButton, useFormaAuth } from "../../lib/forma-auth";
+import { connectionStatusPresentation, type ServerConnectionStatus } from "../../lib/connection-status";
 
 export type ChatListItem = {
   chatId: string;
@@ -38,35 +37,39 @@ function formatSidebarDate(value: string | null) {
   return date.toLocaleDateString([], { month: "short", day: "numeric" });
 }
 
+function ApiConnectionStatus({ status }: { status: ServerConnectionStatus }) {
+  const presentation = connectionStatusPresentation(status);
+  const accessibleLabel = `API ${presentation.label.toLowerCase()}`;
+
+  return (
+    <span
+      className="inline-flex shrink-0 items-center"
+      role="status"
+      aria-live="polite"
+      aria-label={accessibleLabel}
+      title={accessibleLabel}
+    >
+      <span className={`inline-flex h-2.5 w-2.5 shrink-0 rounded-full ${presentation.dotClassName}`} aria-hidden="true" />
+    </span>
+  );
+}
+
 export function MobileWorkspaceBar({
   onOpenSidebar,
   serverStatus = "disconnected",
   authRequired,
 }: {
   onOpenSidebar: () => void;
-  serverStatus?: "connected" | "disconnected";
+  serverStatus?: ServerConnectionStatus;
   authRequired: boolean;
 }) {
-  const ApiStatusIcon = serverStatus === "connected" ? Wifi : WifiOff;
-  const apiStatusLabel = serverStatus === "connected" ? "API connected" : "API disconnected";
-  const apiStatusTone =
-    serverStatus === "connected"
-      ? "border-emerald-500/30 bg-emerald-950/20 text-emerald-300"
-      : "border-orange-500/30 bg-orange-950/20 text-orange-300";
-
   return (
     <header className="fixed inset-x-0 top-0 z-40 flex h-12 shrink-0 items-center gap-3 border-b border-[#292b31] bg-[#141519] px-3 md:hidden">
       <MobileSidebarButton onClick={onOpenSidebar} />
       <div className="min-w-0 flex flex-1 items-center gap-2">
         <span className="truncate text-sm font-black uppercase tracking-[0.22em] text-white">Forma</span>
       </div>
-      <span
-        className={`inline-flex h-8 w-8 shrink-0 items-center justify-center border ${apiStatusTone}`}
-        title={apiStatusLabel}
-        aria-label={apiStatusLabel}
-      >
-        <ApiStatusIcon className="h-4 w-4" />
-      </span>
+      <ApiConnectionStatus status={serverStatus} />
       <AuthStatusControl authRequired={authRequired} compact />
     </header>
   );
@@ -223,17 +226,11 @@ export function ChatSidebar({
   jobsPending?: boolean;
   showDeveloperTools: boolean;
   authRequired: boolean;
-  serverStatus?: "connected" | "disconnected";
+  serverStatus?: ServerConnectionStatus;
   mode?: "desktop" | "drawer";
 }) {
   const isDrawer = mode === "drawer";
   const compact = !isDrawer && collapsed;
-  const ApiStatusIcon = serverStatus === "connected" ? Wifi : WifiOff;
-  const apiStatusLabel = serverStatus === "connected" ? "API connected" : "API disconnected";
-  const apiStatusTone =
-    serverStatus === "connected"
-      ? "border-emerald-500/30 bg-emerald-950/20 text-emerald-300"
-      : "border-orange-500/30 bg-orange-950/20 text-orange-300";
 
   return (
     <aside
@@ -268,13 +265,7 @@ export function ChatSidebar({
           {!compact && (
             <div className="min-w-0 flex items-center gap-2">
               <span className="truncate text-sm font-black uppercase tracking-[0.22em] text-white">Forma</span>
-              <span
-                className={`inline-flex h-7 w-7 shrink-0 items-center justify-center border ${apiStatusTone}`}
-                title={apiStatusLabel}
-                aria-label={apiStatusLabel}
-              >
-                <ApiStatusIcon className="h-3.5 w-3.5" />
-              </span>
+              <ApiConnectionStatus status={serverStatus} />
               <AuthStatusControl authRequired={authRequired} />
             </div>
           )}

--- a/apps/web/lib/connection-status.ts
+++ b/apps/web/lib/connection-status.ts
@@ -1,0 +1,19 @@
+export type ServerConnectionStatus = "connected" | "disconnected";
+
+const CONNECTION_STATUS_PRESENTATION = {
+  connected: {
+    label: "Connected",
+    dotClassName: "bg-emerald-400",
+  },
+  disconnected: {
+    label: "Disconnected",
+    dotClassName: "bg-orange-400",
+  },
+} as const satisfies Record<ServerConnectionStatus, {
+  label: string;
+  dotClassName: string;
+}>;
+
+export function connectionStatusPresentation(status: ServerConnectionStatus) {
+  return CONNECTION_STATUS_PRESENTATION[status];
+}

--- a/apps/web/test/connection-status.test.ts
+++ b/apps/web/test/connection-status.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { connectionStatusPresentation } from "../lib/connection-status";
+
+test("connected status uses a green dot and accessible label", () => {
+  const presentation = connectionStatusPresentation("connected");
+
+  assert.equal(presentation.label, "Connected");
+  assert.match(presentation.dotClassName, /emerald/);
+});
+
+test("disconnected status uses an orange warning dot and accessible label", () => {
+  const presentation = connectionStatusPresentation("disconnected");
+
+  assert.equal(presentation.label, "Disconnected");
+  assert.match(presentation.dotClassName, /orange/);
+});


### PR DESCRIPTION
## Summary
- remove the Wi-Fi/Wi-Fi-off glyphs from desktop and mobile status controls
- show only a static green dot when connected or static orange dot when disconnected
- keep status text out of the visible UI while retaining screen-reader labels and hover tooltips
- remove all connection-dot animation
- add focused tests for connected and disconnected presentation

## Validation
- `npx --yes tsx --test test/connection-status.test.ts`
- `npm run lint` (passes with existing image warnings)
- `npx tsc --noEmit`
- `npm run build`

Closes #166
Related to #98