### PR TITLE
Define worker job contracts and capability registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Tip: load an example directly with http://localhost:3000/?example=pocket_mp3_pla
 ## Documentation
 - [Architecture](docs/architecture.md)
 - [DesignBrief contract](docs/design-brief.md)
+- [Worker contracts and capability registry](docs/worker-contracts.md)
 - [Agents](docs/agents.md)
 - [Hardware IR](docs/hardware-ir.md)
 - [Validation](docs/validation.md)

--- a/blueprint_core/workers/__init__.py
+++ b/blueprint_core/workers/__init__.py
@@ -1,0 +1,41 @@
+from blueprint_core.workers.contracts import (
+    WORKER_CONTRACT_VERSION,
+    WorkerArtifact,
+    WorkerContract,
+    WorkerDependency,
+    WorkerError,
+    WorkerProgress,
+    WorkerProgressStatus,
+    WorkerRequest,
+    WorkerResult,
+    WorkerResultStatus,
+)
+from blueprint_core.workers.registry import (
+    WORKER_REGISTRY_VERSION,
+    WorkerCapability,
+    WorkerDefinition,
+    WorkerDefinitionProvider,
+    WorkerRegistry,
+    WorkerRegistryError,
+    WorkerResolution,
+)
+
+__all__ = [
+    "WORKER_CONTRACT_VERSION",
+    "WORKER_REGISTRY_VERSION",
+    "WorkerArtifact",
+    "WorkerCapability",
+    "WorkerContract",
+    "WorkerDefinition",
+    "WorkerDefinitionProvider",
+    "WorkerDependency",
+    "WorkerError",
+    "WorkerProgress",
+    "WorkerProgressStatus",
+    "WorkerRegistry",
+    "WorkerRegistryError",
+    "WorkerRequest",
+    "WorkerResolution",
+    "WorkerResult",
+    "WorkerResultStatus",
+]

