### PR TITLE
Fix human context checkpoint skip flow

### DIFF
--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -14,6 +14,10 @@ import { buildProjectDocsMarkdown, docsExportFilename } from "../lib/docs-export
 import { deploymentComposerDefaults } from "../lib/deployment-composer-defaults";
 import { useFormaAuth } from "../lib/forma-auth";
 import {
+  humanContextDefaultsChatSummary,
+  humanContextDefaultsPromptSection,
+} from "../lib/human-context-defaults";
+import {
   useAdminSession,
   useBackendLogs,
   useJobs,
@@ -1054,18 +1058,6 @@ function messagesWithoutMissingProject(messages: ChatMessage[], projectId: strin
     projectId: null,
   };
   return [...normalizedMessages, noticeMessage].slice(-MAX_PROJECT_CHAT_MESSAGES);
-}
-
-function automaticHumanContextPromptSection(basePrompt: string) {
-  const inferredQuestions = humanContextQuestionsForPrompt(basePrompt);
-  return [
-    basePrompt,
-    "",
-    "HUMAN-IN-THE-LOOP CONTEXT:",
-    "- User submitted this from the chat interface; generate the project immediately.",
-    "- Missing human context should be recorded as unspecified in project docs, not invented.",
-    ...inferredQuestions.map((question) => `- ${question.label}: not specified at creation time; preserve as an explicit open question if it affects safety, wiring, materials, or validation.`),
-  ].join("\n");
 }
 
 function humanContextQuestionsForPrompt(promptText: string): HumanContextQuestion[] {
@@ -2920,6 +2912,10 @@ export function FormaWorkspace({
       return;
     }
     const contextCheckpoint = pendingHumanContext;
+    const submitter = (event.nativeEvent as SubmitEvent).submitter as HTMLButtonElement | null;
+    const useHumanContextDefaults = Boolean(
+      contextCheckpoint && submitter?.name === "humanContextAction" && submitter.value === "use-defaults"
+    );
     const validationSubject = contextCheckpoint ? contextCheckpoint.basePrompt : prompt;
     const validation = validateGenerationInput(validationSubject, Boolean(selectedImage));
     if (!validation.isValid) {
@@ -3011,10 +3007,14 @@ export function FormaWorkspace({
 
     const finalContextNotes = contextCheckpoint ? prompt.trim() : "";
     const promptText = contextCheckpoint
-      ? humanContextPromptSection(contextCheckpoint, finalContextNotes)
+      ? useHumanContextDefaults
+        ? humanContextDefaultsPromptSection(contextCheckpoint.basePrompt, contextCheckpoint.questions, finalContextNotes)
+        : humanContextPromptSection(contextCheckpoint, finalContextNotes)
       : rawPromptText;
     const userMessageContent = contextCheckpoint
-      ? humanContextChatSummary(contextCheckpoint, finalContextNotes)
+      ? useHumanContextDefaults
+        ? humanContextDefaultsChatSummary(contextCheckpoint.questions, finalContextNotes)
+        : humanContextChatSummary(contextCheckpoint, finalContextNotes)
       : rawPromptText;
     let generatedProject = false;
     let generatedProjectId: string | null = null;

--- a/apps/web/app/blueprint-workspace/home-chat-view.tsx
+++ b/apps/web/app/blueprint-workspace/home-chat-view.tsx
@@ -190,7 +190,7 @@ export default function HomeChatView({
                   <Info className="h-3.5 w-3.5" />
                   Human Context Checkpoint
                 </div>
-                <div className="min-w-0 break-anywhere text-xs leading-5 text-slate-500">Answer what matters. Blank answers are recorded as unspecified.</div>
+                <div className="min-w-0 break-anywhere text-xs leading-5 text-slate-500">Optional: answer what matters, or use safe prototype defaults.</div>
               </div>
               <div className="break-anywhere mt-3 max-h-24 overflow-y-auto border border-[#2c2f37] bg-[#0f1014] px-3 py-2 text-xs leading-5 text-slate-400">
                 {pendingContext.basePrompt}
@@ -229,6 +229,16 @@ export default function HomeChatView({
                 >
                   {isLoading ? <RefreshCw className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
                   Build with context
+                </button>
+                <button
+                  type="submit"
+                  name="humanContextAction"
+                  value="use-defaults"
+                  disabled={isLoading || !generationReady}
+                  className="inline-flex h-10 items-center justify-center gap-2 border border-cyan-300/40 px-4 text-xs font-black uppercase text-cyan-100 hover:bg-cyan-300 hover:text-black disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <ArrowRight className="h-4 w-4" />
+                  Skip — use defaults
                 </button>
                 <button
                   type="button"

--- a/apps/web/lib/human-context-defaults.ts
+++ b/apps/web/lib/human-context-defaults.ts
@@ -1,0 +1,65 @@
+export type HumanContextQuestionForDefaults = {
+  id: string;
+  label: string;
+};
+
+const DEFAULT_ANSWERS: Record<string, string> = {
+  sample_assay: "Use a non-hazardous, research-only demonstration sample; keep the exact assay as an explicit open choice.",
+  instrumentation: "Use the simplest non-hazardous detection method compatible with the requested function.",
+  validation: "Start with bench safety, core-function, and repeatability checks, plus leak testing when fluids are involved.",
+  environment: "Assume an indoor bench prototype unless the request explicitly names another environment.",
+  motion_power: "Use low-voltage, low-force actuation with a manual release and no mains voltage.",
+  success: "Safely demonstrate the requested core function and document any missing quantitative targets as open choices.",
+  controller_modules: "Choose common, compatible, readily available modules that minimize wiring and integration risk.",
+  power: "Use a safe low-voltage USB-C 5 V supply and no mains voltage unless the request requires another source.",
+  outputs: "Implement only requested outputs; otherwise include a simple status indicator for the core function.",
+  use_case: "Treat version one as an indoor bench prototype for technical evaluation.",
+  constraints: "Prefer safe low-voltage operation, readily available components, and a cost-conscious build.",
+  artifacts: "Prioritize buildability, clear wiring or materials, a BOM, assembly steps, and basic validation.",
+};
+
+export function humanContextDefaultAnswer(question: HumanContextQuestionForDefaults) {
+  if (question.label.trim().toLowerCase() === "artifacts") {
+    return DEFAULT_ANSWERS.artifacts;
+  }
+  return (
+    DEFAULT_ANSWERS[question.id] ||
+    `Use Forma's conservative prototype default for ${question.label.toLowerCase()} and document the choice.`
+  );
+}
+
+export function humanContextDefaultsPromptSection(
+  basePrompt: string,
+  questions: HumanContextQuestionForDefaults[],
+  finalNotes = "",
+) {
+  const contextLines = questions.map(
+    (question) => `- ${question.label}: ${humanContextDefaultAnswer(question)}`,
+  );
+  if (finalNotes.trim()) {
+    contextLines.push(`- Additional human notes: ${finalNotes.trim()}`);
+  }
+  return [
+    basePrompt,
+    "",
+    "HUMAN-IN-THE-LOOP CONTEXT:",
+    "- The user skipped optional clarification and asked Forma to apply these defaults:",
+    ...contextLines,
+    "",
+    "The original request takes precedence over these defaults. Keep any safety-critical uncertainty explicit in the project docs instead of inventing hidden constraints.",
+  ].join("\n");
+}
+
+export function humanContextDefaultsChatSummary(
+  questions: HumanContextQuestionForDefaults[],
+  finalNotes = "",
+) {
+  const lines = [
+    "Skipped questions and used Forma defaults:",
+    ...questions.map((question) => `- ${question.label}: ${humanContextDefaultAnswer(question)}`),
+  ];
+  if (finalNotes.trim()) {
+    lines.push(`- Additional notes: ${finalNotes.trim()}`);
+  }
+  return lines.join("\n");
+}

--- a/apps/web/test/human-context-defaults.test.ts
+++ b/apps/web/test/human-context-defaults.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  humanContextDefaultAnswer,
+  humanContextDefaultsChatSummary,
+  humanContextDefaultsPromptSection,
+} from "../lib/human-context-defaults";
+
+const electronicsQuestions = [
+  { id: "controller_modules", label: "Controller / Modules" },
+  { id: "power", label: "Power" },
+  { id: "outputs", label: "Outputs" },
+];
+
+test("skipped electronics questions get deterministic safe defaults", () => {
+  const prompt = humanContextDefaultsPromptSection("Build an Arduino button panel", electronicsQuestions);
+
+  assert.match(prompt, /common, compatible, readily available modules/);
+  assert.match(prompt, /USB-C 5 V/);
+  assert.match(prompt, /simple status indicator/);
+  assert.match(prompt, /original request takes precedence/i);
+  assert.doesNotMatch(prompt, /not specified/);
+});
+
+test("unknown clarifier questions receive a documented conservative default", () => {
+  assert.equal(
+    humanContextDefaultAnswer({ id: "custom", label: "Mounting" }),
+    "Use Forma's conservative prototype default for mounting and document the choice.",
+  );
+});
+
+test("the reused outputs id still gets an artifact default when labeled Artifacts", () => {
+  assert.match(
+    humanContextDefaultAnswer({ id: "outputs", label: "Artifacts" }),
+    /buildability, clear wiring or materials/,
+  );
+});
+
+test("the chat summary makes applied defaults visible to the user", () => {
+  const summary = humanContextDefaultsChatSummary(electronicsQuestions, "Use an Arduino Uno.");
+
+  assert.match(summary, /^Skipped questions and used Forma defaults:/);
+  assert.match(summary, /- Power: Use a safe low-voltage USB-C 5 V supply/);
+  assert.match(summary, /- Additional notes: Use an Arduino Uno\./);
+});


### PR DESCRIPTION
## Summary
- add an explicit **Skip — use defaults** action to the human context checkpoint
- apply documented, conservative defaults for skipped clarification questions
- preserve original prompt precedence and optional final notes
- show applied defaults in chat and cover the behavior with unit tests

## Verification
- `npx --yes tsx --test test/*.test.ts` (15 passed)
- `npx tsc --noEmit`
- `npm run build`

Closes #134