### PR TITLE
feat: add readiness and build transition semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ Tip: load an example directly with http://localhost:3000/?example=pocket_mp3_pla
 - [DesignBrief contract](docs/design-brief.md)
 - [Worker contracts and capability registry](docs/worker-contracts.md)
 - [Project workflow state machine](docs/project-workflow.md)
+- [Conversational context gathering](docs/context-gathering.md)
 - [Agents](docs/agents.md)
 - [Hardware IR](docs/hardware-ir.md)
 - [Validation](docs/validation.md)

--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ Tip: load an example directly with http://localhost:3000/?example=pocket_mp3_pla
 - [Worker contracts and capability registry](docs/worker-contracts.md)
 - [Project workflow state machine](docs/project-workflow.md)
 - [Conversational context gathering](docs/context-gathering.md)
+- [Project readiness and build initiation](docs/project-readiness.md)
 - [Agents](docs/agents.md)
 - [Hardware IR](docs/hardware-ir.md)
 - [Validation](docs/validation.md)

--- a/apps/api/a2a.py
+++ b/apps/api/a2a.py
@@ -18,7 +18,12 @@ from blueprint_core.agents.workflows import (
     normalize_workflow_id,
 )
 from blueprint_core.agents.orchestrator import HardwarePipelineOrchestrator
-from blueprint_core.database import get_generated_project, save_generated_project, update_generated_project_hardware_ir
+from blueprint_core.database import (
+    ensure_project_action_allowed,
+    get_generated_project,
+    save_generated_project,
+    update_generated_project_hardware_ir,
+)
 from blueprint_core.images import build_image_provider, build_project_visual_spec, get_image_output_debug_config
 from apps.api.auth_mode import clerk_auth_required
 from blueprint_core.jobs.store import JOB_STORE
