### PR TITLE
Define and persist DesignBrief v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ Tip: load an example directly with http://localhost:3000/?example=pocket_mp3_pla
 
 ## Documentation
 - [Architecture](docs/architecture.md)
+- [DesignBrief contract](docs/design-brief.md)
 - [Agents](docs/agents.md)
 - [Hardware IR](docs/hardware-ir.md)
 - [Validation](docs/validation.md)

--- a/apps/api/design_briefs_api.py
+++ b/apps/api/design_briefs_api.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Path, status
+
+from apps.api.auth import UserContext, require_user_context
+from blueprint_core.database import (
+    DesignBriefAccessError,
+    DesignBriefNotFoundError,
+    create_design_brief_version,
+    get_design_brief_version,
+    get_latest_design_brief,
+    list_design_brief_versions,
+)
+from blueprint_core.workspaces.design_briefs import (
+    DesignBrief,
+    DesignBriefCreate,
+    DesignBriefVersionList,
+)
+
+
+router = APIRouter(prefix="/projects/{project_id}/design-briefs", tags=["design-briefs"])
+
+
+def _owner_user_id(user_context: UserContext) -> str:
+    owner_user_id = str(user_context.owner_user_id or "").strip()
+    if not owner_user_id:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"code": "authentication_required", "message": "Sign in to manage design briefs."},
+        )
+    return owner_user_id
+
+
+def _not_found() -> HTTPException:
+    return HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail={"code": "design_brief_not_found", "message": "DesignBrief not found."},
+    )
+
+
+@router.post("", response_model=DesignBrief, status_code=status.HTTP_201_CREATED)
+def create_design_brief_endpoint(
+    project_id: UUID,
+    request: DesignBriefCreate,
+    user_context: UserContext = Depends(require_user_context),
+) -> DesignBrief:
+    try:
+        return create_design_brief_version(
+            str(project_id),
+            _owner_user_id(user_context),
+            request,
+        )
+    except DesignBriefAccessError as exc:
+        raise _not_found() from exc
+
+
+@router.get("", response_model=DesignBriefVersionList)
+def list_design_briefs_endpoint(
+    project_id: UUID,
+    user_context: UserContext = Depends(require_user_context),
+) -> DesignBriefVersionList:
+    versions = list_design_brief_versions(str(project_id), _owner_user_id(user_context))
+    return DesignBriefVersionList(project_id=project_id, versions=versions)
+
+
+@router.get("/latest", response_model=DesignBrief)
+def get_latest_design_brief_endpoint(
+    project_id: UUID,
+    user_context: UserContext = Depends(require_user_context),
+) -> DesignBrief:
+    try:
+        return get_latest_design_brief(str(project_id), _owner_user_id(user_context))
+    except DesignBriefNotFoundError as exc:
+        raise _not_found() from exc
+
+
+@router.get("/{brief_version}", response_model=DesignBrief)
+def get_design_brief_version_endpoint(
+    project_id: UUID,
+    brief_version: int = Path(ge=1),
+    user_context: UserContext = Depends(require_user_context),
+) -> DesignBrief:
+    try:
+        return get_design_brief_version(
+            str(project_id),
+            _owner_user_id(user_context),
+            brief_version,
+        )
+    except DesignBriefNotFoundError as exc:
+        raise _not_found() from exc

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -126,6 +126,7 @@ from blueprint_core.agents.video_correction import FireworksVideoSelfCorrectionA
 from blueprint_core.video_review import FireworksVideoReviewClient
 from apps.api.logs_api import router as logs_router
 from apps.api.streams_api import router as streams_router
