### PR TITLE
Build dependency-aware concurrent worker orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ Tip: load an example directly with http://localhost:3000/?example=pocket_mp3_pla
 - [Architecture](docs/architecture.md)
 - [DesignBrief contract](docs/design-brief.md)
 - [Worker contracts and capability registry](docs/worker-contracts.md)
+- [Dependency-aware worker orchestration](docs/worker-orchestration.md)
 - [Project workflow state machine](docs/project-workflow.md)
 - [Conversational context gathering](docs/context-gathering.md)
 - [Project readiness and build initiation](docs/project-readiness.md)

--- a/blueprint_core/persistence/models.py
+++ b/blueprint_core/persistence/models.py
@@ -114,6 +114,21 @@ class DBProjectBuild(Base):
     created_at = Column(String, index=True, nullable=False)
 
 
+class DBWorkerExecutionPlan(Base):
+    __tablename__ = "worker_execution_plans"
+
+    id = Column(String, primary_key=True)
+    project_id = Column(String, index=True, nullable=False)
+    owner_user_id = Column(String, index=True, nullable=False)
+    correlation_id = Column(String, index=True, nullable=False)
+    status = Column(String, index=True, nullable=False)
+    max_concurrency = Column(Integer, nullable=False)
+    state_json = Column(JSON, nullable=False)
+    created_at = Column(String, nullable=False)
+    updated_at = Column(String, index=True, nullable=False)
+    completed_at = Column(String, nullable=True)
+
+
 class DBProjectContributionConsent(Base):
     __tablename__ = "project_contribution_consents"
     __table_args__ = (UniqueConstraint("project_id", "user_id", name="uq_project_contribution_consent_project_user"),)

--- a/blueprint_core/persistence/repositories/base.py
+++ b/blueprint_core/persistence/repositories/base.py
@@ -74,6 +74,17 @@ class ApplicationRepository(Protocol):
         expected_revision: int,
     ) -> Optional[tuple[Any, Any, Any]]: ...
 
+    def insert_worker_execution_plan(self, record: Dict[str, Any]) -> Any: ...
+
+    def get_worker_execution_plan(self, plan_id: str, owner_user_id: str) -> Optional[Any]: ...
+
+    def update_worker_execution_plan(
+        self,
+        plan_id: str,
+        owner_user_id: str,
+        updates: Dict[str, Any],
+    ) -> Optional[Any]: ...
+
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]: ...
 
     def update_project_deletion_state(

--- a/blueprint_core/persistence/repositories/sqlite.py
+++ b/blueprint_core/persistence/repositories/sqlite.py
@@ -17,6 +17,7 @@ from blueprint_core.persistence.models import (
     DBProjectDeletionAudit,
     DBProjectWorkflow,
     DBProjectWorkflowTransition,
+    DBWorkerExecutionPlan,
     DBUserSettings,
 )
 
@@ -266,6 +267,42 @@ class SqlAlchemyRepository:
         except IntegrityError:
             return None
 
+    def insert_worker_execution_plan(self, record: Dict[str, Any]) -> Any:
+        with self._session() as session, session.begin():
+            plan = DBWorkerExecutionPlan(**record)
+            session.add(plan)
+            session.flush()
+            session.refresh(plan)
+            session.expunge(plan)
+            return plan
+
+    def get_worker_execution_plan(self, plan_id: str, owner_user_id: str) -> Optional[Any]:
+        with self._session() as session:
+            return session.query(DBWorkerExecutionPlan).filter(
+                DBWorkerExecutionPlan.id == plan_id,
+                DBWorkerExecutionPlan.owner_user_id == owner_user_id,
+            ).first()
+
+    def update_worker_execution_plan(
+        self,
+        plan_id: str,
+        owner_user_id: str,
+        updates: Dict[str, Any],
+    ) -> Optional[Any]:
+        with self._session() as session, session.begin():
+            plan = session.query(DBWorkerExecutionPlan).filter(
+                DBWorkerExecutionPlan.id == plan_id,
+                DBWorkerExecutionPlan.owner_user_id == owner_user_id,
+            ).first()
+            if plan is None:
+                return None
+            for key, value in updates.items():
+                setattr(plan, key, value)
+            session.flush()
+            session.refresh(plan)
+            session.expunge(plan)
+            return plan
+
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]:
         with self._session() as session:
             return (
@@ -317,6 +354,9 @@ class SqlAlchemyRepository:
                 return False
             chat_id = project.chat_id
             project_owner_user_id = project.owner_user_id
+            session.query(DBWorkerExecutionPlan).filter(
+                DBWorkerExecutionPlan.project_id == project_id
+            ).delete(synchronize_session=False)
             session.query(DBProjectBuild).filter(DBProjectBuild.project_id == project_id).delete(
                 synchronize_session=False
             )
@@ -398,6 +438,9 @@ class SqlAlchemyRepository:
             ).first()
             if not project:
                 return False
+            session.query(DBWorkerExecutionPlan).filter(
+                DBWorkerExecutionPlan.project_id == project_id
+            ).delete(synchronize_session=False)
             session.query(DBProjectBuild).filter(DBProjectBuild.project_id == project_id).delete(
                 synchronize_session=False
             )

--- a/blueprint_core/persistence/repositories/supabase.py
+++ b/blueprint_core/persistence/repositories/supabase.py
@@ -226,6 +226,40 @@ class SupabaseRepository:
             return None
         return _record(payload["workflow"]), _record(payload["transition"]), _record(payload["build"])
 