--- a/blueprint_core/workers/contracts.py
+++ b/blueprint_core/workers/contracts.py
@@ -1,0 +1,180 @@
+"""Versioned contracts shared by specialized Forma workers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Annotated, Any
+from uuid import UUID, uuid4
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    StringConstraints,
+    field_validator,
+    model_validator,
+)
+from pydantic_core import PydanticCustomError
+
+
+WORKER_CONTRACT_VERSION = "1.0"
+NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+def utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class WorkerProgressStatus(str, Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    WAITING = "waiting"
+
+
+class WorkerResultStatus(str, Enum):
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class WorkerContract(BaseModel):
+    """Common identity and correlation fields carried by every worker envelope."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    contract_version: str
+    project_id: UUID
+    project_revision: int = Field(ge=1)
+    design_brief_id: UUID
+    design_brief_version: int = Field(ge=1)
+    job_id: NonEmptyString
+    correlation_id: NonEmptyString
+    worker_id: NonEmptyString
+    capability_id: NonEmptyString
+
+    @field_validator("contract_version")
+    @classmethod
+    def validate_contract_version(cls, value: str) -> str:
+        normalized = str(value).strip()
+        if normalized != WORKER_CONTRACT_VERSION:
+            raise PydanticCustomError(
+                "unsupported_worker_contract_version",
+                "Unsupported worker envelope version '{version}'; supported versions: {supported_versions}",
+                {"version": normalized, "supported_versions": [WORKER_CONTRACT_VERSION]},
+            )
+        return normalized
+
+    def context_identity(self) -> tuple[object, ...]:
+        return (
+            self.project_id,
+            self.project_revision,
+            self.design_brief_id,
+            self.design_brief_version,
+            self.job_id,
+            self.correlation_id,
+            self.worker_id,
+            self.capability_id,
+        )
+
+
+class WorkerDependency(BaseModel):
+    """A prerequisite job whose result is required or advisory for a request."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    dependency_id: NonEmptyString = Field(default_factory=lambda: f"dep_{uuid4().hex}")
+    job_id: NonEmptyString
+    worker_id: NonEmptyString | None = None
+    capability_id: NonEmptyString | None = None
+    required: bool = True
+
+
+class WorkerRequest(WorkerContract):
+    """Validated input handed to one worker capability."""
+
+    input_contract_version: NonEmptyString
+    dependencies: list[WorkerDependency] = Field(default_factory=list)
+    payload: dict[str, Any] = Field(default_factory=dict)
+    requested_at: datetime = Field(default_factory=utc_now)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def require_unique_dependencies(self) -> "WorkerRequest":
+        dependency_ids = [dependency.dependency_id for dependency in self.dependencies]
+        if len(dependency_ids) != len(set(dependency_ids)):
+            raise ValueError("WorkerRequest dependency_id values must be unique.")
+        return self
+
+
+class WorkerProgress(WorkerContract):
+    """Ordered progress observation emitted while a request is running."""
+
+    sequence: int = Field(ge=0)
+    status: WorkerProgressStatus
+    percent_complete: float | None = Field(default=None, ge=0, le=100)
+    message: NonEmptyString | None = None
+    created_at: datetime = Field(default_factory=utc_now)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class WorkerArtifact(WorkerContract):
+    """Durable reference to one artifact produced by a worker."""
+
+    artifact_id: NonEmptyString = Field(default_factory=lambda: f"artifact_{uuid4().hex}")
+    kind: NonEmptyString
+    uri: NonEmptyString
+    media_type: NonEmptyString | None = None
+    checksum: NonEmptyString | None = None
+    created_at: datetime = Field(default_factory=utc_now)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class WorkerError(WorkerContract):
+    """Stable machine-readable worker failure shape."""
+
+    error_id: NonEmptyString = Field(default_factory=lambda: f"error_{uuid4().hex}")
+    code: NonEmptyString
+    message: NonEmptyString
+    retryable: bool = False
+    details: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=utc_now)
+
+
+class WorkerResult(WorkerContract):
+    """Terminal output for one worker request."""
+
+    output_contract_version: NonEmptyString
+    status: WorkerResultStatus
+    output: dict[str, Any] = Field(default_factory=dict)
+    artifacts: list[WorkerArtifact] = Field(default_factory=list)
+    error: WorkerError | None = None
+    completed_at: datetime = Field(default_factory=utc_now)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def validate_terminal_shape(self) -> "WorkerResult":
+        if self.status == WorkerResultStatus.FAILED and self.error is None:
+            raise ValueError("A failed WorkerResult requires error details.")
+        if self.status == WorkerResultStatus.SUCCEEDED and self.error is not None:
+            raise ValueError("A successful WorkerResult cannot include an error.")
+        for artifact in self.artifacts:
+            if artifact.context_identity() != self.context_identity():
+                raise ValueError("WorkerArtifact context must match its WorkerResult.")
+        if self.error is not None and self.error.context_identity() != self.context_identity():
+            raise ValueError("WorkerError context must match its WorkerResult.")
+        return self
+
+
+__all__ = [
+    "WORKER_CONTRACT_VERSION",
+    "WorkerArtifact",
+    "WorkerContract",
+    "WorkerDependency",
+    "WorkerError",
+    "WorkerProgress",
+    "WorkerProgressStatus",
+    "WorkerRequest",
+    "WorkerResult",
+    "WorkerResultStatus",
+]

--- a/blueprint_core/workers/registry.py
+++ b/blueprint_core/workers/registry.py
@@ -1,0 +1,222 @@
+"""Capability registry and compatibility gates for specialized workers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from blueprint_core.workers.contracts import NonEmptyString, WorkerRequest, WorkerResult
+
+
+WORKER_REGISTRY_VERSION = "1.0"
+
+
+class WorkerCapability(BaseModel):
+    """One callable capability and the payload versions it accepts and returns."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    capability_id: NonEmptyString
+    description: NonEmptyString
+    supported_input_versions: list[NonEmptyString] = Field(min_length=1)
+    supported_output_versions: list[NonEmptyString] = Field(min_length=1)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def normalize_versions(self) -> "WorkerCapability":
+        self.supported_input_versions = list(dict.fromkeys(self.supported_input_versions))
+        self.supported_output_versions = list(dict.fromkeys(self.supported_output_versions))
+        return self
+
+
+class WorkerDefinition(BaseModel):
+    """Portable declaration registered before a worker can receive jobs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    worker_id: NonEmptyString
+    name: NonEmptyString
+    worker_version: NonEmptyString
+    capabilities: list[WorkerCapability] = Field(min_length=1)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def require_unique_capabilities(self) -> "WorkerDefinition":
+        capability_ids = [capability.capability_id for capability in self.capabilities]
+        if len(capability_ids) != len(set(capability_ids)):
+            raise ValueError("WorkerDefinition capability_id values must be unique.")
+        return self
+
+    def capability(self, capability_id: str) -> WorkerCapability | None:
+        normalized = capability_id.strip()
+        return next(
+            (capability for capability in self.capabilities if capability.capability_id == normalized),
+            None,
+        )
+
+
+@runtime_checkable
+class WorkerDefinitionProvider(Protocol):
+    """Minimal declaration surface implemented by concrete workers."""
+
+    def worker_definition(self) -> WorkerDefinition: ...
+
+
+class WorkerRegistryError(Exception):
+    """Structured pre-execution registry failure."""
+
+    def __init__(self, code: str, message: str, *, context: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.context = context or {}
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"code": self.code, "message": self.message, "context": dict(self.context)}
+
+
+@dataclass(frozen=True)
+class WorkerResolution:
+    worker: WorkerDefinition
+    capability: WorkerCapability
+
+
+class WorkerRegistry:
+    """In-memory declaration registry used as a gate before job execution."""
+
+    def __init__(
+        self,
+        workers: list[WorkerDefinition | WorkerDefinitionProvider] | None = None,
+    ) -> None:
+        self._workers: dict[str, WorkerDefinition] = {}
+        for worker in workers or []:
+            self.register(worker)
+
+    @staticmethod
+    def _definition(worker: WorkerDefinition | WorkerDefinitionProvider) -> WorkerDefinition:
+        if isinstance(worker, WorkerDefinition):
+            return worker
+        if isinstance(worker, WorkerDefinitionProvider):
+            return WorkerDefinition.model_validate(worker.worker_definition())
+        raise TypeError("Workers must provide a WorkerDefinition.")
+
+    def register(self, worker: WorkerDefinition | WorkerDefinitionProvider) -> WorkerDefinition:
+        definition = self._definition(worker)
+        if definition.worker_id in self._workers:
+            raise WorkerRegistryError(
+                "duplicate_worker",
+                f"Worker '{definition.worker_id}' is already registered.",
+                context={"worker_id": definition.worker_id},
+            )
+        self._workers[definition.worker_id] = definition
+        return definition
+
+    def get(self, worker_id: str) -> WorkerDefinition:
+        normalized = worker_id.strip()
+        worker = self._workers.get(normalized)
+        if worker is None:
+            raise WorkerRegistryError(
+                "unknown_worker",
+                f"Unknown worker '{normalized}'.",
+                context={"worker_id": normalized},
+            )
+        return worker
+
+    def resolve(self, worker_id: str, capability_id: str) -> WorkerResolution:
+        worker = self.get(worker_id)
+        capability = worker.capability(capability_id)
+        if capability is None:
+            raise WorkerRegistryError(
+                "unknown_worker_capability",
+                f"Worker '{worker.worker_id}' does not declare capability '{capability_id.strip()}'.",
+                context={
+                    "worker_id": worker.worker_id,
+                    "capability_id": capability_id.strip(),
+                    "available_capabilities": [item.capability_id for item in worker.capabilities],
+                },
+            )
+        return WorkerResolution(worker=worker, capability=capability)
+
+    @staticmethod
+    def _require_version(
+        *,
+        resolution: WorkerResolution,
+        requested_version: str,
+        supported_versions: list[str],
+        direction: str,
+    ) -> None:
+        if requested_version in supported_versions:
+            return
+        raise WorkerRegistryError(
+            "incompatible_worker_contract_version",
+            (
+                f"Worker '{resolution.worker.worker_id}' capability "
+                f"'{resolution.capability.capability_id}' does not support {direction} version "
+                f"'{requested_version}'."
+            ),
+            context={
+                "worker_id": resolution.worker.worker_id,
+                "capability_id": resolution.capability.capability_id,
+                "direction": direction,
+                "requested_version": requested_version,
+                "supported_versions": list(supported_versions),
+            },
+        )
+
+    def validate_request(self, request: WorkerRequest) -> WorkerResolution:
+        resolution = self.resolve(request.worker_id, request.capability_id)
+        self._require_version(
+            resolution=resolution,
+            requested_version=request.input_contract_version,
+            supported_versions=resolution.capability.supported_input_versions,
+            direction="input",
+        )
+        return resolution
+
+    def validate_result(self, result: WorkerResult) -> WorkerResolution:
+        resolution = self.resolve(result.worker_id, result.capability_id)
+        self._require_version(
+            resolution=resolution,
+            requested_version=result.output_contract_version,
+            supported_versions=resolution.capability.supported_output_versions,
+            direction="output",
+        )
+        return resolution
+
+    def list_workers(self) -> list[WorkerDefinition]:
+        return [self._workers[worker_id] for worker_id in sorted(self._workers)]
+
+    def find_capability(
+        self,
+        capability_id: str,
+        *,
+        input_contract_version: str | None = None,
+    ) -> list[WorkerResolution]:
+        matches: list[WorkerResolution] = []
+        for worker in self.list_workers():
+            capability = worker.capability(capability_id)
+            if capability is None:
+                continue
+            if input_contract_version and input_contract_version not in capability.supported_input_versions:
+                continue
+            matches.append(WorkerResolution(worker=worker, capability=capability))
+        return matches
+
+    def manifest(self) -> dict[str, Any]:
+        return {
+            "registry_version": WORKER_REGISTRY_VERSION,
+            "workers": [worker.model_dump(mode="json") for worker in self.list_workers()],
+        }
+
+
+__all__ = [
+    "WORKER_REGISTRY_VERSION",
+    "WorkerCapability",
+    "WorkerDefinition",
+    "WorkerDefinitionProvider",
+    "WorkerRegistry",
+    "WorkerRegistryError",
+    "WorkerResolution",
+]

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -70,3 +70,4 @@ flowchart LR
 - If a live LLM provider isn’t configured (or generation fails), the backend uses a deterministic **simulation fallback** backed by the example projects.
 - The pipeline is designed to swap models or add agents without rewriting the core IR schema.
 - External agents can call or listen to Forma through the A2A layer documented in `docs/a2a.md`.
