### PR TITLE
fix: use dark CAID logo in light mode

### DIFF
--- a/apps/web/app/about/page.tsx
+++ b/apps/web/app/about/page.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
-import Image from "next/image";
 import Link from "next/link";
 import { ArrowLeft, ArrowUpRight, Cpu, Handshake, ShieldCheck } from "lucide-react";
 import LegalFooter from "../../components/legal-footer";
+import CaidLogo from "../../components/caid-logo";
 import PartnerLogoMarquee from "../../components/partner-logo-marquee";
 import { legalContactEmail, legalEntityName } from "../../lib/legal-docs";
 import { aboutMarqueePartners } from "../../lib/partners";
@@ -25,15 +25,7 @@ export default function AboutPage() {
             Forma
           </Link>
           <div className="inline-flex h-11 items-center gap-2 border border-[#2c2f37] px-3 text-xs font-black uppercase tracking-widest text-slate-400">
-            <Image
-              src="/brand/caid-dark-logo-cropped.png"
-              alt=""
-              width={44}
-              height={24}
-              className="h-6 w-11 object-contain"
-              unoptimized
-              aria-hidden="true"
-            />
+            <CaidLogo className="h-6 w-11" sizes="44px" />
             About us
           </div>
         </div>

--- a/apps/web/app/blueprint-workspace/sidebar.tsx
+++ b/apps/web/app/blueprint-workspace/sidebar.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import Image from "next/image";
 import {
   Database,
   Handshake,
@@ -19,6 +18,7 @@ import {
   X,
 } from "lucide-react";
 
+import CaidLogo from "../../components/caid-logo";
 import { FormaUserButton, useFormaAuth } from "../../lib/forma-auth";
 import { connectionStatusPresentation, type ServerConnectionStatus } from "../../lib/connection-status";
 
@@ -252,15 +252,7 @@ export function ChatSidebar({
             aria-label="Home"
             title="Home"
           >
-            <Image
-              src="/brand/caid-dark-logo-cropped.png"
-              alt=""
-              width={36}
-              height={20}
-              className="h-5 w-9 object-contain"
-              unoptimized
-              aria-hidden="true"
-            />
+            <CaidLogo className="h-5 w-9" sizes="36px" />
           </button>
           {!compact && (
             <div className="min-w-0 flex items-center gap-2">

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -194,6 +194,18 @@ button:disabled {
   mask-image: linear-gradient(90deg, transparent, #000 10%, #000 90%, transparent);
 }
 
+.caid-logo-on-light {
+  display: none;
+}
+
+html[data-theme="light"] .caid-logo-on-dark {
+  display: none;
+}
+
+html[data-theme="light"] .caid-logo-on-light {
+  display: block;
+}
+
 .partner-logo-track {
   width: max-content;
   animation: partner-logo-scroll 32s linear infinite;

--- a/apps/web/components/caid-logo.tsx
+++ b/apps/web/components/caid-logo.tsx
@@ -1,0 +1,29 @@
+import Image from "next/image";
+
+type CaidLogoProps = {
+  className?: string;
+  sizes?: string;
+};
+
+export default function CaidLogo({ className = "h-5 w-9", sizes = "44px" }: CaidLogoProps) {
+  return (
+    <span className={`relative inline-block shrink-0 overflow-hidden align-middle ${className}`} aria-hidden="true">
+      <Image
+        src="/brand/caid-dark-logo-cropped.png"
+        alt=""
+        fill
+        sizes={sizes}
+        className="caid-logo-on-dark object-contain"
+        unoptimized
+      />
+      <Image
+        src="/brand/caid-logo.jpg"
+        alt=""
+        fill
+        sizes={sizes}
+        className="caid-logo-on-light object-cover"
+        unoptimized
+      />
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

- add a reusable theme-aware CAID logo component
- show the dark logo asset in light mode and the white logo asset in dark mode
- apply the logo swap to the workspace sidebar and About page without layout shift

## Testing

- npm run build
- npm run lint
- browser verification confirmed light theme selects the dark asset at the existing 36 x 20 sidebar dimensions

Closes #176