### PR TITLE
feat: implement project workflow state machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ Tip: load an example directly with http://localhost:3000/?example=pocket_mp3_pla
 - [Architecture](docs/architecture.md)
 - [DesignBrief contract](docs/design-brief.md)
 - [Worker contracts and capability registry](docs/worker-contracts.md)
+- [Project workflow state machine](docs/project-workflow.md)
 - [Agents](docs/agents.md)
 - [Hardware IR](docs/hardware-ir.md)
 - [Validation](docs/validation.md)

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -127,6 +127,7 @@ from blueprint_core.video_review import FireworksVideoReviewClient
 from apps.api.logs_api import router as logs_router
 from apps.api.streams_api import router as streams_router
 from apps.api.design_briefs_api import router as design_briefs_router
+from apps.api.project_workflow_api import router as project_workflow_router
 from apps.api.user_integrations_api import router as user_integrations_router
 from apps.api.user_settings_api import router as user_settings_router
 from apps.api.auth import (
@@ -278,6 +279,7 @@ app.add_middleware(
 app.include_router(logs_router, dependencies=[Depends(require_admin_user_context)])
 app.include_router(streams_router, dependencies=[Depends(require_admin_user_context)])
 app.include_router(design_briefs_router)
+app.include_router(project_workflow_router)
 app.include_router(user_integrations_router)
 app.include_router(user_settings_router)
 

--- a/apps/api/project_workflow_api.py
+++ b/apps/api/project_workflow_api.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from apps.api.auth import UserContext, require_user_context
+from blueprint_core.database import (
+    get_project_workflow,
+    initialize_project_workflow,
+    list_project_workflow_transitions,
+    transition_project_workflow,
+)
+from blueprint_core.workspaces.workflow import (
+    ProjectWorkflow,
+    ProjectWorkflowHistory,
+    WorkflowActorType,
+    WorkflowStateError,
+    WorkflowTransitionCommand,
+    WorkflowTransitionOutcome,
+)
+
+
+router = APIRouter(prefix="/projects/{project_id}/workflow", tags=["project-workflow"])
+
+
+def _owner(user: UserContext) -> str:
+    owner_user_id = str(user.owner_user_id or "").strip()
+    if not owner_user_id:
+        raise HTTPException(status_code=401, detail={"code": "authentication_required", "message": "Sign in."})
+    return owner_user_id
+
+
+def _workflow_error(exc: WorkflowStateError) -> HTTPException:
+    status_code = 404 if exc.code == "workflow_not_found" else status.HTTP_409_CONFLICT
+    return HTTPException(status_code=status_code, detail=exc.as_dict())
+
+
+@router.post("", response_model=WorkflowTransitionOutcome)
+def initialize_workflow_endpoint(
+    project_id: UUID,
+    user: UserContext = Depends(require_user_context),
+) -> WorkflowTransitionOutcome:
+    try:
+        owner = _owner(user)
+        return initialize_project_workflow(
+            str(project_id),
+            owner,
+            actor_type=WorkflowActorType.USER,
+            actor_id=owner,
+            reason="User started a project conversation.",
+        )
+    except WorkflowStateError as exc:
+        raise _workflow_error(exc) from exc
+
+
+@router.get("", response_model=ProjectWorkflow)
+def get_workflow_endpoint(
+    project_id: UUID,
+    user: UserContext = Depends(require_user_context),
+) -> ProjectWorkflow:
+    try:
+        return get_project_workflow(str(project_id), _owner(user))
+    except WorkflowStateError as exc:
+        raise _workflow_error(exc) from exc
+
+
+@router.get("/transitions", response_model=ProjectWorkflowHistory)
+def get_workflow_history_endpoint(
+    project_id: UUID,
+    user: UserContext = Depends(require_user_context),
+) -> ProjectWorkflowHistory:
+    try:
+        owner = _owner(user)
+        workflow = get_project_workflow(str(project_id), owner)
+        transitions = list_project_workflow_transitions(str(project_id), owner)
+        return ProjectWorkflowHistory(workflow=workflow, transitions=transitions)
+    except WorkflowStateError as exc:
+        raise _workflow_error(exc) from exc
+
+
+@router.post("/transitions", response_model=WorkflowTransitionOutcome)
+def transition_workflow_endpoint(
+    project_id: UUID,
+    command: WorkflowTransitionCommand,
+    user: UserContext = Depends(require_user_context),
+) -> WorkflowTransitionOutcome:
+    try:
+        owner = _owner(user)
+        return transition_project_workflow(
+            str(project_id),
+            owner,
+            command.to_state,
+            actor_type=WorkflowActorType.USER,
+            actor_id=owner,
+            reason=command.reason,
+            idempotency_key=command.idempotency_key,
+        )
+    except WorkflowStateError as exc:
+        raise _workflow_error(exc) from exc

--- a/blueprint_core/database.py
+++ b/blueprint_core/database.py
@@ -11,6 +11,14 @@ from blueprint_core.runtime import blueprint_dev_mode_enabled
 from blueprint_core.project_list_cache import invalidate_project_lists
 from blueprint_core.workspaces.projects.objects import attach_project_object_metadata_to_dict
 from blueprint_core.workspaces.design_briefs import DesignBrief, DesignBriefCreate
+from blueprint_core.workspaces.workflow import (
+    ProjectWorkflow,
+    ProjectWorkflowService,
+    ProjectWorkflowState,
+    ProjectWorkflowTransition,
+    WorkflowActorType,
+    WorkflowTransitionOutcome,
+)
 from blueprint_core.persistence.base import DatabaseProvider
 from blueprint_core.persistence.models import (
     Base,
@@ -358,6 +366,9 @@ def save_generated_project(
     linked_brief = _DATABASE_REPOSITORY.get_latest_design_brief(project_id, None)
     if linked_brief is not None and getattr(linked_brief, "owner_user_id", None) != normalized_owner_user_id:
         raise DesignBriefAccessError("DesignBrief is not owned by the project owner.")
+    linked_workflow = _DATABASE_REPOSITORY.get_project_workflow(project_id, None)
+    if linked_workflow is not None and getattr(linked_workflow, "owner_user_id", None) != normalized_owner_user_id:
+        raise DesignBriefAccessError("Workflow is not owned by the project owner.")
     normalized_visibility = _normalize_visibility(visibility)
     record = {
         "project_id": project_id,
@@ -416,6 +427,10 @@ def create_design_brief_version(
             raise DesignBriefAccessError("Project is not owned by the current user.")
         if getattr(project, "status", "active") != "active":
             raise DesignBriefAccessError("Cannot append a DesignBrief to a deleted project.")
+
+    workflow = _DATABASE_REPOSITORY.get_project_workflow(canonical_project_id, None)
+    if workflow is not None and getattr(workflow, "owner_user_id", None) != normalized_owner_user_id:
+        raise DesignBriefAccessError("Project workflow is not owned by the current user.")
 
     previous = _DATABASE_REPOSITORY.get_latest_design_brief(canonical_project_id, None)
     if previous is not None and getattr(previous, "owner_user_id", None) != normalized_owner_user_id:
@@ -490,6 +505,55 @@ def get_latest_design_brief(project_id: str, owner_user_id: str) -> DesignBrief:
     if record is None:
         raise DesignBriefNotFoundError("DesignBrief not found.")
     return _design_brief_from_record(record)
+
+
+def initialize_project_workflow(
+    project_id: str,
+    owner_user_id: str,
+    *,
+    actor_type: WorkflowActorType = WorkflowActorType.SYSTEM,
+    actor_id: Optional[str] = None,
+    reason: str = "Project workflow initialized.",
+) -> WorkflowTransitionOutcome:
+    return ProjectWorkflowService(_DATABASE_REPOSITORY).initialize(
+        project_id,
+        owner_user_id,
+        actor_type=actor_type,
+        actor_id=actor_id,
+        reason=reason,
+    )
+
+
+def get_project_workflow(project_id: str, owner_user_id: str) -> ProjectWorkflow:
+    return ProjectWorkflowService(_DATABASE_REPOSITORY).get(project_id, owner_user_id)
+
+
+def list_project_workflow_transitions(
+    project_id: str,
+    owner_user_id: str,
+) -> List[ProjectWorkflowTransition]:
+    return ProjectWorkflowService(_DATABASE_REPOSITORY).history(project_id, owner_user_id)
+
+
+def transition_project_workflow(
+    project_id: str,
+    owner_user_id: str,
+    to_state: ProjectWorkflowState,
+    *,
+    actor_type: WorkflowActorType,
+    actor_id: Optional[str],
+    reason: str,
+    idempotency_key: Optional[str] = None,
+) -> WorkflowTransitionOutcome:
+    return ProjectWorkflowService(_DATABASE_REPOSITORY).transition(
+        project_id,
+        owner_user_id,
+        to_state,
+        actor_type=actor_type,
+        actor_id=actor_id,
+        reason=reason,
+        idempotency_key=idempotency_key,
+    )
 
 
 def list_due_project_purges(before: str, limit: int = 25) -> List[Any]:

--- a/blueprint_core/persistence/models.py
+++ b/blueprint_core/persistence/models.py
@@ -60,6 +60,37 @@ class DBDesignBrief(Base):
     created_at = Column(String, index=True, nullable=False)
 
 
+class DBProjectWorkflow(Base):
+    __tablename__ = "project_workflows"
+
+    project_id = Column(String, primary_key=True)
+    owner_user_id = Column(String, index=True, nullable=False)
+    state = Column(String, index=True, nullable=False)
+    revision = Column(Integer, nullable=False)
+    created_at = Column(String, nullable=False)
+    updated_at = Column(String, index=True, nullable=False)
+
+
+class DBProjectWorkflowTransition(Base):
+    __tablename__ = "project_workflow_transitions"
+    __table_args__ = (
+        UniqueConstraint("project_id", "revision", name="uq_project_workflow_transition_revision"),
+        UniqueConstraint("project_id", "idempotency_key", name="uq_project_workflow_transition_idempotency"),
+    )
+
+    id = Column(String, primary_key=True)
+    project_id = Column(String, index=True, nullable=False)
+    owner_user_id = Column(String, index=True, nullable=False)
+    from_state = Column(String, nullable=True)
+    to_state = Column(String, index=True, nullable=False)
+    actor_type = Column(String, nullable=False)
+    actor_id = Column(String, index=True, nullable=True)
+    reason = Column(Text, nullable=False)
+    idempotency_key = Column(String, nullable=True)
+    revision = Column(Integer, nullable=False)
+    created_at = Column(String, index=True, nullable=False)
+
+
 class DBProjectContributionConsent(Base):
     __tablename__ = "project_contribution_consents"
     __table_args__ = (UniqueConstraint("project_id", "user_id", name="uq_project_contribution_consent_project_user"),)

--- a/blueprint_core/persistence/repositories/base.py
+++ b/blueprint_core/persistence/repositories/base.py
@@ -37,6 +37,25 @@ class ApplicationRepository(Protocol):
 
     def get_latest_design_brief(self, project_id: str, owner_user_id: Optional[str]) -> Optional[Any]: ...
 
+    def get_project_workflow(self, project_id: str, owner_user_id: Optional[str]) -> Optional[Any]: ...
+
+    def list_project_workflow_transitions(self, project_id: str, owner_user_id: str) -> List[Any]: ...
+
+    def get_project_workflow_transition_by_idempotency(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        idempotency_key: str,
+    ) -> Optional[Any]: ...
+
+    def apply_project_workflow_transition(
+        self,
+        state_record: Dict[str, Any],
+        transition_record: Dict[str, Any],
+        expected_state: Optional[str],
+        expected_revision: Optional[int],
+    ) -> Optional[tuple[Any, Any]]: ...
+
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]: ...
 
     def update_project_deletion_state(

--- a/blueprint_core/persistence/repositories/sqlite.py
+++ b/blueprint_core/persistence/repositories/sqlite.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
 from blueprint_core.persistence.models import (
@@ -13,6 +14,8 @@ from blueprint_core.persistence.models import (
     DBProjectContributionSnapshot,
     DBProjectChat,
     DBProjectDeletionAudit,
+    DBProjectWorkflow,
+    DBProjectWorkflowTransition,
     DBUserSettings,
 )
 
@@ -124,6 +127,81 @@ class SqlAlchemyRepository:
                 query = query.filter(DBDesignBrief.owner_user_id == owner_user_id)
             return query.order_by(DBDesignBrief.brief_version.desc()).first()
 
+    def get_project_workflow(self, project_id: str, owner_user_id: Optional[str]) -> Optional[Any]:
+        with self._session() as session:
+            query = session.query(DBProjectWorkflow).filter(DBProjectWorkflow.project_id == project_id)
+            if owner_user_id:
+                query = query.filter(DBProjectWorkflow.owner_user_id == owner_user_id)
+            return query.first()
+
+    def list_project_workflow_transitions(self, project_id: str, owner_user_id: str) -> List[Any]:
+        with self._session() as session:
+            return (
+                session.query(DBProjectWorkflowTransition)
+                .filter(
+                    DBProjectWorkflowTransition.project_id == project_id,
+                    DBProjectWorkflowTransition.owner_user_id == owner_user_id,
+                )
+                .order_by(DBProjectWorkflowTransition.revision.asc())
+                .all()
+            )
+
+    def get_project_workflow_transition_by_idempotency(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        idempotency_key: str,
+    ) -> Optional[Any]:
+        with self._session() as session:
+            return (
+                session.query(DBProjectWorkflowTransition)
+                .filter(
+                    DBProjectWorkflowTransition.project_id == project_id,
+                    DBProjectWorkflowTransition.owner_user_id == owner_user_id,
+                    DBProjectWorkflowTransition.idempotency_key == idempotency_key,
+                )
+                .first()
+            )
+
+    def apply_project_workflow_transition(
+        self,
+        state_record: Dict[str, Any],
+        transition_record: Dict[str, Any],
+        expected_state: Optional[str],
+        expected_revision: Optional[int],
+    ) -> Optional[tuple[Any, Any]]:
+        try:
+            with self._session() as session, session.begin():
+                workflow = session.query(DBProjectWorkflow).filter(
+                    DBProjectWorkflow.project_id == state_record["project_id"]
+                ).first()
+                if expected_state is None:
+                    if workflow is not None:
+                        return None
+                    workflow = DBProjectWorkflow(**state_record)
+                    session.add(workflow)
+                else:
+                    if (
+                        workflow is None
+                        or workflow.owner_user_id != state_record["owner_user_id"]
+                        or workflow.state != expected_state
+                        or workflow.revision != expected_revision
+                    ):
+                        return None
+                    workflow.state = state_record["state"]
+                    workflow.revision = state_record["revision"]
+                    workflow.updated_at = state_record["updated_at"]
+                transition = DBProjectWorkflowTransition(**transition_record)
+                session.add(transition)
+                session.flush()
+                session.refresh(workflow)
+                session.refresh(transition)
+                session.expunge(workflow)
+                session.expunge(transition)
+                return workflow, transition
+        except IntegrityError:
+            return None
+
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]:
         with self._session() as session:
             return (
@@ -176,6 +254,12 @@ class SqlAlchemyRepository:
             chat_id = project.chat_id
             project_owner_user_id = project.owner_user_id
             session.query(DBDesignBrief).filter(DBDesignBrief.project_id == project_id).delete(
+                synchronize_session=False
+            )
+            session.query(DBProjectWorkflowTransition).filter(
+                DBProjectWorkflowTransition.project_id == project_id
+            ).delete(synchronize_session=False)
+            session.query(DBProjectWorkflow).filter(DBProjectWorkflow.project_id == project_id).delete(
                 synchronize_session=False
             )
             session.delete(project)
@@ -248,6 +332,12 @@ class SqlAlchemyRepository:
             if not project:
                 return False
             session.query(DBDesignBrief).filter(DBDesignBrief.project_id == project_id).delete(
+                synchronize_session=False
+            )
+            session.query(DBProjectWorkflowTransition).filter(
+                DBProjectWorkflowTransition.project_id == project_id
+            ).delete(synchronize_session=False)
+            session.query(DBProjectWorkflow).filter(DBProjectWorkflow.project_id == project_id).delete(
                 synchronize_session=False
             )
             session.delete(project)

--- a/blueprint_core/persistence/repositories/supabase.py
+++ b/blueprint_core/persistence/repositories/supabase.py
@@ -106,6 +106,68 @@ class SupabaseRepository:
         rows = query.order("brief_version", desc=True).limit(1).execute().data or []
         return _record(rows[0]) if rows else None
 
+    def get_project_workflow(self, project_id: str, owner_user_id: Optional[str]) -> Optional[Any]:
+        query = self._client.table("project_workflows").select("*").eq("project_id", project_id)
+        if owner_user_id:
+            query = query.eq("owner_user_id", owner_user_id)
+        rows = query.limit(1).execute().data or []
+        return _record(rows[0]) if rows else None
+
+    def list_project_workflow_transitions(self, project_id: str, owner_user_id: str) -> List[Any]:
+        rows = (
+            self._client.table("project_workflow_transitions")
+            .select("*")
+            .eq("project_id", project_id)
+            .eq("owner_user_id", owner_user_id)
+            .order("revision")
+            .execute()
+            .data
+            or []
+        )
+        return [_record(row) for row in rows]
+
+    def get_project_workflow_transition_by_idempotency(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        idempotency_key: str,
+    ) -> Optional[Any]:
+        rows = (
+            self._client.table("project_workflow_transitions")
+            .select("*")
+            .eq("project_id", project_id)
+            .eq("owner_user_id", owner_user_id)
+            .eq("idempotency_key", idempotency_key)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
+    def apply_project_workflow_transition(
+        self,
+        state_record: Dict[str, Any],
+        transition_record: Dict[str, Any],
+        expected_state: Optional[str],
+        expected_revision: Optional[int],
+    ) -> Optional[tuple[Any, Any]]:
+        data = (
+            self._client.rpc(
+                "apply_project_workflow_transition",
+                {
+                    "p_state": state_record,
+                    "p_transition": transition_record,
+                    "p_expected_state": expected_state,
+                    "p_expected_revision": expected_revision,
+                },
+            ).execute().data
+        )
+        payload = data[0] if isinstance(data, list) and data else data
+        if not isinstance(payload, dict) or not payload.get("workflow") or not payload.get("transition"):
+            return None
+        return _record(payload["workflow"]), _record(payload["transition"])
+
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]:
         rows = (
             self._client.table("generated_projects")
@@ -151,6 +213,8 @@ class SupabaseRepository:
         deleted = bool(query.execute().data)
         if deleted:
             self._client.table("design_briefs").delete().eq("project_id", project_id).execute()
+            self._client.table("project_workflow_transitions").delete().eq("project_id", project_id).execute()
+            self._client.table("project_workflows").delete().eq("project_id", project_id).execute()
         if not deleted or not getattr(project, "chat_id", None) or not getattr(project, "owner_user_id", None):
             return deleted
         remaining = (
@@ -219,6 +283,8 @@ class SupabaseRepository:
         deleted = bool(response.data)
         if deleted:
             self._client.table("design_briefs").delete().eq("project_id", project_id).execute()
+            self._client.table("project_workflow_transitions").delete().eq("project_id", project_id).execute()
+            self._client.table("project_workflows").delete().eq("project_id", project_id).execute()
         return deleted
 
     def delete_generated_project(self, project_id: str, owner_user_id: str) -> bool:

--- a/blueprint_core/persistence/schema.py
+++ b/blueprint_core/persistence/schema.py
@@ -30,6 +30,17 @@ APPLICATION_SCHEMA: Tuple[TableContract, ...] = (
         ),
     ),
     TableContract(
+        "project_workflows",
+        ("project_id", "owner_user_id", "state", "revision", "created_at", "updated_at"),
+    ),
+    TableContract(
+        "project_workflow_transitions",
+        (
+            "id", "project_id", "owner_user_id", "from_state", "to_state", "actor_type", "actor_id", "reason",
+            "idempotency_key", "revision", "created_at",
+        ),
+    ),
+    TableContract(
         "project_contribution_consents",
         (
             "id", "project_id", "user_id", "workspace_id", "consent_version", "permitted_purposes", "granted_at",

--- a/blueprint_core/workspaces/workflow/__init__.py
+++ b/blueprint_core/workspaces/workflow/__init__.py
@@ -1,0 +1,27 @@
+from blueprint_core.workspaces.workflow.models import (
+    ProjectWorkflow,
+    ProjectWorkflowHistory,
+    ProjectWorkflowState,
+    ProjectWorkflowTransition,
+    WorkflowActorType,
+    WorkflowTransitionCommand,
+    WorkflowTransitionOutcome,
+)
+from blueprint_core.workspaces.workflow.service import (
+    ALLOWED_WORKFLOW_TRANSITIONS,
+    ProjectWorkflowService,
+    WorkflowStateError,
+)
+
+__all__ = [
+    "ALLOWED_WORKFLOW_TRANSITIONS",
+    "ProjectWorkflow",
+    "ProjectWorkflowHistory",
+    "ProjectWorkflowService",
+    "ProjectWorkflowState",
+    "ProjectWorkflowTransition",
+    "WorkflowActorType",
+    "WorkflowStateError",
+    "WorkflowTransitionCommand",
+    "WorkflowTransitionOutcome",
+]

--- a/blueprint_core/workspaces/workflow/models.py
+++ b/blueprint_core/workspaces/workflow/models.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Annotated
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+
+
+NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class ProjectWorkflowState(str, Enum):
+    GATHERING_CONTEXT = "gathering_context"
+    READY_TO_BUILD = "ready_to_build"
+    BUILDING = "building"
+    AWAITING_FEEDBACK = "awaiting_feedback"
+    COMPLETED = "completed"
+    CANCELLED = "cancelled"
+    FAILED = "failed"
+
+
+class WorkflowActorType(str, Enum):
+    USER = "user"
+    SYSTEM = "system"
+
+
+class ProjectWorkflow(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    project_id: UUID
+    owner_user_id: NonEmptyString
+    state: ProjectWorkflowState
+    revision: int = Field(ge=1)
+    created_at: datetime
+    updated_at: datetime
+
+
+class ProjectWorkflowTransition(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    transition_id: UUID
+    project_id: UUID
+    owner_user_id: NonEmptyString
+    from_state: ProjectWorkflowState | None
+    to_state: ProjectWorkflowState
+    actor_type: WorkflowActorType
+    actor_id: NonEmptyString | None = None
+    reason: NonEmptyString
+    idempotency_key: NonEmptyString | None = None
+    revision: int = Field(ge=1)
+    created_at: datetime
+
+
+class WorkflowTransitionCommand(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    to_state: ProjectWorkflowState
+    reason: NonEmptyString
+    idempotency_key: NonEmptyString | None = None
+
+
+class WorkflowTransitionOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workflow: ProjectWorkflow
+    transition: ProjectWorkflowTransition | None
+    idempotent_replay: bool = False
+
+
+class ProjectWorkflowHistory(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workflow: ProjectWorkflow
+    transitions: list[ProjectWorkflowTransition]
+

--- a/blueprint_core/workspaces/workflow/service.py
+++ b/blueprint_core/workspaces/workflow/service.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Protocol
+from uuid import UUID, uuid4
+
+from blueprint_core.workspaces.workflow.models import (
+    ProjectWorkflow,
+    ProjectWorkflowState,
+    ProjectWorkflowTransition,
+    WorkflowActorType,
+    WorkflowTransitionOutcome,
+)
+
+
+ALLOWED_WORKFLOW_TRANSITIONS: dict[ProjectWorkflowState, frozenset[ProjectWorkflowState]] = {
+    ProjectWorkflowState.GATHERING_CONTEXT: frozenset({
+        ProjectWorkflowState.READY_TO_BUILD,
+        ProjectWorkflowState.BUILDING,
+        ProjectWorkflowState.CANCELLED,
+        ProjectWorkflowState.FAILED,
+    }),
+    ProjectWorkflowState.READY_TO_BUILD: frozenset({
+        ProjectWorkflowState.GATHERING_CONTEXT,
+        ProjectWorkflowState.BUILDING,
+        ProjectWorkflowState.CANCELLED,
+        ProjectWorkflowState.FAILED,
+    }),
+    ProjectWorkflowState.BUILDING: frozenset({
+        ProjectWorkflowState.AWAITING_FEEDBACK,
+        ProjectWorkflowState.CANCELLED,
+        ProjectWorkflowState.FAILED,
+    }),
+    ProjectWorkflowState.AWAITING_FEEDBACK: frozenset({
+        ProjectWorkflowState.GATHERING_CONTEXT,
+        ProjectWorkflowState.BUILDING,
+        ProjectWorkflowState.COMPLETED,
+        ProjectWorkflowState.CANCELLED,
+        ProjectWorkflowState.FAILED,
+    }),
+    ProjectWorkflowState.COMPLETED: frozenset(),
+    ProjectWorkflowState.CANCELLED: frozenset(),
+    ProjectWorkflowState.FAILED: frozenset({
+        ProjectWorkflowState.GATHERING_CONTEXT,
+        ProjectWorkflowState.READY_TO_BUILD,
+        ProjectWorkflowState.BUILDING,
+        ProjectWorkflowState.CANCELLED,
+    }),
+}
+
+
+class WorkflowRepository(Protocol):
+    def get_project_workflow(self, project_id: str, owner_user_id: str | None) -> Any | None: ...
+    def list_project_workflow_transitions(self, project_id: str, owner_user_id: str) -> list[Any]: ...
+    def get_project_workflow_transition_by_idempotency(
+        self, project_id: str, owner_user_id: str, idempotency_key: str
+    ) -> Any | None: ...
+    def apply_project_workflow_transition(
+        self,
+        state_record: dict[str, Any],
+        transition_record: dict[str, Any],
+        expected_state: str | None,
+        expected_revision: int | None,
+    ) -> tuple[Any, Any] | None: ...
+
+
+class WorkflowStateError(RuntimeError):
+    def __init__(self, code: str, message: str, *, context: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.context = context or {}
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"code": self.code, "message": self.message, "context": dict(self.context)}
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _project_id(value: str | UUID) -> str:
+    try:
+        return str(UUID(str(value).strip()))
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise ValueError("project_id must be a UUID.") from exc
+
+
+def _owner_id(value: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ValueError("owner_user_id is required.")
+    return normalized
+
+
+def _reason(value: str) -> str:
+    normalized = str(value or "").strip()
+    if not normalized:
+        raise ValueError("A workflow transition reason is required.")
+    return normalized
+
+
+def _workflow(record: Any) -> ProjectWorkflow:
+    return ProjectWorkflow.model_validate({
+        "project_id": record.project_id,
+        "owner_user_id": record.owner_user_id,
+        "state": record.state,
+        "revision": record.revision,
+        "created_at": record.created_at,
+        "updated_at": record.updated_at,
+    })
+
+
+def _transition(record: Any) -> ProjectWorkflowTransition:
+    return ProjectWorkflowTransition.model_validate({
+        "transition_id": record.id,
+        "project_id": record.project_id,
+        "owner_user_id": record.owner_user_id,
+        "from_state": record.from_state,
+        "to_state": record.to_state,
+        "actor_type": record.actor_type,
+        "actor_id": record.actor_id,
+        "reason": record.reason,
+        "idempotency_key": record.idempotency_key,
+        "revision": record.revision,
+        "created_at": record.created_at,
+    })
+
+
+class ProjectWorkflowService:
+    def __init__(self, repository: WorkflowRepository) -> None:
+        self._repository = repository
+
+    def initialize(
+        self,
+        project_id: str | UUID,
+        owner_user_id: str,
+        *,
+        actor_type: WorkflowActorType = WorkflowActorType.SYSTEM,
+        actor_id: str | None = None,
+        reason: str = "Project workflow initialized.",
+    ) -> WorkflowTransitionOutcome:
+        project = _project_id(project_id)
+        owner = _owner_id(owner_user_id)
+        existing = self._repository.get_project_workflow(project, None)
+        if existing is not None:
+            if existing.owner_user_id != owner:
+                raise WorkflowStateError("workflow_not_found", "Project workflow not found.")
+            return WorkflowTransitionOutcome(workflow=_workflow(existing), transition=None, idempotent_replay=True)
+        now = _utc_now()
+        transition_id = str(uuid4())
+        state_record = {
+            "project_id": project,
+            "owner_user_id": owner,
+            "state": ProjectWorkflowState.GATHERING_CONTEXT.value,
+            "revision": 1,
+            "created_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+        }
+        transition_record = {
+            "id": transition_id,
+            "project_id": project,
+            "owner_user_id": owner,
+            "from_state": None,
+            "to_state": ProjectWorkflowState.GATHERING_CONTEXT.value,
+            "actor_type": actor_type.value,
+            "actor_id": str(actor_id).strip() if actor_id else None,
+            "reason": _reason(reason),
+            "idempotency_key": f"workflow:init:{project}",
+            "revision": 1,
+            "created_at": now.isoformat(),
+        }
+        applied = self._repository.apply_project_workflow_transition(state_record, transition_record, None, None)
+        if applied is None:
+            existing = self._repository.get_project_workflow(project, None)
+            if existing is not None and existing.owner_user_id == owner:
+                return WorkflowTransitionOutcome(workflow=_workflow(existing), transition=None, idempotent_replay=True)
+            raise WorkflowStateError("workflow_transition_conflict", "Workflow initialization conflicted.")
+        workflow_record, transition_record_obj = applied
+        return WorkflowTransitionOutcome(
+            workflow=_workflow(workflow_record),
+            transition=_transition(transition_record_obj),
+        )
+
+    def get(self, project_id: str | UUID, owner_user_id: str) -> ProjectWorkflow:
+        record = self._repository.get_project_workflow(_project_id(project_id), _owner_id(owner_user_id))
+        if record is None:
+            raise WorkflowStateError("workflow_not_found", "Project workflow not found.")
+        return _workflow(record)
+
+    def history(self, project_id: str | UUID, owner_user_id: str) -> list[ProjectWorkflowTransition]:
+        project = _project_id(project_id)
+        owner = _owner_id(owner_user_id)
+        self.get(project, owner)
+        return [_transition(item) for item in self._repository.list_project_workflow_transitions(project, owner)]
+
+    def transition(
+        self,
+        project_id: str | UUID,
+        owner_user_id: str,
+        to_state: ProjectWorkflowState,
+        *,
+        actor_type: WorkflowActorType,
+        actor_id: str | None,
+        reason: str,
+        idempotency_key: str | None = None,
+    ) -> WorkflowTransitionOutcome:
+        project = _project_id(project_id)
+        owner = _owner_id(owner_user_id)
+        key = str(idempotency_key or "").strip() or None
+        if key:
+            replay = self._repository.get_project_workflow_transition_by_idempotency(project, owner, key)
+            if replay is not None:
+                current = self.get(project, owner)
+                prior = _transition(replay)
+                historical = current.model_copy(update={
+                    "state": prior.to_state,
+                    "revision": prior.revision,
+                    "updated_at": prior.created_at,
+                })
+                return WorkflowTransitionOutcome(
+                    workflow=historical,
+                    transition=prior,
+                    idempotent_replay=True,
+                )
+        current = self.get(project, owner)
+        if current.state == to_state:
+            return WorkflowTransitionOutcome(workflow=current, transition=None, idempotent_replay=True)
+        allowed = ALLOWED_WORKFLOW_TRANSITIONS[current.state]
+        if to_state not in allowed:
+            raise WorkflowStateError(
+                "invalid_workflow_transition",
+                f"Cannot transition project workflow from {current.state.value} to {to_state.value}.",
+                context={
+                    "project_id": project,
+                    "current_state": current.state.value,
+                    "requested_state": to_state.value,
+                    "allowed_states": sorted(state.value for state in allowed),
+                },
+            )
+        now = _utc_now()
+        next_revision = current.revision + 1
+        state_record = {
+            "project_id": project,
+            "owner_user_id": owner,
+            "state": to_state.value,
+            "revision": next_revision,
+            "created_at": current.created_at.isoformat(),
+            "updated_at": now.isoformat(),
+        }
+        transition_record = {
+            "id": str(uuid4()),
+            "project_id": project,
+            "owner_user_id": owner,
+            "from_state": current.state.value,
+            "to_state": to_state.value,
+            "actor_type": actor_type.value,
+            "actor_id": str(actor_id).strip() if actor_id else None,
+            "reason": _reason(reason),
+            "idempotency_key": key,
+            "revision": next_revision,
+            "created_at": now.isoformat(),
+        }
+        applied = self._repository.apply_project_workflow_transition(
+            state_record,
+            transition_record,
+            current.state.value,
+            current.revision,
+        )
+        if applied is None:
+            if key:
+                replay = self._repository.get_project_workflow_transition_by_idempotency(project, owner, key)
+                if replay is not None:
+                    return self.transition(
+                        project, owner, to_state,
+                        actor_type=actor_type, actor_id=actor_id, reason=reason, idempotency_key=key,
+                    )
+            raise WorkflowStateError(
+                "workflow_transition_conflict",
+                "Project workflow changed before the transition could be committed.",
+                context={"project_id": project, "expected_revision": current.revision},
+            )
+        workflow_record, transition_record_obj = applied
+        return WorkflowTransitionOutcome(
+            workflow=_workflow(workflow_record),
+            transition=_transition(transition_record_obj),
+        )

--- a/docs/project-workflow.md
+++ b/docs/project-workflow.md
@@ -1,0 +1,40 @@
+# Project workflow state machine
+
+Forma keeps conversational and build lifecycle state separate from generated-project deletion status. `ProjectWorkflowService` is the single authority for validating transitions, while the persistence repository atomically updates the current state and appends an immutable transition record.
+
+## States and transitions
+
+```text
+gathering_context -> ready_to_build | building | cancelled | failed
+ready_to_build    -> gathering_context | building | cancelled | failed
+building          -> awaiting_feedback | cancelled | failed
+awaiting_feedback -> gathering_context | building | completed | cancelled | failed
+failed            -> gathering_context | ready_to_build | building | cancelled
+completed         -> terminal
+cancelled         -> terminal
+```
+
+The direct `gathering_context -> building` transition supports the later **Build anyway** action. A transition to the current state is a no-op. Repeated commands with the same project-scoped `idempotency_key` return the original transition without appending history.
+
+Each transition records:
+
+- project and owner identifiers;
+- prior and resulting states;
+- monotonically increasing workflow revision;
+- user or system actor and optional actor identifier;
+- reason, timestamp, and optional idempotency key.
+
+## API
+
+Authenticated, owner-scoped routes are:
+
+- `POST /projects/{project_id}/workflow` — idempotently initialize `gathering_context`.
+- `GET /projects/{project_id}/workflow` — return current state.
+- `GET /projects/{project_id}/workflow/transitions` — return current state and ordered history.
+- `POST /projects/{project_id}/workflow/transitions` — request a validated transition.
+
+Invalid transitions return HTTP 409 with code `invalid_workflow_transition` and the allowed target states. Optimistic concurrency conflicts use `workflow_transition_conflict`; inaccessible workflows use the non-enumerating `workflow_not_found` response.
+
+## Persistence
+
+SQLite performs the state update and history insert in one SQLAlchemy transaction. Supabase uses the `apply_project_workflow_transition` database function so the same operation remains atomic through PostgREST. Browser roles cannot access either workflow table directly.

--- a/supabase/migrations/20260801000200_project_workflow_state.sql
+++ b/supabase/migrations/20260801000200_project_workflow_state.sql
@@ -1,0 +1,121 @@
+-- Central project workflow state and append-only transition history.
+
+create table if not exists public.project_workflows (
+  project_id text primary key,
+  owner_user_id text not null,
+  state text not null,
+  revision integer not null check (revision >= 1),
+  created_at text not null,
+  updated_at text not null,
+  constraint project_workflows_state_valid check (
+    state in ('gathering_context', 'ready_to_build', 'building', 'awaiting_feedback', 'completed', 'cancelled', 'failed')
+  )
+);
+
+create index if not exists idx_project_workflows_owner_updated
+  on public.project_workflows (owner_user_id, updated_at desc);
+
+create table if not exists public.project_workflow_transitions (
+  id text primary key,
+  project_id text not null,
+  owner_user_id text not null,
+  from_state text,
+  to_state text not null,
+  actor_type text not null,
+  actor_id text,
+  reason text not null,
+  idempotency_key text,
+  revision integer not null check (revision >= 1),
+  created_at text not null,
+  constraint project_workflow_transitions_from_state_valid check (
+    from_state is null or from_state in ('gathering_context', 'ready_to_build', 'building', 'awaiting_feedback', 'completed', 'cancelled', 'failed')
+  ),
+  constraint project_workflow_transitions_to_state_valid check (
+    to_state in ('gathering_context', 'ready_to_build', 'building', 'awaiting_feedback', 'completed', 'cancelled', 'failed')
+  ),
+  constraint project_workflow_transitions_actor_valid check (actor_type in ('user', 'system')),
+  constraint project_workflow_transitions_project_revision_unique unique (project_id, revision),
+  constraint project_workflow_transitions_project_idempotency_unique unique (project_id, idempotency_key)
+);
+
+create index if not exists idx_project_workflow_transitions_owner_project
+  on public.project_workflow_transitions (owner_user_id, project_id, revision);
+
+create or replace function public.apply_project_workflow_transition(
+  p_state jsonb,
+  p_transition jsonb,
+  p_expected_state text,
+  p_expected_revision integer
+) returns jsonb
+language plpgsql
+set search_path = public
+as $$
+declare
+  current_workflow public.project_workflows%rowtype;
+  saved_workflow public.project_workflows%rowtype;
+  saved_transition public.project_workflow_transitions%rowtype;
+begin
+  select * into current_workflow
+  from public.project_workflows
+  where project_id = p_state->>'project_id'
+  for update;
+
+  if p_expected_state is null then
+    if found then
+      return null;
+    end if;
+    insert into public.project_workflows (
+      project_id, owner_user_id, state, revision, created_at, updated_at
+    ) values (
+      p_state->>'project_id', p_state->>'owner_user_id', p_state->>'state',
+      (p_state->>'revision')::integer, p_state->>'created_at', p_state->>'updated_at'
+    ) returning * into saved_workflow;
+  else
+    if not found
+      or current_workflow.owner_user_id <> p_state->>'owner_user_id'
+      or current_workflow.state <> p_expected_state
+      or current_workflow.revision <> p_expected_revision then
+      return null;
+    end if;
+    update public.project_workflows
+    set state = p_state->>'state',
+        revision = (p_state->>'revision')::integer,
+        updated_at = p_state->>'updated_at'
+    where project_id = p_state->>'project_id'
+    returning * into saved_workflow;
+  end if;
+
+  insert into public.project_workflow_transitions (
+    id, project_id, owner_user_id, from_state, to_state, actor_type, actor_id,
+    reason, idempotency_key, revision, created_at
+  ) values (
+    p_transition->>'id', p_transition->>'project_id', p_transition->>'owner_user_id',
+    nullif(p_transition->>'from_state', ''), p_transition->>'to_state', p_transition->>'actor_type',
+    nullif(p_transition->>'actor_id', ''), p_transition->>'reason',
+    nullif(p_transition->>'idempotency_key', ''), (p_transition->>'revision')::integer,
+    p_transition->>'created_at'
+  ) returning * into saved_transition;
+
+  return jsonb_build_object(
+    'workflow', to_jsonb(saved_workflow),
+    'transition', to_jsonb(saved_transition)
+  );
+exception
+  when unique_violation then
+    return null;
+end;
+$$;
+
+alter table public.project_workflows enable row level security;
+alter table public.project_workflow_transitions enable row level security;
+
+revoke all on table public.project_workflows from anon, authenticated;
+revoke all on table public.project_workflow_transitions from anon, authenticated;
+grant select, insert, update, delete on table public.project_workflows to service_role;
+grant select, insert, delete on table public.project_workflow_transitions to service_role;
+
+revoke all on function public.apply_project_workflow_transition(jsonb, jsonb, text, integer) from public, anon, authenticated;
+grant execute on function public.apply_project_workflow_transition(jsonb, jsonb, text, integer) to service_role;
+
+comment on table public.project_workflows is 'Current state for the centralized project workflow state machine.';
+comment on table public.project_workflow_transitions is 'Append-only workflow state transition history.';

--- a/tests/projects/test_workflow_state.py
+++ b/tests/projects/test_workflow_state.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Iterator
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from apps.api.auth import UserContext, require_user_context
+from apps.api.project_workflow_api import router
+from blueprint_core import database
+from blueprint_core.persistence.providers import create_sqlite_provider
+from blueprint_core.persistence.repositories import SqlAlchemyRepository
+from blueprint_core.workspaces.workflow import (
+    ALLOWED_WORKFLOW_TRANSITIONS,
+    ProjectWorkflowService,
+    ProjectWorkflowState,
+    WorkflowActorType,
+    WorkflowStateError,
+)
+
+
+OWNER = "workflow-user"
+USER = UserContext(
+    provider="test",
+    subject=OWNER,
+    owner_user_id=OWNER,
+    is_authenticated=True,
+    is_admin=False,
+)
+
+
+@contextmanager
+def sqlite_repository() -> Iterator[None]:
+    with tempfile.TemporaryDirectory() as directory:
+        provider = create_sqlite_provider(
+            source="workflow test",
+            url=f"sqlite:///{Path(directory) / 'blueprint.db'}",
+            import_legacy_jobs=False,
+        )
+        assert provider.session_factory is not None
+        provider.initialize()
+        original = database._DATABASE_REPOSITORY
+        try:
+            database._DATABASE_REPOSITORY = SqlAlchemyRepository(provider.session_factory)
+            yield
+        finally:
+            database._DATABASE_REPOSITORY = original
+
+
+class StateRepository:
+    def __init__(self, state: ProjectWorkflowState) -> None:
+        self.workflow = SimpleNamespace(
+            project_id=str(uuid.uuid4()),
+            owner_user_id=OWNER,
+            state=state.value,
+            revision=3,
+            created_at="2026-08-01T12:00:00Z",
+            updated_at="2026-08-01T12:01:00Z",
+        )
+
+    def get_project_workflow(self, project_id: str, owner_user_id: str | None) -> Any:
+        if project_id != self.workflow.project_id:
+            return None
+        if owner_user_id and owner_user_id != self.workflow.owner_user_id:
+            return None
+        return self.workflow
+
+    def list_project_workflow_transitions(self, project_id: str, owner_user_id: str) -> list[Any]:
+        return []
+
+    def get_project_workflow_transition_by_idempotency(
+        self, project_id: str, owner_user_id: str, idempotency_key: str
+    ) -> None:
+        return None
+
+    def apply_project_workflow_transition(
+        self,
+        state_record: dict[str, Any],
+        transition_record: dict[str, Any],
+        expected_state: str | None,
+        expected_revision: int | None,
+    ) -> tuple[Any, Any] | None:
+        if self.workflow.state != expected_state or self.workflow.revision != expected_revision:
+            return None
+        self.workflow = SimpleNamespace(**state_record)
+        return self.workflow, SimpleNamespace(**transition_record)
+
+
+class WorkflowTransitionMatrixTests(unittest.TestCase):
+    def test_every_allowed_and_rejected_transition(self) -> None:
+        states = list(ProjectWorkflowState)
+        for source in states:
+            for target in states:
+                with self.subTest(source=source.value, target=target.value):
+                    repository = StateRepository(source)
+                    service = ProjectWorkflowService(repository)
+                    if source == target:
+                        outcome = service.transition(
+                            repository.workflow.project_id,
+                            OWNER,
+                            target,
+                            actor_type=WorkflowActorType.USER,
+                            actor_id=OWNER,
+                            reason="Repeat current state.",
+                        )
+                        self.assertTrue(outcome.idempotent_replay)
+                    elif target in ALLOWED_WORKFLOW_TRANSITIONS[source]:
+                        outcome = service.transition(
+                            repository.workflow.project_id,
+                            OWNER,
+                            target,
+                            actor_type=WorkflowActorType.USER,
+                            actor_id=OWNER,
+                            reason="Exercise allowed transition.",
+                        )
+                        self.assertEqual(target, outcome.workflow.state)
+                        self.assertEqual(source, outcome.transition.from_state)
+                    else:
+                        with self.assertRaises(WorkflowStateError) as raised:
+                            service.transition(
+                                repository.workflow.project_id,
+                                OWNER,
+                                target,
+                                actor_type=WorkflowActorType.USER,
+                                actor_id=OWNER,
+                                reason="Exercise rejected transition.",
+                            )
+                        self.assertEqual("invalid_workflow_transition", raised.exception.code)
+
+
+class WorkflowPersistenceTests(unittest.TestCase):
+    def test_initialization_history_and_idempotent_transition_are_persisted(self) -> None:
+        project_id = str(uuid.uuid4())
+        with sqlite_repository():
+            initial = database.initialize_project_workflow(project_id, OWNER, actor_id=OWNER)
+            repeated_initial = database.initialize_project_workflow(project_id, OWNER, actor_id=OWNER)
+            ready = database.transition_project_workflow(
+                project_id,
+                OWNER,
+                ProjectWorkflowState.READY_TO_BUILD,
+                actor_type=WorkflowActorType.USER,
+                actor_id=OWNER,
+                reason="Minimum context is present.",
+                idempotency_key="ready-request-1",
+            )
+            replay = database.transition_project_workflow(
+                project_id,
+                OWNER,
+                ProjectWorkflowState.READY_TO_BUILD,
+                actor_type=WorkflowActorType.USER,
+                actor_id=OWNER,
+                reason="Minimum context is present.",
+                idempotency_key="ready-request-1",
+            )
+            current = database.get_project_workflow(project_id, OWNER)
+            history = database.list_project_workflow_transitions(project_id, OWNER)
+
+        self.assertEqual(ProjectWorkflowState.GATHERING_CONTEXT, initial.workflow.state)
+        self.assertEqual(1, initial.workflow.revision)
+        self.assertTrue(repeated_initial.idempotent_replay)
+        self.assertEqual(ProjectWorkflowState.READY_TO_BUILD, current.state)
+        self.assertEqual(2, current.revision)
+        self.assertEqual(2, ready.workflow.revision)
+        self.assertTrue(replay.idempotent_replay)
+        self.assertEqual(ready.transition.transition_id, replay.transition.transition_id)
+        self.assertEqual([1, 2], [transition.revision for transition in history])
+        self.assertEqual(OWNER, history[1].actor_id)
+        self.assertEqual("Minimum context is present.", history[1].reason)
+
+    def test_owner_scope_and_generated_project_claim_use_the_same_identity(self) -> None:
+        project_id = str(uuid.uuid4())
+        with sqlite_repository():
+            database.initialize_project_workflow(project_id, OWNER)
+            with self.assertRaises(WorkflowStateError):
+                database.get_project_workflow(project_id, "other-user")
+            with self.assertRaises(database.DesignBriefAccessError):
+                database.save_generated_project(
+                    project_id=project_id,
+                    title="Wrong owner",
+                    prompt="Do not save",
+                    hardware_ir={},
+                    created_at="2026-08-01T12:00:00Z",
+                    owner_user_id="other-user",
+                )
+
+
+class WorkflowApiTests(unittest.TestCase):
+    def test_api_starts_in_gathering_context_and_returns_structured_rejection(self) -> None:
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_user_context] = lambda: USER
+        client = TestClient(app)
+        project_id = str(uuid.uuid4())
+
+        with sqlite_repository():
+            initialized = client.post(f"/projects/{project_id}/workflow")
+            rejected = client.post(
+                f"/projects/{project_id}/workflow/transitions",
+                json={"to_state": "completed", "reason": "Invalid shortcut"},
+            )
+            history = client.get(f"/projects/{project_id}/workflow/transitions")
+
+        self.assertEqual(200, initialized.status_code)
+        self.assertEqual("gathering_context", initialized.json()["workflow"]["state"])
+        self.assertEqual(409, rejected.status_code)
+        self.assertEqual("invalid_workflow_transition", rejected.json()["detail"]["code"])
+        self.assertEqual(1, len(history.json()["transitions"]))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #182

## Summary
- add the persisted seven-state project workflow model and centralized transition graph
- record actor, reason, timestamp, revision, and idempotency metadata for every transition
- expose current workflow state and transition history through authenticated project APIs
- add SQLite and Supabase persistence, including the atomic Supabase transition RPC
- enforce workflow ownership across DesignBrief and generated-project claims

## Verification
- exhaustive allowed/rejected transition matrix
- persistence, idempotency, ownership, and API tests
- full quality suite: 391 passed, 1 skipped
- Supabase migration syntax validated against local PostgreSQL in a rolled-back transaction