### PR TITLE
feat: implement conversational context-gathering loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ Tip: load an example directly with http://localhost:3000/?example=pocket_mp3_pla
 - [DesignBrief contract](docs/design-brief.md)
 - [Worker contracts and capability registry](docs/worker-contracts.md)
 - [Project workflow state machine](docs/project-workflow.md)
+- [Conversational context gathering](docs/context-gathering.md)
 - [Agents](docs/agents.md)
 - [Hardware IR](docs/hardware-ir.md)
 - [Validation](docs/validation.md)

--- a/apps/api/a2a.py
+++ b/apps/api/a2a.py
@@ -18,7 +18,12 @@ from blueprint_core.agents.workflows import (
     normalize_workflow_id,
 )
 from blueprint_core.agents.orchestrator import HardwarePipelineOrchestrator
-from blueprint_core.database import get_generated_project, save_generated_project, update_generated_project_hardware_ir
+from blueprint_core.database import (
+    ensure_project_action_allowed,
+    get_generated_project,
+    save_generated_project,
+    update_generated_project_hardware_ir,
+)
 from blueprint_core.images import build_image_provider, build_project_visual_spec, get_image_output_debug_config
 from apps.api.auth_mode import clerk_auth_required
 from blueprint_core.jobs.store import JOB_STORE