+    def insert_worker_execution_plan(self, record: Dict[str, Any]) -> Any:
+        rows = self._client.table("worker_execution_plans").insert(record).execute().data or []
+        return _record(rows[0]) if rows else _record(record)
+
+    def get_worker_execution_plan(self, plan_id: str, owner_user_id: str) -> Optional[Any]:
+        rows = (
+            self._client.table("worker_execution_plans")
+            .select("*")
+            .eq("id", plan_id)
+            .eq("owner_user_id", owner_user_id)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
+    def update_worker_execution_plan(
+        self,
+        plan_id: str,
+        owner_user_id: str,
+        updates: Dict[str, Any],
+    ) -> Optional[Any]:
+        rows = (
+            self._client.table("worker_execution_plans")
+            .update(updates)
+            .eq("id", plan_id)
+            .eq("owner_user_id", owner_user_id)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]:
         rows = (
             self._client.table("generated_projects")
@@ -270,6 +304,7 @@ class SupabaseRepository:
             query = query.eq("owner_user_id", owner_user_id)
         deleted = bool(query.execute().data)
         if deleted:
+            self._client.table("worker_execution_plans").delete().eq("project_id", project_id).execute()
             self._client.table("project_builds").delete().eq("project_id", project_id).execute()
             self._client.table("design_briefs").delete().eq("project_id", project_id).execute()
             self._client.table("project_workflow_transitions").delete().eq("project_id", project_id).execute()
@@ -351,6 +386,7 @@ class SupabaseRepository:
         )
         deleted = bool(response.data)
         if deleted:
+            self._client.table("worker_execution_plans").delete().eq("project_id", project_id).execute()
             self._client.table("project_builds").delete().eq("project_id", project_id).execute()
             self._client.table("design_briefs").delete().eq("project_id", project_id).execute()
             self._client.table("project_workflow_transitions").delete().eq("project_id", project_id).execute()

--- a/blueprint_core/persistence/schema.py
+++ b/blueprint_core/persistence/schema.py
@@ -49,6 +49,13 @@ APPLICATION_SCHEMA: Tuple[TableContract, ...] = (
         ),
     ),
     TableContract(
+        "worker_execution_plans",
+        (
+            "id", "project_id", "owner_user_id", "correlation_id", "status", "max_concurrency",
+            "state_json", "created_at", "updated_at", "completed_at",
+        ),
+    ),
+    TableContract(
         "project_contribution_consents",
         (
             "id", "project_id", "user_id", "workspace_id", "consent_version", "permitted_purposes", "granted_at",

--- a/blueprint_core/workers/__init__.py
+++ b/blueprint_core/workers/__init__.py
@@ -19,10 +19,23 @@ from blueprint_core.workers.registry import (
     WorkerRegistryError,
     WorkerResolution,
 )
+from blueprint_core.workers.orchestration import (
+    OrchestrationTaskState,
+    OrchestrationTaskStatus,
+    ProgressReporter,
+    WorkerExecutionPlan,
+    WorkerExecutor,
+    WorkerOrchestrator,
+    WorkerPlanStatus,
+    WorkerPlanningError,
+)
 
 __all__ = [
     "WORKER_CONTRACT_VERSION",
     "WORKER_REGISTRY_VERSION",
+    "OrchestrationTaskState",
+    "OrchestrationTaskStatus",
+    "ProgressReporter",
     "WorkerArtifact",
     "WorkerCapability",
     "WorkerContract",
@@ -30,6 +43,11 @@ __all__ = [
     "WorkerDefinitionProvider",
     "WorkerDependency",
     "WorkerError",
+    "WorkerExecutionPlan",
+    "WorkerExecutor",
+    "WorkerOrchestrator",
+    "WorkerPlanStatus",
+    "WorkerPlanningError",
     "WorkerProgress",
     "WorkerProgressStatus",
     "WorkerRegistry",

--- a/blueprint_core/workers/orchestration.py
+++ b/blueprint_core/workers/orchestration.py
@@ -1,0 +1,508 @@
+"""Dependency-aware, restart-safe orchestration for specialized workers."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Awaitable, Callable, Protocol, Sequence
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from blueprint_core.workers.contracts import (
+    NonEmptyString,
+    WorkerError,
+    WorkerProgress,
+    WorkerRequest,
+    WorkerResult,
+    WorkerResultStatus,
+)
+from blueprint_core.workers.registry import WorkerDefinitionProvider, WorkerRegistry, WorkerRegistryError
+from blueprint_core.workspaces.workflow import (
+    ProjectWorkflowService,
+    ProjectWorkflowState,
+    WorkflowActorType,
+)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class OrchestrationTaskStatus(str, Enum):
+    QUEUED = "queued"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    BLOCKED = "blocked"
+
+
+class WorkerPlanStatus(str, Enum):
+    PLANNED = "planned"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+
+
+TERMINAL_JOB_STATUSES = frozenset({
+    OrchestrationTaskStatus.SUCCEEDED,
+    OrchestrationTaskStatus.FAILED,
+    OrchestrationTaskStatus.BLOCKED,
+})
+TERMINAL_PLAN_STATUSES = frozenset({WorkerPlanStatus.SUCCEEDED, WorkerPlanStatus.FAILED})
+
+
+class OrchestrationTaskState(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    request: WorkerRequest
+    status: OrchestrationTaskStatus = OrchestrationTaskStatus.QUEUED
+    progress: list[WorkerProgress] = Field(default_factory=list)
+    result: WorkerResult | None = None
+    error: WorkerError | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+
+
+class WorkerExecutionPlan(BaseModel):
+    """The complete durable state needed to inspect or resume one worker graph."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    plan_id: NonEmptyString = Field(default_factory=lambda: f"plan_{uuid4().hex}")
+    owner_user_id: NonEmptyString
+    project_id: str
+    correlation_id: NonEmptyString
+    status: WorkerPlanStatus = WorkerPlanStatus.PLANNED
+    max_concurrency: int = Field(default=4, ge=1, le=64)
+    jobs: dict[str, OrchestrationTaskState]
+    aggregate: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=_utc_now)
+    updated_at: datetime = Field(default_factory=_utc_now)
+    completed_at: datetime | None = None
+
+    @model_validator(mode="after")
+    def job_keys_match_requests(self) -> "WorkerExecutionPlan":
+        for job_id, job in self.jobs.items():
+            if job.request.job_id != job_id:
+                raise ValueError("Worker execution plan job keys must match request job_id values.")
+        return self
+
+
+class WorkerPlanningError(ValueError):
+    def __init__(self, code: str, message: str, *, context: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.context = context or {}
+
+    def as_dict(self) -> dict[str, Any]:
+        return {"code": self.code, "message": self.message, "context": dict(self.context)}
+
+
+class WorkerPlanRepository(Protocol):
+    def insert_worker_execution_plan(self, record: dict[str, Any]) -> Any: ...
+    def get_worker_execution_plan(self, plan_id: str, owner_user_id: str) -> Any | None: ...
+    def update_worker_execution_plan(
+        self,
+        plan_id: str,
+        owner_user_id: str,
+        updates: dict[str, Any],
+    ) -> Any | None: ...
+
+
+ProgressReporter = Callable[[WorkerProgress], Awaitable[None]]
+
+
+class WorkerExecutor(WorkerDefinitionProvider, Protocol):
+    def execute(
+        self,
+        request: WorkerRequest,
+        report_progress: ProgressReporter,
+    ) -> WorkerResult | Awaitable[WorkerResult]: ...
+
+
+def _record_to_plan(record: Any) -> WorkerExecutionPlan:
+    payload = getattr(record, "state_json", None)
+    if not isinstance(payload, dict):
+        raise RuntimeError("Persisted worker execution plan state is invalid.")
+    return WorkerExecutionPlan.model_validate(payload)
+
+
+class WorkerOrchestrator:
+    """Validate a worker DAG, execute ready jobs concurrently, and persist every state change."""
+
+    def __init__(
+        self,
+        repository: WorkerPlanRepository,
+        workers: Sequence[WorkerExecutor],
+        *,
+        workflow_service: ProjectWorkflowService | None = None,
+    ) -> None:
+        self._repository = repository
+        self._workers = {worker.worker_definition().worker_id: worker for worker in workers}
+        self._registry = WorkerRegistry(list(workers))
+        self._workflow = workflow_service or ProjectWorkflowService(repository)
+        self._state_lock = asyncio.Lock()
+
+    def create_plan(
+        self,
+        requests: Sequence[WorkerRequest],
+        owner_user_id: str,
+        *,
+        max_concurrency: int = 4,
+        plan_id: str | None = None,
+    ) -> WorkerExecutionPlan:
+        normalized_owner = str(owner_user_id or "").strip()
+        if not normalized_owner:
+            raise WorkerPlanningError("owner_required", "owner_user_id is required.")
+        if not requests:
+            raise WorkerPlanningError("empty_worker_plan", "A worker plan requires at least one job.")
+
+        jobs: dict[str, OrchestrationTaskState] = {}
+        first = requests[0]
+        identity = (
+            first.project_id,
+            first.project_revision,
+            first.design_brief_id,
+            first.design_brief_version,
+            first.correlation_id,
+        )
+        for request in requests:
+            if request.job_id in jobs:
+                raise WorkerPlanningError(
+                    "duplicate_worker_job",
+                    f"Worker job '{request.job_id}' appears more than once.",
+                    context={"job_id": request.job_id},
+                )
+            request_identity = (
+                request.project_id,
+                request.project_revision,
+                request.design_brief_id,
+                request.design_brief_version,
+                request.correlation_id,
+            )
+            if request_identity != identity:
+                raise WorkerPlanningError(
+                    "mixed_worker_context",
+                    "All worker jobs in a plan must share project, revision, brief, and correlation context.",
+                    context={"job_id": request.job_id},
+                )
+            try:
+                self._registry.validate_request(request)
+            except WorkerRegistryError as exc:
+                raise WorkerPlanningError(exc.code, exc.message, context=exc.context) from exc
+            if request.worker_id not in self._workers:
+                raise WorkerPlanningError(
+                    "worker_not_executable",
+                    f"Worker '{request.worker_id}' is registered but has no executor.",
+                    context={"worker_id": request.worker_id},
+                )
+            jobs[request.job_id] = OrchestrationTaskState(request=request)
+
+        self._validate_graph(jobs)
+        plan = WorkerExecutionPlan(
+            plan_id=str(plan_id or f"plan_{uuid4().hex}").strip(),
+            owner_user_id=normalized_owner,
+            project_id=str(first.project_id),
+            correlation_id=first.correlation_id,
+            max_concurrency=max_concurrency,
+            jobs=jobs,
+        )
+        self._repository.insert_worker_execution_plan(self._record(plan))
+        return plan
+
+    @staticmethod
+    def _validate_graph(jobs: dict[str, OrchestrationTaskState]) -> None:
+        indegree = {job_id: 0 for job_id in jobs}
+        dependents: dict[str, list[str]] = {job_id: [] for job_id in jobs}
+        for job_id, job in jobs.items():
+            seen: set[str] = set()
+            for dependency in job.request.dependencies:
+                dependency_job = jobs.get(dependency.job_id)
+                if dependency_job is None:
+                    raise WorkerPlanningError(
+                        "missing_worker_dependency",
+                        f"Worker job '{job_id}' depends on missing job '{dependency.job_id}'.",
+                        context={"job_id": job_id, "dependency_job_id": dependency.job_id},
+                    )
+                if dependency.job_id in seen:
+                    raise WorkerPlanningError(
+                        "duplicate_worker_dependency",
+                        f"Worker job '{job_id}' declares dependency '{dependency.job_id}' more than once.",
+                        context={"job_id": job_id, "dependency_job_id": dependency.job_id},
+                    )
+                seen.add(dependency.job_id)
+                target = dependency_job.request
+                if dependency.worker_id and dependency.worker_id != target.worker_id:
+                    raise WorkerPlanningError(
+                        "worker_dependency_identity_mismatch",
+                        f"Dependency '{dependency.dependency_id}' worker_id does not match its target job.",
+                        context={"job_id": job_id, "dependency_job_id": dependency.job_id},
+                    )
+                if dependency.capability_id and dependency.capability_id != target.capability_id:
+                    raise WorkerPlanningError(
+                        "worker_dependency_identity_mismatch",
+                        f"Dependency '{dependency.dependency_id}' capability_id does not match its target job.",
+                        context={"job_id": job_id, "dependency_job_id": dependency.job_id},
+                    )
+                indegree[job_id] += 1
+                dependents[dependency.job_id].append(job_id)
+
+        ready = [job_id for job_id, degree in indegree.items() if degree == 0]
+        visited = 0
+        while ready:
+            current = ready.pop()
+            visited += 1
+            for dependent in dependents[current]:
+                indegree[dependent] -= 1
+                if indegree[dependent] == 0:
+                    ready.append(dependent)
+        if visited != len(jobs):
+            cyclic_jobs = sorted(job_id for job_id, degree in indegree.items() if degree > 0)
+            raise WorkerPlanningError(
+                "cyclic_worker_dependencies",
+                "Worker dependency graph contains a cycle.",
+                context={"job_ids": cyclic_jobs},
+            )
+
+    def get_plan(self, plan_id: str, owner_user_id: str) -> WorkerExecutionPlan:
+        record = self._repository.get_worker_execution_plan(plan_id, owner_user_id)
+        if record is None:
+            raise WorkerPlanningError("worker_plan_not_found", "Worker execution plan not found.")
+        return _record_to_plan(record)
+
+    async def execute(self, plan_id: str, owner_user_id: str) -> WorkerExecutionPlan:
+        plan = self.get_plan(plan_id, owner_user_id)
+        if plan.status in TERMINAL_PLAN_STATUSES:
+            await self._advance_workflow(plan)
+            return plan
+
+        for job in plan.jobs.values():
+            if job.status == OrchestrationTaskStatus.RUNNING:
+                job.status = OrchestrationTaskStatus.QUEUED
+                job.started_at = None
+        plan.status = WorkerPlanStatus.RUNNING
+        await self._persist(plan)
+
+        while True:
+            changed = self._block_unsatisfied_jobs(plan)
+            if changed:
+                await self._persist(plan)
+            ready = self._ready_jobs(plan)
+            if not ready:
+                break
+            semaphore = asyncio.Semaphore(plan.max_concurrency)
+            await asyncio.gather(*(self._execute_job(plan, job_id, semaphore) for job_id in ready))
+
+        unfinished = [job_id for job_id, job in plan.jobs.items() if job.status not in TERMINAL_JOB_STATUSES]
+        if unfinished:
+            raise RuntimeError(f"Worker plan stalled with unfinished jobs: {', '.join(sorted(unfinished))}.")
+
+        plan.aggregate = {
+            job_id: job.result.model_dump(mode="json")
+            for job_id, job in plan.jobs.items()
+            if job.status == OrchestrationTaskStatus.SUCCEEDED and job.result is not None
+        }
+        plan.status = (
+            WorkerPlanStatus.SUCCEEDED
+            if all(job.status == OrchestrationTaskStatus.SUCCEEDED for job in plan.jobs.values())
+            else WorkerPlanStatus.FAILED
+        )
+        plan.completed_at = _utc_now()
+        await self._persist(plan)
+        await self._advance_workflow(plan)
+        return plan
+
+    def _ready_jobs(self, plan: WorkerExecutionPlan) -> list[str]:
+        ready: list[str] = []
+        for job_id, job in plan.jobs.items():
+            if job.status != OrchestrationTaskStatus.QUEUED:
+                continue
+            dependencies = [plan.jobs[item.job_id] for item in job.request.dependencies]
+            if all(dependency.status in TERMINAL_JOB_STATUSES for dependency in dependencies):
+                ready.append(job_id)
+        return ready
+
+    @staticmethod
+    def _block_unsatisfied_jobs(plan: WorkerExecutionPlan) -> bool:
+        changed = False
+        for job in plan.jobs.values():
+            if job.status != OrchestrationTaskStatus.QUEUED:
+                continue
+            required_failures = [
+                dependency.job_id
+                for dependency in job.request.dependencies
+                if dependency.required
+                and plan.jobs[dependency.job_id].status in {
+                    OrchestrationTaskStatus.FAILED,
+                    OrchestrationTaskStatus.BLOCKED,
+                }
+            ]
+            if not required_failures:
+                continue
+            job.status = OrchestrationTaskStatus.BLOCKED
+            job.completed_at = _utc_now()
+            job.error = WorkerError(
+                **job.request.model_dump(
+                    include={
+                        "contract_version", "project_id", "project_revision", "design_brief_id",
+                        "design_brief_version", "job_id", "correlation_id", "worker_id", "capability_id",
+                    }
+                ),
+                code="required_dependency_failed",
+                message="One or more required worker dependencies did not succeed.",
+                details={"dependency_job_ids": required_failures},
+            )
+            changed = True
+        return changed
+
+    async def _execute_job(
+        self,
+        plan: WorkerExecutionPlan,
+        job_id: str,
+        semaphore: asyncio.Semaphore,
+    ) -> None:
+        async with semaphore:
+            async with self._state_lock:
+                job = plan.jobs[job_id]
+                job.status = OrchestrationTaskStatus.RUNNING
+                job.started_at = _utc_now()
+                await self._persist_unlocked(plan)
+
+            request = self._request_with_dependency_results(plan, job.request)
+
+            async def report_progress(progress: WorkerProgress) -> None:
+                if progress.context_identity() != request.context_identity():
+                    raise ValueError("Worker progress context must match its request.")
+                async with self._state_lock:
+                    state = plan.jobs[job_id]
+                    if state.progress and progress.sequence <= state.progress[-1].sequence:
+                        raise ValueError("Worker progress sequence values must increase.")
+                    state.progress.append(progress)
+                    await self._persist_unlocked(plan)
+
+            try:
+                candidate = self._workers[request.worker_id].execute(request, report_progress)
+                result = await candidate if inspect.isawaitable(candidate) else candidate
+                result = WorkerResult.model_validate(result)
+                if result.context_identity() != request.context_identity():
+                    raise ValueError("Worker result context must match its request.")
+                self._registry.validate_result(result)
+            except Exception as exc:
+                result = self._failure_result(request, exc)
+
+            async with self._state_lock:
+                state = plan.jobs[job_id]
+                state.result = result
+                state.error = result.error
+                state.status = (
+                    OrchestrationTaskStatus.SUCCEEDED
+                    if result.status == WorkerResultStatus.SUCCEEDED
+                    else OrchestrationTaskStatus.FAILED
+                )
+                state.completed_at = result.completed_at
+                await self._persist_unlocked(plan)
+
+    @staticmethod
+    def _request_with_dependency_results(
+        plan: WorkerExecutionPlan,
+        request: WorkerRequest,
+    ) -> WorkerRequest:
+        if not request.dependencies:
+            return request
+        dependency_results = {
+            dependency.job_id: (
+                plan.jobs[dependency.job_id].result.model_dump(mode="json")
+                if plan.jobs[dependency.job_id].result is not None
+                else None
+            )
+            for dependency in request.dependencies
+        }
+        return request.model_copy(update={
+            "payload": {**request.payload, "dependency_results": dependency_results},
+        })
+
+    def _failure_result(self, request: WorkerRequest, exc: Exception) -> WorkerResult:
+        resolution = self._registry.resolve(request.worker_id, request.capability_id)
+        context = request.model_dump(
+            include={
+                "contract_version", "project_id", "project_revision", "design_brief_id",
+                "design_brief_version", "job_id", "correlation_id", "worker_id", "capability_id",
+            }
+        )
+        error = WorkerError(
+            **context,
+            code="worker_execution_failed",
+            message=str(exc) or exc.__class__.__name__,
+            retryable=False,
+            details={"exception_type": exc.__class__.__name__},
+        )
+        return WorkerResult(
+            **context,
+            output_contract_version=resolution.capability.supported_output_versions[0],
+            status=WorkerResultStatus.FAILED,
+            error=error,
+        )
+
+    async def _advance_workflow(self, plan: WorkerExecutionPlan) -> None:
+        self._workflow.transition(
+            plan.project_id,
+            plan.owner_user_id,
+            ProjectWorkflowState.AWAITING_FEEDBACK,
+            actor_type=WorkflowActorType.SYSTEM,
+            actor_id="worker-orchestrator",
+            reason=f"Worker execution plan {plan.plan_id} reached a terminal result.",
+            idempotency_key=f"worker-plan:{plan.plan_id}:terminal",
+        )
+
+    async def _persist(self, plan: WorkerExecutionPlan) -> None:
+        async with self._state_lock:
+            await self._persist_unlocked(plan)
+
+    async def _persist_unlocked(self, plan: WorkerExecutionPlan) -> None:
+        plan.updated_at = _utc_now()
+        updated = self._repository.update_worker_execution_plan(
+            plan.plan_id,
+            plan.owner_user_id,
+            {
+                "status": plan.status.value,
+                "state_json": plan.model_dump(mode="json"),
+                "updated_at": plan.updated_at.isoformat(),
+                "completed_at": plan.completed_at.isoformat() if plan.completed_at else None,
+            },
+        )
+        if updated is None:
+            raise RuntimeError(f"Worker execution plan '{plan.plan_id}' could not be persisted.")
+
+    @staticmethod
+    def _record(plan: WorkerExecutionPlan) -> dict[str, Any]:
+        return {
+            "id": plan.plan_id,
+            "project_id": plan.project_id,
+            "owner_user_id": plan.owner_user_id,
+            "correlation_id": plan.correlation_id,
+            "status": plan.status.value,
+            "max_concurrency": plan.max_concurrency,
+            "state_json": plan.model_dump(mode="json"),
+            "created_at": plan.created_at.isoformat(),
+            "updated_at": plan.updated_at.isoformat(),
+            "completed_at": plan.completed_at.isoformat() if plan.completed_at else None,
+        }
+
+
+__all__ = [
+    "ProgressReporter",
+    "OrchestrationTaskState",
+    "OrchestrationTaskStatus",
+    "TERMINAL_JOB_STATUSES",
+    "TERMINAL_PLAN_STATUSES",
+    "WorkerExecutionPlan",
+    "WorkerExecutor",
+    "WorkerOrchestrator",
+    "WorkerPlanRepository",
+    "WorkerPlanStatus",
+    "WorkerPlanningError",
+]

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -71,3 +71,4 @@ flowchart LR
 - The pipeline is designed to swap models or add agents without rewriting the core IR schema.
 - External agents can call or listen to Forma through the A2A layer documented in `docs/a2a.md`.
 - Specialized worker execution boundaries use the versioned contracts and capability registry documented in `docs/worker-contracts.md`.
+- Dependency-aware concurrent execution and restart recovery are documented in `docs/worker-orchestration.md`.

--- a/docs/worker-contracts.md
+++ b/docs/worker-contracts.md
@@ -1,12 +1,12 @@
 # Worker contracts and capability registry
 
-Specialized workers exchange versioned envelopes through `blueprint_core.workers`. These contracts define the boundary between orchestration and worker implementations; they do not schedule work, retry jobs, or implement any production worker.
+Specialized workers exchange versioned envelopes through `blueprint_core.workers`. These contracts define the boundary between orchestration and worker implementations; the dependency-aware execution lifecycle is documented in [worker orchestration](worker-orchestration.md).
 
 The worker registry is intentionally separate from the Lattice agent registry:
 
 - Lattice cards describe discoverable domain agents, tools, and handoffs.
 - Worker definitions declare executable capabilities and compatible payload versions.
-- A future orchestrator may connect the two, but it must validate a `WorkerRequest` through `WorkerRegistry` before invoking worker code.
+- `WorkerOrchestrator` validates every `WorkerRequest` through `WorkerRegistry` before invoking worker code.
 
 ## Envelope version
 

--- a/docs/worker-orchestration.md
+++ b/docs/worker-orchestration.md
@@ -1,0 +1,30 @@
+# Worker orchestration
+
+`WorkerOrchestrator` runs a validated graph of specialized worker requests. It is intentionally downstream of context gathering and build initiation: workers receive the frozen project, revision, and DesignBrief identity from `WorkerRequest`, not the raw conversation.
+
+## Planning
+
+`create_plan()` validates the complete graph before persisting or executing it:
+
+- every worker and capability exists in `WorkerRegistry`
+- request payload versions are supported
+- job IDs are unique
+- dependency targets exist and optional worker/capability identities match
+- all requests share project, revision, DesignBrief, and correlation context
+- the dependency graph is acyclic
+
+Planning failures raise `WorkerPlanningError` with stable codes and structured context. No worker is invoked when planning fails.
+
+## Execution
+
+Ready jobs run concurrently up to the plan's `max_concurrency`. A job becomes ready only after all declared dependencies reach a terminal state. Required dependency failures block the dependent job; advisory dependency failures are included in `dependency_results` and allow it to continue.
+
+Workers implement `worker_definition()` plus `execute(request, report_progress)`. Their progress and terminal results must preserve the request identity and declare compatible output versions. Exceptions and invalid results become durable `WorkerError` records.
+
+Successful outputs are aggregated by job ID from validated `WorkerResult` values. The orchestrator does not reinterpret the original conversation.
+
+## Persistence and recovery
+
+The `worker_execution_plans` record contains the validated requests and every job's status, progress events, result, artifacts, and error, along with the aggregate output. A new orchestrator instance can reload and resume a plan after process restart. Completed jobs are retained; jobs that were running when the process stopped are safely requeued.
+
+When all jobs are terminal, the project workflow advances from `building` to `awaiting_feedback` with an idempotent system transition. Both successful and failed terminal plans preserve their results for feedback and diagnosis.

--- a/supabase/migrations/20260801000400_worker_execution_plans.sql
+++ b/supabase/migrations/20260801000400_worker_execution_plans.sql
@@ -1,0 +1,28 @@
+-- Durable dependency-aware worker execution state.
+
+create table if not exists public.worker_execution_plans (
+  id text primary key,
+  project_id text not null,
+  owner_user_id text not null,
+  correlation_id text not null,
+  status text not null check (status in ('planned', 'running', 'succeeded', 'failed')),
+  max_concurrency integer not null check (max_concurrency >= 1 and max_concurrency <= 64),
+  state_json jsonb not null,
+  created_at text not null,
+  updated_at text not null,
+  completed_at text
+);
+
+create index if not exists idx_worker_execution_plans_owner_project_updated
+  on public.worker_execution_plans (owner_user_id, project_id, updated_at desc);
+
+create index if not exists idx_worker_execution_plans_correlation
+  on public.worker_execution_plans (correlation_id);
+
+alter table public.worker_execution_plans enable row level security;
+
+revoke all on table public.worker_execution_plans from anon, authenticated;
+grant select, insert, update, delete on table public.worker_execution_plans to service_role;
+
+comment on table public.worker_execution_plans is
+  'Restart-safe worker dependency graphs with durable request, progress, result, artifact, error, and aggregate state.';

--- a/tests/agents/test_worker_orchestrator.py
+++ b/tests/agents/test_worker_orchestrator.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+import asyncio
+import tempfile
+import unittest
+import uuid
+from pathlib import Path
+from typing import Any
+
+from blueprint_core.persistence.providers import create_sqlite_provider
+from blueprint_core.persistence.repositories import SqlAlchemyRepository
+from blueprint_core.workers import (
+    WORKER_CONTRACT_VERSION,
+    OrchestrationTaskStatus,
+    WorkerCapability,
+    WorkerDefinition,
+    WorkerDependency,
+    WorkerOrchestrator,
+    WorkerPlanStatus,
+    WorkerPlanningError,
+    WorkerProgress,
+    WorkerRequest,
+    WorkerResult,
+)
+from blueprint_core.workspaces.workflow import (
+    ProjectWorkflowService,
+    ProjectWorkflowState,
+    WorkflowActorType,
+)
+
+
+OWNER = "orchestrator-user"
+PROJECT_ID = uuid.UUID("a296d80f-99da-4db5-9f95-3d062b553d30")
+BRIEF_ID = uuid.UUID("ecaa71e8-f1c5-4a94-bf21-a08128cddeca")
+
+
+def request_context(worker_id: str, capability_id: str, job_id: str) -> dict[str, Any]:
+    return {
+        "contract_version": WORKER_CONTRACT_VERSION,
+        "project_id": PROJECT_ID,
+        "project_revision": 4,
+        "design_brief_id": BRIEF_ID,
+        "design_brief_version": 2,
+        "job_id": job_id,
+        "correlation_id": "corr_orchestration_test",
+        "worker_id": worker_id,
+        "capability_id": capability_id,
+    }
+
+
+def make_request(
+    worker_id: str,
+    job_id: str,
+    *,
+    dependencies: list[WorkerDependency] | None = None,
+) -> WorkerRequest:
+    return WorkerRequest(
+        **request_context(worker_id, f"{worker_id}.run", job_id),
+        input_contract_version="design-brief.v1",
+        dependencies=dependencies or [],
+        payload={"job": job_id},
+    )
+
+
+class FakeWorker:
+    def __init__(
+        self,
+        worker_id: str,
+        *,
+        delay: float = 0.0,
+        events: list[str] | None = None,
+        tracker: dict[str, int] | None = None,
+        fail: bool = False,
+    ) -> None:
+        self.worker_id = worker_id
+        self.delay = delay
+        self.events = events if events is not None else []
+        self.tracker = tracker
+        self.fail = fail
+        self.execution_count = 0
+        self.received: list[WorkerRequest] = []
+
+    def worker_definition(self) -> WorkerDefinition:
+        return WorkerDefinition(
+            worker_id=self.worker_id,
+            name=f"Fake {self.worker_id}",
+            worker_version="1.0",
+            capabilities=[
+                WorkerCapability(
+                    capability_id=f"{self.worker_id}.run",
+                    description="Exercise orchestration behavior.",
+                    supported_input_versions=["design-brief.v1"],
+                    supported_output_versions=["worker-output.v1"],
+                )
+            ],
+        )
+
+    async def execute(self, request: WorkerRequest, report_progress: Any) -> WorkerResult:
+        self.execution_count += 1
+        self.received.append(request)
+        self.events.append(f"start:{request.job_id}")
+        if self.tracker is not None:
+            self.tracker["active"] += 1
+            self.tracker["maximum"] = max(self.tracker["maximum"], self.tracker["active"])
+        await report_progress(
+            WorkerProgress(
+                **request_context(request.worker_id, request.capability_id, request.job_id),
+                sequence=1,
+                status="running",
+                percent_complete=50,
+                message="Fake worker is running.",
+            )
+        )
+        if self.delay:
+            await asyncio.sleep(self.delay)
+        if self.tracker is not None:
+            self.tracker["active"] -= 1
+        if self.fail:
+            raise RuntimeError(f"{self.worker_id} failed")
+        self.events.append(f"end:{request.job_id}")
+        return WorkerResult(
+            **request_context(request.worker_id, request.capability_id, request.job_id),
+            output_contract_version="worker-output.v1",
+            status="succeeded",
+            output={"completed": request.job_id},
+        )
+
+
+class WorkerOrchestratorIntegrationTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.directory = tempfile.TemporaryDirectory()
+        provider = create_sqlite_provider(
+            source="worker orchestrator test",
+            url=f"sqlite:///{Path(self.directory.name) / 'blueprint.db'}",
+            import_legacy_jobs=False,
+        )
+        provider.initialize()
+        self.repository = SqlAlchemyRepository(provider.session_factory)
+        self.workflow = ProjectWorkflowService(self.repository)
+
+    def tearDown(self) -> None:
+        self.directory.cleanup()
+
+    def enter_building(self) -> None:
+        self.workflow.initialize(str(PROJECT_ID), OWNER)
+        self.workflow.transition(
+            str(PROJECT_ID),
+            OWNER,
+            ProjectWorkflowState.BUILDING,
+            actor_type=WorkflowActorType.USER,
+            actor_id=OWNER,
+            reason="Begin test build.",
+        )
+
+    async def test_independent_jobs_overlap_and_terminal_plan_advances_workflow(self) -> None:
+        self.enter_building()
+        tracker = {"active": 0, "maximum": 0}
+        electrical = FakeWorker("electrical", delay=0.04, tracker=tracker)
+        mechanical = FakeWorker("mechanical", delay=0.04, tracker=tracker)
+        orchestrator = WorkerOrchestrator(
+            self.repository,
+            [electrical, mechanical],
+            workflow_service=self.workflow,
+        )
+        plan = orchestrator.create_plan(
+            [make_request("electrical", "job-electrical"), make_request("mechanical", "job-mechanical")],
+            OWNER,
+            max_concurrency=2,
+        )
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+        persisted = orchestrator.get_plan(plan.plan_id, OWNER)
+        workflow = self.workflow.get(str(PROJECT_ID), OWNER)
+
+        self.assertEqual(2, tracker["maximum"])
+        self.assertEqual(WorkerPlanStatus.SUCCEEDED, completed.status)
+        self.assertEqual(completed, persisted)
+        self.assertEqual({"job-electrical", "job-mechanical"}, set(completed.aggregate))
+        self.assertEqual(ProjectWorkflowState.AWAITING_FEEDBACK, workflow.state)
+        self.assertEqual(1, len(completed.jobs["job-electrical"].progress))
+
+    async def test_dependency_waits_for_success_and_receives_only_persisted_worker_results(self) -> None:
+        self.enter_building()
+        events: list[str] = []
+        source = FakeWorker("source", delay=0.02, events=events)
+        dependent = FakeWorker("dependent", events=events)
+        orchestrator = WorkerOrchestrator(self.repository, [source, dependent], workflow_service=self.workflow)
+        source_request = make_request("source", "job-source")
+        dependent_request = make_request(
+            "dependent",
+            "job-dependent",
+            dependencies=[WorkerDependency(job_id="job-source", required=True)],
+        )
+        plan = orchestrator.create_plan([source_request, dependent_request], OWNER)
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+
+        self.assertLess(events.index("end:job-source"), events.index("start:job-dependent"))
+        dependency_results = dependent.received[0].payload["dependency_results"]
+        self.assertEqual("succeeded", dependency_results["job-source"]["status"])
+        self.assertNotIn("conversation", dependent.received[0].payload)
+        self.assertEqual(OrchestrationTaskStatus.SUCCEEDED, completed.jobs["job-dependent"].status)
+
+    async def test_failed_required_dependency_blocks_dependent_and_persists_error(self) -> None:
+        self.enter_building()
+        failing = FakeWorker("failing", fail=True)
+        dependent = FakeWorker("dependent")
+        orchestrator = WorkerOrchestrator(self.repository, [failing, dependent], workflow_service=self.workflow)
+        plan = orchestrator.create_plan(
+            [
+                make_request("failing", "job-failing"),
+                make_request(
+                    "dependent",
+                    "job-dependent",
+                    dependencies=[WorkerDependency(job_id="job-failing", required=True)],
+                ),
+            ],
+            OWNER,
+        )
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+
+        self.assertEqual(WorkerPlanStatus.FAILED, completed.status)
+        self.assertEqual(OrchestrationTaskStatus.FAILED, completed.jobs["job-failing"].status)
+        self.assertEqual("worker_execution_failed", completed.jobs["job-failing"].error.code)
+        self.assertEqual(OrchestrationTaskStatus.BLOCKED, completed.jobs["job-dependent"].status)
+        self.assertEqual("required_dependency_failed", completed.jobs["job-dependent"].error.code)
+        self.assertEqual(0, dependent.execution_count)
+
+    async def test_persisted_plan_survives_orchestrator_restart_without_rerunning_success(self) -> None:
+        self.enter_building()
+        first = FakeWorker("first")
+        second = FakeWorker("second")
+        orchestrator = WorkerOrchestrator(self.repository, [first, second], workflow_service=self.workflow)
+        plan = orchestrator.create_plan(
+            [
+                make_request("first", "job-first"),
+                make_request(
+                    "second",
+                    "job-second",
+                    dependencies=[WorkerDependency(job_id="job-first")],
+                ),
+            ],
+            OWNER,
+        )
+        first_request = plan.jobs["job-first"].request
+        first_result = WorkerResult(
+            **request_context("first", "first.run", "job-first"),
+            output_contract_version="worker-output.v1",
+            status="succeeded",
+            output={"completed": "job-first"},
+        )
+        plan.jobs["job-first"].status = OrchestrationTaskStatus.SUCCEEDED
+        plan.jobs["job-first"].result = first_result
+        plan.jobs["job-first"].completed_at = first_result.completed_at
+        plan.jobs["job-second"].status = OrchestrationTaskStatus.RUNNING
+        self.repository.update_worker_execution_plan(
+            plan.plan_id,
+            OWNER,
+            {"status": "running", "state_json": plan.model_dump(mode="json")},
+        )
+
+        restarted_first = FakeWorker("first")
+        restarted_second = FakeWorker("second")
+        restarted = WorkerOrchestrator(
+            self.repository,
+            [restarted_first, restarted_second],
+            workflow_service=ProjectWorkflowService(self.repository),
+        )
+        restored = restarted.get_plan(plan.plan_id, OWNER)
+        completed = await restarted.execute(plan.plan_id, OWNER)
+
+        self.assertEqual(first_request, restored.jobs["job-first"].request)
+        self.assertEqual(OrchestrationTaskStatus.SUCCEEDED, restored.jobs["job-first"].status)
+        self.assertEqual(0, restarted_first.execution_count)
+        self.assertEqual(1, restarted_second.execution_count)
+        self.assertEqual(WorkerPlanStatus.SUCCEEDED, completed.status)
+
+    async def test_missing_dependencies_and_cycles_fail_before_execution(self) -> None:
+        first = FakeWorker("first")
+        second = FakeWorker("second")
+        orchestrator = WorkerOrchestrator(self.repository, [first, second], workflow_service=self.workflow)
+
+        with self.assertRaises(WorkerPlanningError) as missing:
+            orchestrator.create_plan(
+                [
+                    make_request(
+                        "first",
+                        "job-first",
+                        dependencies=[WorkerDependency(job_id="job-missing")],
+                    )
+                ],
+                OWNER,
+            )
+
+        with self.assertRaises(WorkerPlanningError) as cyclic:
+            orchestrator.create_plan(
+                [
+                    make_request(
+                        "first",
+                        "job-first",
+                        dependencies=[WorkerDependency(job_id="job-second")],
+                    ),
+                    make_request(
+                        "second",
+                        "job-second",
+                        dependencies=[WorkerDependency(job_id="job-first")],
+                    ),
+                ],
+                OWNER,
+            )
+
+        self.assertEqual("missing_worker_dependency", missing.exception.code)
+        self.assertEqual("cyclic_worker_dependencies", cyclic.exception.code)
+        self.assertEqual(0, first.execution_count)
+        self.assertEqual(0, second.execution_count)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #186

## Summary

- validate worker dependency graphs, request compatibility, missing dependencies, identity mismatches, and cycles before execution
- dispatch ready workers concurrently with a configurable concurrency bound
- wait for dependencies, pass validated dependency results downstream, and block tasks when required dependencies fail
- persist requests, task status, progress, results, errors, artifacts, and aggregate output in restart-safe execution plans
- resume interrupted plans without rerunning successful work
- advance terminal plans to `awaiting_feedback` through an idempotent workflow transition
- add SQLite and Supabase persistence plus project-deletion cleanup
- document orchestration and recovery behavior

## Verification

- `CLOUDFLARE_ENABLE_THINKING=false ./scripts/quality/test.sh`
  - 409 passed, 1 skipped
- focused integration tests cover concurrent, dependent, failure, restart, missing-dependency, and cycle paths
- migration `20260801000400_worker_execution_plans.sql` applied successfully to local Supabase and the table was queried successfully