+- Specialized worker execution boundaries use the versioned contracts and capability registry documented in `docs/worker-contracts.md`.

--- a/docs/worker-contracts.md
+++ b/docs/worker-contracts.md
@@ -1,0 +1,69 @@
+# Worker contracts and capability registry
+
+Specialized workers exchange versioned envelopes through `blueprint_core.workers`. These contracts define the boundary between orchestration and worker implementations; they do not schedule work, retry jobs, or implement any production worker.
+
+The worker registry is intentionally separate from the Lattice agent registry:
+
+- Lattice cards describe discoverable domain agents, tools, and handoffs.
+- Worker definitions declare executable capabilities and compatible payload versions.
+- A future orchestrator may connect the two, but it must validate a `WorkerRequest` through `WorkerRegistry` before invoking worker code.
+
+## Envelope version
+
+Every `WorkerRequest`, `WorkerProgress`, `WorkerResult`, `WorkerArtifact`, and `WorkerError` requires `contract_version: "1.0"`. Unsupported envelope versions fail Pydantic validation with error type `unsupported_worker_contract_version`.
+
+Every envelope carries the same execution context:
+
+- `project_id` and `project_revision`
+- `design_brief_id` and `design_brief_version`
+- `job_id` and `correlation_id`
+- `worker_id` and `capability_id`
+
+Artifacts and errors embedded in a result must have exactly the same context as that result.
+
+## Payload compatibility
+
+Envelope versions and capability payload versions evolve independently:
+
+- `WorkerRequest.input_contract_version` identifies the request payload schema.
+- `WorkerResult.output_contract_version` identifies the result payload schema.
+- Each `WorkerCapability` declares `supported_input_versions` and `supported_output_versions`.
+
+The registry compares those values before execution or result acceptance. A mismatch raises `WorkerRegistryError` with code `incompatible_worker_contract_version` and structured context containing the worker, capability, direction, requested version, and supported versions.
+
+## Declaring and validating a worker
+
+```python
+from blueprint_core.workers import (
+    WorkerCapability,
+    WorkerDefinition,
+    WorkerRegistry,
+)
+
+electrical = WorkerDefinition(
+    worker_id="electrical-worker",
+    name="Electrical Worker",
+    worker_version="1.0.0",
+    capabilities=[
+        WorkerCapability(
+            capability_id="electrical.plan",
+            description="Create a validated electrical plan.",
+            supported_input_versions=["design-brief.v1"],
+            supported_output_versions=["electrical-plan.v1"],
+        )
+    ],
+)
+
+registry = WorkerRegistry([electrical])
+resolution = registry.validate_request(request)
+# Invoke the resolved worker only after validation succeeds.
+```
+
+A concrete worker can instead implement `worker_definition()` and register itself. Duplicate worker IDs, unknown workers, and capabilities not declared by the selected worker fail with structured registry errors.
+
+## Contract evolution
+
+- Additive payload changes should introduce a new capability input or output version when consumers need to distinguish behavior.
+- Breaking envelope changes require a new worker `contract_version` and corresponding model support.
+- Existing versions remain declared while active callers or stored job records depend on them.
+- Registry compatibility tests must cover each newly supported version before it is used by an orchestrator.