@@ -754,6 +759,7 @@ def build_generation_response(
     owner_user_id: Optional[str] = None,
     data_sources: Optional[List[str]] = None,
     past_job_context: Optional[PastJobContext] = None,
+    project_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     _apply_owner_user_integrations(owner_user_id)
 
@@ -792,6 +798,7 @@ def build_generation_response(
         "workflow": workflow_id,
         "chat_id": chat_id,
         "source_project_id": source_project_id,
+        "project_id": project_id,
         "owner_user_id": owner_user_id,
         "requested_provider": provider,
         "requested_model": model,
@@ -833,6 +840,7 @@ def build_generation_response(
                 model_name=model,
                 external_source_provider=external_source_provider,
                 generation_metadata={
+                    "project_id": project_id,
                     "chat_id": chat_id,
                     "source_project_id": source_project_id,
                     "frontend_job_id": frontend_job_id,
@@ -846,6 +854,7 @@ def build_generation_response(
             ensure_agent_pipeline_active()
             ir.assembly_metadata = {
                 **(ir.assembly_metadata or {}),
+                "project_id": project_id or (ir.assembly_metadata or {}).get("project_id"),
                 "chat_id": chat_id or (ir.assembly_metadata or {}).get("chat_id"),
                 "source_project_id": source_project_id or (ir.assembly_metadata or {}).get("source_project_id"),
                 "frontend_job_id": frontend_job_id or (ir.assembly_metadata or {}).get("frontend_job_id"),
@@ -938,6 +947,15 @@ def build_generation_response(
 async def call_blueprint_action(action: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     normalized = action.removeprefix("blueprint.")
     owner_user_id = payload.get("owner_user_id")
+    project_id = payload.get("project_id")
+
+    if project_id and owner_user_id:
+        ensure_project_action_allowed(
+            str(project_id),
+            str(owner_user_id),
+            action,
+            require_workflow=normalized == "generate_project",
+        )
 
     _apply_owner_user_integrations(owner_user_id if isinstance(owner_user_id, str) else None)
 
@@ -966,6 +984,7 @@ async def call_blueprint_action(action: str, payload: Dict[str, Any]) -> Dict[st
             payload.get("owner_user_id"),
             data_sources,
             past_job_context,
+            payload.get("project_id"),
         )
 
     if normalized == "debug_config":
@@ -1007,6 +1026,15 @@ def _is_server_message(message: A2AMessage) -> bool:
 async def submit_a2a_message(message: A2AMessage) -> A2AEvent:
     await A2A_HUB.register(message.sender)
     server_owned = _is_server_message(message)
+    project_id = message.payload.get("project_id")
+    owner_user_id = message.payload.get("owner_user_id")
+    if server_owned and project_id and owner_user_id:
+        ensure_project_action_allowed(
+            str(project_id),
+            str(owner_user_id),
+            message.action,
+            require_workflow=message.action.removeprefix("blueprint.") == "generate_project",
+        )
     job = JOB_STORE.create_job(
         job_id=message.job_id,
         message_id=message.message_id,

--- a/apps/api/context_gathering_api.py
+++ b/apps/api/context_gathering_api.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from apps.api.auth import UserContext, require_user_context
+from blueprint_core.agents.context_gathering import ContextGatheringAgent
+from blueprint_core.database import (
+    DesignBriefAccessError,
+    DesignBriefNotFoundError,
+    create_design_brief_version,
+    get_latest_design_brief,
+    get_project_chat,
+    initialize_project_workflow,
+    upsert_project_chat,
+)
+from blueprint_core.workspaces.context import (
+    ContextGatheringRequest,
+    ContextGatheringResponse,
+)
+from blueprint_core.workspaces.workflow import ProjectWorkflowState, WorkflowActorType, WorkflowStateError
+
+
+router = APIRouter(prefix="/projects/{project_id}/context", tags=["context-gathering"])
+
+
+def _owner(user: UserContext) -> str:
+    owner = str(user.owner_user_id or "").strip()
+    if not owner:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"code": "authentication_required", "message": "Sign in to gather project context."},
+        )
+    return owner
+
+
+def _workflow_error(exc: WorkflowStateError) -> HTTPException:
+    status_code = status.HTTP_404_NOT_FOUND if exc.code == "workflow_not_found" else status.HTTP_409_CONFLICT
+    return HTTPException(status_code=status_code, detail=exc.as_dict())
+
+
+@router.post("/messages", response_model=ContextGatheringResponse, status_code=status.HTTP_201_CREATED)
+def gather_project_context_endpoint(
+    project_id: UUID,
+    request: ContextGatheringRequest,
+    user: UserContext = Depends(require_user_context),
+) -> ContextGatheringResponse:
+    """Persist one conversational turn without invoking generation or worker tools."""
+
+    owner = _owner(user)
+    try:
+        initialized = initialize_project_workflow(
+            str(project_id),
+            owner,
+            actor_type=WorkflowActorType.USER,
+            actor_id=owner,
+            reason="Context-gathering conversation started.",
+        )
+    except WorkflowStateError as exc:
+        raise _workflow_error(exc) from exc
+    workflow = initialized.workflow
+    if workflow.state != ProjectWorkflowState.GATHERING_CONTEXT:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "context_gathering_not_active",
+                "message": "Project context can only be updated while gathering_context is active.",
+                "context": {"project_id": str(project_id), "workflow_state": workflow.state.value},
+            },
+        )
+
+    try:
+        previous = get_latest_design_brief(str(project_id), owner)
+    except DesignBriefNotFoundError:
+        previous = None
+    if previous and previous.conversation_id != request.conversation_id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "context_conversation_mismatch",
+                "message": "This project is already associated with a different conversation.",
+                "context": {"conversation_id": previous.conversation_id},
+            },
+        )
+
+    brief_create, assistant_message, questions = ContextGatheringAgent().update(request, previous)
+    try:
+        brief = create_design_brief_version(str(project_id), owner, brief_create)
+    except DesignBriefAccessError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "project_not_found", "message": "Project not found."},
+        ) from exc
+
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    existing_chat = get_project_chat(request.conversation_id, owner)
+    existing_messages = list(getattr(existing_chat, "messages", None) or [])
+    attachments = [
+        {
+            "attachmentId": item.attachment_id,
+            "kind": item.kind,
+            "name": item.name,
+            "mediaType": item.media_type,
+            "uri": item.uri,
+            "source": item.source,
+            "hasInlineData": bool(item.data_url),
+        }
+        for item in request.attachments
+    ]
+    existing_messages.extend([
+        {
+            "id": f"context-user-{uuid4().hex}",
+            "role": "user",
+            "content": request.text or "Shared a project reference.",
+            "status": "complete",
+            "timestamp": now,
+            "contextProjectId": str(project_id),
+            "attachments": attachments,
+        },
+        {
+            "id": f"context-assistant-{uuid4().hex}",
+            "role": "assistant",
+            "content": assistant_message,
+            "status": "complete",
+            "timestamp": now,
+            "contextProjectId": str(project_id),
+            "designBriefVersion": brief.brief_version,
+            "questions": questions,
+        },
+    ])
+    title = str(getattr(existing_chat, "title", "") or "").strip()
+    if not title:
+        title = (request.text or brief.summary)[:100]
+    created_at = str(getattr(existing_chat, "created_at", "") or now)
+    upsert_project_chat(
+        chat_id=request.conversation_id,
+        owner_user_id=owner,
+        title=title,
+        messages=existing_messages,
+        created_at=created_at,
+        updated_at=now,
+    )
+    return ContextGatheringResponse(
+        workflow=workflow,
+        design_brief=brief,
+        assistant_message=assistant_message,
+        questions=questions,
+    )

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -71,6 +71,7 @@ from blueprint_core.database import (
     count_component_templates,
     delete_generated_project,
     delete_project_chat,
+    ensure_project_action_allowed,
     get_database_config,
     get_generated_project,
     get_latest_project_deletion_audit,
@@ -100,6 +101,7 @@ from blueprint_core.workspaces.projects.models import (
     ConnectionNet, GenerateProjectRequest, HardwareIR, IterateProjectRequest,
     ProjectContributionConsentRequest, ProjectUpdateRequest, ValidationIssue, ValidationReport, VideoSelfCorrectRequest,
 )
+from blueprint_core.workspaces.workflow import WorkflowStateError
 from blueprint_core.signups.models import AlphaSignupRequest, AlphaSignupResponse
 from blueprint_core.agents.orchestrator import HardwarePipelineOrchestrator
 from apps.api.a2a import (
@@ -127,6 +129,7 @@ from blueprint_core.video_review import FireworksVideoReviewClient
 from apps.api.logs_api import router as logs_router
 from apps.api.streams_api import router as streams_router
 from apps.api.design_briefs_api import router as design_briefs_router
+from apps.api.context_gathering_api import router as context_gathering_router
 from apps.api.project_workflow_api import router as project_workflow_router
 from apps.api.user_integrations_api import router as user_integrations_router
 from apps.api.user_settings_api import router as user_settings_router
@@ -279,6 +282,7 @@ app.add_middleware(
 app.include_router(logs_router, dependencies=[Depends(require_admin_user_context)])
 app.include_router(streams_router, dependencies=[Depends(require_admin_user_context)])
 app.include_router(design_briefs_router)
+app.include_router(context_gathering_router)
 app.include_router(project_workflow_router)
 app.include_router(user_integrations_router)
 app.include_router(user_settings_router)
@@ -494,6 +498,18 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
     Submits a natural language hardware idea and optional multimodal reference image.
     Runs the 7-agent compilation workflow, circuit safety auditor, and returns a verified Hardware IR, SVG schematic, and Mermaid diagram.
     """
+    owner_user_id = _require_authenticated_user(user)
+    if request.project_id:
+        try:
+            ensure_project_action_allowed(
+                request.project_id,
+                owner_user_id,
+                "blueprint.generate_project",
+                require_workflow=True,
+            )
+        except WorkflowStateError as exc:
+            status_code = status.HTTP_404_NOT_FOUND if exc.code == "workflow_not_found" else status.HTTP_409_CONFLICT
+            raise HTTPException(status_code=status_code, detail=exc.as_dict()) from exc
     _apply_user_integrations(user)
     try:
         llm_config = get_workflow_debug_config(
@@ -553,7 +569,6 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
 
     job_id = request.client_job_id or f"job_frontend_{uuid4().hex}"
     message_id = f"msg_{uuid4().hex}"
-    owner_user_id = _require_authenticated_user(user)
     if request.source_project_id:
         source_project = get_generated_project(request.source_project_id)
         if not source_project:
@@ -561,6 +576,7 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
         _require_project_chat_owner(source_project, user)
     payload = {
         "prompt": request.prompt,
+        "project_id": request.project_id,
         "workflow": request.workflow,
         "image_data": request.image_data,
         "generate_image": request.generate_image,
@@ -615,6 +631,7 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
                 owner_user_id=owner_user_id,
                 data_sources=request.data_sources,
                 past_job_context=past_job_context,
+                project_id=request.project_id,
             )
         if JOB_STORE.is_cancelled(job_id):
             raise JobCancelledError(f"Job {job_id} was cancelled.")
@@ -2010,6 +2027,11 @@ def iterate_project_endpoint(
         raise HTTPException(status_code=404, detail="Project not found.")
     _require_project_reader(project, user)
     save_owner_user_id = _require_project_owner(project, user) if request.save else None
+    if save_owner_user_id:
+        try:
+            ensure_project_action_allowed(project.project_id, save_owner_user_id, "blueprint.iterate_project")
+        except WorkflowStateError as exc:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=exc.as_dict()) from exc
 
     try:
         current_ir = HardwareIR(**project.hardware_ir)

--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -173,6 +173,7 @@ type ChatMessage = {
   timestamp: string;
   projectId?: string | null;
   pipelineProgress?: AgentPipelineProgress | null;
+  imagePreview?: string | null;
 };
 
 type ActiveGenerationRun = {
@@ -402,6 +403,7 @@ function normalizeChatMessage(value: any): ChatMessage | null {
     timestamp: typeof value.timestamp === "string" && value.timestamp ? value.timestamp : chatTimestamp(),
     projectId: typeof value.projectId === "string" ? value.projectId : null,
     pipelineProgress: normalizeAgentPipelineProgress(value.pipelineProgress),
+    imagePreview: typeof value.imagePreview === "string" ? value.imagePreview : null,
   };
 }
 
@@ -1511,6 +1513,7 @@ export function FormaWorkspace({
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>(() => initialChatMessages());
   const [pendingHumanContext, setPendingHumanContext] = useState<PendingHumanContext | null>(null);
+  const contextProjectIdsRef = useRef<Record<string, string>>({});
   const [chatThreads, setChatThreads] = useState<Record<string, ChatMessage[]>>({});
   const [projectChatInput, setProjectChatInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -1548,6 +1551,7 @@ export function FormaWorkspace({
     () => lastKnownServerStatus || "disconnected"
   );
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [selectedImageSource, setSelectedImageSource] = useState<"upload" | "clipboard">("upload");
   const [generationInputNotice, setGenerationInputNotice] = useState<string | null>(null);
   const [videoGenerationConfig, setVideoGenerationConfig] = useState<VideoGenerationConfig>({
     configured: null,
@@ -1683,16 +1687,12 @@ export function FormaWorkspace({
     () => generationLlms.find((option) => generationLlmKey(option) === generationLlmKeyValue) || generationLlms[0] || null,
     [generationLlmKeyValue, generationLlms]
   );
-  const generationLlmsReady = Boolean(selectedGenerationLlm);
   const needsGenerationProvider = generationLlmsLoaded && providerSetup.llmRequired && (!authRequired || authLoaded);
   const needsImageProvider = imageGenerationConfigLoaded && providerSetup.imageRequired && (!authRequired || authLoaded);
-  const visibleGenerationInputNotice =
-    generationInputNotice ||
-    (needsGenerationProvider
-      ? "No model provider is active. Add and enable one in Settings before building."
-      : (prompt.trim() || pendingHumanContext) && !generationInputValidation.isValid
-        ? generationInputValidation.message
-        : null);
+  const visibleContextInputNotice =
+    generationInputNotice || ((prompt.trim() || selectedImage) && !generationInputValidation.isValid
+      ? generationInputValidation.message
+      : null);
   const appendChatMessage = (message: Omit<ChatMessage, "id" | "timestamp"> & { id?: string }) => {
     const nextMessage: ChatMessage = {
       id: message.id || newChatMessageId(),
@@ -1701,6 +1701,7 @@ export function FormaWorkspace({
       status: message.status || "idle",
       projectId: message.projectId,
       pipelineProgress: message.pipelineProgress || null,
+      imagePreview: message.imagePreview || null,
       timestamp: chatTimestamp(),
     };
     setChatMessages((current) => [...current, nextMessage]);
@@ -1748,6 +1749,7 @@ export function FormaWorkspace({
       status: message.status || "idle",
       projectId: message.projectId,
       pipelineProgress: message.pipelineProgress || null,
+      imagePreview: message.imagePreview || null,
       timestamp: chatTimestamp(),
     };
     setChatThreads((current) => {
@@ -2129,6 +2131,7 @@ export function FormaWorkspace({
     setPendingHumanContext(null);
     setGenerationInputNotice(null);
     setSelectedImage(null);
+    setSelectedImageSource("upload");
     setChatRouteTransition(null);
     setProjectIR(null);
     setActiveTab("overview");
@@ -2718,7 +2721,7 @@ export function FormaWorkspace({
     };
   }, [blueprintDevMode, chatListItems, currentRouteProjectId, myProjectHistory, optionalAuthHeaders, projectHistory, projectGalleryImages, projectIR, visibleProjectGalleryIds]);
 
-  const attachImageFile = (file: File) => {
+  const attachImageFile = (file: File, source: "upload" | "clipboard" = "upload") => {
     if (!file.type.startsWith("image/")) {
       setGenerationInputNotice("Only image files can be attached as hardware references.");
       return;
@@ -2731,6 +2734,7 @@ export function FormaWorkspace({
       }
       setGenerationInputNotice(null);
       setSelectedImage(reader.result);
+      setSelectedImageSource(source);
     };
     reader.onerror = () => {
       setGenerationInputNotice("Forma could not read that image. Try copying or uploading it again.");
@@ -2740,7 +2744,7 @@ export function FormaWorkspace({
 
   const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    if (file) attachImageFile(file);
+    if (file) attachImageFile(file, "upload");
   };
 
   const handleImagePaste = (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
@@ -2748,12 +2752,13 @@ export function FormaWorkspace({
       || Array.from(event.clipboardData.items)
         .find((item) => item.type.startsWith("image/"))
         ?.getAsFile();
-    if (imageFile) attachImageFile(imageFile);
+    if (imageFile) attachImageFile(imageFile, "clipboard");
   };
 
   const removeSelectedImage = () => {
     setGenerationInputNotice(null);
     setSelectedImage(null);
+    setSelectedImageSource("upload");
     if (fileInputRefSidebar.current) fileInputRefSidebar.current.value = "";
     if (fileInputRefCenter.current) fileInputRefCenter.current.value = "";
   };
@@ -2823,6 +2828,88 @@ export function FormaWorkspace({
     setGenerationInputNotice("Generation stopped. You can send another message whenever you're ready.");
     if (run.jobId) void cancelGenerationJob(run.jobId);
     finishGenerationRun(run);
+  };
+
+  const handleGatherContext = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (isLoading || activeGenerationRef.current) return;
+    if (!(await requireSignedInForGeneration())) return;
+
+    const validation = validateGenerationInput(prompt, Boolean(selectedImage));
+    if (!validation.isValid) {
+      setGenerationInputNotice(validation.message);
+      return;
+    }
+
+    const requestChatId = activeChatId || newBuildChatId();
+    const requestProjectId = contextProjectIdsRef.current[requestChatId] || (
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(requestChatId)
+        ? requestChatId
+        : newBuildChatId()
+    );
+    contextProjectIdsRef.current[requestChatId] = requestProjectId;
+    const text = prompt.trim();
+    const imageData = selectedImage;
+    const userMessageId = newChatMessageId();
+    const assistantMessageId = newChatMessageId();
+    const userContent = text || "Shared a hardware reference image.";
+
+    setActiveChatId(requestChatId);
+    rememberChatItem({
+      chatId: requestChatId,
+      title: text || "Hardware reference",
+      projectId: "",
+      createdAt: chatTimestamp(),
+      projectCount: 0,
+    });
+    syncChatRoute(requestChatId);
+    appendChatMessage({ id: userMessageId, role: "user", content: userContent, imagePreview: imageData, status: "idle" });
+    appendThreadMessage(requestChatId, { id: userMessageId, role: "user", content: userContent, imagePreview: imageData, status: "idle" });
+    appendChatMessage({ id: assistantMessageId, role: "assistant", content: "Saving project context…", status: "loading" });
+    appendThreadMessage(requestChatId, { id: assistantMessageId, role: "assistant", content: "Saving project context…", status: "loading" });
+    setPrompt("");
+    setSelectedImage(null);
+    setSelectedImageSource("upload");
+    setGenerationInputNotice(null);
+    setIsLoading(true);
+
+    try {
+      const res = await fetch(`${API_URL}/projects/${encodeURIComponent(requestProjectId)}/context/messages`, {
+        method: "POST",
+        headers: await generationRequestHeaders(),
+        body: JSON.stringify({
+          conversation_id: requestChatId,
+          text,
+          attachments: imageData ? [{
+            attachment_id: `context-image-${userMessageId}`,
+            kind: "image",
+            name: "hardware-reference.png",
+            media_type: imageData.match(/^data:([^;,]+)/)?.[1] || "image/png",
+            data_url: imageData,
+            source: selectedImageSource,
+          }] : [],
+        }),
+      });
+      if (!res.ok) throw new Error(await readApiErrorMessage(res));
+      const data = await res.json();
+      const persistedProjectId = typeof data?.design_brief?.project_id === "string"
+        ? data.design_brief.project_id
+        : requestProjectId;
+      contextProjectIdsRef.current[requestChatId] = persistedProjectId;
+      const assistantContent = typeof data?.assistant_message === "string"
+        ? data.assistant_message
+        : "I saved that project context. What else should the design account for?";
+      updateChatMessage(assistantMessageId, { content: assistantContent, status: "success" });
+      updateThreadMessage(requestChatId, assistantMessageId, { content: assistantContent, status: "success" });
+      setGenerationInputNotice("Context saved. Continue the conversation to refine the design brief.");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Could not save project context.";
+      updateChatMessage(assistantMessageId, { content: message, status: "error" });
+      updateThreadMessage(requestChatId, assistantMessageId, { content: message, status: "error" });
+      setGenerationInputNotice(message);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleGenerate = async (event: React.FormEvent) => {
@@ -4258,17 +4345,17 @@ export function FormaWorkspace({
                 setPendingHumanContext(null);
                 setPrompt(example);
               }}
-              onSubmit={handleGenerate}
+              onSubmit={handleGatherContext}
               pendingContext={pendingHumanContext}
               onContextAnswer={updateHumanContextAnswer}
               onClearContext={clearHumanContextCheckpoint}
               isLoading={isLoading}
-              generationReady={generationLlmsReady}
-              needsGenerationProvider={needsGenerationProvider}
-              needsImageProvider={needsImageProvider}
+              generationReady
+              needsGenerationProvider={false}
+              needsImageProvider={false}
               selectedImage={selectedImage}
               onRemoveImage={removeSelectedImage}
-              notice={visibleGenerationInputNotice}
+              notice={visibleContextInputNotice}
               prompt={prompt}
               onPromptChange={(value) => {
                 setGenerationInputNotice(null);

--- a/apps/web/app/blueprint-workspace/home-chat-view.tsx
+++ b/apps/web/app/blueprint-workspace/home-chat-view.tsx
@@ -25,6 +25,7 @@ type HomeChatMessage = {
   timestamp: string;
   projectId?: string | null;
   pipelineProgress?: unknown;
+  imagePreview?: string | null;
 };
 
 type PendingContext = {
@@ -158,6 +159,13 @@ export default function HomeChatView({
                       <span suppressHydrationWarning>{formatTimestamp(message.timestamp)}</span>
                     </div>
                     <p className="break-anywhere whitespace-pre-wrap text-sm leading-6">{message.content}</p>
+                    {message.imagePreview && (
+                      <img
+                        src={message.imagePreview}
+                        alt="Hardware reference thumbnail"
+                        className="mt-3 h-24 w-36 border border-cyan-300/25 object-cover"
+                      />
+                    )}
                     {!message.projectId && renderPipelineProgress(message)}
                   </div>
                 </div>
@@ -329,7 +337,7 @@ export default function HomeChatView({
                   if (!isLoading) event.currentTarget.form?.requestSubmit();
                 }
               }}
-              placeholder={pendingContext ? "Optional: add final context notes before building..." : "Ask Forma to build a lab-on-chip reader, self-assembling tent, sensor node, robot fixture..."}
+              placeholder={pendingContext ? "Add more context…" : "Describe the product, constraints, references, and outputs you need…"}
               aria-invalid={Boolean(notice)}
               aria-describedby={notice ? "generation-input-notice" : undefined}
               className={`${pendingContext ? "min-h-[72px] sm:min-h-[96px]" : "min-h-[98px] sm:min-h-[104px]"} w-full resize-none border border-[#2c2f37] bg-[#0f1014] py-3 pl-14 pr-14 text-sm leading-6 text-slate-100 outline-none placeholder:text-slate-600 focus:border-cyan-300 sm:py-4 sm:pl-16 sm:pr-16 sm:leading-7`}
@@ -348,8 +356,8 @@ export default function HomeChatView({
               onClick={generationActive ? onStop : undefined}
               disabled={!generationActive && (isLoading || !hasGenerationInput || !generationReady)}
               className="absolute bottom-3 right-3 inline-flex h-9 w-9 items-center justify-center bg-white text-black transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-40 sm:bottom-4 sm:right-4 sm:h-10 sm:w-10"
-              aria-label={generationActive ? "Stop generation" : inputValid ? "Send build request" : "Check hardware idea"}
-              title={generationActive ? "Stop generation" : inputValid ? "Send build request" : "Check hardware idea"}
+              aria-label={generationActive ? "Stop generation" : inputValid ? "Send context" : "Check hardware idea"}
+              title={generationActive ? "Stop generation" : inputValid ? "Send context" : "Check hardware idea"}
             >
               {generationActive ? <Square className="h-4 w-4 fill-current" /> : isLoading ? <RefreshCw className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
             </button>

--- a/blueprint_core/agents/__init__.py
+++ b/blueprint_core/agents/__init__.py
@@ -2,6 +2,7 @@
 
 __all__ = [
     "ContextClarifierAgent",
+    "ContextGatheringAgent",
     "ContinuousAgentCoordinator",
     "FireworksVideoSelfCorrectionAgent",
     "HardwarePipelineOrchestrator",
@@ -18,6 +19,10 @@ def __getattr__(name: str):
         from blueprint_core.agents.clarification import ContextClarifierAgent
 
         return ContextClarifierAgent
+    if name == "ContextGatheringAgent":
+        from blueprint_core.agents.context_gathering import ContextGatheringAgent
+
+        return ContextGatheringAgent
     if name == "ContinuousAgentCoordinator":
         from blueprint_core.agents.continuous import ContinuousAgentCoordinator
 

--- a/blueprint_core/agents/context_gathering.py
+++ b/blueprint_core/agents/context_gathering.py
@@ -1,0 +1,5 @@
+from blueprint_core.workspaces.context.agent import ContextBriefUpdater
+
+
+class ContextGatheringAgent(ContextBriefUpdater):
+    """Conversational agent that gathers context without executing tools."""

--- a/blueprint_core/database.py
+++ b/blueprint_core/database.py
@@ -18,6 +18,7 @@ from blueprint_core.workspaces.workflow import (
     ProjectWorkflowTransition,
     WorkflowActorType,
     WorkflowTransitionOutcome,
+    ensure_action_allowed,
 )
 from blueprint_core.persistence.base import DatabaseProvider
 from blueprint_core.persistence.models import (
@@ -554,6 +555,24 @@ def transition_project_workflow(
         reason=reason,
         idempotency_key=idempotency_key,
     )
+
+
+def ensure_project_action_allowed(
+    project_id: str,
+    owner_user_id: str,
+    action: str,
+    *,
+    require_workflow: bool = False,
+) -> None:
+    """Apply project workflow execution policy without coupling callers to persistence."""
+
+    try:
+        workflow = ProjectWorkflowService(_DATABASE_REPOSITORY).get(project_id, owner_user_id)
+    except WorkflowStateError:
+        if not require_workflow:
+            return
+        raise
+    ensure_action_allowed(workflow, action)
 
 
 def list_due_project_purges(before: str, limit: int = 25) -> List[Any]:

--- a/blueprint_core/workspaces/context/__init__.py
+++ b/blueprint_core/workspaces/context/__init__.py
@@ -1,0 +1,11 @@
+from blueprint_core.workspaces.context.models import (
+    ContextAttachment,
+    ContextGatheringRequest,
+    ContextGatheringResponse,
+)
+
+__all__ = [
+    "ContextAttachment",
+    "ContextGatheringRequest",
+    "ContextGatheringResponse",
+]

--- a/blueprint_core/workspaces/context/agent.py
+++ b/blueprint_core/workspaces/context/agent.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import hashlib
+import re
+
+from blueprint_core.agents.clarification import ask_clarifying_questions
+from blueprint_core.workspaces.context.models import ContextAttachment, ContextGatheringRequest
+from blueprint_core.workspaces.design_briefs import (
+    DESIGN_BRIEF_SCHEMA_VERSION,
+    DesignBrief,
+    DesignBriefCreate,
+    DesignBriefReadiness,
+    DesignBriefReference,
+)
+from blueprint_core.workspaces.projects.models import ClarifyingQuestionsRequest
+
+
+def _unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        normalized = re.sub(r"\s+", " ", str(value or "")).strip()
+        key = normalized.casefold()
+        if normalized and key not in seen:
+            seen.add(key)
+            result.append(normalized)
+    return result
+
+
+def _sentences(text: str) -> list[str]:
+    return _unique(re.split(r"(?:[\r\n]+|(?<=[.!?])\s+)", text.strip()))
+
+
+def _intent(text: str, previous: DesignBrief | None) -> str:
+    lowered = text.casefold()
+    if any(word in lowered for word in ("modify", "revise", "change", "iterate", "update")):
+        return "modify a hardware design"
+    if any(word in lowered for word in ("reverse engineer", "identify this", "recreate this")):
+        return "reverse engineer a hardware reference"
+    if any(word in lowered for word in ("validate", "review", "check this design")):
+        return "validate a hardware design"
+    if previous:
+        return previous.intent
+    return "design a buildable hardware product"
+
+
+def _requested_outputs(text: str) -> list[str]:
+    mappings = {
+        "wiring": ("wire", "wiring", "pinout"),
+        "schematic": ("schematic", "circuit diagram"),
+        "bom": ("bom", "bill of materials", "parts list"),
+        "firmware": ("firmware", "code", "software"),
+        "enclosure": ("enclosure", "case", "housing"),
+        "cad": ("cad", "step file", "stl", "3d model"),
+        "product images": ("product image", "render", "concept image"),
+        "validation": ("validation", "test plan", "verify"),
+        "assembly instructions": ("assembly", "build guide", "instructions"),
+    }
+    lowered = text.casefold()
+    return [output for output, markers in mappings.items() if any(marker in lowered for marker in markers)]
+
+
+def _reference(attachment: ContextAttachment) -> DesignBriefReference:
+    identity = attachment.attachment_id
+    if not identity:
+        digest_source = "|".join((attachment.kind, attachment.name or "", attachment.uri or "", attachment.data_url or ""))
+        identity = f"attachment-{hashlib.sha256(digest_source.encode()).hexdigest()[:20]}"
+    metadata: dict[str, object] = {"source": attachment.source}
+    if attachment.data_url:
+        metadata["inline_data_supplied"] = True
+        metadata["inline_data_length"] = len(attachment.data_url)
+    if attachment.extracted_text:
+        metadata["text_extracted"] = True
+    return DesignBriefReference(
+        reference_id=identity,
+        kind=f"uploaded_{attachment.kind}",
+        label=attachment.name,
+        uri=attachment.uri,
+        media_type=attachment.media_type,
+        metadata=metadata,
+    )
+
+
+class ContextBriefUpdater:
+    """Updates a DesignBrief without invoking a model, tool, or worker job."""
+
+    def update(self, request: ContextGatheringRequest, previous: DesignBrief | None = None) -> tuple[DesignBriefCreate, str, list[str]]:
+        text = request.text.strip()
+        attachment_text = [item.extracted_text for item in request.attachments if item.extracted_text]
+        combined_update = "\n".join([text, *attachment_text]).strip()
+        update_sentences = _sentences(combined_update)
+
+        prior_requirements = list(previous.requirements) if previous else []
+        requirements = _unique([*prior_requirements, *update_sentences])
+        constraint_markers = re.compile(
+            r"\b(must|only|under|maximum|max\b|minimum|min\b|budget|fit|within|voltage|battery|usb|no\s+|without|weatherproof|waterproof|material)\b",
+            re.IGNORECASE,
+        )
+        constraints = _unique([
+            *(list(previous.constraints) if previous else []),
+            *(sentence for sentence in update_sentences if constraint_markers.search(sentence)),
+        ])
+        assumption_markers = re.compile(r"\b(assume|assuming|probably|for now)\b", re.IGNORECASE)
+        assumptions = _unique([
+            *(list(previous.assumptions) if previous else []),
+            *(sentence for sentence in update_sentences if assumption_markers.search(sentence)),
+        ])
+        validation_markers = re.compile(r"\b(success|validate|validation|test|verify|passes|works when)\b", re.IGNORECASE)
+        validation = _unique([
+            *(list(previous.validation_criteria) if previous else []),
+            *(sentence for sentence in update_sentences if validation_markers.search(sentence)),
+        ])
+
+        references = list(previous.references) if previous else []
+        references_by_id = {item.reference_id: item for item in references}
+        for attachment in request.attachments:
+            item = _reference(attachment)
+            references_by_id[item.reference_id] = item
+
+        prior_outputs = list(previous.requested_outputs) if previous else []
+        requested_outputs = _unique([*prior_outputs, *_requested_outputs(combined_update)])
+        full_context = "\n".join(_unique([*requirements, *constraints]))
+        clarification = ask_clarifying_questions(ClarifyingQuestionsRequest(
+            prompt=full_context,
+            has_image=any(item.kind == "image" for item in request.attachments) or any(
+                reference.kind == "uploaded_image" for reference in references_by_id.values()
+            ),
+            workflow="default",
+            force=False,
+            max_questions=3,
+        ))
+        questions = _unique([
+            *(list(previous.unresolved_questions) if previous else []),
+            *(question.question for question in clarification.questions),
+        ])
+
+        if previous and previous.summary:
+            summary = previous.summary
+        elif text:
+            summary = text[:500]
+        elif request.attachments:
+            kinds = ", ".join(sorted({item.kind for item in request.attachments}))
+            summary = f"Hardware design based on the supplied {kinds} reference."
+        else:  # model validation makes this unreachable
+            summary = "Hardware design context"
+
+        brief = DesignBriefCreate(
+            schema_version=DESIGN_BRIEF_SCHEMA_VERSION,
+            conversation_id=request.conversation_id,
+            intent=_intent(combined_update, previous),
+            summary=summary,
+            requirements=requirements,
+            constraints=constraints,
+            references=list(references_by_id.values()),
+            requested_outputs=requested_outputs,
+            validation_criteria=validation,
+            unresolved_questions=questions,
+            assumptions=assumptions,
+            readiness=DesignBriefReadiness.NEEDS_CLARIFICATION if questions else DesignBriefReadiness.DRAFT,
+        )
+        if questions:
+            assistant_message = "I’ve saved that context. " + " ".join(questions)
+        else:
+            assistant_message = "I’ve saved that context. Add any remaining constraints, references, or expected outputs when you’re ready."
+        return brief, assistant_message, questions

--- a/blueprint_core/workspaces/context/models.py
+++ b/blueprint_core/workspaces/context/models.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+
+from blueprint_core.workspaces.design_briefs import DesignBrief
+from blueprint_core.workspaces.workflow import ProjectWorkflow
+
+
+NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class ContextAttachment(BaseModel):
+    """A user-supplied reference available to the context-gathering agent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    attachment_id: NonEmptyString | None = None
+    kind: Literal["image", "document"]
+    name: NonEmptyString | None = None
+    media_type: NonEmptyString | None = None
+    uri: NonEmptyString | None = None
+    data_url: NonEmptyString | None = None
+    extracted_text: NonEmptyString | None = None
+    source: Literal["upload", "clipboard", "url"] = "upload"
+
+    @model_validator(mode="after")
+    def require_attachment_content(self) -> "ContextAttachment":
+        if not any((self.uri, self.data_url, self.extracted_text)):
+            raise ValueError("An attachment requires uri, data_url, or extracted_text.")
+        return self
+
+
+class ContextGatheringRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    conversation_id: NonEmptyString
+    text: str = ""
+    attachments: list[ContextAttachment] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def require_context_input(self) -> "ContextGatheringRequest":
+        self.text = self.text.strip()
+        if not self.text and not self.attachments:
+            raise ValueError("Provide text or at least one attachment.")
+        return self
+
+
+class ContextGatheringResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workflow: ProjectWorkflow
+    design_brief: DesignBrief
+    assistant_message: NonEmptyString
+    questions: list[NonEmptyString] = Field(default_factory=list)

--- a/blueprint_core/workspaces/projects/models.py
+++ b/blueprint_core/workspaces/projects/models.py
@@ -190,6 +190,10 @@ class Project(BaseModel):
 
 class GenerateProjectRequest(BaseModel):
     prompt: str = Field(..., description="User's natural language project description")
+    project_id: Optional[str] = Field(
+        None,
+        description="Optional context project id whose workflow authorizes this generation.",
+    )
     workflow: str = Field(
         "default",
         description="Generation workflow id: default or web_research"
@@ -237,7 +241,7 @@ class GenerateProjectRequest(BaseModel):
         description="Maximum number of relevant completed jobs to include when data_sources contains past_jobs.",
     )
 
-    @field_validator("provider", "model", "chat_id", "source_project_id", "client_job_id", "external_source_provider", mode="before")
+    @field_validator("provider", "model", "project_id", "chat_id", "source_project_id", "client_job_id", "external_source_provider", mode="before")
     @classmethod
     def strip_optional_generation_selector(cls, value: Any) -> Any:
         if isinstance(value, str):

--- a/blueprint_core/workspaces/workflow/__init__.py
+++ b/blueprint_core/workspaces/workflow/__init__.py
@@ -12,6 +12,7 @@ from blueprint_core.workspaces.workflow.service import (
     ProjectWorkflowService,
     WorkflowStateError,
 )
+from blueprint_core.workspaces.workflow.guard import ensure_action_allowed
 
 __all__ = [
     "ALLOWED_WORKFLOW_TRANSITIONS",
@@ -24,4 +25,5 @@ __all__ = [
     "WorkflowStateError",
     "WorkflowTransitionCommand",
     "WorkflowTransitionOutcome",
+    "ensure_action_allowed",
 ]

--- a/blueprint_core/workspaces/workflow/guard.py
+++ b/blueprint_core/workspaces/workflow/guard.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from blueprint_core.workspaces.workflow.models import ProjectWorkflow, ProjectWorkflowState
+from blueprint_core.workspaces.workflow.service import WorkflowStateError
+
+
+MUTATING_ACTION_MARKERS = (
+    "generate",
+    "build",
+    "fabricat",
+    "opencad",
+    "cad.mutat",
+    "iterate",
+)
+
+
+def ensure_action_allowed(workflow: ProjectWorkflow, action: str) -> None:
+    """Prevent tool-backed project mutations while context is still being gathered."""
+
+    normalized = str(action or "").strip().casefold()
+    if workflow.state != ProjectWorkflowState.GATHERING_CONTEXT:
+        return
+    if not any(marker in normalized for marker in MUTATING_ACTION_MARKERS):
+        return
+    raise WorkflowStateError(
+        "tool_execution_blocked_while_gathering_context",
+        "Build, generation, fabrication, and OpenCAD mutations are blocked while project context is being gathered.",
+        context={
+            "project_id": str(workflow.project_id),
+            "workflow_state": workflow.state.value,
+            "action": action,
+        },
+    )

--- a/docs/context-gathering.md
+++ b/docs/context-gathering.md
@@ -1,0 +1,26 @@
+# Conversational context gathering
+
+New project conversations begin in `gathering_context`. During this phase, Forma accepts text and image or document references, appends an immutable `DesignBrief` version, persists the user and assistant messages, and returns targeted clarification questions.
+
+```http
+POST /projects/{project_id}/context/messages
+Content-Type: application/json
+
+{
+  "conversation_id": "chat-id",
+  "text": "Build a USB-C environmental monitor",
+  "attachments": [
+    {
+      "kind": "image",
+      "name": "reference.png",
+      "media_type": "image/png",
+      "data_url": "data:image/png;base64,...",
+      "source": "clipboard"
+    }
+  ]
+}
+```
+
+The context agent is deterministic and does not call an LLM, enqueue a worker job, or execute tools. Generation, iteration, fabrication, and OpenCAD mutation actions that identify a project in `gathering_context` fail with `tool_execution_blocked_while_gathering_context`. A later readiness/build action must transition the project before those tools can run.
+
+Inline attachment bytes are not copied into the DesignBrief. The brief stores a stable reference plus media/source metadata; extracted document text is merged into its requirements.

--- a/tests/agents/test_agent_packages.py
+++ b/tests/agents/test_agent_packages.py
@@ -6,6 +6,7 @@ import unittest
 
 import blueprint_core.agents as agents
 from blueprint_core.agents.clarification import ContextClarifierAgent
+from blueprint_core.agents.context_gathering import ContextGatheringAgent
 from blueprint_core.agents.continuous import ContinuousAgentCoordinator
 from blueprint_core.agents.project_correction import ProjectSelfCorrectionAgent
 from blueprint_core.agents.prompt_compaction import PromptCompactionAgent
@@ -15,6 +16,7 @@ from blueprint_core.agents.video_correction import FireworksVideoSelfCorrectionA
 class AgentPackageTests(unittest.TestCase):
     def test_common_agents_are_discoverable_from_the_package(self) -> None:
         self.assertIs(agents.ContextClarifierAgent, ContextClarifierAgent)
+        self.assertIs(agents.ContextGatheringAgent, ContextGatheringAgent)
         self.assertIs(agents.ContinuousAgentCoordinator, ContinuousAgentCoordinator)
         self.assertIs(agents.ProjectSelfCorrectionAgent, ProjectSelfCorrectionAgent)
         self.assertIs(agents.PromptCompactionAgent, PromptCompactionAgent)

--- a/tests/projects/test_context_gathering.py
+++ b/tests/projects/test_context_gathering.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from apps.api import a2a, main
+from apps.api.a2a import A2AMessage
+from apps.api.auth import UserContext, require_user_context
+from apps.api.context_gathering_api import router
+from blueprint_core import database
+from blueprint_core.persistence.providers import create_sqlite_provider
+from blueprint_core.persistence.repositories import SqlAlchemyRepository
+from blueprint_core.workspaces.projects.models import GenerateProjectRequest
+from blueprint_core.workspaces.workflow import WorkflowStateError
+
+
+OWNER = "context-user"
+USER = UserContext(
+    provider="test",
+    subject=OWNER,
+    owner_user_id=OWNER,
+    is_authenticated=True,
+    is_admin=False,
+)
+
+
+@contextmanager
+def sqlite_repository() -> Iterator[None]:
+    with tempfile.TemporaryDirectory() as directory:
+        provider = create_sqlite_provider(
+            source="context gathering test",
+            url=f"sqlite:///{Path(directory) / 'blueprint.db'}",
+            import_legacy_jobs=False,
+        )
+        assert provider.session_factory is not None
+        provider.initialize()
+        original = database._DATABASE_REPOSITORY
+        try:
+            database._DATABASE_REPOSITORY = SqlAlchemyRepository(provider.session_factory)
+            yield
+        finally:
+            database._DATABASE_REPOSITORY = original
+
+
+class ContextGatheringIntegrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_user_context] = lambda: USER
+        self.client = TestClient(app)
+
+    def test_text_image_and_document_append_brief_versions_without_enqueuing_jobs(self) -> None:
+        project_id = str(uuid.uuid4())
+        conversation_id = "context-chat-1"
+
+        with sqlite_repository(), patch.object(a2a.JOB_STORE, "create_job") as create_job:
+            first = self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={
+                    "conversation_id": conversation_id,
+                    "text": "Build an ESP32 environmental monitor with USB-C power and wiring.",
+                },
+            )
+            second = self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={
+                    "conversation_id": conversation_id,
+                    "text": "It must fit within 100 mm and include product images.",
+                    "attachments": [
+                        {
+                            "attachment_id": "clipboard-image",
+                            "kind": "image",
+                            "name": "reference.png",
+                            "media_type": "image/png",
+                            "data_url": "data:image/png;base64,aW1hZ2U=",
+                            "source": "clipboard",
+                        },
+                        {
+                            "attachment_id": "requirements-document",
+                            "kind": "document",
+                            "name": "requirements.txt",
+                            "media_type": "text/plain",
+                            "extracted_text": "The display must remain readable outdoors.",
+                        },
+                    ],
+                },
+            )
+            versions = database.list_design_brief_versions(project_id, OWNER)
+            chat = database.get_project_chat(conversation_id, OWNER)
+
+        self.assertEqual(201, first.status_code, first.text)
+        self.assertEqual("gathering_context", first.json()["workflow"]["state"])
+        self.assertTrue(first.json()["questions"])
+        self.assertEqual(201, second.status_code, second.text)
+        self.assertEqual(2, second.json()["design_brief"]["brief_version"])
+        self.assertEqual([1, 2], [brief.brief_version for brief in versions])
+        self.assertEqual(2, len(versions[-1].references))
+        self.assertIn("product images", versions[-1].requested_outputs)
+        self.assertIn("The display must remain readable outdoors.", versions[-1].requirements)
+        self.assertEqual(4, len(chat.messages))
+        create_job.assert_not_called()
+
+    def test_generation_and_mutating_tools_are_blocked_during_gathering(self) -> None:
+        project_id = str(uuid.uuid4())
+        with sqlite_repository():
+            database.initialize_project_workflow(project_id, OWNER)
+
+            for action in ("blueprint.generate_project", "fabricator.plan", "opencad.mutate"):
+                with self.subTest(action=action), self.assertRaises(WorkflowStateError) as raised:
+                    database.ensure_project_action_allowed(project_id, OWNER, action, require_workflow=True)
+                self.assertEqual("tool_execution_blocked_while_gathering_context", raised.exception.code)
+
+    def test_generate_endpoint_rejects_before_worker_job_is_created(self) -> None:
+        project_id = str(uuid.uuid4())
+        with sqlite_repository(), patch.object(main.JOB_STORE, "create_job") as create_job:
+            database.initialize_project_workflow(project_id, OWNER)
+            with self.assertRaises(HTTPException) as raised:
+                asyncio.run(main.generate_project_endpoint(
+                    GenerateProjectRequest(prompt="Build it", project_id=project_id),
+                    USER,
+                ))
+
+        self.assertEqual(409, raised.exception.status_code)
+        self.assertEqual("tool_execution_blocked_while_gathering_context", raised.exception.detail["code"])
+        create_job.assert_not_called()
+
+    def test_a2a_generation_rejects_before_worker_job_is_created(self) -> None:
+        project_id = str(uuid.uuid4())
+        message = A2AMessage(
+            sender="test-agent",
+            action="blueprint.generate_project",
+            payload={"project_id": project_id, "owner_user_id": OWNER, "prompt": "Build it"},
+        )
+        with sqlite_repository(), patch.object(a2a.A2A_HUB, "register", new=AsyncMock()), patch.object(
+            a2a.JOB_STORE, "create_job"
+        ) as create_job:
+            database.initialize_project_workflow(project_id, OWNER)
+            with self.assertRaises(WorkflowStateError):
+                asyncio.run(a2a.submit_a2a_message(message))
+
+        create_job.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #184

Stacked on #197, which implements the required project workflow state machine from #182. Retarget this PR to `dev` after #197 merges.

## Summary
- add a tool-free conversational context agent and authenticated context-message API
- merge text, clipboard images, uploaded images, and document references into immutable DesignBrief versions
- persist targeted clarification questions and both sides of each conversation turn
- route the main chat through context gathering without requiring BYOK credentials
- retain submitted image thumbnails in the conversation
- block generation, iteration, Fabricator, and OpenCAD mutations while state is `gathering_context`
- carry the context project ID into later generation so the eventual build remains attached to the same project

## Verification
- integration coverage proves context turns create no worker jobs
- generation and A2A rejection tests assert blocking occurs before enqueue
- text, image, and document inputs append DesignBrief versions and persisted chat turns
- full quality suite: 395 passed, 1 skipped
- Next.js production build passes