### PR TITLE
feat: add persistent light theme

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -4,6 +4,20 @@
 
 :root {
   color-scheme: dark;
+  --forma-page: #141519;
+  --forma-surface: #17181d;
+  --forma-surface-muted: #101115;
+  --forma-border: #2c2f37;
+  --forma-text: #f8fafc;
+}
+
+:root[data-theme="light"] {
+  color-scheme: light;
+  --forma-page: #eef2f7;
+  --forma-surface: #ffffff;
+  --forma-surface-muted: #f8fafc;
+  --forma-border: #cbd5e1;
+  --forma-text: #0f172a;
 }
 
 * {
@@ -16,8 +30,8 @@ body {
   width: 100%;
   max-width: 100%;
   overflow-x: hidden;
-  background: #141519;
-  color: #f8fafc;
+  background: var(--forma-page);
+  color: var(--forma-text);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   text-rendering: geometricPrecision;
 }
@@ -251,4 +265,164 @@ button:disabled {
 
 ::-webkit-scrollbar-thumb:hover {
   background: #5b606c;
+}
+
+/*
+ * The original interface uses a compact set of Tailwind color utilities.
+ * These overrides translate that existing palette to light surfaces while
+ * keeping semantic status colors and media overlays intact.
+ */
+html[data-theme="light"] [class~='bg-[#141519]'] {
+  background-color: var(--forma-page);
+}
+
+html[data-theme="light"] [class~='bg-[#141519]/95'] {
+  background-color: rgb(238 242 247 / 0.95);
+}
+
+html[data-theme="light"] [class~='bg-[#17181d]'],
+html[data-theme="light"] [class~='bg-[#15161b]'],
+html[data-theme="light"] [class~='bg-[#111216]'],
+html[data-theme="light"] [class~='bg-[#101116]'],
+html[data-theme="light"] [class~='bg-[#101115]'],
+html[data-theme="light"] [class~='bg-[#0f1014]'],
+html[data-theme="light"] [class~='bg-[#0f1013]'],
+html[data-theme="light"] [class~='bg-[#0f1720]'],
+html[data-theme="light"] [class~='bg-[#111820]'],
+html[data-theme="light"] [class~='bg-[#1d1f26]'],
+html[data-theme="light"] [class~='bg-[#1d2027]'],
+html[data-theme="light"] [class~='bg-[#20242d]'],
+html[data-theme="light"] [class~='bg-[#242832]'],
+html[data-theme="light"] [class~='bg-[#252832]'],
+html[data-theme="light"] [class~='bg-[#0c0d10]'],
+html[data-theme="light"] [class~='bg-[#050609]'],
+html[data-theme="light"] [class~="bg-black"] {
+  background-color: var(--forma-surface);
+}
+
+html[data-theme="light"] [class~='bg-[#101115]'],
+html[data-theme="light"] [class~='bg-[#0f1014]'] {
+  background-color: var(--forma-surface-muted);
+}
+
+html[data-theme="light"] [class~="text-white"],
+html[data-theme="light"] [class~="text-slate-100"] {
+  color: #0f172a;
+}
+
+html[data-theme="light"] [class~="text-slate-200"],
+html[data-theme="light"] [class~="text-slate-300"] {
+  color: #334155;
+}
+
+html[data-theme="light"] [class~="text-slate-400"] {
+  color: #475569;
+}
+
+html[data-theme="light"] [class~="text-slate-500"],
+html[data-theme="light"] [class~="text-slate-600"],
+html[data-theme="light"] [class~="text-slate-700"] {
+  color: #64748b;
+}
+
+html[data-theme="light"] [class~="text-cyan-50"],
+html[data-theme="light"] [class~="text-cyan-100"],
+html[data-theme="light"] [class~="text-cyan-200"],
+html[data-theme="light"] [class~="text-cyan-300"] {
+  color: #0e7490;
+}
+
+html[data-theme="light"] [class~="text-emerald-50"],
+html[data-theme="light"] [class~="text-emerald-100"],
+html[data-theme="light"] [class~="text-emerald-200"],
+html[data-theme="light"] [class~="text-emerald-300"] {
+  color: #047857;
+}
+
+html[data-theme="light"] [class~="text-amber-50"],
+html[data-theme="light"] [class~="text-amber-100"],
+html[data-theme="light"] [class~="text-amber-200"],
+html[data-theme="light"] [class~="text-amber-300"] {
+  color: #a16207;
+}
+
+html[data-theme="light"] [class~="text-red-100"],
+html[data-theme="light"] [class~="text-red-200"],
+html[data-theme="light"] [class~="text-red-300"],
+html[data-theme="light"] [class~="text-rose-100"],
+html[data-theme="light"] [class~="text-rose-200"],
+html[data-theme="light"] [class~="text-rose-300"] {
+  color: #be123c;
+}
+
+html[data-theme="light"] [class~="text-violet-100"],
+html[data-theme="light"] [class~="text-violet-200"],
+html[data-theme="light"] [class~="text-violet-300"],
+html[data-theme="light"] [class~="text-fuchsia-200"],
+html[data-theme="light"] [class~="text-fuchsia-300"] {
+  color: #7e22ce;
+}
+
+html[data-theme="light"] [class~='border-[#24262c]'],
+html[data-theme="light"] [class~='border-[#242832]'],
+html[data-theme="light"] [class~='border-[#25272e]'],
+html[data-theme="light"] [class~='border-[#282a30]'],
+html[data-theme="light"] [class~='border-[#292b31]'],
+html[data-theme="light"] [class~='border-[#2a2c33]'],
+html[data-theme="light"] [class~='border-[#2b3038]'],
+html[data-theme="light"] [class~='border-[#2c2f37]'],
+html[data-theme="light"] [class~='border-[#2f333c]'],
+html[data-theme="light"] [class~='border-[#30323a]'],
+html[data-theme="light"] [class~='border-[#30333b]'],
+html[data-theme="light"] [class~='border-[#30333d]'],
+html[data-theme="light"] [class~='border-[#30343d]'],
+html[data-theme="light"] [class~='border-[#333640]'],
+html[data-theme="light"] [class~='border-[#333844]'],
+html[data-theme="light"] [class~='border-[#34363f]'],
+html[data-theme="light"] [class~='border-[#343740]'],
+html[data-theme="light"] [class~='border-[#3a3d46]'],
+html[data-theme="light"] [class~='border-[#4b4d56]'] {
+  border-color: var(--forma-border);
+}
+
+html[data-theme="light"] [class~="bg-white"][class~="text-black"] {
+  background-color: #0f172a;
+  color: #ffffff;
+}
+
+html[data-theme="light"] [class~="hover:bg-white"]:hover {
+  background-color: #0f172a;
+}
+
+html[data-theme="light"] [class~="hover:text-black"]:hover,
+html[data-theme="light"] [class~="group-hover:text-black"]:where(.group:hover *) {
+  color: #ffffff;
+}
+
+html[data-theme="light"] .schematic-card,
+html[data-theme="light"] .schematic-controller-card {
+  background: #ffffff;
+  color: #0f172a;
+  box-shadow: 0 18px 38px rgb(15 23 42 / 0.12);
+}
+
+html[data-theme="light"] .schematic-pin-row {
+  border-color: #cbd5e1;
+  background: #f8fafc;
+}
+
+html[data-theme="light"] .react-flow__controls-button {
+  background: #ffffff !important;
+  border-bottom-color: #cbd5e1 !important;
+  color: #334155 !important;
+  fill: #334155 !important;
+}
+
+html[data-theme="light"] ::-webkit-scrollbar-track {
+  background: #eef2f7;
+}
+
+html[data-theme="light"] ::-webkit-scrollbar-thumb {
+  background: #94a3b8;
+  border-color: #eef2f7;
 }

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { ClerkProvider } from "@clerk/nextjs";
 import { blueprintAuthMode } from "../lib/auth-mode";
 import { FormaAuthProvider } from "../lib/forma-auth";
+import { themeBootstrapScript } from "../lib/theme";
+import { ThemeProvider } from "../lib/theme-provider";
 import "./globals.css";
 
 export const dynamic = "force-dynamic";
@@ -18,9 +20,14 @@ export default function RootLayout({
 }>) {
   const authMode = blueprintAuthMode();
   const document = (
-    <html lang="en">
+    <html lang="en" data-theme="dark" suppressHydrationWarning>
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeBootstrapScript }} />
+      </head>
       <body data-auth-mode={authMode} data-auth-required={authMode === "clerk" ? "true" : "false"}>
-        <FormaAuthProvider mode={authMode}>{children}</FormaAuthProvider>
+        <ThemeProvider>
+          <FormaAuthProvider mode={authMode}>{children}</FormaAuthProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/apps/web/app/user/user-integrations-page.tsx
+++ b/apps/web/app/user/user-integrations-page.tsx
@@ -9,11 +9,14 @@ import {
   ChevronDown,
   FlaskConical,
   KeyRound,
+  Moon,
+  Palette,
   RefreshCw,
   Save,
   Search,
   ShieldCheck,
   SlidersHorizontal,
+  Sun,
   Trash2,
 } from "lucide-react";
 import {
@@ -24,6 +27,7 @@ import {
   type ProviderModelOption,
 } from "../../lib/provider-model-catalog";
 import { useFormaAuth } from "../../lib/forma-auth";
+import { useTheme } from "../../lib/theme-provider";
 
 const DEFAULT_API_URL = process.env.NODE_ENV === "development" ? "http://localhost:8000" : "";
 const API_URL = normalizeApiUrl(process.env.NEXT_PUBLIC_API_URL || process.env.NEXT_PUBLIC_BACKEND_URL || DEFAULT_API_URL);
@@ -1175,6 +1179,90 @@ function ImageModelTestPanel({
   );
 }
 
+function ThemeSettingsPanel() {
+  const { theme, setTheme } = useTheme();
+  const options = [
+    {
+      id: "light" as const,
+      label: "Light",
+      description: "Bright surfaces with dark text for daytime and high-ambient-light use.",
+      icon: Sun,
+      previewStyle: { backgroundColor: "#f8fafc", borderColor: "#cbd5e1", color: "#1e293b" },
+    },
+    {
+      id: "dark" as const,
+      label: "Dark",
+      description: "Low-luminance surfaces with light text for focused or low-light use.",
+      icon: Moon,
+      previewStyle: { backgroundColor: "#111216", borderColor: "#343740", color: "#f1f5f9" },
+    },
+  ];
+
+  return (
+    <article className="border border-[#2c2f37] bg-[#17181d]">
+      <div className="border-b border-[#2c2f37] p-5">
+        <div className="flex flex-wrap items-center gap-2">
+          <Palette className="h-5 w-5 text-cyan-300" />
+          <h2 className="text-xl font-black uppercase tracking-wide text-white">Appearance</h2>
+          <span className="border border-cyan-300/30 bg-cyan-300/10 px-2 py-1 text-[10px] font-black uppercase text-cyan-200">
+            Browser preference
+          </span>
+        </div>
+        <p className="mt-3 max-w-3xl text-sm leading-6 text-slate-400">
+          Choose how Forma looks in this browser. Changes apply immediately across the workspace.
+        </p>
+      </div>
+
+      <div className="grid gap-5 p-5">
+        <section className="border border-[#2c2f37] bg-[#101115] p-4 sm:p-5">
+          <div>
+            <h3 className="text-sm font-black uppercase tracking-wide text-white">Theme</h3>
+            <p className="mt-2 text-xs leading-5 text-slate-500">
+              Your selection is saved automatically on this device and restored before the interface loads.
+            </p>
+          </div>
+
+          <div className="mt-5 grid gap-3 sm:grid-cols-2" role="radiogroup" aria-label="Color theme">
+            {options.map((option) => {
+              const Icon = option.icon;
+              const selected = theme === option.id;
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  onClick={() => setTheme(option.id)}
+                  className={`min-w-0 border p-4 text-left transition ${
+                    selected
+                      ? "border-cyan-300 bg-cyan-300/10"
+                      : "border-[#2c2f37] bg-[#141519] hover:border-slate-500"
+                  }`}
+                >
+                  <span className="flex h-20 items-center justify-center border" style={option.previewStyle} aria-hidden="true">
+                    <Icon className="h-7 w-7" />
+                  </span>
+                  <span className="mt-4 flex items-center justify-between gap-3">
+                    <span className="text-sm font-black uppercase tracking-wide text-white">{option.label}</span>
+                    <span className={`border px-2 py-1 text-[10px] font-black uppercase ${
+                      selected
+                        ? "border-cyan-300/40 bg-cyan-300/10 text-cyan-200"
+                        : "border-[#2c2f37] text-slate-500"
+                    }`}>
+                      {selected ? "Selected" : "Choose"}
+                    </span>
+                  </span>
+                  <span className="mt-2 block text-xs leading-5 text-slate-500">{option.description}</span>
+                </button>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+    </article>
+  );
+}
+
 export default function UserIntegrationsPage() {
   const { authRequired, getToken, hasIdentity, isLoaded, isSignedIn, openSignIn } = useFormaAuth();
   const [payload, setPayload] = useState<IntegrationsPayload | null>(null);
@@ -1207,8 +1295,10 @@ export default function UserIntegrationsPage() {
     [navigationGroups, selectedNavigationKey]
   );
 
+  const isAppearanceView = selectedNavigationKey === "appearance:theme";
   const isDataPrivacyView = selectedNavigationKey === "privacy:data-usage";
-  const selectedIntegration = isDataPrivacyView
+  const isLocalSettingsView = isAppearanceView || isDataPrivacyView;
+  const selectedIntegration = isLocalSettingsView
     ? null
     : selectedNavigationItem?.integration || payload?.integrations[0] || null;
   const selectedView = selectedNavigationItem?.view || "all";
@@ -1295,7 +1385,7 @@ export default function UserIntegrationsPage() {
       setForms(Object.fromEntries(data.integrations.map((integration) => [integration.id, formFromIntegration(integration)])));
       const availableNavigationItems = integrationNavigationGroups(data.integrations).flatMap((group) => group.items);
       setSelectedNavigationKey((current) =>
-        current === "privacy:data-usage" || availableNavigationItems.some((item) => item.key === current)
+        current === "appearance:theme" || current === "privacy:data-usage" || availableNavigationItems.some((item) => item.key === current)
           ? current
           : availableNavigationItems[0]?.key || "runtime:all"
       );
@@ -1589,11 +1679,11 @@ export default function UserIntegrationsPage() {
                 <h1 className="truncate text-lg font-black uppercase tracking-wide text-white">Settings</h1>
               </div>
               <p className="mt-1 text-xs leading-5 text-slate-500">
-                Provider credentials, model defaults, and account data preferences for your Forma workspace.
+                Appearance, provider credentials, model defaults, and account data preferences for your Forma workspace.
               </p>
             </div>
           </div>
-          {!isDataPrivacyView && (
+          {!isLocalSettingsView && (
             <button
               type="button"
               onClick={reloadRuntime}
@@ -1612,8 +1702,9 @@ export default function UserIntegrationsPage() {
           <div className="border border-[#2c2f37] bg-[#17181d] p-6 text-sm text-slate-500">Checking session...</div>
         </section>
       ) : !hasIdentity ? (
-        <section className="mx-auto w-full max-w-7xl px-4 py-5">
-          <div className="max-w-xl border border-[#2c2f37] bg-[#17181d] p-6">
+        <section className="mx-auto grid w-full max-w-7xl gap-5 px-4 py-5 lg:grid-cols-[minmax(0,1fr)_360px]">
+          <ThemeSettingsPanel />
+          <div className="h-fit border border-[#2c2f37] bg-[#17181d] p-6">
             <div className="inline-flex items-center gap-2 text-sm font-black uppercase tracking-wide text-white">
               <KeyRound className="h-4 w-4 text-cyan-300" />
               Sign in required
@@ -1661,6 +1752,24 @@ export default function UserIntegrationsPage() {
                 <p className="mt-2 text-[11px] leading-5 text-slate-500">Privacy and personal account preferences.</p>
               </div>
               <div className="p-3">
+                <div className="mb-2 border-l border-[#3a3d46] pl-3 text-[10px] font-black uppercase tracking-[0.18em] text-slate-500">
+                  Personalization
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setSelectedNavigationKey("appearance:theme")}
+                  className={`mb-4 block w-full border p-3 text-left transition ${
+                    isAppearanceView
+                      ? "border-cyan-300 bg-cyan-300/10"
+                      : "border-[#2c2f37] bg-[#141519] hover:border-slate-500"
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <span className="truncate text-sm font-black uppercase tracking-wide text-white">Appearance</span>
+                    <Palette className="h-4 w-4 shrink-0 text-cyan-300" />
+                  </div>
+                  <p className="mt-2 line-clamp-1 text-xs text-slate-500">Choose and save your light or dark theme.</p>
+                </button>
                 <div className="mb-2 border-l border-[#3a3d46] pl-3 text-[10px] font-black uppercase tracking-[0.18em] text-slate-500">
                   Data controls
                 </div>
@@ -1768,7 +1877,7 @@ export default function UserIntegrationsPage() {
             </div>
           )}
 
-          {!isDataPrivacyView && payload && selectedView === "image" && (
+          {!isLocalSettingsView && payload && selectedView === "image" && (
             <section className="mb-4 border border-cyan-300/40 bg-[#17181d] p-5">
               <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
                 <div className="min-w-0">
@@ -1801,7 +1910,9 @@ export default function UserIntegrationsPage() {
             </section>
           )}
 
-          {isDataPrivacyView ? (
+          {isAppearanceView ? (
+            <ThemeSettingsPanel />
+          ) : isDataPrivacyView ? (
             <article className="border border-[#2c2f37] bg-[#17181d]">
               <div className="border-b border-[#2c2f37] p-5">
                 <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/lib/theme-provider.tsx
+++ b/apps/web/lib/theme-provider.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
+import { normalizeTheme, THEME_STORAGE_KEY, type FormaTheme } from "./theme";
+
+type ThemeContextValue = {
+  theme: FormaTheme;
+  setTheme: (theme: FormaTheme) => void;
+};
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+function applyTheme(theme: FormaTheme) {
+  document.documentElement.dataset.theme = theme;
+  document.documentElement.style.colorScheme = theme;
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<FormaTheme>("dark");
+
+  const setTheme = useCallback((nextTheme: FormaTheme) => {
+    const normalizedTheme = normalizeTheme(nextTheme);
+    setThemeState(normalizedTheme);
+    applyTheme(normalizedTheme);
+    try {
+      window.localStorage.setItem(THEME_STORAGE_KEY, normalizedTheme);
+    } catch {
+      // The active theme still applies when storage is unavailable.
+    }
+  }, []);
+
+  useEffect(() => {
+    const initialTheme = normalizeTheme(document.documentElement.dataset.theme);
+    setThemeState(initialTheme);
+    applyTheme(initialTheme);
+
+    function syncTheme(event: StorageEvent) {
+      if (event.key !== THEME_STORAGE_KEY) return;
+      const nextTheme = normalizeTheme(event.newValue);
+      setThemeState(nextTheme);
+      applyTheme(nextTheme);
+    }
+
+    window.addEventListener("storage", syncTheme);
+    return () => window.removeEventListener("storage", syncTheme);
+  }, []);
+
+  const value = useMemo(() => ({ theme, setTheme }), [setTheme, theme]);
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme() {
+  const value = useContext(ThemeContext);
+  if (!value) throw new Error("useTheme must be used inside ThemeProvider.");
+  return value;
+}

--- a/apps/web/lib/theme.ts
+++ b/apps/web/lib/theme.ts
@@ -1,0 +1,19 @@
+export const THEME_STORAGE_KEY = "forma-theme";
+
+export type FormaTheme = "dark" | "light";
+
+export function normalizeTheme(value: unknown): FormaTheme {
+  return value === "light" ? "light" : "dark";
+}
+
+export const themeBootstrapScript = `
+  try {
+    var savedTheme = window.localStorage.getItem("${THEME_STORAGE_KEY}");
+    var theme = savedTheme === "light" ? "light" : "dark";
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.style.colorScheme = theme;
+  } catch (error) {
+    document.documentElement.dataset.theme = "dark";
+    document.documentElement.style.colorScheme = "dark";
+  }
+`;

--- a/apps/web/test/theme.test.ts
+++ b/apps/web/test/theme.test.ts
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { normalizeTheme, THEME_STORAGE_KEY } from "../lib/theme";
+
+test("theme preferences use a stable local storage key", () => {
+  assert.equal(THEME_STORAGE_KEY, "forma-theme");
+});
+
+test("theme preferences accept light and default every other value to dark", () => {
+  assert.equal(normalizeTheme("light"), "light");
+  assert.equal(normalizeTheme("dark"), "dark");
+  assert.equal(normalizeTheme(null), "dark");
+  assert.equal(normalizeTheme("system"), "dark");
+});


### PR DESCRIPTION
## Summary

- add app-wide light and dark themes with pre-hydration preference loading
- persist the selected theme in browser storage and synchronize changes across tabs
- add an accessible Appearance section to Settings, including signed-out access
- translate existing workspace, Settings, schematic, control, and status palettes for light mode

## Validation

- `npx tsc --noEmit`
- `npx tsx --test test/*.test.ts` (17 passed)
- `npm run build`
- visually smoke-tested Settings and the main workspace in dark and light themes

Closes #85