@@ -754,6 +759,7 @@ def build_generation_response(
     owner_user_id: Optional[str] = None,
     data_sources: Optional[List[str]] = None,
     past_job_context: Optional[PastJobContext] = None,
+    project_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     _apply_owner_user_integrations(owner_user_id)
 
@@ -792,6 +798,7 @@ def build_generation_response(
         "workflow": workflow_id,
         "chat_id": chat_id,
         "source_project_id": source_project_id,
+        "project_id": project_id,
         "owner_user_id": owner_user_id,
         "requested_provider": provider,
         "requested_model": model,
@@ -833,6 +840,7 @@ def build_generation_response(
                 model_name=model,
                 external_source_provider=external_source_provider,
                 generation_metadata={
+                    "project_id": project_id,
                     "chat_id": chat_id,
                     "source_project_id": source_project_id,
                     "frontend_job_id": frontend_job_id,
@@ -846,6 +854,7 @@ def build_generation_response(
             ensure_agent_pipeline_active()
             ir.assembly_metadata = {
                 **(ir.assembly_metadata or {}),
+                "project_id": project_id or (ir.assembly_metadata or {}).get("project_id"),
                 "chat_id": chat_id or (ir.assembly_metadata or {}).get("chat_id"),
                 "source_project_id": source_project_id or (ir.assembly_metadata or {}).get("source_project_id"),
                 "frontend_job_id": frontend_job_id or (ir.assembly_metadata or {}).get("frontend_job_id"),
@@ -938,6 +947,15 @@ def build_generation_response(
 async def call_blueprint_action(action: str, payload: Dict[str, Any]) -> Dict[str, Any]:
     normalized = action.removeprefix("blueprint.")
     owner_user_id = payload.get("owner_user_id")
+    project_id = payload.get("project_id")
+
+    if project_id and owner_user_id:
+        ensure_project_action_allowed(
+            str(project_id),
+            str(owner_user_id),
+            action,
+            require_workflow=normalized == "generate_project",
+        )
 
     _apply_owner_user_integrations(owner_user_id if isinstance(owner_user_id, str) else None)
 
@@ -966,6 +984,7 @@ async def call_blueprint_action(action: str, payload: Dict[str, Any]) -> Dict[st
             payload.get("owner_user_id"),
             data_sources,
             past_job_context,
+            payload.get("project_id"),
         )
 
     if normalized == "debug_config":
@@ -1007,6 +1026,15 @@ def _is_server_message(message: A2AMessage) -> bool:
 async def submit_a2a_message(message: A2AMessage) -> A2AEvent:
     await A2A_HUB.register(message.sender)
     server_owned = _is_server_message(message)
+    project_id = message.payload.get("project_id")
+    owner_user_id = message.payload.get("owner_user_id")
+    if server_owned and project_id and owner_user_id:
+        ensure_project_action_allowed(
+            str(project_id),
+            str(owner_user_id),
+            message.action,
+            require_workflow=message.action.removeprefix("blueprint.") == "generate_project",
+        )
     job = JOB_STORE.create_job(
         job_id=message.job_id,
         message_id=message.message_id,

--- a/apps/api/context_gathering_api.py
+++ b/apps/api/context_gathering_api.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from apps.api.auth import UserContext, require_user_context
+from blueprint_core.agents.context_gathering import ContextGatheringAgent
+from blueprint_core.database import (
+    DesignBriefAccessError,
+    DesignBriefNotFoundError,
+    create_design_brief_version,
+    get_latest_design_brief,
+    get_project_chat,
+    initialize_project_workflow,
+    upsert_project_chat,
+)
+from blueprint_core.workspaces.context import (
+    ContextGatheringRequest,
+    ContextGatheringResponse,
+)
+from blueprint_core.workspaces.workflow import ProjectWorkflowState, WorkflowActorType, WorkflowStateError
+
+
+router = APIRouter(prefix="/projects/{project_id}/context", tags=["context-gathering"])
+
+
+def _owner(user: UserContext) -> str:
+    owner = str(user.owner_user_id or "").strip()
+    if not owner:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"code": "authentication_required", "message": "Sign in to gather project context."},
+        )
+    return owner
+
+
+def _workflow_error(exc: WorkflowStateError) -> HTTPException:
+    status_code = status.HTTP_404_NOT_FOUND if exc.code == "workflow_not_found" else status.HTTP_409_CONFLICT
+    return HTTPException(status_code=status_code, detail=exc.as_dict())
+
+
+@router.post("/messages", response_model=ContextGatheringResponse, status_code=status.HTTP_201_CREATED)
+def gather_project_context_endpoint(
+    project_id: UUID,
+    request: ContextGatheringRequest,
+    user: UserContext = Depends(require_user_context),
+) -> ContextGatheringResponse:
+    """Persist one conversational turn without invoking generation or worker tools."""
+
+    owner = _owner(user)
+    try:
+        initialized = initialize_project_workflow(
+            str(project_id),
+            owner,
+            actor_type=WorkflowActorType.USER,
+            actor_id=owner,
+            reason="Context-gathering conversation started.",
+        )
+    except WorkflowStateError as exc:
+        raise _workflow_error(exc) from exc
+    workflow = initialized.workflow
+    if workflow.state != ProjectWorkflowState.GATHERING_CONTEXT:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "context_gathering_not_active",
+                "message": "Project context can only be updated while gathering_context is active.",
+                "context": {"project_id": str(project_id), "workflow_state": workflow.state.value},
+            },
+        )
+
+    try:
+        previous = get_latest_design_brief(str(project_id), owner)
+    except DesignBriefNotFoundError:
+        previous = None
+    if previous and previous.conversation_id != request.conversation_id:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "context_conversation_mismatch",
+                "message": "This project is already associated with a different conversation.",
+                "context": {"conversation_id": previous.conversation_id},
+            },
+        )
+
+    brief_create, assistant_message, questions = ContextGatheringAgent().update(request, previous)
+    try:
+        brief = create_design_brief_version(str(project_id), owner, brief_create)
+    except DesignBriefAccessError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail={"code": "project_not_found", "message": "Project not found."},
+        ) from exc
+
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    existing_chat = get_project_chat(request.conversation_id, owner)
+    existing_messages = list(getattr(existing_chat, "messages", None) or [])
+    attachments = [
+        {
+            "attachmentId": item.attachment_id,
+            "kind": item.kind,
+            "name": item.name,
+            "mediaType": item.media_type,
+            "uri": item.uri,
+            "source": item.source,
+            "hasInlineData": bool(item.data_url),
+        }
+        for item in request.attachments
+    ]
+    existing_messages.extend([
+        {
+            "id": f"context-user-{uuid4().hex}",
+            "role": "user",
+            "content": request.text or "Shared a project reference.",
+            "status": "complete",
+            "timestamp": now,
+            "contextProjectId": str(project_id),
+            "attachments": attachments,
+        },
+        {
+            "id": f"context-assistant-{uuid4().hex}",
+            "role": "assistant",
+            "content": assistant_message,
+            "status": "complete",
+            "timestamp": now,
+            "contextProjectId": str(project_id),
+            "designBriefVersion": brief.brief_version,
+            "questions": questions,
+        },
+    ])
+    title = str(getattr(existing_chat, "title", "") or "").strip()
+    if not title:
+        title = (request.text or brief.summary)[:100]
+    created_at = str(getattr(existing_chat, "created_at", "") or now)
+    upsert_project_chat(
+        chat_id=request.conversation_id,
+        owner_user_id=owner,
+        title=title,
+        messages=existing_messages,
+        created_at=created_at,
+        updated_at=now,
+    )
+    return ContextGatheringResponse(
+        workflow=workflow,
+        design_brief=brief,
+        assistant_message=assistant_message,
+        questions=questions,
+    )

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -71,6 +71,7 @@ from blueprint_core.database import (
     count_component_templates,
     delete_generated_project,
     delete_project_chat,
+    ensure_project_action_allowed,
     get_database_config,
     get_generated_project,
     get_latest_project_deletion_audit,
@@ -100,6 +101,7 @@ from blueprint_core.workspaces.projects.models import (
     ConnectionNet, GenerateProjectRequest, HardwareIR, IterateProjectRequest,
     ProjectContributionConsentRequest, ProjectUpdateRequest, ValidationIssue, ValidationReport, VideoSelfCorrectRequest,
 )
+from blueprint_core.workspaces.workflow import WorkflowStateError
 from blueprint_core.signups.models import AlphaSignupRequest, AlphaSignupResponse
 from blueprint_core.agents.orchestrator import HardwarePipelineOrchestrator
 from apps.api.a2a import (
@@ -127,6 +129,7 @@ from blueprint_core.video_review import FireworksVideoReviewClient
 from apps.api.logs_api import router as logs_router
 from apps.api.streams_api import router as streams_router
 from apps.api.design_briefs_api import router as design_briefs_router
+from apps.api.context_gathering_api import router as context_gathering_router
 from apps.api.project_workflow_api import router as project_workflow_router
 from apps.api.user_integrations_api import router as user_integrations_router
 from apps.api.user_settings_api import router as user_settings_router
@@ -279,6 +282,7 @@ app.add_middleware(
 app.include_router(logs_router, dependencies=[Depends(require_admin_user_context)])
 app.include_router(streams_router, dependencies=[Depends(require_admin_user_context)])
 app.include_router(design_briefs_router)
+app.include_router(context_gathering_router)
 app.include_router(project_workflow_router)
 app.include_router(user_integrations_router)
 app.include_router(user_settings_router)
@@ -494,6 +498,18 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
     Submits a natural language hardware idea and optional multimodal reference image.
     Runs the 7-agent compilation workflow, circuit safety auditor, and returns a verified Hardware IR, SVG schematic, and Mermaid diagram.
     """
+    owner_user_id = _require_authenticated_user(user)
+    if request.project_id:
+        try:
+            ensure_project_action_allowed(
+                request.project_id,
+                owner_user_id,
+                "blueprint.generate_project",
+                require_workflow=True,
+            )
+        except WorkflowStateError as exc:
+            status_code = status.HTTP_404_NOT_FOUND if exc.code == "workflow_not_found" else status.HTTP_409_CONFLICT
+            raise HTTPException(status_code=status_code, detail=exc.as_dict()) from exc
     _apply_user_integrations(user)
     try:
         llm_config = get_workflow_debug_config(
@@ -553,7 +569,6 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
 
     job_id = request.client_job_id or f"job_frontend_{uuid4().hex}"
     message_id = f"msg_{uuid4().hex}"
-    owner_user_id = _require_authenticated_user(user)
     if request.source_project_id:
         source_project = get_generated_project(request.source_project_id)
         if not source_project:
@@ -561,6 +576,7 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
         _require_project_chat_owner(source_project, user)
     payload = {
         "prompt": request.prompt,
+        "project_id": request.project_id,
         "workflow": request.workflow,
         "image_data": request.image_data,
         "generate_image": request.generate_image,
@@ -615,6 +631,7 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
                 owner_user_id=owner_user_id,
                 data_sources=request.data_sources,
                 past_job_context=past_job_context,
+                project_id=request.project_id,
             )
         if JOB_STORE.is_cancelled(job_id):
             raise JobCancelledError(f"Job {job_id} was cancelled.")
@@ -2010,6 +2027,11 @@ def iterate_project_endpoint(
         raise HTTPException(status_code=404, detail="Project not found.")
     _require_project_reader(project, user)
     save_owner_user_id = _require_project_owner(project, user) if request.save else None
+    if save_owner_user_id:
+        try:
+            ensure_project_action_allowed(project.project_id, save_owner_user_id, "blueprint.iterate_project")
+        except WorkflowStateError as exc:
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=exc.as_dict()) from exc
 
     try:
         current_ir = HardwareIR(**project.hardware_ir)

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -131,6 +131,7 @@ from apps.api.streams_api import router as streams_router
 from apps.api.design_briefs_api import router as design_briefs_router
 from apps.api.context_gathering_api import router as context_gathering_router
 from apps.api.project_workflow_api import router as project_workflow_router
+from apps.api.readiness_api import router as readiness_router
 from apps.api.user_integrations_api import router as user_integrations_router
 from apps.api.user_settings_api import router as user_settings_router
 from apps.api.auth import (
@@ -284,6 +285,7 @@ app.include_router(streams_router, dependencies=[Depends(require_admin_user_cont
 app.include_router(design_briefs_router)
 app.include_router(context_gathering_router)
 app.include_router(project_workflow_router)
+app.include_router(readiness_router)
 app.include_router(user_integrations_router)
 app.include_router(user_settings_router)
 

--- a/apps/api/readiness_api.py
+++ b/apps/api/readiness_api.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from apps.api.auth import UserContext, require_user_context
+from blueprint_core.database import (
+    evaluate_project_readiness,
+    get_latest_project_build,
+    initiate_project_build,
+)
+from blueprint_core.workspaces.readiness import (
+    BuildAnywayRequest,
+    BuildInitiationOutcome,
+    BuildMode,
+    BuildRequest,
+    ProjectBuild,
+    ReadinessError,
+    ReadinessResult,
+)
+from blueprint_core.workspaces.workflow import WorkflowStateError
+
+
+router = APIRouter(prefix="/projects/{project_id}", tags=["project-readiness"])
+
+
+def _owner(user: UserContext) -> str:
+    owner = str(user.owner_user_id or "").strip()
+    if not owner:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={"code": "authentication_required", "message": "Sign in to evaluate or build a project."},
+        )
+    return owner
+
+
+def _domain_error(exc: ReadinessError | WorkflowStateError) -> HTTPException:
+    not_found_codes = {"design_brief_not_found", "project_build_not_found", "workflow_not_found"}
+    status_code = status.HTTP_404_NOT_FOUND if exc.code in not_found_codes else status.HTTP_409_CONFLICT
+    return HTTPException(status_code=status_code, detail=exc.as_dict())
+
+
+@router.get("/readiness", response_model=ReadinessResult)
+def evaluate_readiness_endpoint(
+    project_id: UUID,
+    user: UserContext = Depends(require_user_context),
+) -> ReadinessResult:
+    try:
+        return evaluate_project_readiness(str(project_id), _owner(user))
+    except (ReadinessError, WorkflowStateError) as exc:
+        raise _domain_error(exc) from exc
+
+
+@router.post("/build", response_model=BuildInitiationOutcome)
+def build_project_endpoint(
+    project_id: UUID,
+    request: BuildRequest,
+    user: UserContext = Depends(require_user_context),
+) -> BuildInitiationOutcome:
+    owner = _owner(user)
+    try:
+        return initiate_project_build(
+            str(project_id),
+            owner,
+            mode=BuildMode.BUILD,
+            actor_id=owner,
+            idempotency_key=request.idempotency_key,
+        )
+    except (ReadinessError, WorkflowStateError) as exc:
+        raise _domain_error(exc) from exc
+
+
+@router.post("/build-anyway", response_model=BuildInitiationOutcome)
+def build_project_anyway_endpoint(
+    project_id: UUID,
+    request: BuildAnywayRequest,
+    user: UserContext = Depends(require_user_context),
+) -> BuildInitiationOutcome:
+    owner = _owner(user)
+    try:
+        return initiate_project_build(
+            str(project_id),
+            owner,
+            mode=BuildMode.BUILD_ANYWAY,
+            actor_id=owner,
+            assumptions=request.assumptions,
+            idempotency_key=request.idempotency_key,
+        )
+    except (ReadinessError, WorkflowStateError) as exc:
+        raise _domain_error(exc) from exc
+
+
+@router.get("/build", response_model=ProjectBuild)
+def get_frozen_build_endpoint(
+    project_id: UUID,
+    user: UserContext = Depends(require_user_context),
+) -> ProjectBuild:
+    try:
+        return get_latest_project_build(str(project_id), _owner(user))
+    except (ReadinessError, WorkflowStateError) as exc:
+        raise _domain_error(exc) from exc

--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -173,6 +173,7 @@ type ChatMessage = {
   timestamp: string;
   projectId?: string | null;
   pipelineProgress?: AgentPipelineProgress | null;
+  imagePreview?: string | null;
 };
 
 type ActiveGenerationRun = {
@@ -402,6 +403,7 @@ function normalizeChatMessage(value: any): ChatMessage | null {
     timestamp: typeof value.timestamp === "string" && value.timestamp ? value.timestamp : chatTimestamp(),
     projectId: typeof value.projectId === "string" ? value.projectId : null,
     pipelineProgress: normalizeAgentPipelineProgress(value.pipelineProgress),
+    imagePreview: typeof value.imagePreview === "string" ? value.imagePreview : null,
   };
 }
 
@@ -1511,6 +1513,7 @@ export function FormaWorkspace({
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>(() => initialChatMessages());
   const [pendingHumanContext, setPendingHumanContext] = useState<PendingHumanContext | null>(null);
+  const contextProjectIdsRef = useRef<Record<string, string>>({});
   const [chatThreads, setChatThreads] = useState<Record<string, ChatMessage[]>>({});
   const [projectChatInput, setProjectChatInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -1548,6 +1551,7 @@ export function FormaWorkspace({
     () => lastKnownServerStatus || "disconnected"
   );
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
+  const [selectedImageSource, setSelectedImageSource] = useState<"upload" | "clipboard">("upload");
   const [generationInputNotice, setGenerationInputNotice] = useState<string | null>(null);
   const [videoGenerationConfig, setVideoGenerationConfig] = useState<VideoGenerationConfig>({
     configured: null,
@@ -1683,16 +1687,12 @@ export function FormaWorkspace({
     () => generationLlms.find((option) => generationLlmKey(option) === generationLlmKeyValue) || generationLlms[0] || null,
     [generationLlmKeyValue, generationLlms]
   );
-  const generationLlmsReady = Boolean(selectedGenerationLlm);
   const needsGenerationProvider = generationLlmsLoaded && providerSetup.llmRequired && (!authRequired || authLoaded);
   const needsImageProvider = imageGenerationConfigLoaded && providerSetup.imageRequired && (!authRequired || authLoaded);
-  const visibleGenerationInputNotice =
-    generationInputNotice ||
-    (needsGenerationProvider
-      ? "No model provider is active. Add and enable one in Settings before building."
-      : (prompt.trim() || pendingHumanContext) && !generationInputValidation.isValid
-        ? generationInputValidation.message
-        : null);
+  const visibleContextInputNotice =
+    generationInputNotice || ((prompt.trim() || selectedImage) && !generationInputValidation.isValid
+      ? generationInputValidation.message
+      : null);
   const appendChatMessage = (message: Omit<ChatMessage, "id" | "timestamp"> & { id?: string }) => {
     const nextMessage: ChatMessage = {
       id: message.id || newChatMessageId(),
@@ -1701,6 +1701,7 @@ export function FormaWorkspace({
       status: message.status || "idle",
       projectId: message.projectId,
       pipelineProgress: message.pipelineProgress || null,
+      imagePreview: message.imagePreview || null,
       timestamp: chatTimestamp(),
     };
     setChatMessages((current) => [...current, nextMessage]);
@@ -1748,6 +1749,7 @@ export function FormaWorkspace({
       status: message.status || "idle",
       projectId: message.projectId,
       pipelineProgress: message.pipelineProgress || null,
+      imagePreview: message.imagePreview || null,
       timestamp: chatTimestamp(),
     };
     setChatThreads((current) => {
@@ -2129,6 +2131,7 @@ export function FormaWorkspace({
     setPendingHumanContext(null);
     setGenerationInputNotice(null);
     setSelectedImage(null);
+    setSelectedImageSource("upload");
     setChatRouteTransition(null);
     setProjectIR(null);
     setActiveTab("overview");
@@ -2718,7 +2721,7 @@ export function FormaWorkspace({
     };
   }, [blueprintDevMode, chatListItems, currentRouteProjectId, myProjectHistory, optionalAuthHeaders, projectHistory, projectGalleryImages, projectIR, visibleProjectGalleryIds]);
 
-  const attachImageFile = (file: File) => {
+  const attachImageFile = (file: File, source: "upload" | "clipboard" = "upload") => {
     if (!file.type.startsWith("image/")) {
       setGenerationInputNotice("Only image files can be attached as hardware references.");
       return;
@@ -2731,6 +2734,7 @@ export function FormaWorkspace({
       }
       setGenerationInputNotice(null);
       setSelectedImage(reader.result);
+      setSelectedImageSource(source);
     };
     reader.onerror = () => {
       setGenerationInputNotice("Forma could not read that image. Try copying or uploading it again.");
@@ -2740,7 +2744,7 @@ export function FormaWorkspace({
 
   const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
-    if (file) attachImageFile(file);
+    if (file) attachImageFile(file, "upload");
   };
 
   const handleImagePaste = (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
@@ -2748,12 +2752,13 @@ export function FormaWorkspace({
       || Array.from(event.clipboardData.items)
         .find((item) => item.type.startsWith("image/"))
         ?.getAsFile();
-    if (imageFile) attachImageFile(imageFile);
+    if (imageFile) attachImageFile(imageFile, "clipboard");
   };
 
   const removeSelectedImage = () => {
     setGenerationInputNotice(null);
     setSelectedImage(null);
+    setSelectedImageSource("upload");
     if (fileInputRefSidebar.current) fileInputRefSidebar.current.value = "";
     if (fileInputRefCenter.current) fileInputRefCenter.current.value = "";
   };
@@ -2823,6 +2828,88 @@ export function FormaWorkspace({
     setGenerationInputNotice("Generation stopped. You can send another message whenever you're ready.");
     if (run.jobId) void cancelGenerationJob(run.jobId);
     finishGenerationRun(run);
+  };
+
+  const handleGatherContext = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (isLoading || activeGenerationRef.current) return;
+    if (!(await requireSignedInForGeneration())) return;
+
+    const validation = validateGenerationInput(prompt, Boolean(selectedImage));
+    if (!validation.isValid) {
+      setGenerationInputNotice(validation.message);
+      return;
+    }
+
+    const requestChatId = activeChatId || newBuildChatId();
+    const requestProjectId = contextProjectIdsRef.current[requestChatId] || (
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(requestChatId)
+        ? requestChatId
+        : newBuildChatId()
+    );
+    contextProjectIdsRef.current[requestChatId] = requestProjectId;
+    const text = prompt.trim();
+    const imageData = selectedImage;
+    const userMessageId = newChatMessageId();
+    const assistantMessageId = newChatMessageId();
+    const userContent = text || "Shared a hardware reference image.";
+
+    setActiveChatId(requestChatId);
+    rememberChatItem({
+      chatId: requestChatId,
+      title: text || "Hardware reference",
+      projectId: "",
+      createdAt: chatTimestamp(),
+      projectCount: 0,
+    });
+    syncChatRoute(requestChatId);
+    appendChatMessage({ id: userMessageId, role: "user", content: userContent, imagePreview: imageData, status: "idle" });
+    appendThreadMessage(requestChatId, { id: userMessageId, role: "user", content: userContent, imagePreview: imageData, status: "idle" });
+    appendChatMessage({ id: assistantMessageId, role: "assistant", content: "Saving project context…", status: "loading" });
+    appendThreadMessage(requestChatId, { id: assistantMessageId, role: "assistant", content: "Saving project context…", status: "loading" });
+    setPrompt("");
+    setSelectedImage(null);
+    setSelectedImageSource("upload");
+    setGenerationInputNotice(null);
+    setIsLoading(true);
+
+    try {
+      const res = await fetch(`${API_URL}/projects/${encodeURIComponent(requestProjectId)}/context/messages`, {
+        method: "POST",
+        headers: await generationRequestHeaders(),
+        body: JSON.stringify({
+          conversation_id: requestChatId,
+          text,
+          attachments: imageData ? [{
+            attachment_id: `context-image-${userMessageId}`,
+            kind: "image",
+            name: "hardware-reference.png",
+            media_type: imageData.match(/^data:([^;,]+)/)?.[1] || "image/png",
+            data_url: imageData,
+            source: selectedImageSource,
+          }] : [],
+        }),
+      });
+      if (!res.ok) throw new Error(await readApiErrorMessage(res));
+      const data = await res.json();
+      const persistedProjectId = typeof data?.design_brief?.project_id === "string"
+        ? data.design_brief.project_id
+        : requestProjectId;
+      contextProjectIdsRef.current[requestChatId] = persistedProjectId;
+      const assistantContent = typeof data?.assistant_message === "string"
+        ? data.assistant_message
+        : "I saved that project context. What else should the design account for?";
+      updateChatMessage(assistantMessageId, { content: assistantContent, status: "success" });
+      updateThreadMessage(requestChatId, assistantMessageId, { content: assistantContent, status: "success" });
+      setGenerationInputNotice("Context saved. Continue the conversation to refine the design brief.");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Could not save project context.";
+      updateChatMessage(assistantMessageId, { content: message, status: "error" });
+      updateThreadMessage(requestChatId, assistantMessageId, { content: message, status: "error" });
+      setGenerationInputNotice(message);
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleGenerate = async (event: React.FormEvent) => {
@@ -4258,17 +4345,17 @@ export function FormaWorkspace({
                 setPendingHumanContext(null);
                 setPrompt(example);
               }}
-              onSubmit={handleGenerate}
+              onSubmit={handleGatherContext}
               pendingContext={pendingHumanContext}
               onContextAnswer={updateHumanContextAnswer}
               onClearContext={clearHumanContextCheckpoint}
               isLoading={isLoading}
-              generationReady={generationLlmsReady}
-              needsGenerationProvider={needsGenerationProvider}
-              needsImageProvider={needsImageProvider}
+              generationReady
+              needsGenerationProvider={false}
+              needsImageProvider={false}
               selectedImage={selectedImage}
               onRemoveImage={removeSelectedImage}
-              notice={visibleGenerationInputNotice}
+              notice={visibleContextInputNotice}
               prompt={prompt}
               onPromptChange={(value) => {
                 setGenerationInputNotice(null);

--- a/apps/web/app/blueprint-workspace/home-chat-view.tsx
+++ b/apps/web/app/blueprint-workspace/home-chat-view.tsx
@@ -25,6 +25,7 @@ type HomeChatMessage = {
   timestamp: string;
   projectId?: string | null;
   pipelineProgress?: unknown;
+  imagePreview?: string | null;
 };
 
 type PendingContext = {
@@ -158,6 +159,13 @@ export default function HomeChatView({
                       <span suppressHydrationWarning>{formatTimestamp(message.timestamp)}</span>
                     </div>
                     <p className="break-anywhere whitespace-pre-wrap text-sm leading-6">{message.content}</p>
+                    {message.imagePreview && (
+                      <img
+                        src={message.imagePreview}
+                        alt="Hardware reference thumbnail"
+                        className="mt-3 h-24 w-36 border border-cyan-300/25 object-cover"
+                      />
+                    )}
                     {!message.projectId && renderPipelineProgress(message)}
                   </div>
                 </div>
@@ -329,7 +337,7 @@ export default function HomeChatView({
                   if (!isLoading) event.currentTarget.form?.requestSubmit();
                 }
               }}
-              placeholder={pendingContext ? "Optional: add final context notes before building..." : "Ask Forma to build a lab-on-chip reader, self-assembling tent, sensor node, robot fixture..."}
+              placeholder={pendingContext ? "Add more context…" : "Describe the product, constraints, references, and outputs you need…"}
               aria-invalid={Boolean(notice)}
               aria-describedby={notice ? "generation-input-notice" : undefined}
               className={`${pendingContext ? "min-h-[72px] sm:min-h-[96px]" : "min-h-[98px] sm:min-h-[104px]"} w-full resize-none border border-[#2c2f37] bg-[#0f1014] py-3 pl-14 pr-14 text-sm leading-6 text-slate-100 outline-none placeholder:text-slate-600 focus:border-cyan-300 sm:py-4 sm:pl-16 sm:pr-16 sm:leading-7`}
@@ -348,8 +356,8 @@ export default function HomeChatView({
               onClick={generationActive ? onStop : undefined}
               disabled={!generationActive && (isLoading || !hasGenerationInput || !generationReady)}
               className="absolute bottom-3 right-3 inline-flex h-9 w-9 items-center justify-center bg-white text-black transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-40 sm:bottom-4 sm:right-4 sm:h-10 sm:w-10"
-              aria-label={generationActive ? "Stop generation" : inputValid ? "Send build request" : "Check hardware idea"}
-              title={generationActive ? "Stop generation" : inputValid ? "Send build request" : "Check hardware idea"}
+              aria-label={generationActive ? "Stop generation" : inputValid ? "Send context" : "Check hardware idea"}
+              title={generationActive ? "Stop generation" : inputValid ? "Send context" : "Check hardware idea"}
             >
               {generationActive ? <Square className="h-4 w-4 fill-current" /> : isLoading ? <RefreshCw className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
             </button>

--- a/blueprint_core/agents/__init__.py
+++ b/blueprint_core/agents/__init__.py
@@ -2,6 +2,7 @@
 
 __all__ = [
     "ContextClarifierAgent",
+    "ContextGatheringAgent",
     "ContinuousAgentCoordinator",
     "FireworksVideoSelfCorrectionAgent",
     "HardwarePipelineOrchestrator",
@@ -18,6 +19,10 @@ def __getattr__(name: str):
         from blueprint_core.agents.clarification import ContextClarifierAgent
 
         return ContextClarifierAgent
+    if name == "ContextGatheringAgent":
+        from blueprint_core.agents.context_gathering import ContextGatheringAgent
+
+        return ContextGatheringAgent
     if name == "ContinuousAgentCoordinator":
         from blueprint_core.agents.continuous import ContinuousAgentCoordinator
 

--- a/blueprint_core/agents/context_gathering.py
+++ b/blueprint_core/agents/context_gathering.py
@@ -1,0 +1,5 @@
+from blueprint_core.workspaces.context.agent import ContextBriefUpdater
+
+
+class ContextGatheringAgent(ContextBriefUpdater):
+    """Conversational agent that gathers context without executing tools."""

--- a/blueprint_core/database.py
+++ b/blueprint_core/database.py
@@ -11,6 +11,16 @@ from blueprint_core.runtime import blueprint_dev_mode_enabled
 from blueprint_core.project_list_cache import invalidate_project_lists
 from blueprint_core.workspaces.projects.objects import attach_project_object_metadata_to_dict
 from blueprint_core.workspaces.design_briefs import DesignBrief, DesignBriefCreate
+from blueprint_core.workspaces.readiness import (
+    BuildInitiationOutcome,
+    BuildMode,
+    ProjectBuild,
+    ProjectBuildService,
+    ReadinessError,
+    ReadinessResult,
+    ReadinessStatus,
+    evaluate_readiness,
+)
 from blueprint_core.workspaces.workflow import (
     ProjectWorkflow,
     ProjectWorkflowService,
@@ -506,6 +516,137 @@ def get_latest_design_brief(project_id: str, owner_user_id: str) -> DesignBrief:
     if record is None:
         raise DesignBriefNotFoundError("DesignBrief not found.")
     return _design_brief_from_record(record)
+
+
+def evaluate_project_readiness(project_id: str, owner_user_id: str) -> ReadinessResult:
+    try:
+        brief = get_latest_design_brief(project_id, owner_user_id)
+    except DesignBriefNotFoundError as exc:
+        raise ReadinessError("design_brief_not_found", "DesignBrief not found.") from exc
+    return evaluate_readiness(brief)
+
+
+def _project_build_from_record(record: Any) -> ProjectBuild:
+    return ProjectBuild.model_validate({
+        "build_id": record.id,
+        "project_id": record.project_id,
+        "owner_user_id": record.owner_user_id,
+        "design_brief_id": record.design_brief_id,
+        "brief_version": record.brief_version,
+        "brief_snapshot": record.brief_snapshot_json,
+        "mode": record.mode,
+        "readiness": record.readiness_result_json,
+        "introduced_assumptions": record.introduced_assumptions_json,
+        "warnings": record.warnings_json,
+        "transition_id": record.transition_id,
+        "idempotency_key": record.idempotency_key,
+        "initiated_by": record.initiated_by,
+        "created_at": record.created_at,
+    })
+
+
+def get_latest_project_build(project_id: str, owner_user_id: str) -> ProjectBuild:
+    canonical_project_id = _canonical_project_id(project_id)
+    normalized_owner_user_id = _normalize_user_id(owner_user_id)
+    record = None
+    if normalized_owner_user_id:
+        record = _DATABASE_REPOSITORY.get_latest_project_build(canonical_project_id, normalized_owner_user_id)
+    if record is None:
+        raise ReadinessError("project_build_not_found", "Project build not found.")
+    return _project_build_from_record(record)
+
+
+def initiate_project_build(
+    project_id: str,
+    owner_user_id: str,
+    *,
+    mode: BuildMode,
+    actor_id: str,
+    assumptions: Optional[List[str]] = None,
+    idempotency_key: Optional[str] = None,
+) -> BuildInitiationOutcome:
+    canonical_project_id = _canonical_project_id(project_id)
+    normalized_owner_user_id = _normalize_user_id(owner_user_id)
+    if not normalized_owner_user_id:
+        raise ValueError("owner_user_id is required.")
+    try:
+        latest = get_latest_design_brief(canonical_project_id, normalized_owner_user_id)
+    except DesignBriefNotFoundError as exc:
+        raise ReadinessError("design_brief_not_found", "DesignBrief not found.") from exc
+    readiness = evaluate_readiness(latest)
+    service = ProjectBuildService(_DATABASE_REPOSITORY)
+    normalized_key = str(idempotency_key or "").strip() or None
+    normalized_assumptions = list(dict.fromkeys(
+        normalized
+        for item in assumptions or []
+        if (normalized := str(item or "").strip())
+    ))
+
+    if normalized_key and _DATABASE_REPOSITORY.get_project_build_by_idempotency(
+        canonical_project_id, normalized_owner_user_id, normalized_key
+    ) is not None:
+        return service.initiate(
+            latest,
+            readiness,
+            normalized_owner_user_id,
+            mode=mode,
+            actor_id=actor_id,
+            introduced_assumptions=normalized_assumptions,
+            warnings=[],
+            idempotency_key=normalized_key,
+        )
+
+    # Validate workflow ownership/state before appending an assumption-bearing brief.
+    workflow = get_project_workflow(canonical_project_id, normalized_owner_user_id)
+    if workflow.state not in {ProjectWorkflowState.GATHERING_CONTEXT, ProjectWorkflowState.READY_TO_BUILD}:
+        raise ReadinessError(
+            "build_transition_not_allowed",
+            f"Build cannot start while the project workflow is {workflow.state.value}.",
+            context={"project_id": canonical_project_id, "workflow_state": workflow.state.value},
+        )
+
+    frozen_brief = latest
+    warnings: List[str] = []
+    if mode == BuildMode.BUILD_ANYWAY:
+        if readiness.status == ReadinessStatus.BLOCKED:
+            raise ReadinessError(
+                "critical_readiness_blockers",
+                "Build Anyway cannot bypass critical project unknowns.",
+                context=readiness.model_dump(mode="json"),
+            )
+        if readiness.status == ReadinessStatus.NOT_READY and not normalized_assumptions:
+            raise ReadinessError(
+                "build_anyway_assumptions_required",
+                "Build Anyway requires explicit assumptions for incomplete context.",
+            )
+        if normalized_assumptions:
+            payload = latest.model_dump(exclude={
+                "design_brief_id", "project_id", "brief_version", "previous_version", "created_at"
+            })
+            payload["assumptions"] = list(dict.fromkeys([*latest.assumptions, *normalized_assumptions]))
+            frozen_brief = create_design_brief_version(
+                canonical_project_id,
+                normalized_owner_user_id,
+                DesignBriefCreate.model_validate(payload),
+            )
+            readiness = evaluate_readiness(frozen_brief)
+        warnings = [
+            f"Build Anyway bypassed non-critical blocker {blocker.code}: {blocker.message}"
+            for blocker in readiness.unresolved_blockers
+            if not blocker.critical
+        ]
+        warnings.extend(f"Execution relies on user assumption: {assumption}" for assumption in normalized_assumptions)
+
+    return service.initiate(
+        frozen_brief,
+        readiness,
+        normalized_owner_user_id,
+        mode=mode,
+        actor_id=actor_id,
+        introduced_assumptions=normalized_assumptions,
+        warnings=warnings,
+        idempotency_key=normalized_key,
+    )
 
 
 def initialize_project_workflow(

--- a/blueprint_core/database.py
+++ b/blueprint_core/database.py
@@ -18,6 +18,7 @@ from blueprint_core.workspaces.workflow import (
     ProjectWorkflowTransition,
     WorkflowActorType,
     WorkflowTransitionOutcome,
+    ensure_action_allowed,
 )
 from blueprint_core.persistence.base import DatabaseProvider
 from blueprint_core.persistence.models import (
@@ -554,6 +555,24 @@ def transition_project_workflow(
         reason=reason,
         idempotency_key=idempotency_key,
     )
+
+
+def ensure_project_action_allowed(
+    project_id: str,
+    owner_user_id: str,
+    action: str,
+    *,
+    require_workflow: bool = False,
+) -> None:
+    """Apply project workflow execution policy without coupling callers to persistence."""
+
+    try:
+        workflow = ProjectWorkflowService(_DATABASE_REPOSITORY).get(project_id, owner_user_id)
+    except WorkflowStateError:
+        if not require_workflow:
+            return
+        raise
+    ensure_action_allowed(workflow, action)
 
 
 def list_due_project_purges(before: str, limit: int = 25) -> List[Any]:

--- a/blueprint_core/persistence/models.py
+++ b/blueprint_core/persistence/models.py
@@ -91,6 +91,29 @@ class DBProjectWorkflowTransition(Base):
     created_at = Column(String, index=True, nullable=False)
 
 
+class DBProjectBuild(Base):
+    __tablename__ = "project_builds"
+    __table_args__ = (
+        UniqueConstraint("project_id", "idempotency_key", name="uq_project_build_idempotency"),
+        UniqueConstraint("transition_id", name="uq_project_build_transition"),
+    )
+
+    id = Column(String, primary_key=True)
+    project_id = Column(String, index=True, nullable=False)
+    owner_user_id = Column(String, index=True, nullable=False)
+    design_brief_id = Column(String, index=True, nullable=False)
+    brief_version = Column(Integer, nullable=False)
+    brief_snapshot_json = Column(JSON, nullable=False)
+    mode = Column(String, index=True, nullable=False)
+    readiness_result_json = Column(JSON, nullable=False)
+    introduced_assumptions_json = Column(JSON, nullable=False, default=list)
+    warnings_json = Column(JSON, nullable=False, default=list)
+    transition_id = Column(String, nullable=False)
+    idempotency_key = Column(String, nullable=False)
+    initiated_by = Column(String, nullable=False)
+    created_at = Column(String, index=True, nullable=False)
+
+
 class DBProjectContributionConsent(Base):
     __tablename__ = "project_contribution_consents"
     __table_args__ = (UniqueConstraint("project_id", "user_id", name="uq_project_contribution_consent_project_user"),)

--- a/blueprint_core/persistence/repositories/base.py
+++ b/blueprint_core/persistence/repositories/base.py
@@ -56,6 +56,24 @@ class ApplicationRepository(Protocol):
         expected_revision: Optional[int],
     ) -> Optional[tuple[Any, Any]]: ...
 
+    def get_project_build_by_idempotency(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        idempotency_key: str,
+    ) -> Optional[Any]: ...
+
+    def get_latest_project_build(self, project_id: str, owner_user_id: str) -> Optional[Any]: ...
+
+    def apply_project_build_initiation(
+        self,
+        state_record: Dict[str, Any],
+        transition_record: Dict[str, Any],
+        build_record: Dict[str, Any],
+        expected_state: str,
+        expected_revision: int,
+    ) -> Optional[tuple[Any, Any, Any]]: ...
+
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]: ...
 
     def update_project_deletion_state(

--- a/blueprint_core/persistence/repositories/sqlite.py
+++ b/blueprint_core/persistence/repositories/sqlite.py
@@ -13,6 +13,7 @@ from blueprint_core.persistence.models import (
     DBProjectContributionConsent,
     DBProjectContributionSnapshot,
     DBProjectChat,
+    DBProjectBuild,
     DBProjectDeletionAudit,
     DBProjectWorkflow,
     DBProjectWorkflowTransition,
@@ -202,6 +203,69 @@ class SqlAlchemyRepository:
         except IntegrityError:
             return None
 
+    def get_project_build_by_idempotency(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        idempotency_key: str,
+    ) -> Optional[Any]:
+        with self._session() as session:
+            return session.query(DBProjectBuild).filter(
+                DBProjectBuild.project_id == project_id,
+                DBProjectBuild.owner_user_id == owner_user_id,
+                DBProjectBuild.idempotency_key == idempotency_key,
+            ).first()
+
+    def get_latest_project_build(self, project_id: str, owner_user_id: str) -> Optional[Any]:
+        with self._session() as session:
+            return (
+                session.query(DBProjectBuild)
+                .filter(
+                    DBProjectBuild.project_id == project_id,
+                    DBProjectBuild.owner_user_id == owner_user_id,
+                )
+                .order_by(DBProjectBuild.created_at.desc())
+                .first()
+            )
+
+    def apply_project_build_initiation(
+        self,
+        state_record: Dict[str, Any],
+        transition_record: Dict[str, Any],
+        build_record: Dict[str, Any],
+        expected_state: str,
+        expected_revision: int,
+    ) -> Optional[tuple[Any, Any, Any]]:
+        try:
+            with self._session() as session, session.begin():
+                workflow = session.query(DBProjectWorkflow).filter(
+                    DBProjectWorkflow.project_id == state_record["project_id"]
+                ).first()
+                if (
+                    workflow is None
+                    or workflow.owner_user_id != state_record["owner_user_id"]
+                    or workflow.state != expected_state
+                    or workflow.revision != expected_revision
+                ):
+                    return None
+                workflow.state = state_record["state"]
+                workflow.revision = state_record["revision"]
+                workflow.updated_at = state_record["updated_at"]
+                transition = DBProjectWorkflowTransition(**transition_record)
+                build = DBProjectBuild(**build_record)
+                session.add(transition)
+                session.add(build)
+                session.flush()
+                session.refresh(workflow)
+                session.refresh(transition)
+                session.refresh(build)
+                session.expunge(workflow)
+                session.expunge(transition)
+                session.expunge(build)
+                return workflow, transition, build
+        except IntegrityError:
+            return None
+
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]:
         with self._session() as session:
             return (
@@ -253,6 +317,9 @@ class SqlAlchemyRepository:
                 return False
             chat_id = project.chat_id
             project_owner_user_id = project.owner_user_id
+            session.query(DBProjectBuild).filter(DBProjectBuild.project_id == project_id).delete(
+                synchronize_session=False
+            )
             session.query(DBDesignBrief).filter(DBDesignBrief.project_id == project_id).delete(
                 synchronize_session=False
             )
@@ -331,6 +398,9 @@ class SqlAlchemyRepository:
             ).first()
             if not project:
                 return False
+            session.query(DBProjectBuild).filter(DBProjectBuild.project_id == project_id).delete(
+                synchronize_session=False
+            )
             session.query(DBDesignBrief).filter(DBDesignBrief.project_id == project_id).delete(
                 synchronize_session=False
             )

--- a/blueprint_core/persistence/repositories/supabase.py
+++ b/blueprint_core/persistence/repositories/supabase.py
@@ -168,6 +168,64 @@ class SupabaseRepository:
             return None
         return _record(payload["workflow"]), _record(payload["transition"])
 
+    def get_project_build_by_idempotency(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        idempotency_key: str,
+    ) -> Optional[Any]:
+        rows = (
+            self._client.table("project_builds")
+            .select("*")
+            .eq("project_id", project_id)
+            .eq("owner_user_id", owner_user_id)
+            .eq("idempotency_key", idempotency_key)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
+    def get_latest_project_build(self, project_id: str, owner_user_id: str) -> Optional[Any]:
+        rows = (
+            self._client.table("project_builds")
+            .select("*")
+            .eq("project_id", project_id)
+            .eq("owner_user_id", owner_user_id)
+            .order("created_at", desc=True)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
+    def apply_project_build_initiation(
+        self,
+        state_record: Dict[str, Any],
+        transition_record: Dict[str, Any],
+        build_record: Dict[str, Any],
+        expected_state: str,
+        expected_revision: int,
+    ) -> Optional[tuple[Any, Any, Any]]:
+        data = (
+            self._client.rpc(
+                "apply_project_build_initiation",
+                {
+                    "p_state": state_record,
+                    "p_transition": transition_record,
+                    "p_build": build_record,
+                    "p_expected_state": expected_state,
+                    "p_expected_revision": expected_revision,
+                },
+            ).execute().data
+        )
+        payload = data[0] if isinstance(data, list) and data else data
+        if not isinstance(payload, dict) or not all(payload.get(key) for key in ("workflow", "transition", "build")):
+            return None
+        return _record(payload["workflow"]), _record(payload["transition"]), _record(payload["build"])
+
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]:
         rows = (
             self._client.table("generated_projects")
@@ -212,6 +270,7 @@ class SupabaseRepository:
             query = query.eq("owner_user_id", owner_user_id)
         deleted = bool(query.execute().data)
         if deleted:
+            self._client.table("project_builds").delete().eq("project_id", project_id).execute()
             self._client.table("design_briefs").delete().eq("project_id", project_id).execute()
             self._client.table("project_workflow_transitions").delete().eq("project_id", project_id).execute()
             self._client.table("project_workflows").delete().eq("project_id", project_id).execute()
@@ -280,12 +339,7 @@ class SupabaseRepository:
             .eq("status", "active")
             .execute()
         )
-        deleted = bool(response.data)
-        if deleted:
-            self._client.table("design_briefs").delete().eq("project_id", project_id).execute()
-            self._client.table("project_workflow_transitions").delete().eq("project_id", project_id).execute()
-            self._client.table("project_workflows").delete().eq("project_id", project_id).execute()
-        return deleted
+        return bool(response.data)
 
     def delete_generated_project(self, project_id: str, owner_user_id: str) -> bool:
         response = (
@@ -295,7 +349,13 @@ class SupabaseRepository:
             .eq("owner_user_id", owner_user_id)
             .execute()
         )
-        return bool(response.data)
+        deleted = bool(response.data)
+        if deleted:
+            self._client.table("project_builds").delete().eq("project_id", project_id).execute()
+            self._client.table("design_briefs").delete().eq("project_id", project_id).execute()
+            self._client.table("project_workflow_transitions").delete().eq("project_id", project_id).execute()
+            self._client.table("project_workflows").delete().eq("project_id", project_id).execute()
+        return deleted
 
     def get_project_contribution_consent(self, project_id: str, user_id: str) -> Optional[Any]:
         rows = (

--- a/blueprint_core/persistence/schema.py
+++ b/blueprint_core/persistence/schema.py
@@ -41,6 +41,14 @@ APPLICATION_SCHEMA: Tuple[TableContract, ...] = (
         ),
     ),
     TableContract(
+        "project_builds",
+        (
+            "id", "project_id", "owner_user_id", "design_brief_id", "brief_version", "brief_snapshot_json",
+            "mode", "readiness_result_json", "introduced_assumptions_json", "warnings_json", "transition_id",
+            "idempotency_key", "initiated_by", "created_at",
+        ),
+    ),
+    TableContract(
         "project_contribution_consents",
         (
             "id", "project_id", "user_id", "workspace_id", "consent_version", "permitted_purposes", "granted_at",

--- a/blueprint_core/workspaces/context/__init__.py
+++ b/blueprint_core/workspaces/context/__init__.py
@@ -1,0 +1,11 @@
+from blueprint_core.workspaces.context.models import (
+    ContextAttachment,
+    ContextGatheringRequest,
+    ContextGatheringResponse,
+)
+
+__all__ = [
+    "ContextAttachment",
+    "ContextGatheringRequest",
+    "ContextGatheringResponse",
+]

--- a/blueprint_core/workspaces/context/agent.py
+++ b/blueprint_core/workspaces/context/agent.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import hashlib
+import re
+
+from blueprint_core.agents.clarification import ask_clarifying_questions
+from blueprint_core.workspaces.context.models import ContextAttachment, ContextGatheringRequest
+from blueprint_core.workspaces.design_briefs import (
+    DESIGN_BRIEF_SCHEMA_VERSION,
+    DesignBrief,
+    DesignBriefCreate,
+    DesignBriefReadiness,
+    DesignBriefReference,
+)
+from blueprint_core.workspaces.projects.models import ClarifyingQuestionsRequest
+
+
+def _unique(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        normalized = re.sub(r"\s+", " ", str(value or "")).strip()
+        key = normalized.casefold()
+        if normalized and key not in seen:
+            seen.add(key)
+            result.append(normalized)
+    return result
+
+
+def _sentences(text: str) -> list[str]:
+    return _unique(re.split(r"(?:[\r\n]+|(?<=[.!?])\s+)", text.strip()))
+
+
+def _intent(text: str, previous: DesignBrief | None) -> str:
+    lowered = text.casefold()
+    if any(word in lowered for word in ("modify", "revise", "change", "iterate", "update")):
+        return "modify a hardware design"
+    if any(word in lowered for word in ("reverse engineer", "identify this", "recreate this")):
+        return "reverse engineer a hardware reference"
+    if any(word in lowered for word in ("validate", "review", "check this design")):
+        return "validate a hardware design"
+    if previous:
+        return previous.intent
+    return "design a buildable hardware product"
+
+
+def _requested_outputs(text: str) -> list[str]:
+    mappings = {
+        "wiring": ("wire", "wiring", "pinout"),
+        "schematic": ("schematic", "circuit diagram"),
+        "bom": ("bom", "bill of materials", "parts list"),
+        "firmware": ("firmware", "code", "software"),
+        "enclosure": ("enclosure", "case", "housing"),
+        "cad": ("cad", "step file", "stl", "3d model"),
+        "product images": ("product image", "render", "concept image"),
+        "validation": ("validation", "test plan", "verify"),
+        "assembly instructions": ("assembly", "build guide", "instructions"),
+    }
+    lowered = text.casefold()
+    return [output for output, markers in mappings.items() if any(marker in lowered for marker in markers)]
+
+
+def _reference(attachment: ContextAttachment) -> DesignBriefReference:
+    identity = attachment.attachment_id
+    if not identity:
+        digest_source = "|".join((attachment.kind, attachment.name or "", attachment.uri or "", attachment.data_url or ""))
+        identity = f"attachment-{hashlib.sha256(digest_source.encode()).hexdigest()[:20]}"
+    metadata: dict[str, object] = {"source": attachment.source}
+    if attachment.data_url:
+        metadata["inline_data_supplied"] = True
+        metadata["inline_data_length"] = len(attachment.data_url)
+    if attachment.extracted_text:
+        metadata["text_extracted"] = True
+    return DesignBriefReference(
+        reference_id=identity,
+        kind=f"uploaded_{attachment.kind}",
+        label=attachment.name,
+        uri=attachment.uri,
+        media_type=attachment.media_type,
+        metadata=metadata,
+    )
+
+
+class ContextBriefUpdater:
+    """Updates a DesignBrief without invoking a model, tool, or worker job."""
+
+    def update(self, request: ContextGatheringRequest, previous: DesignBrief | None = None) -> tuple[DesignBriefCreate, str, list[str]]:
+        text = request.text.strip()
+        attachment_text = [item.extracted_text for item in request.attachments if item.extracted_text]
+        combined_update = "\n".join([text, *attachment_text]).strip()
+        update_sentences = _sentences(combined_update)
+
+        prior_requirements = list(previous.requirements) if previous else []
+        requirements = _unique([*prior_requirements, *update_sentences])
+        constraint_markers = re.compile(
+            r"\b(must|only|under|maximum|max\b|minimum|min\b|budget|fit|within|voltage|battery|usb|no\s+|without|weatherproof|waterproof|material)\b",
+            re.IGNORECASE,
+        )
+        constraints = _unique([
+            *(list(previous.constraints) if previous else []),
+            *(sentence for sentence in update_sentences if constraint_markers.search(sentence)),
+        ])
+        assumption_markers = re.compile(r"\b(assume|assuming|probably|for now)\b", re.IGNORECASE)
+        assumptions = _unique([
+            *(list(previous.assumptions) if previous else []),
+            *(sentence for sentence in update_sentences if assumption_markers.search(sentence)),
+        ])
+        validation_markers = re.compile(r"\b(success|validate|validation|test|verify|passes|works when)\b", re.IGNORECASE)
+        validation = _unique([
+            *(list(previous.validation_criteria) if previous else []),
+            *(sentence for sentence in update_sentences if validation_markers.search(sentence)),
+        ])
+
+        references = list(previous.references) if previous else []
+        references_by_id = {item.reference_id: item for item in references}
+        for attachment in request.attachments:
+            item = _reference(attachment)
+            references_by_id[item.reference_id] = item
+
+        prior_outputs = list(previous.requested_outputs) if previous else []
+        requested_outputs = _unique([*prior_outputs, *_requested_outputs(combined_update)])
+        full_context = "\n".join(_unique([*requirements, *constraints]))
+        clarification = ask_clarifying_questions(ClarifyingQuestionsRequest(
+            prompt=full_context,
+            has_image=any(item.kind == "image" for item in request.attachments) or any(
+                reference.kind == "uploaded_image" for reference in references_by_id.values()
+            ),
+            workflow="default",
+            force=False,
+            max_questions=3,
+        ))
+        questions = _unique([
+            *(list(previous.unresolved_questions) if previous else []),
+            *(question.question for question in clarification.questions),
+        ])
+
+        if previous and previous.summary:
+            summary = previous.summary
+        elif text:
+            summary = text[:500]
+        elif request.attachments:
+            kinds = ", ".join(sorted({item.kind for item in request.attachments}))
+            summary = f"Hardware design based on the supplied {kinds} reference."
+        else:  # model validation makes this unreachable
+            summary = "Hardware design context"
+
+        brief = DesignBriefCreate(
+            schema_version=DESIGN_BRIEF_SCHEMA_VERSION,
+            conversation_id=request.conversation_id,
+            intent=_intent(combined_update, previous),
+            summary=summary,
+            requirements=requirements,
+            constraints=constraints,
+            references=list(references_by_id.values()),
+            requested_outputs=requested_outputs,
+            validation_criteria=validation,
+            unresolved_questions=questions,
+            assumptions=assumptions,
+            readiness=DesignBriefReadiness.NEEDS_CLARIFICATION if questions else DesignBriefReadiness.DRAFT,
+        )
+        if questions:
+            assistant_message = "I’ve saved that context. " + " ".join(questions)
+        else:
+            assistant_message = "I’ve saved that context. Add any remaining constraints, references, or expected outputs when you’re ready."
+        return brief, assistant_message, questions

--- a/blueprint_core/workspaces/context/agent.py
+++ b/blueprint_core/workspaces/context/agent.py
@@ -81,6 +81,25 @@ def _reference(attachment: ContextAttachment) -> DesignBriefReference:
     )
 
 
+def _question_answered(question: str, context: str) -> bool:
+    question_lower = question.casefold()
+    context_lower = context.casefold()
+    answer_patterns: tuple[tuple[tuple[str, ...], str], ...] = (
+        (("controller", "major modules"), r"\b(esp32|arduino|raspberry|stm32|rp2040|controller|module)\b"),
+        (("power", "battery", "adapter", "rail"), r"(?:\b\d+(?:\.\d+)?\s*v\b|\busb(?:-c)?\b|\bbattery\b|\badapter\b|\bno mains\b)"),
+        (("control or display", "system control", "outputs"), r"\b(display|oled|screen|relay|motor|pump|fan|led|buzzer|actuator|log|control)\b"),
+        (("weather", "environment", "where will"), r"\b(indoor|outdoor|field|bench|lab|rain|wind|weather|temperature)\b"),
+        (("successful", "success", "validated"), r"\b(success|validate|validation|test|verify|within|under\s+\d+)\b"),
+        (("hard constraints", "constraints should"), r"\b(must|only|under|within|budget|voltage|usb|battery|waterproof|weatherproof|no\s+)\b"),
+        (("optimize", "artifacts"), r"\b(wiring|schematic|bom|bill of materials|firmware|cad|enclosure|image|render|validation|assembly)\b"),
+        (("who uses", "where does", "use case"), r"\b(user|operator|student|engineer|indoor|outdoor|field|bench|lab|classroom|consumer)\b"),
+    )
+    for question_markers, answer_pattern in answer_patterns:
+        if any(marker in question_lower for marker in question_markers):
+            return bool(re.search(answer_pattern, context_lower, re.IGNORECASE))
+    return False
+
+
 class ContextBriefUpdater:
     """Updates a DesignBrief without invoking a model, tool, or worker job."""
 
@@ -129,10 +148,17 @@ class ContextBriefUpdater:
             force=False,
             max_questions=3,
         ))
-        questions = _unique([
-            *(list(previous.unresolved_questions) if previous else []),
-            *(question.question for question in clarification.questions),
-        ])
+        prior_questions = [
+            question
+            for question in (list(previous.unresolved_questions) if previous else [])
+            if not _question_answered(question, combined_update)
+        ]
+        new_questions = [
+            question.question
+            for question in clarification.questions
+            if not _question_answered(question.question, full_context)
+        ]
+        questions = _unique([*prior_questions, *new_questions])
 
         if previous and previous.summary:
             summary = previous.summary

--- a/blueprint_core/workspaces/context/models.py
+++ b/blueprint_core/workspaces/context/models.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+
+from blueprint_core.workspaces.design_briefs import DesignBrief
+from blueprint_core.workspaces.workflow import ProjectWorkflow
+
+
+NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class ContextAttachment(BaseModel):
+    """A user-supplied reference available to the context-gathering agent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    attachment_id: NonEmptyString | None = None
+    kind: Literal["image", "document"]
+    name: NonEmptyString | None = None
+    media_type: NonEmptyString | None = None
+    uri: NonEmptyString | None = None
+    data_url: NonEmptyString | None = None
+    extracted_text: NonEmptyString | None = None
+    source: Literal["upload", "clipboard", "url"] = "upload"
+
+    @model_validator(mode="after")
+    def require_attachment_content(self) -> "ContextAttachment":
+        if not any((self.uri, self.data_url, self.extracted_text)):
+            raise ValueError("An attachment requires uri, data_url, or extracted_text.")
+        return self
+
+
+class ContextGatheringRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    conversation_id: NonEmptyString
+    text: str = ""
+    attachments: list[ContextAttachment] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def require_context_input(self) -> "ContextGatheringRequest":
+        self.text = self.text.strip()
+        if not self.text and not self.attachments:
+            raise ValueError("Provide text or at least one attachment.")
+        return self
+
+
+class ContextGatheringResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    workflow: ProjectWorkflow
+    design_brief: DesignBrief
+    assistant_message: NonEmptyString
+    questions: list[NonEmptyString] = Field(default_factory=list)

--- a/blueprint_core/workspaces/projects/models.py
+++ b/blueprint_core/workspaces/projects/models.py
@@ -190,6 +190,10 @@ class Project(BaseModel):
 
 class GenerateProjectRequest(BaseModel):
     prompt: str = Field(..., description="User's natural language project description")
+    project_id: Optional[str] = Field(
+        None,
+        description="Optional context project id whose workflow authorizes this generation.",
+    )
     workflow: str = Field(
         "default",
         description="Generation workflow id: default or web_research"
@@ -237,7 +241,7 @@ class GenerateProjectRequest(BaseModel):
         description="Maximum number of relevant completed jobs to include when data_sources contains past_jobs.",
     )
 
-    @field_validator("provider", "model", "chat_id", "source_project_id", "client_job_id", "external_source_provider", mode="before")
+    @field_validator("provider", "model", "project_id", "chat_id", "source_project_id", "client_job_id", "external_source_provider", mode="before")
     @classmethod
     def strip_optional_generation_selector(cls, value: Any) -> Any:
         if isinstance(value, str):

--- a/blueprint_core/workspaces/readiness/__init__.py
+++ b/blueprint_core/workspaces/readiness/__init__.py
@@ -1,0 +1,28 @@
+from blueprint_core.workspaces.readiness.evaluator import evaluate_readiness
+from blueprint_core.workspaces.readiness.models import (
+    BuildAnywayRequest,
+    BuildInitiationOutcome,
+    BuildMode,
+    BuildRequest,
+    ProjectBuild,
+    ReadinessBlocker,
+    ReadinessBlockerCategory,
+    ReadinessResult,
+    ReadinessStatus,
+)
+from blueprint_core.workspaces.readiness.service import ProjectBuildService, ReadinessError
+
+__all__ = [
+    "BuildAnywayRequest",
+    "BuildInitiationOutcome",
+    "BuildMode",
+    "BuildRequest",
+    "ProjectBuild",
+    "ProjectBuildService",
+    "ReadinessBlocker",
+    "ReadinessBlockerCategory",
+    "ReadinessError",
+    "ReadinessResult",
+    "ReadinessStatus",
+    "evaluate_readiness",
+]

--- a/blueprint_core/workspaces/readiness/evaluator.py
+++ b/blueprint_core/workspaces/readiness/evaluator.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+
+from blueprint_core.workspaces.design_briefs import DesignBrief
+from blueprint_core.workspaces.readiness.models import (
+    ReadinessBlocker,
+    ReadinessBlockerCategory,
+    ReadinessResult,
+    ReadinessStatus,
+)
+
+
+CRITICAL_QUESTION_PATTERNS: tuple[tuple[ReadinessBlockerCategory, re.Pattern[str]], ...] = (
+    (ReadinessBlockerCategory.SAFETY, re.compile(
+        r"\b(safe|safety|hazard|protection|emergency|mains|medical|flammab|pressure limit|current limit)\b",
+        re.IGNORECASE,
+    )),
+    (ReadinessBlockerCategory.DIMENSIONAL, re.compile(
+        r"\b(dimension\w*|size|fit|clearance\w*|tolerance\w*|length|width|height|diameter|footprint|mounting)\b",
+        re.IGNORECASE,
+    )),
+    (ReadinessBlockerCategory.ELECTRICAL, re.compile(
+        r"\b(electrical|voltage|current|power|rail|battery|adapter|usb|connector|wire|wiring|gpio|controller|motor|stall)\b",
+        re.IGNORECASE,
+    )),
+    (ReadinessBlockerCategory.MATERIAL, re.compile(
+        r"\b(material|temperature|chemical|biocompat|waterproof|weatherproof|corrosion|food.safe)\b",
+        re.IGNORECASE,
+    )),
+    (ReadinessBlockerCategory.MANUFACTURING, re.compile(
+        r"\b(manufactur|fabricat|tooling|assembly method|3d print|injection mold|pcb stack|process)\b",
+        re.IGNORECASE,
+    )),
+)
+
+
+def _question_blocker(index: int, question: str) -> ReadinessBlocker:
+    for category, pattern in CRITICAL_QUESTION_PATTERNS:
+        if pattern.search(question):
+            return ReadinessBlocker(
+                code=f"critical_{category.value}_unknown",
+                category=category,
+                message=question,
+                critical=True,
+                source=f"unresolved_questions[{index}]",
+            )
+    return ReadinessBlocker(
+        code="unresolved_context_question",
+        category=ReadinessBlockerCategory.OTHER,
+        message=question,
+        critical=False,
+        source=f"unresolved_questions[{index}]",
+    )
+
+
+def evaluate_readiness(brief: DesignBrief) -> ReadinessResult:
+    blockers: list[ReadinessBlocker] = []
+    if not brief.requirements:
+        blockers.append(ReadinessBlocker(
+            code="requirements_missing",
+            category=ReadinessBlockerCategory.REQUIREMENTS,
+            message="At least one concrete product requirement is required.",
+            critical=False,
+            source="requirements",
+        ))
+    if not brief.requested_outputs:
+        blockers.append(ReadinessBlocker(
+            code="requested_outputs_missing",
+            category=ReadinessBlockerCategory.OUTPUTS,
+            message="Specify at least one output to produce in the build.",
+            critical=False,
+            source="requested_outputs",
+        ))
+    if not brief.validation_criteria:
+        blockers.append(ReadinessBlocker(
+            code="validation_criteria_missing",
+            category=ReadinessBlockerCategory.VALIDATION,
+            message="Define at least one criterion for validating the result.",
+            critical=False,
+            source="validation_criteria",
+        ))
+    blockers.extend(_question_blocker(index, question) for index, question in enumerate(brief.unresolved_questions))
+
+    if any(blocker.critical for blocker in blockers):
+        status = ReadinessStatus.BLOCKED
+        reasons = ["Critical project unknowns must be resolved before execution can start."]
+    elif blockers:
+        status = ReadinessStatus.NOT_READY
+        reasons = ["The brief is incomplete but contains no critical execution blocker."]
+    else:
+        status = ReadinessStatus.READY
+        reasons = ["The brief contains requirements, requested outputs, validation criteria, and no unresolved questions."]
+    return ReadinessResult(
+        project_id=brief.project_id,
+        design_brief_id=brief.design_brief_id,
+        brief_version=brief.brief_version,
+        status=status,
+        reasons=reasons,
+        unresolved_blockers=blockers,
+        evaluated_at=datetime.now(timezone.utc),
+    )

--- a/blueprint_core/workspaces/readiness/models.py
+++ b/blueprint_core/workspaces/readiness/models.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Annotated, Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints
+
+from blueprint_core.workspaces.design_briefs import DesignBrief
+from blueprint_core.workspaces.workflow import ProjectWorkflow, ProjectWorkflowTransition
+
+
+NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class ReadinessStatus(str, Enum):
+    READY = "ready"
+    NOT_READY = "not_ready"
+    BLOCKED = "blocked"
+
+
+class ReadinessBlockerCategory(str, Enum):
+    REQUIREMENTS = "requirements"
+    OUTPUTS = "outputs"
+    VALIDATION = "validation"
+    SAFETY = "safety"
+    DIMENSIONAL = "dimensional"
+    ELECTRICAL = "electrical"
+    MATERIAL = "material"
+    MANUFACTURING = "manufacturing"
+    OTHER = "other"
+
+
+class ReadinessBlocker(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: NonEmptyString
+    category: ReadinessBlockerCategory
+    message: NonEmptyString
+    critical: bool
+    source: NonEmptyString
+
+
+class ReadinessResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    project_id: UUID
+    design_brief_id: UUID
+    brief_version: int = Field(ge=1)
+    status: ReadinessStatus
+    reasons: list[NonEmptyString]
+    unresolved_blockers: list[ReadinessBlocker]
+    evaluated_at: datetime
+
+
+class BuildMode(str, Enum):
+    BUILD = "build"
+    BUILD_ANYWAY = "build_anyway"
+
+
+class BuildRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    idempotency_key: NonEmptyString | None = None
+
+
+class BuildAnywayRequest(BuildRequest):
+    assumptions: list[NonEmptyString] = Field(min_length=1)
+
+
+class ProjectBuild(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    build_id: UUID
+    project_id: UUID
+    owner_user_id: NonEmptyString
+    design_brief_id: UUID
+    brief_version: int = Field(ge=1)
+    brief_snapshot: DesignBrief
+    mode: BuildMode
+    readiness: ReadinessResult
+    introduced_assumptions: list[NonEmptyString]
+    warnings: list[NonEmptyString]
+    transition_id: UUID
+    idempotency_key: NonEmptyString | None = None
+    initiated_by: NonEmptyString
+    created_at: datetime
+
+
+class BuildInitiationOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    build: ProjectBuild
+    workflow: ProjectWorkflow
+    transition: ProjectWorkflowTransition
+    idempotent_replay: bool = False

--- a/blueprint_core/workspaces/readiness/service.py
+++ b/blueprint_core/workspaces/readiness/service.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Protocol
+from uuid import uuid4
+
+from blueprint_core.workspaces.design_briefs import DesignBrief
+from blueprint_core.workspaces.readiness.models import (
+    BuildInitiationOutcome,
+    BuildMode,
+    ProjectBuild,
+    ReadinessResult,
+    ReadinessStatus,
+)
+from blueprint_core.workspaces.workflow import (
+    ProjectWorkflow,
+    ProjectWorkflowState,
+    ProjectWorkflowTransition,
+    WorkflowActorType,
+)
+
+
+class BuildRepository(Protocol):
+    def get_project_workflow(self, project_id: str, owner_user_id: str | None) -> Any | None: ...
+    def get_project_build_by_idempotency(self, project_id: str, owner_user_id: str, idempotency_key: str) -> Any | None: ...
+    def get_project_workflow_transition_by_idempotency(
+        self, project_id: str, owner_user_id: str, idempotency_key: str
+    ) -> Any | None: ...
+    def apply_project_build_initiation(
+        self,
+        state_record: dict[str, Any],
+        transition_record: dict[str, Any],
+        build_record: dict[str, Any],
+        expected_state: str,
+        expected_revision: int,
+    ) -> tuple[Any, Any, Any] | None: ...
+
+
+class ReadinessError(RuntimeError):
+    def __init__(self, code: str, message: str, *, context: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.context = context or {}
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"code": self.code, "message": self.message, "context": dict(self.context)}
+
+
+def _workflow(record: Any) -> ProjectWorkflow:
+    return ProjectWorkflow.model_validate({
+        "project_id": record.project_id,
+        "owner_user_id": record.owner_user_id,
+        "state": record.state,
+        "revision": record.revision,
+        "created_at": record.created_at,
+        "updated_at": record.updated_at,
+    })
+
+
+def _transition(record: Any) -> ProjectWorkflowTransition:
+    return ProjectWorkflowTransition.model_validate({
+        "transition_id": record.id,
+        "project_id": record.project_id,
+        "owner_user_id": record.owner_user_id,
+        "from_state": record.from_state,
+        "to_state": record.to_state,
+        "actor_type": record.actor_type,
+        "actor_id": record.actor_id,
+        "reason": record.reason,
+        "idempotency_key": record.idempotency_key,
+        "revision": record.revision,
+        "created_at": record.created_at,
+    })
+
+
+def _build(record: Any) -> ProjectBuild:
+    return ProjectBuild.model_validate({
+        "build_id": record.id,
+        "project_id": record.project_id,
+        "owner_user_id": record.owner_user_id,
+        "design_brief_id": record.design_brief_id,
+        "brief_version": record.brief_version,
+        "brief_snapshot": record.brief_snapshot_json,
+        "mode": record.mode,
+        "readiness": record.readiness_result_json,
+        "introduced_assumptions": record.introduced_assumptions_json,
+        "warnings": record.warnings_json,
+        "transition_id": record.transition_id,
+        "idempotency_key": record.idempotency_key,
+        "initiated_by": record.initiated_by,
+        "created_at": record.created_at,
+    })
+
+
+class ProjectBuildService:
+    def __init__(self, repository: BuildRepository) -> None:
+        self._repository = repository
+
+    def initiate(
+        self,
+        brief: DesignBrief,
+        readiness: ReadinessResult,
+        owner_user_id: str,
+        *,
+        mode: BuildMode,
+        actor_id: str,
+        introduced_assumptions: list[str],
+        warnings: list[str],
+        idempotency_key: str | None,
+    ) -> BuildInitiationOutcome:
+        project_id = str(brief.project_id)
+        owner = str(owner_user_id or "").strip()
+        actor = str(actor_id or "").strip()
+        key = str(idempotency_key or "").strip() or None
+        if not owner or not actor:
+            raise ValueError("owner_user_id and actor_id are required.")
+        if key:
+            existing_build = self._repository.get_project_build_by_idempotency(project_id, owner, key)
+            existing_transition = self._repository.get_project_workflow_transition_by_idempotency(project_id, owner, key)
+            if existing_build is not None and existing_transition is not None:
+                current = self._repository.get_project_workflow(project_id, owner)
+                if current is None:
+                    raise ReadinessError("workflow_not_found", "Project workflow not found.")
+                return BuildInitiationOutcome(
+                    build=_build(existing_build),
+                    workflow=_workflow(current),
+                    transition=_transition(existing_transition),
+                    idempotent_replay=True,
+                )
+
+        current_record = self._repository.get_project_workflow(project_id, owner)
+        if current_record is None:
+            raise ReadinessError("workflow_not_found", "Project workflow not found.")
+        current = _workflow(current_record)
+        if current.state not in {ProjectWorkflowState.GATHERING_CONTEXT, ProjectWorkflowState.READY_TO_BUILD}:
+            raise ReadinessError(
+                "build_transition_not_allowed",
+                f"Build cannot start while the project workflow is {current.state.value}.",
+                context={"project_id": project_id, "workflow_state": current.state.value},
+            )
+        if mode == BuildMode.BUILD and readiness.status != ReadinessStatus.READY:
+            code = "readiness_blocked" if readiness.status == ReadinessStatus.BLOCKED else "readiness_not_ready"
+            raise ReadinessError(code, "The DesignBrief is not ready for Build.", context=readiness.model_dump(mode="json"))
+        if mode == BuildMode.BUILD_ANYWAY:
+            if readiness.status == ReadinessStatus.BLOCKED:
+                raise ReadinessError(
+                    "critical_readiness_blockers",
+                    "Build Anyway cannot bypass critical project unknowns.",
+                    context=readiness.model_dump(mode="json"),
+                )
+            if readiness.status == ReadinessStatus.NOT_READY and not introduced_assumptions:
+                raise ReadinessError(
+                    "build_anyway_assumptions_required",
+                    "Build Anyway requires explicit assumptions for incomplete context.",
+                )
+
+        now = datetime.now(timezone.utc)
+        build_id = str(uuid4())
+        transition_id = str(uuid4())
+        transition_key = key or f"build:{build_id}"
+        next_revision = current.revision + 1
+        state_record = {
+            "project_id": project_id,
+            "owner_user_id": owner,
+            "state": ProjectWorkflowState.BUILDING.value,
+            "revision": next_revision,
+            "created_at": current.created_at.isoformat(),
+            "updated_at": now.isoformat(),
+        }
+        transition_record = {
+            "id": transition_id,
+            "project_id": project_id,
+            "owner_user_id": owner,
+            "from_state": current.state.value,
+            "to_state": ProjectWorkflowState.BUILDING.value,
+            "actor_type": WorkflowActorType.USER.value,
+            "actor_id": actor,
+            "reason": "User started Build Anyway." if mode == BuildMode.BUILD_ANYWAY else "User started Build.",
+            "idempotency_key": transition_key,
+            "revision": next_revision,
+            "created_at": now.isoformat(),
+        }
+        build_record = {
+            "id": build_id,
+            "project_id": project_id,
+            "owner_user_id": owner,
+            "design_brief_id": str(brief.design_brief_id),
+            "brief_version": brief.brief_version,
+            "brief_snapshot_json": brief.model_dump(mode="json"),
+            "mode": mode.value,
+            "readiness_result_json": readiness.model_dump(mode="json"),
+            "introduced_assumptions_json": introduced_assumptions,
+            "warnings_json": warnings,
+            "transition_id": transition_id,
+            "idempotency_key": transition_key,
+            "initiated_by": actor,
+            "created_at": now.isoformat(),
+        }
+        applied = self._repository.apply_project_build_initiation(
+            state_record,
+            transition_record,
+            build_record,
+            current.state.value,
+            current.revision,
+        )
+        if applied is None:
+            if key:
+                return self.initiate(
+                    brief,
+                    readiness,
+                    owner,
+                    mode=mode,
+                    actor_id=actor,
+                    introduced_assumptions=introduced_assumptions,
+                    warnings=warnings,
+                    idempotency_key=key,
+                )
+            raise ReadinessError("build_transition_conflict", "Project workflow changed before Build could start.")
+        workflow_record, transition_record_obj, build_record_obj = applied
+        return BuildInitiationOutcome(
+            build=_build(build_record_obj),
+            workflow=_workflow(workflow_record),
+            transition=_transition(transition_record_obj),
+        )

--- a/blueprint_core/workspaces/workflow/__init__.py
+++ b/blueprint_core/workspaces/workflow/__init__.py
@@ -12,6 +12,7 @@ from blueprint_core.workspaces.workflow.service import (
     ProjectWorkflowService,
     WorkflowStateError,
 )
+from blueprint_core.workspaces.workflow.guard import ensure_action_allowed
 
 __all__ = [
     "ALLOWED_WORKFLOW_TRANSITIONS",
@@ -24,4 +25,5 @@ __all__ = [
     "WorkflowStateError",
     "WorkflowTransitionCommand",
     "WorkflowTransitionOutcome",
+    "ensure_action_allowed",
 ]

--- a/blueprint_core/workspaces/workflow/guard.py
+++ b/blueprint_core/workspaces/workflow/guard.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from blueprint_core.workspaces.workflow.models import ProjectWorkflow, ProjectWorkflowState
+from blueprint_core.workspaces.workflow.service import WorkflowStateError
+
+
+MUTATING_ACTION_MARKERS = (
+    "generate",
+    "build",
+    "fabricat",
+    "opencad",
+    "cad.mutat",
+    "iterate",
+)
+
+
+def ensure_action_allowed(workflow: ProjectWorkflow, action: str) -> None:
+    """Prevent tool-backed project mutations while context is still being gathered."""
+
+    normalized = str(action or "").strip().casefold()
+    if workflow.state != ProjectWorkflowState.GATHERING_CONTEXT:
+        return
+    if not any(marker in normalized for marker in MUTATING_ACTION_MARKERS):
+        return
+    raise WorkflowStateError(
+        "tool_execution_blocked_while_gathering_context",
+        "Build, generation, fabrication, and OpenCAD mutations are blocked while project context is being gathered.",
+        context={
+            "project_id": str(workflow.project_id),
+            "workflow_state": workflow.state.value,
+            "action": action,
+        },
+    )

--- a/docs/context-gathering.md
+++ b/docs/context-gathering.md
@@ -1,0 +1,26 @@
+# Conversational context gathering
+
+New project conversations begin in `gathering_context`. During this phase, Forma accepts text and image or document references, appends an immutable `DesignBrief` version, persists the user and assistant messages, and returns targeted clarification questions.
+
+```http
+POST /projects/{project_id}/context/messages
+Content-Type: application/json
+
+{
+  "conversation_id": "chat-id",
+  "text": "Build a USB-C environmental monitor",
+  "attachments": [
+    {
+      "kind": "image",
+      "name": "reference.png",
+      "media_type": "image/png",
+      "data_url": "data:image/png;base64,...",
+      "source": "clipboard"
+    }
+  ]
+}
+```
+
+The context agent is deterministic and does not call an LLM, enqueue a worker job, or execute tools. Generation, iteration, fabrication, and OpenCAD mutation actions that identify a project in `gathering_context` fail with `tool_execution_blocked_while_gathering_context`. A later readiness/build action must transition the project before those tools can run.
+
+Inline attachment bytes are not copied into the DesignBrief. The brief stores a stable reference plus media/source metadata; extracted document text is merged into its requirements.

--- a/docs/project-readiness.md
+++ b/docs/project-readiness.md
@@ -1,0 +1,39 @@
+# Project readiness and build initiation
+
+Forma evaluates the latest immutable `DesignBrief` before execution. The result is one of:
+
+- `ready`: requirements, requested outputs, and validation criteria exist, with no unresolved questions.
+- `not_ready`: only non-critical context is missing. Normal Build is rejected, while Build Anyway may proceed with explicit assumptions.
+- `blocked`: a safety, dimensional, electrical, material, or manufacturing unknown remains. Neither Build nor Build Anyway can proceed.
+
+Every result includes human-readable reasons and structured `unresolved_blockers` containing a stable code, category, source field, and critical flag.
+
+## API
+
+```text
+GET  /projects/{project_id}/readiness
+POST /projects/{project_id}/build
+POST /projects/{project_id}/build-anyway
+GET  /projects/{project_id}/build
+```
+
+Normal Build accepts an optional `idempotency_key`. Build Anyway also requires a non-empty `assumptions` list:
+
+```json
+{
+  "idempotency_key": "build-from-chat-42",
+  "assumptions": [
+    "Produce wiring and a BOM in the first build",
+    "Validate against a bench prototype"
+  ]
+}
+```
+
+Build Anyway appends a new DesignBrief version containing every supplied assumption. Successful initiation atomically:
+
+1. freezes the full, exact DesignBrief snapshot and version;
+2. stores the readiness result, assumptions, and warnings;
+3. records the user-attributed workflow transition; and
+4. enters `building`.
+
+The `project_builds` record is the durable execution contract. Worker scheduling and frontend build controls are intentionally outside this layer.

--- a/supabase/migrations/20260801000300_project_build_readiness.sql
+++ b/supabase/migrations/20260801000300_project_build_readiness.sql
@@ -1,0 +1,105 @@
+-- Freeze DesignBrief inputs and atomically enter the building workflow state.
+
+create table if not exists public.project_builds (
+  id text primary key,
+  project_id text not null,
+  owner_user_id text not null,
+  design_brief_id text not null,
+  brief_version integer not null check (brief_version >= 1),
+  brief_snapshot_json jsonb not null,
+  mode text not null check (mode in ('build', 'build_anyway')),
+  readiness_result_json jsonb not null,
+  introduced_assumptions_json jsonb not null default '[]'::jsonb,
+  warnings_json jsonb not null default '[]'::jsonb,
+  transition_id text not null unique,
+  idempotency_key text not null,
+  initiated_by text not null,
+  created_at text not null,
+  constraint project_builds_project_idempotency_unique unique (project_id, idempotency_key)
+);
+
+create index if not exists idx_project_builds_owner_project_created
+  on public.project_builds (owner_user_id, project_id, created_at desc);
+
+create or replace function public.apply_project_build_initiation(
+  p_state jsonb,
+  p_transition jsonb,
+  p_build jsonb,
+  p_expected_state text,
+  p_expected_revision integer
+) returns jsonb
+language plpgsql
+set search_path = public
+as $$
+declare
+  current_workflow public.project_workflows%rowtype;
+  saved_workflow public.project_workflows%rowtype;
+  saved_transition public.project_workflow_transitions%rowtype;
+  saved_build public.project_builds%rowtype;
+begin
+  select * into current_workflow
+  from public.project_workflows
+  where project_id = p_state->>'project_id'
+  for update;
+
+  if not found
+    or current_workflow.owner_user_id <> p_state->>'owner_user_id'
+    or current_workflow.state <> p_expected_state
+    or current_workflow.revision <> p_expected_revision then
+    return null;
+  end if;
+
+  update public.project_workflows
+  set state = p_state->>'state',
+      revision = (p_state->>'revision')::integer,
+      updated_at = p_state->>'updated_at'
+  where project_id = p_state->>'project_id'
+  returning * into saved_workflow;
+
+  insert into public.project_workflow_transitions (
+    id, project_id, owner_user_id, from_state, to_state, actor_type, actor_id,
+    reason, idempotency_key, revision, created_at
+  ) values (
+    p_transition->>'id', p_transition->>'project_id', p_transition->>'owner_user_id',
+    nullif(p_transition->>'from_state', ''), p_transition->>'to_state', p_transition->>'actor_type',
+    nullif(p_transition->>'actor_id', ''), p_transition->>'reason',
+    p_transition->>'idempotency_key', (p_transition->>'revision')::integer,
+    p_transition->>'created_at'
+  ) returning * into saved_transition;
+
+  insert into public.project_builds (
+    id, project_id, owner_user_id, design_brief_id, brief_version, brief_snapshot_json,
+    mode, readiness_result_json, introduced_assumptions_json, warnings_json,
+    transition_id, idempotency_key, initiated_by, created_at
+  ) values (
+    p_build->>'id', p_build->>'project_id', p_build->>'owner_user_id',
+    p_build->>'design_brief_id', (p_build->>'brief_version')::integer,
+    p_build->'brief_snapshot_json', p_build->>'mode', p_build->'readiness_result_json',
+    coalesce(p_build->'introduced_assumptions_json', '[]'::jsonb),
+    coalesce(p_build->'warnings_json', '[]'::jsonb), p_build->>'transition_id',
+    p_build->>'idempotency_key', p_build->>'initiated_by', p_build->>'created_at'
+  ) returning * into saved_build;
+
+  return jsonb_build_object(
+    'workflow', to_jsonb(saved_workflow),
+    'transition', to_jsonb(saved_transition),
+    'build', to_jsonb(saved_build)
+  );
+exception
+  when unique_violation then
+    return null;
+end;
+$$;
+
+alter table public.project_builds enable row level security;
+
+revoke all on table public.project_builds from anon, authenticated;
+grant select, insert, delete on table public.project_builds to service_role;
+
+revoke all on function public.apply_project_build_initiation(jsonb, jsonb, jsonb, text, integer)
+  from public, anon, authenticated;
+grant execute on function public.apply_project_build_initiation(jsonb, jsonb, jsonb, text, integer)
+  to service_role;
+
+comment on table public.project_builds is
+  'Immutable build initiation records containing the exact frozen DesignBrief and readiness decision.';

--- a/tests/agents/test_agent_packages.py
+++ b/tests/agents/test_agent_packages.py
@@ -6,6 +6,7 @@ import unittest
 
 import blueprint_core.agents as agents
 from blueprint_core.agents.clarification import ContextClarifierAgent
+from blueprint_core.agents.context_gathering import ContextGatheringAgent
 from blueprint_core.agents.continuous import ContinuousAgentCoordinator
 from blueprint_core.agents.project_correction import ProjectSelfCorrectionAgent
 from blueprint_core.agents.prompt_compaction import PromptCompactionAgent
@@ -15,6 +16,7 @@ from blueprint_core.agents.video_correction import FireworksVideoSelfCorrectionA
 class AgentPackageTests(unittest.TestCase):
     def test_common_agents_are_discoverable_from_the_package(self) -> None:
         self.assertIs(agents.ContextClarifierAgent, ContextClarifierAgent)
+        self.assertIs(agents.ContextGatheringAgent, ContextGatheringAgent)
         self.assertIs(agents.ContinuousAgentCoordinator, ContinuousAgentCoordinator)
         self.assertIs(agents.ProjectSelfCorrectionAgent, ProjectSelfCorrectionAgent)
         self.assertIs(agents.PromptCompactionAgent, PromptCompactionAgent)

--- a/tests/projects/test_context_gathering.py
+++ b/tests/projects/test_context_gathering.py
@@ -133,6 +133,31 @@ class ContextGatheringIntegrationTests(unittest.TestCase):
         self.assertEqual("tool_execution_blocked_while_gathering_context", raised.exception.detail["code"])
         create_job.assert_not_called()
 
+    def test_explicit_follow_up_answers_clear_matching_questions(self) -> None:
+        project_id = str(uuid.uuid4())
+        conversation_id = "context-chat-answers"
+        with sqlite_repository():
+            first = self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={"conversation_id": conversation_id, "text": "Build a compact environmental sensor."},
+            )
+            second = self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={
+                    "conversation_id": conversation_id,
+                    "text": (
+                        "Use an ESP32-S3 powered from USB-C 5 V. Show readings on an OLED. "
+                        "It is a bench tool for engineers, must fit within 100 mm, and should include wiring and a BOM. "
+                        "Validate that readings remain within the sensor tolerance."
+                    ),
+                },
+            )
+
+        self.assertEqual(201, first.status_code)
+        self.assertTrue(first.json()["questions"])
+        self.assertEqual(201, second.status_code)
+        self.assertEqual([], second.json()["questions"])
+
     def test_a2a_generation_rejects_before_worker_job_is_created(self) -> None:
         project_id = str(uuid.uuid4())
         message = A2AMessage(

--- a/tests/projects/test_context_gathering.py
+++ b/tests/projects/test_context_gathering.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from apps.api import a2a, main
+from apps.api.a2a import A2AMessage
+from apps.api.auth import UserContext, require_user_context
+from apps.api.context_gathering_api import router
+from blueprint_core import database
+from blueprint_core.persistence.providers import create_sqlite_provider
+from blueprint_core.persistence.repositories import SqlAlchemyRepository
+from blueprint_core.workspaces.projects.models import GenerateProjectRequest
+from blueprint_core.workspaces.workflow import WorkflowStateError
+
+
+OWNER = "context-user"
+USER = UserContext(
+    provider="test",
+    subject=OWNER,
+    owner_user_id=OWNER,
+    is_authenticated=True,
+    is_admin=False,
+)
+
+
+@contextmanager
+def sqlite_repository() -> Iterator[None]:
+    with tempfile.TemporaryDirectory() as directory:
+        provider = create_sqlite_provider(
+            source="context gathering test",
+            url=f"sqlite:///{Path(directory) / 'blueprint.db'}",
+            import_legacy_jobs=False,
+        )
+        assert provider.session_factory is not None
+        provider.initialize()
+        original = database._DATABASE_REPOSITORY
+        try:
+            database._DATABASE_REPOSITORY = SqlAlchemyRepository(provider.session_factory)
+            yield
+        finally:
+            database._DATABASE_REPOSITORY = original
+
+
+class ContextGatheringIntegrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_user_context] = lambda: USER
+        self.client = TestClient(app)
+
+    def test_text_image_and_document_append_brief_versions_without_enqueuing_jobs(self) -> None:
+        project_id = str(uuid.uuid4())
+        conversation_id = "context-chat-1"
+
+        with sqlite_repository(), patch.object(a2a.JOB_STORE, "create_job") as create_job:
+            first = self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={
+                    "conversation_id": conversation_id,
+                    "text": "Build an ESP32 environmental monitor with USB-C power and wiring.",
+                },
+            )
+            second = self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={
+                    "conversation_id": conversation_id,
+                    "text": "It must fit within 100 mm and include product images.",
+                    "attachments": [
+                        {
+                            "attachment_id": "clipboard-image",
+                            "kind": "image",
+                            "name": "reference.png",
+                            "media_type": "image/png",
+                            "data_url": "data:image/png;base64,aW1hZ2U=",
+                            "source": "clipboard",
+                        },
+                        {
+                            "attachment_id": "requirements-document",
+                            "kind": "document",
+                            "name": "requirements.txt",
+                            "media_type": "text/plain",
+                            "extracted_text": "The display must remain readable outdoors.",
+                        },
+                    ],
+                },
+            )
+            versions = database.list_design_brief_versions(project_id, OWNER)
+            chat = database.get_project_chat(conversation_id, OWNER)
+
+        self.assertEqual(201, first.status_code, first.text)
+        self.assertEqual("gathering_context", first.json()["workflow"]["state"])
+        self.assertTrue(first.json()["questions"])
+        self.assertEqual(201, second.status_code, second.text)
+        self.assertEqual(2, second.json()["design_brief"]["brief_version"])
+        self.assertEqual([1, 2], [brief.brief_version for brief in versions])
+        self.assertEqual(2, len(versions[-1].references))
+        self.assertIn("product images", versions[-1].requested_outputs)
+        self.assertIn("The display must remain readable outdoors.", versions[-1].requirements)
+        self.assertEqual(4, len(chat.messages))
+        create_job.assert_not_called()
+
+    def test_generation_and_mutating_tools_are_blocked_during_gathering(self) -> None:
+        project_id = str(uuid.uuid4())
+        with sqlite_repository():
+            database.initialize_project_workflow(project_id, OWNER)
+
+            for action in ("blueprint.generate_project", "fabricator.plan", "opencad.mutate"):
+                with self.subTest(action=action), self.assertRaises(WorkflowStateError) as raised:
+                    database.ensure_project_action_allowed(project_id, OWNER, action, require_workflow=True)
+                self.assertEqual("tool_execution_blocked_while_gathering_context", raised.exception.code)
+
+    def test_generate_endpoint_rejects_before_worker_job_is_created(self) -> None:
+        project_id = str(uuid.uuid4())
+        with sqlite_repository(), patch.object(main.JOB_STORE, "create_job") as create_job:
+            database.initialize_project_workflow(project_id, OWNER)
+            with self.assertRaises(HTTPException) as raised:
+                asyncio.run(main.generate_project_endpoint(
+                    GenerateProjectRequest(prompt="Build it", project_id=project_id),
+                    USER,
+                ))
+
+        self.assertEqual(409, raised.exception.status_code)
+        self.assertEqual("tool_execution_blocked_while_gathering_context", raised.exception.detail["code"])
+        create_job.assert_not_called()
+
+    def test_a2a_generation_rejects_before_worker_job_is_created(self) -> None:
+        project_id = str(uuid.uuid4())
+        message = A2AMessage(
+            sender="test-agent",
+            action="blueprint.generate_project",
+            payload={"project_id": project_id, "owner_user_id": OWNER, "prompt": "Build it"},
+        )
+        with sqlite_repository(), patch.object(a2a.A2A_HUB, "register", new=AsyncMock()), patch.object(
+            a2a.JOB_STORE, "create_job"
+        ) as create_job:
+            database.initialize_project_workflow(project_id, OWNER)
+            with self.assertRaises(WorkflowStateError):
+                asyncio.run(a2a.submit_a2a_message(message))
+
+        create_job.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/projects/test_readiness_build.py
+++ b/tests/projects/test_readiness_build.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from fastapi.testclient import TestClient
+
+from apps.api.auth import UserContext, require_user_context
+from apps.api.readiness_api import router
+from blueprint_core import database
+from blueprint_core.persistence.providers import create_sqlite_provider
+from blueprint_core.persistence.repositories import SqlAlchemyRepository
+from blueprint_core.workspaces.design_briefs import DesignBriefCreate
+from blueprint_core.workspaces.readiness import BuildMode, ReadinessError, ReadinessStatus
+
+
+OWNER = "readiness-user"
+USER = UserContext(
+    provider="test",
+    subject=OWNER,
+    owner_user_id=OWNER,
+    is_authenticated=True,
+    is_admin=False,
+)
+
+
+@contextmanager
+def sqlite_repository() -> Iterator[None]:
+    with tempfile.TemporaryDirectory() as directory:
+        provider = create_sqlite_provider(
+            source="readiness test",
+            url=f"sqlite:///{Path(directory) / 'blueprint.db'}",
+            import_legacy_jobs=False,
+        )
+        assert provider.session_factory is not None
+        provider.initialize()
+        original = database._DATABASE_REPOSITORY
+        try:
+            database._DATABASE_REPOSITORY = SqlAlchemyRepository(provider.session_factory)
+            yield
+        finally:
+            database._DATABASE_REPOSITORY = original
+
+
+def brief_payload(
+    *,
+    outputs: list[str] | None = None,
+    validation: list[str] | None = None,
+    questions: list[str] | None = None,
+) -> DesignBriefCreate:
+    return DesignBriefCreate.model_validate({
+        "schema_version": "1.0",
+        "conversation_id": "readiness-chat",
+        "intent": "Design a compact environmental monitor",
+        "summary": "USB-C environmental monitor with an OLED display",
+        "requirements": ["Measure temperature and humidity", "Display the latest readings"],
+        "constraints": ["Use USB-C 5 V power", "Fit within a 100 mm enclosure"],
+        "references": [],
+        "requested_outputs": ["wiring", "bom"] if outputs is None else outputs,
+        "validation_criteria": ["Readings remain within sensor tolerance"] if validation is None else validation,
+        "unresolved_questions": [] if questions is None else questions,
+        "assumptions": [],
+        "readiness": "draft",
+    })
+
+
+def create_project_context(project_id: str, brief: DesignBriefCreate) -> None:
+    database.initialize_project_workflow(project_id, OWNER)
+    database.create_design_brief_version(project_id, OWNER, brief)
+
+
+class ReadinessEvaluationTests(unittest.TestCase):
+    def test_ready_incomplete_and_critical_results_explain_their_blockers(self) -> None:
+        ready_id = str(uuid.uuid4())
+        incomplete_id = str(uuid.uuid4())
+        blocked_id = str(uuid.uuid4())
+        with sqlite_repository():
+            create_project_context(ready_id, brief_payload())
+            create_project_context(incomplete_id, brief_payload(outputs=[], validation=[]))
+            create_project_context(
+                blocked_id,
+                brief_payload(questions=["What voltage and maximum current must the power rail support?"]),
+            )
+            ready = database.evaluate_project_readiness(ready_id, OWNER)
+            incomplete = database.evaluate_project_readiness(incomplete_id, OWNER)
+            blocked = database.evaluate_project_readiness(blocked_id, OWNER)
+
+        self.assertEqual(ReadinessStatus.READY, ready.status)
+        self.assertEqual(ReadinessStatus.NOT_READY, incomplete.status)
+        self.assertEqual({"requested_outputs_missing", "validation_criteria_missing"}, {
+            blocker.code for blocker in incomplete.unresolved_blockers
+        })
+        self.assertEqual(ReadinessStatus.BLOCKED, blocked.status)
+        self.assertTrue(blocked.unresolved_blockers[0].critical)
+        self.assertEqual("electrical", blocked.unresolved_blockers[0].category.value)
+
+    def test_every_non_bypassable_unknown_category_is_classified_as_critical(self) -> None:
+        questions = {
+            "safety": "What safety protection and emergency limits are required?",
+            "dimensional": "What enclosure dimensions and mounting tolerances are required?",
+            "electrical": "What voltage and maximum current must the power rail support?",
+            "material": "What material and operating temperature are required?",
+            "manufacturing": "What fabrication process and manufacturing tooling are available?",
+        }
+        with sqlite_repository():
+            for expected_category, question in questions.items():
+                with self.subTest(category=expected_category):
+                    project_id = str(uuid.uuid4())
+                    create_project_context(project_id, brief_payload(questions=[question]))
+                    result = database.evaluate_project_readiness(project_id, OWNER)
+                    self.assertEqual(ReadinessStatus.BLOCKED, result.status)
+                    self.assertTrue(result.unresolved_blockers[0].critical)
+                    self.assertEqual(expected_category, result.unresolved_blockers[0].category.value)
+
+
+class BuildSemanticsTests(unittest.TestCase):
+    def test_build_freezes_exact_ready_brief_and_enters_building(self) -> None:
+        project_id = str(uuid.uuid4())
+        with sqlite_repository():
+            create_project_context(project_id, brief_payload())
+            outcome = database.initiate_project_build(
+                project_id,
+                OWNER,
+                mode=BuildMode.BUILD,
+                actor_id=OWNER,
+                idempotency_key="ready-build",
+            )
+            persisted = database.get_latest_project_build(project_id, OWNER)
+            history = database.list_project_workflow_transitions(project_id, OWNER)
+
+        self.assertEqual("building", outcome.workflow.state.value)
+        self.assertEqual("build", outcome.build.mode.value)
+        self.assertEqual(1, outcome.build.brief_version)
+        self.assertEqual(outcome.build.brief_snapshot, persisted.brief_snapshot)
+        self.assertEqual(outcome.build.design_brief_id, outcome.build.brief_snapshot.design_brief_id)
+        self.assertEqual(["gathering_context", "building"], [item.to_state.value for item in history])
+
+    def test_build_rejects_incomplete_brief_without_persisting_or_transitioning(self) -> None:
+        project_id = str(uuid.uuid4())
+        with sqlite_repository():
+            create_project_context(project_id, brief_payload(outputs=[]))
+            with self.assertRaises(ReadinessError) as raised:
+                database.initiate_project_build(
+                    project_id,
+                    OWNER,
+                    mode=BuildMode.BUILD,
+                    actor_id=OWNER,
+                )
+            workflow = database.get_project_workflow(project_id, OWNER)
+            with self.assertRaises(ReadinessError):
+                database.get_latest_project_build(project_id, OWNER)
+
+        self.assertEqual("readiness_not_ready", raised.exception.code)
+        self.assertEqual("gathering_context", workflow.state.value)
+
+    def test_build_anyway_persists_assumptions_warnings_and_the_new_frozen_version(self) -> None:
+        project_id = str(uuid.uuid4())
+        assumptions = ["Produce wiring and a BOM in the first build", "Validate against a bench prototype"]
+        with sqlite_repository():
+            create_project_context(project_id, brief_payload(outputs=[], validation=[]))
+            first = database.initiate_project_build(
+                project_id,
+                OWNER,
+                mode=BuildMode.BUILD_ANYWAY,
+                actor_id=OWNER,
+                assumptions=assumptions,
+                idempotency_key="build-anyway-1",
+            )
+            replay = database.initiate_project_build(
+                project_id,
+                OWNER,
+                mode=BuildMode.BUILD_ANYWAY,
+                actor_id=OWNER,
+                assumptions=assumptions,
+                idempotency_key="build-anyway-1",
+            )
+            versions = database.list_design_brief_versions(project_id, OWNER)
+
+        self.assertEqual(2, first.build.brief_version)
+        self.assertEqual(2, first.build.readiness.brief_version)
+        self.assertEqual(assumptions, first.build.introduced_assumptions)
+        self.assertEqual(assumptions, first.build.brief_snapshot.assumptions)
+        self.assertTrue(any("requested_outputs_missing" in warning for warning in first.build.warnings))
+        self.assertTrue(any("validation_criteria_missing" in warning for warning in first.build.warnings))
+        self.assertEqual([1, 2], [brief.brief_version for brief in versions])
+        self.assertTrue(replay.idempotent_replay)
+        self.assertEqual(first.build.build_id, replay.build.build_id)
+
+    def test_build_anyway_cannot_bypass_critical_unknowns(self) -> None:
+        project_id = str(uuid.uuid4())
+        with sqlite_repository():
+            create_project_context(
+                project_id,
+                brief_payload(questions=["What enclosure dimensions and electrical clearances are required?"]),
+            )
+            with self.assertRaises(ReadinessError) as raised:
+                database.initiate_project_build(
+                    project_id,
+                    OWNER,
+                    mode=BuildMode.BUILD_ANYWAY,
+                    actor_id=OWNER,
+                    assumptions=["Use common prototype dimensions"],
+                )
+            workflow = database.get_project_workflow(project_id, OWNER)
+            versions = database.list_design_brief_versions(project_id, OWNER)
+
+        self.assertEqual("critical_readiness_blockers", raised.exception.code)
+        self.assertEqual("gathering_context", workflow.state.value)
+        self.assertEqual(1, len(versions))
+
+
+class ReadinessApiTests(unittest.TestCase):
+    def setUp(self) -> None:
+        app = FastAPI()
+        app.include_router(router)
+        app.dependency_overrides[require_user_context] = lambda: USER
+        self.client = TestClient(app)
+
+    def test_all_routes_require_authenticated_context(self) -> None:
+        for route in (route for route in router.routes if isinstance(route, APIRoute)):
+            self.assertIn(require_user_context, {dependency.call for dependency in route.dependant.dependencies})
+
+    def test_api_reports_readiness_rejects_build_and_accepts_build_anyway(self) -> None:
+        project_id = str(uuid.uuid4())
+        with sqlite_repository():
+            create_project_context(project_id, brief_payload(outputs=[]))
+            readiness = self.client.get(f"/projects/{project_id}/readiness")
+            rejected = self.client.post(f"/projects/{project_id}/build", json={})
+            built = self.client.post(
+                f"/projects/{project_id}/build-anyway",
+                json={"assumptions": ["Return a wiring plan first"], "idempotency_key": "api-build-anyway"},
+            )
+            frozen = self.client.get(f"/projects/{project_id}/build")
+
+        self.assertEqual(200, readiness.status_code)
+        self.assertEqual("not_ready", readiness.json()["status"])
+        self.assertEqual(409, rejected.status_code)
+        self.assertEqual("readiness_not_ready", rejected.json()["detail"]["code"])
+        self.assertEqual(200, built.status_code, built.text)
+        self.assertEqual("building", built.json()["workflow"]["state"])
+        self.assertEqual(200, frozen.status_code)
+        self.assertEqual(2, frozen.json()["brief_version"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #185

Also includes the #184 conversational context-gathering implementation. PR #198 was merged into the already-merged #182 feature branch, so those changes never reached dev.

## Summary

- add tool-free conversational context gathering for text, image, document, and clipboard inputs
- persist versioned design briefs, clarification questions, and chat history without requiring BYOK
- add structured ready, not-ready, and blocked readiness evaluation
- classify safety, dimensional, electrical, material, and manufacturing gaps
- add Build and Build Anyway transitions with explicit assumptions and warnings
- freeze the exact design snapshot used for a build
- persist build records and workflow transitions atomically and idempotently
- add and apply the project build/readiness database migration

## Verification

- backend test suite: 404 passed, 1 skipped
- frontend production build passed
- local Supabase/PostgREST RPC smoke test passed