--- a/tests/agents/test_worker_contracts.py
+++ b/tests/agents/test_worker_contracts.py
@@ -1,0 +1,282 @@
+from __future__ import annotations
+
+import unittest
+import uuid
+
+from pydantic import ValidationError
+
+from blueprint_core.workers import (
+    WORKER_CONTRACT_VERSION,
+    WorkerArtifact,
+    WorkerCapability,
+    WorkerDefinition,
+    WorkerDependency,
+    WorkerError,
+    WorkerProgress,
+    WorkerRegistry,
+    WorkerRegistryError,
+    WorkerRequest,
+    WorkerResult,
+)
+
+
+PROJECT_ID = uuid.UUID("83b48573-a513-4e51-a562-24d4d1f6c250")
+DESIGN_BRIEF_ID = uuid.UUID("8a44549f-7508-4307-a864-4895d0d2f877")
+
+
+def contract_context(
+    *,
+    worker_id: str = "electrical-worker",
+    capability_id: str = "electrical.plan",
+) -> dict[str, object]:
+    return {
+        "contract_version": WORKER_CONTRACT_VERSION,
+        "project_id": PROJECT_ID,
+        "project_revision": 3,
+        "design_brief_id": DESIGN_BRIEF_ID,
+        "design_brief_version": 2,
+        "job_id": "job_worker_123",
+        "correlation_id": "corr_build_456",
+        "worker_id": worker_id,
+        "capability_id": capability_id,
+    }
+
+
+class FakeElectricalWorker:
+    def __init__(self) -> None:
+        self.execution_count = 0
+
+    def worker_definition(self) -> WorkerDefinition:
+        return WorkerDefinition(
+            worker_id="electrical-worker",
+            name="Fake Electrical Worker",
+            worker_version="0.1.0",
+            capabilities=[
+                WorkerCapability(
+                    capability_id="electrical.plan",
+                    description="Create an electrical plan.",
+                    supported_input_versions=["design-brief.v1"],
+                    supported_output_versions=["electrical-plan.v1"],
+                ),
+                WorkerCapability(
+                    capability_id="hardware.review",
+                    description="Review a hardware plan.",
+                    supported_input_versions=["hardware-review.v1"],
+                    supported_output_versions=["review-findings.v1"],
+                ),
+            ],
+        )
+
+    def execute(self, request: WorkerRequest) -> dict[str, object]:
+        self.execution_count += 1
+        return request.payload
+
+
+class FakeMechanicalWorker:
+    def worker_definition(self) -> WorkerDefinition:
+        return WorkerDefinition(
+            worker_id="mechanical-worker",
+            name="Fake Mechanical Worker",
+            worker_version="0.2.0",
+            capabilities=[
+                WorkerCapability(
+                    capability_id="mechanical.enclosure",
+                    description="Create an enclosure plan.",
+                    supported_input_versions=["design-brief.v1", "mechanical-request.v1"],
+                    supported_output_versions=["enclosure-plan.v1"],
+                ),
+                WorkerCapability(
+                    capability_id="hardware.review",
+                    description="Review mechanical fit.",
+                    supported_input_versions=["hardware-review.v1"],
+                    supported_output_versions=["review-findings.v1"],
+                ),
+            ],
+        )
+
+
+class WorkerContractTests(unittest.TestCase):
+    def test_request_round_trip_carries_context_dependencies_and_correlation(self) -> None:
+        request = WorkerRequest(
+            **contract_context(),
+            input_contract_version="design-brief.v1",
+            dependencies=[
+                WorkerDependency(
+                    dependency_id="dep_context",
+                    job_id="job_context_001",
+                    worker_id="context-worker",
+                    capability_id="context.finalize",
+                )
+            ],
+            payload={"requested_outputs": ["wiring", "bom"]},
+        )
+
+        restored = WorkerRequest.model_validate_json(request.model_dump_json())
+
+        self.assertEqual(request, restored)
+        self.assertEqual(PROJECT_ID, restored.project_id)
+        self.assertEqual(3, restored.project_revision)
+        self.assertEqual(DESIGN_BRIEF_ID, restored.design_brief_id)
+        self.assertEqual(2, restored.design_brief_version)
+        self.assertEqual("job_context_001", restored.dependencies[0].job_id)
+        self.assertEqual("corr_build_456", restored.correlation_id)
+
+    def test_progress_artifacts_errors_and_results_have_stable_serializable_shapes(self) -> None:
+        progress = WorkerProgress(
+            **contract_context(),
+            sequence=4,
+            status="running",
+            percent_complete=62.5,
+            message="Routing power rails",
+        )
+        artifact = WorkerArtifact(
+            **contract_context(),
+            artifact_id="artifact_wiring",
+            kind="wiring-diagram",
+            uri="s3://worker-artifacts/wiring.svg",
+            media_type="image/svg+xml",
+        )
+        error = WorkerError(
+            **contract_context(),
+            error_id="error_catalog_timeout",
+            code="catalog_timeout",
+            message="The component catalog timed out.",
+            retryable=True,
+            details={"provider": "catalog"},
+        )
+        failed = WorkerResult(
+            **contract_context(),
+            output_contract_version="electrical-plan.v1",
+            status="failed",
+            error=error,
+        )
+        succeeded = WorkerResult(
+            **contract_context(),
+            output_contract_version="electrical-plan.v1",
+            status="succeeded",
+            output={"rail_count": 2},
+            artifacts=[artifact],
+        )
+
+        self.assertEqual(progress, WorkerProgress.model_validate_json(progress.model_dump_json()))
+        self.assertEqual(artifact, WorkerArtifact.model_validate_json(artifact.model_dump_json()))
+        self.assertEqual(error, WorkerError.model_validate_json(error.model_dump_json()))
+        self.assertEqual(failed, WorkerResult.model_validate_json(failed.model_dump_json()))
+        self.assertEqual(succeeded, WorkerResult.model_validate_json(succeeded.model_dump_json()))
+
+    def test_envelopes_reject_unsupported_versions_with_a_structured_error(self) -> None:
+        with self.assertRaises(ValidationError) as raised:
+            WorkerRequest(
+                **{**contract_context(), "contract_version": "2.0"},
+                input_contract_version="design-brief.v1",
+            )
+
+        error = raised.exception.errors()[0]
+        self.assertEqual("unsupported_worker_contract_version", error["type"])
+        self.assertEqual(["1.0"], error["ctx"]["supported_versions"])
+
+    def test_results_validate_terminal_status_and_nested_context(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "requires error details"):
+            WorkerResult(
+                **contract_context(),
+                output_contract_version="electrical-plan.v1",
+                status="failed",
+            )
+
+        wrong_artifact = WorkerArtifact(
+            **contract_context(worker_id="mechanical-worker"),
+            kind="enclosure",
+            uri="s3://worker-artifacts/enclosure.step",
+        )
+        with self.assertRaisesRegex(ValidationError, "context must match"):
+            WorkerResult(
+                **contract_context(),
+                output_contract_version="electrical-plan.v1",
+                status="succeeded",
+                artifacts=[wrong_artifact],
+            )
+
+
+class WorkerRegistryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.electrical = FakeElectricalWorker()
+        self.mechanical = FakeMechanicalWorker()
+        self.registry = WorkerRegistry([self.electrical, self.mechanical])
+
+    def request(
+        self,
+        *,
+        worker_id: str = "electrical-worker",
+        capability_id: str = "electrical.plan",
+        input_contract_version: str = "design-brief.v1",
+    ) -> WorkerRequest:
+        return WorkerRequest(
+            **contract_context(worker_id=worker_id, capability_id=capability_id),
+            input_contract_version=input_contract_version,
+            payload={"summary": "Build a controller"},
+        )
+
+    def test_two_workers_declare_discoverable_capabilities_and_versions(self) -> None:
+        manifest = self.registry.manifest()
+        reviewers = self.registry.find_capability(
+            "hardware.review",
+            input_contract_version="hardware-review.v1",
+        )
+
+        self.assertEqual(
+            ["electrical-worker", "mechanical-worker"],
+            [item["worker_id"] for item in manifest["workers"]],
+        )
+        self.assertEqual(
+            ["electrical-worker", "mechanical-worker"],
+            [resolution.worker.worker_id for resolution in reviewers],
+        )
+        electrical = self.registry.resolve("electrical-worker", "electrical.plan")
+        self.assertEqual(["design-brief.v1"], electrical.capability.supported_input_versions)
+        self.assertEqual(["electrical-plan.v1"], electrical.capability.supported_output_versions)
+
+    def test_unknown_worker_and_capability_fail_before_execution(self) -> None:
+        for request, expected_code in (
+            (self.request(worker_id="missing-worker"), "unknown_worker"),
+            (self.request(capability_id="electrical.fabricate"), "unknown_worker_capability"),
+        ):
+            with self.subTest(expected_code=expected_code):
+                with self.assertRaises(WorkerRegistryError) as raised:
+                    self.registry.validate_request(request)
+                    self.electrical.execute(request)
+                self.assertEqual(expected_code, raised.exception.code)
+                self.assertEqual(expected_code, raised.exception.as_dict()["code"])
+
+        self.assertEqual(0, self.electrical.execution_count)
+
+    def test_request_and_result_versions_are_checked_against_capability(self) -> None:
+        with self.assertRaises(WorkerRegistryError) as input_error:
+            self.registry.validate_request(self.request(input_contract_version="design-brief.v2"))
+
+        result = WorkerResult(
+            **contract_context(),
+            output_contract_version="electrical-plan.v2",
+            status="succeeded",
+        )
+        with self.assertRaises(WorkerRegistryError) as output_error:
+            self.registry.validate_result(result)
+
+        self.assertEqual("incompatible_worker_contract_version", input_error.exception.code)
+        self.assertEqual("input", input_error.exception.context["direction"])
+        self.assertEqual(["design-brief.v1"], input_error.exception.context["supported_versions"])
+        self.assertEqual("incompatible_worker_contract_version", output_error.exception.code)
+        self.assertEqual("output", output_error.exception.context["direction"])
+
+    def test_compatible_request_is_resolved_before_worker_execution(self) -> None:
+        request = self.request()
+
+        resolution = self.registry.validate_request(request)
+        output = self.electrical.execute(request)
+
+        self.assertEqual("electrical-worker", resolution.worker.worker_id)
+        self.assertEqual({"summary": "Build a controller"}, output)
+        self.assertEqual(1, self.electrical.execution_count)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #183

## Summary
- add versioned WorkerRequest, WorkerProgress, WorkerResult, WorkerArtifact, WorkerError, and dependency contracts
- carry project, revision, DesignBrief, job, worker, capability, and correlation identities through every envelope
- add a capability registry that rejects unknown workers, unknown capabilities, and incompatible input/output versions before execution
- document the worker boundary and compatibility rules

## Testing
- `CLOUDFLARE_ENABLE_THINKING=false ./scripts/quality/test.sh`
- 387 tests passed; 1 skipped