+from apps.api.design_briefs_api import router as design_briefs_router
 from apps.api.user_integrations_api import router as user_integrations_router
 from apps.api.user_settings_api import router as user_settings_router
 from apps.api.auth import (
@@ -276,6 +277,7 @@ app.add_middleware(
 
 app.include_router(logs_router, dependencies=[Depends(require_admin_user_context)])
 app.include_router(streams_router, dependencies=[Depends(require_admin_user_context)])
+app.include_router(design_briefs_router)
 app.include_router(user_integrations_router)
 app.include_router(user_settings_router)
 

--- a/blueprint_core/database.py
+++ b/blueprint_core/database.py
@@ -2,6 +2,7 @@ import logging
 from blueprint_core.config import config
 import uuid
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import urlparse
 
@@ -9,6 +10,7 @@ from dotenv import load_dotenv
 from blueprint_core.runtime import blueprint_dev_mode_enabled
 from blueprint_core.project_list_cache import invalidate_project_lists
 from blueprint_core.workspaces.projects.objects import attach_project_object_metadata_to_dict
+from blueprint_core.workspaces.design_briefs import DesignBrief, DesignBriefCreate
 from blueprint_core.persistence.base import DatabaseProvider
 from blueprint_core.persistence.models import (
     Base,
@@ -44,6 +46,14 @@ class DatabaseConfig:
     backend: str
     source: str
     url: str
+
+
+class DesignBriefNotFoundError(LookupError):
+    """The requested project brief or version is not visible to the caller."""
+
+
+class DesignBriefAccessError(PermissionError):
+    """The project id is already owned by a different user."""
 
 
 def _env(name: str, default: Optional[str] = None) -> Optional[str]:
@@ -345,6 +355,9 @@ def save_generated_project(
     metadata = hardware_ir.get("assembly_metadata") if isinstance(hardware_ir.get("assembly_metadata"), dict) else {}
     normalized_chat_id = _normalize_chat_id(chat_id) or _normalize_chat_id(metadata.get("chat_id"))
     normalized_owner_user_id = _normalize_user_id(owner_user_id)
+    linked_brief = _DATABASE_REPOSITORY.get_latest_design_brief(project_id, None)
+    if linked_brief is not None and getattr(linked_brief, "owner_user_id", None) != normalized_owner_user_id:
+        raise DesignBriefAccessError("DesignBrief is not owned by the project owner.")
     normalized_visibility = _normalize_visibility(visibility)
     record = {
         "project_id": project_id,
@@ -378,6 +391,105 @@ def list_generated_projects(owner_user_id: Optional[str] = None) -> List[Any]:
 
 def get_generated_project(project_id: str, *, include_deleted: bool = False) -> Optional[Any]:
     return _DATABASE_REPOSITORY.get_generated_project(project_id, include_deleted=include_deleted)
+
+
+def _design_brief_from_record(record: Any) -> DesignBrief:
+    payload = getattr(record, "payload_json", None)
+    if not isinstance(payload, dict):
+        raise ValueError("Persisted DesignBrief payload_json must be an object.")
+    return DesignBrief.model_validate(payload)
+
+
+def create_design_brief_version(
+    project_id: str,
+    owner_user_id: str,
+    brief: DesignBriefCreate,
+) -> DesignBrief:
+    canonical_project_id = _canonical_project_id(project_id)
+    normalized_owner_user_id = _normalize_user_id(owner_user_id)
+    if not normalized_owner_user_id:
+        raise ValueError("owner_user_id is required.")
+
+    project = _DATABASE_REPOSITORY.get_generated_project(canonical_project_id, include_deleted=True)
+    if project is not None:
+        if getattr(project, "owner_user_id", None) != normalized_owner_user_id:
+            raise DesignBriefAccessError("Project is not owned by the current user.")
+        if getattr(project, "status", "active") != "active":
+            raise DesignBriefAccessError("Cannot append a DesignBrief to a deleted project.")
+
+    previous = _DATABASE_REPOSITORY.get_latest_design_brief(canonical_project_id, None)
+    if previous is not None and getattr(previous, "owner_user_id", None) != normalized_owner_user_id:
+        raise DesignBriefAccessError("Project is not owned by the current user.")
+
+    previous_brief = _design_brief_from_record(previous) if previous is not None else None
+    next_version = previous_brief.brief_version + 1 if previous_brief else 1
+    now = datetime.now(timezone.utc)
+    design_brief = DesignBrief(
+        **brief.model_dump(),
+        design_brief_id=previous_brief.design_brief_id if previous_brief else uuid.uuid4(),
+        project_id=canonical_project_id,
+        brief_version=next_version,
+        previous_version=previous_brief.brief_version if previous_brief else None,
+        created_at=now,
+    )
+    record = {
+        "id": str(uuid.uuid4()),
+        "design_brief_id": str(design_brief.design_brief_id),
+        "project_id": canonical_project_id,
+        "conversation_id": design_brief.conversation_id,
+        "owner_user_id": normalized_owner_user_id,
+        "brief_version": design_brief.brief_version,
+        "schema_version": design_brief.schema_version,
+        "previous_version": design_brief.previous_version,
+        "payload_json": design_brief.model_dump(mode="json"),
+        "created_at": now.isoformat().replace("+00:00", "Z"),
+    }
+    return _design_brief_from_record(_DATABASE_REPOSITORY.insert_design_brief_version(record))
+
+
+def list_design_brief_versions(project_id: str, owner_user_id: str) -> List[DesignBrief]:
+    canonical_project_id = _canonical_project_id(project_id)
+    normalized_owner_user_id = _normalize_user_id(owner_user_id)
+    if not normalized_owner_user_id:
+        return []
+    records = _DATABASE_REPOSITORY.list_design_brief_versions(
+        canonical_project_id,
+        normalized_owner_user_id,
+    )
+    return [_design_brief_from_record(record) for record in records]
+
+
+def get_design_brief_version(
+    project_id: str,
+    owner_user_id: str,
+    brief_version: int,
+) -> DesignBrief:
+    canonical_project_id = _canonical_project_id(project_id)
+    normalized_owner_user_id = _normalize_user_id(owner_user_id)
+    record = None
+    if normalized_owner_user_id and brief_version >= 1:
+        record = _DATABASE_REPOSITORY.get_design_brief_version(
+            canonical_project_id,
+            normalized_owner_user_id,
+            brief_version,
+        )
+    if record is None:
+        raise DesignBriefNotFoundError("DesignBrief version not found.")
+    return _design_brief_from_record(record)
+
+
+def get_latest_design_brief(project_id: str, owner_user_id: str) -> DesignBrief:
+    canonical_project_id = _canonical_project_id(project_id)
+    normalized_owner_user_id = _normalize_user_id(owner_user_id)
+    record = None
+    if normalized_owner_user_id:
+        record = _DATABASE_REPOSITORY.get_latest_design_brief(
+            canonical_project_id,
+            normalized_owner_user_id,
+        )
+    if record is None:
+        raise DesignBriefNotFoundError("DesignBrief not found.")
+    return _design_brief_from_record(record)
 
 
 def list_due_project_purges(before: str, limit: int = 25) -> List[Any]:

--- a/blueprint_core/persistence/models.py
+++ b/blueprint_core/persistence/models.py
@@ -42,6 +42,24 @@ class DBGeneratedProject(Base):
     deletion_error = Column(Text, nullable=True)
 
 
+class DBDesignBrief(Base):
+    __tablename__ = "design_briefs"
+    __table_args__ = (
+        UniqueConstraint("project_id", "brief_version", name="uq_design_briefs_project_version"),
+    )
+
+    id = Column(String, primary_key=True)
+    design_brief_id = Column(String, index=True, nullable=False)
+    project_id = Column(String, index=True, nullable=False)
+    conversation_id = Column(String, index=True, nullable=False)
+    owner_user_id = Column(String, index=True, nullable=False)
+    brief_version = Column(Integer, nullable=False)
+    schema_version = Column(String, nullable=False)
+    previous_version = Column(Integer, nullable=True)
+    payload_json = Column(JSON, nullable=False)
+    created_at = Column(String, index=True, nullable=False)
+
+
 class DBProjectContributionConsent(Base):
     __tablename__ = "project_contribution_consents"
     __table_args__ = (UniqueConstraint("project_id", "user_id", name="uq_project_contribution_consent_project_user"),)

--- a/blueprint_core/persistence/repositories/base.py
+++ b/blueprint_core/persistence/repositories/base.py
@@ -24,6 +24,19 @@ class ApplicationRepository(Protocol):
 
     def get_generated_project(self, project_id: str, include_deleted: bool = False) -> Optional[Any]: ...
 
+    def insert_design_brief_version(self, record: Dict[str, Any]) -> Any: ...
+
+    def list_design_brief_versions(self, project_id: str, owner_user_id: str) -> List[Any]: ...
+
+    def get_design_brief_version(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        brief_version: int,
+    ) -> Optional[Any]: ...
+
+    def get_latest_design_brief(self, project_id: str, owner_user_id: Optional[str]) -> Optional[Any]: ...
+
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]: ...
 
     def update_project_deletion_state(

--- a/blueprint_core/persistence/repositories/sqlite.py
+++ b/blueprint_core/persistence/repositories/sqlite.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import sessionmaker
 from blueprint_core.persistence.models import (
     DBAlphaSignup,
     DBComponentTemplate,
+    DBDesignBrief,
     DBGeneratedProject,
     DBProjectContributionConsent,
     DBProjectContributionSnapshot,
@@ -78,6 +79,51 @@ class SqlAlchemyRepository:
                 query = query.filter(DBGeneratedProject.status == "active")
             return query.first()
 
+    def insert_design_brief_version(self, record: Dict[str, Any]) -> Any:
+        with self._session() as session, session.begin():
+            design_brief = DBDesignBrief(**record)
+            session.add(design_brief)
+            session.flush()
+            session.refresh(design_brief)
+            session.expunge(design_brief)
+            return design_brief
+
+    def list_design_brief_versions(self, project_id: str, owner_user_id: str) -> List[Any]:
+        with self._session() as session:
+            return (
+                session.query(DBDesignBrief)
+                .filter(
+                    DBDesignBrief.project_id == project_id,
+                    DBDesignBrief.owner_user_id == owner_user_id,
+                )
+                .order_by(DBDesignBrief.brief_version.asc())
+                .all()
+            )
+
+    def get_design_brief_version(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        brief_version: int,
+    ) -> Optional[Any]:
+        with self._session() as session:
+            return (
+                session.query(DBDesignBrief)
+                .filter(
+                    DBDesignBrief.project_id == project_id,
+                    DBDesignBrief.owner_user_id == owner_user_id,
+                    DBDesignBrief.brief_version == brief_version,
+                )
+                .first()
+            )
+
+    def get_latest_design_brief(self, project_id: str, owner_user_id: Optional[str]) -> Optional[Any]:
+        with self._session() as session:
+            query = session.query(DBDesignBrief).filter(DBDesignBrief.project_id == project_id)
+            if owner_user_id:
+                query = query.filter(DBDesignBrief.owner_user_id == owner_user_id)
+            return query.order_by(DBDesignBrief.brief_version.desc()).first()
+
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]:
         with self._session() as session:
             return (
@@ -129,6 +175,9 @@ class SqlAlchemyRepository:
                 return False
             chat_id = project.chat_id
             project_owner_user_id = project.owner_user_id
+            session.query(DBDesignBrief).filter(DBDesignBrief.project_id == project_id).delete(
+                synchronize_session=False
+            )
             session.delete(project)
             session.flush()
             if chat_id and project_owner_user_id:
@@ -198,6 +247,9 @@ class SqlAlchemyRepository:
             ).first()
             if not project:
                 return False
+            session.query(DBDesignBrief).filter(DBDesignBrief.project_id == project_id).delete(
+                synchronize_session=False
+            )
             session.delete(project)
             return True
 

--- a/blueprint_core/persistence/repositories/supabase.py
+++ b/blueprint_core/persistence/repositories/supabase.py
@@ -63,6 +63,49 @@ class SupabaseRepository:
         rows = query.limit(1).execute().data or []
         return _record(rows[0]) if rows else None
 
+    def insert_design_brief_version(self, record: Dict[str, Any]) -> Any:
+        rows = self._client.table("design_briefs").insert(record).execute().data or []
+        return _record(rows[0]) if rows else _record(record)
+
+    def list_design_brief_versions(self, project_id: str, owner_user_id: str) -> List[Any]:
+        rows = (
+            self._client.table("design_briefs")
+            .select("*")
+            .eq("project_id", project_id)
+            .eq("owner_user_id", owner_user_id)
+            .order("brief_version")
+            .execute()
+            .data
+            or []
+        )
+        return [_record(row) for row in rows]
+
+    def get_design_brief_version(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        brief_version: int,
+    ) -> Optional[Any]:
+        rows = (
+            self._client.table("design_briefs")
+            .select("*")
+            .eq("project_id", project_id)
+            .eq("owner_user_id", owner_user_id)
+            .eq("brief_version", brief_version)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
+    def get_latest_design_brief(self, project_id: str, owner_user_id: Optional[str]) -> Optional[Any]:
+        query = self._client.table("design_briefs").select("*").eq("project_id", project_id)
+        if owner_user_id:
+            query = query.eq("owner_user_id", owner_user_id)
+        rows = query.order("brief_version", desc=True).limit(1).execute().data or []
+        return _record(rows[0]) if rows else None
+
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]:
         rows = (
             self._client.table("generated_projects")
@@ -106,6 +149,8 @@ class SupabaseRepository:
         if owner_user_id:
             query = query.eq("owner_user_id", owner_user_id)
         deleted = bool(query.execute().data)
+        if deleted:
+            self._client.table("design_briefs").delete().eq("project_id", project_id).execute()
         if not deleted or not getattr(project, "chat_id", None) or not getattr(project, "owner_user_id", None):
             return deleted
         remaining = (
@@ -171,7 +216,10 @@ class SupabaseRepository:
             .eq("status", "active")
             .execute()
         )
-        return bool(response.data)
+        deleted = bool(response.data)
+        if deleted:
+            self._client.table("design_briefs").delete().eq("project_id", project_id).execute()
+        return deleted
 
     def delete_generated_project(self, project_id: str, owner_user_id: str) -> bool:
         response = (

--- a/blueprint_core/persistence/schema.py
+++ b/blueprint_core/persistence/schema.py
@@ -23,6 +23,13 @@ APPLICATION_SCHEMA: Tuple[TableContract, ...] = (
         ),
     ),
     TableContract(
+        "design_briefs",
+        (
+            "id", "design_brief_id", "project_id", "conversation_id", "owner_user_id", "brief_version",
+            "schema_version", "previous_version", "payload_json", "created_at",
+        ),
+    ),
+    TableContract(
         "project_contribution_consents",
         (
             "id", "project_id", "user_id", "workspace_id", "consent_version", "permitted_purposes", "granted_at",

--- a/blueprint_core/workspaces/design_briefs/__init__.py
+++ b/blueprint_core/workspaces/design_briefs/__init__.py
@@ -1,0 +1,17 @@
+from blueprint_core.workspaces.design_briefs.models import (
+    DESIGN_BRIEF_SCHEMA_VERSION,
+    DesignBrief,
+    DesignBriefCreate,
+    DesignBriefReadiness,
+    DesignBriefReference,
+    DesignBriefVersionList,
+)
+
+__all__ = [
+    "DESIGN_BRIEF_SCHEMA_VERSION",
+    "DesignBrief",
+    "DesignBriefCreate",
+    "DesignBriefReadiness",
+    "DesignBriefReference",
+    "DesignBriefVersionList",
+]

--- a/blueprint_core/workspaces/design_briefs/models.py
+++ b/blueprint_core/workspaces/design_briefs/models.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Annotated, Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator
+from pydantic_core import PydanticCustomError
+
+
+DESIGN_BRIEF_SCHEMA_VERSION = "1.0"
+NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class DesignBriefReadiness(str, Enum):
+    """Explicit handoff state; scoring belongs to a later readiness service."""
+
+    DRAFT = "draft"
+    NEEDS_CLARIFICATION = "needs_clarification"
+    READY = "ready"
+
+
+class DesignBriefReference(BaseModel):
+    """A durable pointer to context used when preparing a design brief."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    reference_id: NonEmptyString
+    kind: NonEmptyString
+    label: NonEmptyString | None = None
+    uri: NonEmptyString | None = None
+    media_type: NonEmptyString | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class DesignBriefCreate(BaseModel):
+    """Client-authored fields in the canonical DesignBrief v1 contract."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: str
+    conversation_id: NonEmptyString
+    intent: NonEmptyString
+    summary: NonEmptyString
+    requirements: list[NonEmptyString] = Field(default_factory=list)
+    constraints: list[NonEmptyString] = Field(default_factory=list)
+    references: list[DesignBriefReference] = Field(default_factory=list)
+    requested_outputs: list[NonEmptyString] = Field(default_factory=list)
+    validation_criteria: list[NonEmptyString] = Field(default_factory=list)
+    unresolved_questions: list[NonEmptyString] = Field(default_factory=list)
+    assumptions: list[NonEmptyString] = Field(default_factory=list)
+    readiness: DesignBriefReadiness = DesignBriefReadiness.DRAFT
+
+    @field_validator("schema_version")
+    @classmethod
+    def validate_schema_version(cls, value: str) -> str:
+        normalized = str(value).strip()
+        if normalized != DESIGN_BRIEF_SCHEMA_VERSION:
+            raise PydanticCustomError(
+                "unsupported_design_brief_schema_version",
+                "Unsupported DesignBrief schema version '{version}'; supported versions: {supported_versions}",
+                {
+                    "version": normalized,
+                    "supported_versions": [DESIGN_BRIEF_SCHEMA_VERSION],
+                },
+            )
+        return normalized
+
+
+class DesignBrief(DesignBriefCreate):
+    """A server-versioned, immutable DesignBrief snapshot."""
+
+    design_brief_id: UUID
+    project_id: UUID
+    brief_version: int = Field(ge=1)
+    previous_version: int | None = Field(default=None, ge=1)
+    created_at: datetime
+
+
+class DesignBriefVersionList(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    project_id: UUID
+    versions: list[DesignBrief]

--- a/docs/design-brief.md
+++ b/docs/design-brief.md
@@ -1,0 +1,65 @@
+# DesignBrief
+
+`DesignBrief` is Forma's canonical, validated handoff from conversational context to downstream planning and execution. It records what the user wants without defining chat-agent behavior, readiness scoring, or worker execution.
+
+## Version model
+
+Two independent versions are recorded:
+
+- `schema_version` identifies the payload contract. The first supported contract is `1.0`.
+- `brief_version` identifies an immutable snapshot for one project. Creating an update appends the next integer version and records `previous_version`; it never overwrites an older payload.
+
+All snapshots for a project retain one stable `design_brief_id`. Every snapshot also stores its `project_id`, originating `conversation_id`, owner, and creation time.
+
+## DesignBrief v1
+
+Client-authored fields are:
+
+```json
+{
+  "schema_version": "1.0",
+  "conversation_id": "chat-123",
+  "intent": "Design a compact environmental monitor",
+  "summary": "A battery-powered monitor with a local display",
+  "requirements": ["Measure temperature and humidity"],
+  "constraints": ["Fit within a 100 mm enclosure"],
+  "references": [
+    {
+      "reference_id": "uploaded-reference-1",
+      "kind": "uploaded_image",
+      "label": "Existing enclosure",
+      "uri": "s3://design-inputs/enclosure.png",
+      "media_type": "image/png",
+      "metadata": {}
+    }
+  ],
+  "requested_outputs": ["wiring", "bom", "enclosure"],
+  "validation_criteria": ["Sensor readings update every second"],
+  "unresolved_questions": ["What battery life is required?"],
+  "assumptions": ["Indoor operating conditions"],
+  "readiness": "needs_clarification"
+}
+```
+
+The server adds `design_brief_id`, `project_id`, `brief_version`, `previous_version`, and `created_at`. Readiness is an explicit state (`draft`, `needs_clarification`, or `ready`), not a computed score.
+
+## API
+
+Authenticated callers use:
+
+- `POST /projects/{project_id}/design-briefs` to append a snapshot.
+- `GET /projects/{project_id}/design-briefs` to list snapshots in version order.
+- `GET /projects/{project_id}/design-briefs/latest` to retrieve the newest snapshot.
+- `GET /projects/{project_id}/design-briefs/{brief_version}` to retrieve an exact snapshot.
+
+An unsupported schema version returns HTTP 422 with error type `unsupported_design_brief_schema_version`. Missing or inaccessible briefs return a structured `design_brief_not_found` response without revealing another user's project.
+
+## Compatibility rules
+
+- Readers must select behavior by `schema_version`, not `brief_version`.
+- Existing schema versions remain readable after a new version is introduced.
+- Additive optional fields may be introduced in a minor schema revision. Required-field changes, removals, or semantic changes require a new major schema version.
+- A new schema version requires domain validation, persistence round-trip tests, API error tests, migration review, and an update to this document before it is accepted.
+- Stored snapshots are immutable. Normal corrections always create another `brief_version`.
+
+The hosted table is backend-only: browser roles have no direct access, and the authenticated API applies owner scoping.

--- a/supabase/migrations/20260801000100_design_briefs.sql
+++ b/supabase/migrations/20260801000100_design_briefs.sql
@@ -1,0 +1,36 @@
+-- Immutable, versioned DesignBrief snapshots used as the canonical handoff
+-- between conversation context and downstream planning/execution.
+
+create table if not exists public.design_briefs (
+  id text primary key,
+  design_brief_id text not null,
+  project_id text not null,
+  conversation_id text not null,
+  owner_user_id text not null,
+  brief_version integer not null check (brief_version >= 1),
+  schema_version text not null,
+  previous_version integer check (previous_version is null or previous_version >= 1),
+  payload_json jsonb not null,
+  created_at text not null,
+  constraint design_briefs_project_version_unique unique (project_id, brief_version)
+);
+
+create index if not exists idx_design_briefs_stable_id_version
+  on public.design_briefs (design_brief_id, brief_version desc);
+
+create index if not exists idx_design_briefs_owner_project_version
+  on public.design_briefs (owner_user_id, project_id, brief_version desc);
+
+create index if not exists idx_design_briefs_conversation
+  on public.design_briefs (conversation_id);
+
+alter table public.design_briefs enable row level security;
+
+revoke all on table public.design_briefs from anon, authenticated;
+grant select, insert, delete on table public.design_briefs to service_role;
+
+comment on table public.design_briefs is
+  'Append-only DesignBrief snapshots. API updates insert a new brief_version; existing payloads are immutable.';
+
+comment on column public.design_briefs.schema_version is
+  'Version of the DesignBrief payload contract, independent of the snapshot brief_version.';

--- a/tests/persistence/test_database_schema_drift.py
+++ b/tests/persistence/test_database_schema_drift.py
@@ -36,7 +36,15 @@ class FakeSupabaseQuery:
         self.eq_value = value
         return self
 
+    def order(self, _field: str, desc: bool = False) -> "FakeSupabaseQuery":
+        return self
+
+    def limit(self, _value: int) -> "FakeSupabaseQuery":
+        return self
+
     def execute(self) -> FakeSupabaseResponse:
+        if self.operation == "select":
+            return FakeSupabaseResponse()
         self.client.mutations.append(
             {
                 "operation": self.operation,
@@ -61,6 +69,9 @@ class FakeSupabaseTable:
 
     def insert(self, payload: dict[str, Any]) -> FakeSupabaseQuery:
         return FakeSupabaseQuery(self.client, self.name, "insert", payload)
+
+    def select(self, _projection: str) -> FakeSupabaseQuery:
+        return FakeSupabaseQuery(self.client, self.name, "select")
 
     def update(self, payload: dict[str, Any]) -> FakeSupabaseQuery:
         return FakeSupabaseQuery(self.client, self.name, "update", payload)

--- a/tests/persistence/test_design_briefs.py
+++ b/tests/persistence/test_design_briefs.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+from unittest.mock import patch
+
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+from pydantic import ValidationError
+
+from apps.api.auth import UserContext, require_user_context
+from apps.api.design_briefs_api import router
+from blueprint_core import database
+from blueprint_core.persistence.providers import create_sqlite_provider
+from blueprint_core.persistence.repositories import SqlAlchemyRepository
+from blueprint_core.workspaces.design_briefs import (
+    DesignBrief,
+    DesignBriefCreate,
+    DesignBriefReadiness,
+)
+
+
+USER_CONTEXT = UserContext(
+    provider="test",
+    subject="user_design_brief",
+    owner_user_id="user_design_brief",
+    is_authenticated=True,
+    is_admin=False,
+)
+
+
+@contextmanager
+def sqlite_repository() -> Iterator[None]:
+    with tempfile.TemporaryDirectory() as directory:
+        provider = create_sqlite_provider(
+            source="design brief test",
+            url=f"sqlite:///{Path(directory) / 'blueprint.db'}",
+            import_legacy_jobs=False,
+        )
+        assert provider.session_factory is not None
+        provider.initialize()
+        original_repository = database._DATABASE_REPOSITORY
+        try:
+            database._DATABASE_REPOSITORY = SqlAlchemyRepository(provider.session_factory)
+            yield
+        finally:
+            database._DATABASE_REPOSITORY = original_repository
+
+
+def brief_payload(*, summary: str = "A compact controller") -> dict[str, object]:
+    return {
+        "schema_version": "1.0",
+        "conversation_id": "chat-design-1",
+        "intent": "Design a low-voltage motor controller",
+        "summary": summary,
+        "requirements": ["Drive one brushed DC motor", "Expose speed control"],
+        "constraints": ["Use USB-C power", "Fit within 100 mm"],
+        "references": [
+            {
+                "reference_id": "uploaded-hardware-reference",
+                "kind": "uploaded_image",
+                "label": "Existing enclosure",
+                "uri": "s3://design-inputs/enclosure.png",
+                "media_type": "image/png",
+                "metadata": {"source": "clipboard"},
+            }
+        ],
+        "requested_outputs": ["wiring", "bom", "enclosure"],
+        "validation_criteria": ["Motor reaches requested speed"],
+        "unresolved_questions": ["What is the stall current?"],
+        "assumptions": ["The motor is rated for 12 V"],
+        "readiness": "needs_clarification",
+    }
+
+
+class DesignBriefModelTests(unittest.TestCase):
+    def test_v1_round_trips_every_canonical_field(self) -> None:
+        project_id = uuid.uuid4()
+        brief = DesignBrief(
+            **brief_payload(),
+            design_brief_id=uuid.uuid4(),
+            project_id=project_id,
+            brief_version=1,
+            created_at="2026-08-01T18:00:00Z",
+        )
+
+        restored = DesignBrief.model_validate_json(brief.model_dump_json())
+
+        self.assertEqual(brief, restored)
+        self.assertEqual(project_id, restored.project_id)
+        self.assertEqual("clipboard", restored.references[0].metadata["source"])
+        self.assertEqual(DesignBriefReadiness.NEEDS_CLARIFICATION, restored.readiness)
+
+    def test_unsupported_schema_version_has_a_stable_structured_error(self) -> None:
+        payload = brief_payload()
+        payload["schema_version"] = "2.0"
+
+        with self.assertRaises(ValidationError) as raised:
+            DesignBriefCreate.model_validate(payload)
+
+        error = raised.exception.errors()[0]
+        self.assertEqual("unsupported_design_brief_schema_version", error["type"])
+        self.assertEqual(["1.0"], error["ctx"]["supported_versions"])
+
+
+class DesignBriefPersistenceTests(unittest.TestCase):
+    def test_updates_append_traceable_versions_without_overwriting_history(self) -> None:
+        project_id = str(uuid.uuid4())
+        with sqlite_repository():
+            first = database.create_design_brief_version(
+                project_id,
+                "user_design_brief",
+                DesignBriefCreate.model_validate(brief_payload(summary="First summary")),
+            )
+            second = database.create_design_brief_version(
+                project_id,
+                "user_design_brief",
+                DesignBriefCreate.model_validate(brief_payload(summary="Revised summary")),
+            )
+            versions = database.list_design_brief_versions(project_id, "user_design_brief")
+            restored_first = database.get_design_brief_version(project_id, "user_design_brief", 1)
+            latest = database.get_latest_design_brief(project_id, "user_design_brief")
+
+        self.assertEqual(first.design_brief_id, second.design_brief_id)
+        self.assertEqual(1, first.brief_version)
+        self.assertIsNone(first.previous_version)
+        self.assertEqual(2, second.brief_version)
+        self.assertEqual(1, second.previous_version)
+        self.assertEqual([1, 2], [brief.brief_version for brief in versions])
+        self.assertEqual("First summary", restored_first.summary)
+        self.assertEqual("Revised summary", latest.summary)
+        self.assertEqual(project_id, str(latest.project_id))
+        self.assertEqual("chat-design-1", latest.conversation_id)
+
+    def test_first_writer_claim_prevents_cross_user_access(self) -> None:
+        project_id = str(uuid.uuid4())
+        with sqlite_repository():
+            database.create_design_brief_version(
+                project_id,
+                "user_one",
+                DesignBriefCreate.model_validate(brief_payload()),
+            )
+            with self.assertRaises(database.DesignBriefAccessError):
+                database.create_design_brief_version(
+                    project_id,
+                    "user_two",
+                    DesignBriefCreate.model_validate(brief_payload()),
+                )
+            self.assertEqual([], database.list_design_brief_versions(project_id, "user_two"))
+            with self.assertRaises(database.DesignBriefNotFoundError):
+                database.get_latest_design_brief(project_id, "user_two")
+
+    def test_project_creation_respects_brief_owner_and_purge_removes_brief(self) -> None:
+        project_id = str(uuid.uuid4())
+        with sqlite_repository(), patch("blueprint_core.database.invalidate_project_lists"):
+            database.create_design_brief_version(
+                project_id,
+                "user_one",
+                DesignBriefCreate.model_validate(brief_payload()),
+            )
+            with self.assertRaises(database.DesignBriefAccessError):
+                database.save_generated_project(
+                    project_id=project_id,
+                    title="Wrong owner",
+                    prompt="Should not persist",
+                    hardware_ir={},
+                    created_at="2026-08-01T18:00:00Z",
+                    owner_user_id="user_two",
+                )
+            database.save_generated_project(
+                project_id=project_id,
+                title="Owned project",
+                prompt="Persist for the brief owner",
+                hardware_ir={},
+                created_at="2026-08-01T18:00:00Z",
+                owner_user_id="user_one",
+            )
+            self.assertTrue(database.hard_purge_generated_project(project_id, "user_one"))
+            with self.assertRaises(database.DesignBriefNotFoundError):
+                database.get_latest_design_brief(project_id, "user_one")
+
+
+class DesignBriefApiTests(unittest.TestCase):
+    def test_routes_require_authenticated_user_context(self) -> None:
+        routes = [route for route in router.routes if isinstance(route, APIRoute)]
+        self.assertEqual(4, len(routes))
+        for route in routes:
+            dependency_calls = {dependency.call for dependency in route.dependant.dependencies}
+            self.assertIn(require_user_context, dependency_calls, route.path)
+
+    def test_api_appends_lists_and_retrieves_exact_versions(self) -> None:
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_user_context] = lambda: USER_CONTEXT
+        client = TestClient(app)
+        project_id = str(uuid.uuid4())
+
+        with sqlite_repository():
+            first = client.post(f"/projects/{project_id}/design-briefs", json=brief_payload(summary="First"))
+            second = client.post(f"/projects/{project_id}/design-briefs", json=brief_payload(summary="Second"))
+            exact = client.get(f"/projects/{project_id}/design-briefs/1")
+            latest = client.get(f"/projects/{project_id}/design-briefs/latest")
+            listed = client.get(f"/projects/{project_id}/design-briefs")
+
+        self.assertEqual(201, first.status_code)
+        self.assertEqual(201, second.status_code)
+        self.assertEqual("First", exact.json()["summary"])
+        self.assertEqual("Second", latest.json()["summary"])
+        self.assertEqual([1, 2], [item["brief_version"] for item in listed.json()["versions"]])
+
+    def test_api_rejects_unsupported_versions_structurally(self) -> None:
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_user_context] = lambda: USER_CONTEXT
+        client = TestClient(app)
+        payload = brief_payload()
+        payload["schema_version"] = "9.0"
+
+        response = client.post(f"/projects/{uuid.uuid4()}/design-briefs", json=payload)
+
+        self.assertEqual(422, response.status_code)
+        error = response.json()["detail"][0]
+        self.assertEqual("unsupported_design_brief_schema_version", error["type"])
+        self.assertEqual(["1.0"], error["ctx"]["supported_versions"])
+
+    def test_api_requires_an_explicit_schema_version(self) -> None:
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_user_context] = lambda: USER_CONTEXT
+        client = TestClient(app)
+        payload = brief_payload()
+        del payload["schema_version"]
+
+        response = client.post(f"/projects/{uuid.uuid4()}/design-briefs", json=payload)
+
+        self.assertEqual(422, response.status_code)
+        error = response.json()["detail"][0]
+        self.assertEqual("missing", error["type"])
+        self.assertEqual("schema_version", error["loc"][-1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #181

## Summary
- define the canonical, strictly validated DesignBrief v1 domain and API contract
- persist immutable, owner-scoped versions through SQLite and Supabase
- add authenticated create/list/latest/exact-version endpoints and project lifecycle integration
- document schema compatibility rules and add the hosted database migration

## Testing
- `CLOUDFLARE_ENABLE_THINKING=false ./scripts/quality/test.sh`
- 379 tests passed; 1 skipped