### PR TITLE
Implement the Generation worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ Tip: load an example directly with http://localhost:3000/?example=pocket_mp3_pla
 - [DesignBrief contract](docs/design-brief.md)
 - [Worker contracts and capability registry](docs/worker-contracts.md)
 - [Dependency-aware worker orchestration](docs/worker-orchestration.md)
+- [Generation worker and canonical project revisions](docs/generation-worker.md)
 - [Project workflow state machine](docs/project-workflow.md)
 - [Conversational context gathering](docs/context-gathering.md)
 - [Project readiness and build initiation](docs/project-readiness.md)

--- a/blueprint_core/agents/orchestrator.py
+++ b/blueprint_core/agents/orchestrator.py
@@ -557,6 +557,7 @@ class HardwarePipelineOrchestrator:
         provider_name: Optional[str] = None,
         model_name: Optional[str] = None,
         runtime_config: Optional[LLMRuntimeConfig] = None,
+        persist_project: bool = True,
     ):
         self.runtime_config = runtime_config or resolve_llm_runtime_config(
             provider_name=provider_name,
@@ -565,6 +566,7 @@ class HardwarePipelineOrchestrator:
         self.llm_provider = build_llm_provider(runtime_config=self.runtime_config)
         self.use_simulation = use_simulation or not self.llm_provider.is_configured
         self.model_name = self.llm_provider.model_name
+        self.persist_project = persist_project
         self._active_generation_metadata: Dict[str, Any] = {}
 
     def get_debug_config(self) -> Dict[str, Any]:
@@ -1430,8 +1432,10 @@ class HardwarePipelineOrchestrator:
     def save_project_to_db(self, prompt: str, ir: HardwareIR) -> str:
         """Saves a successfully generated HardwareIR to the configured database."""
         ensure_agent_pipeline_active()
-        project_id = canonical_project_uuid((ir.assembly_metadata or {}).get("project_id"))
         generation_metadata = self._active_generation_metadata or {}
+        project_id = canonical_project_uuid(
+            (ir.assembly_metadata or {}).get("project_id") or generation_metadata.get("project_id")
+        )
         public_generation_metadata = {
             key: value
             for key, value in generation_metadata.items()
@@ -1442,6 +1446,8 @@ class HardwarePipelineOrchestrator:
             **public_generation_metadata,
             "project_id": project_id,
         }
+        if not self.persist_project:
+            return project_id
         try:
             save_generated_project(
                 project_id=project_id,

--- a/blueprint_core/database.py
+++ b/blueprint_core/database.py
@@ -11,6 +11,7 @@ from blueprint_core.runtime import blueprint_dev_mode_enabled
 from blueprint_core.project_list_cache import invalidate_project_lists
 from blueprint_core.workspaces.projects.objects import attach_project_object_metadata_to_dict
 from blueprint_core.workspaces.design_briefs import DesignBrief, DesignBriefCreate
+from blueprint_core.workspaces.projects import ProjectRevision, ProjectStateService
 from blueprint_core.workspaces.readiness import (
     BuildInitiationOutcome,
     BuildMode,
@@ -668,6 +669,12 @@ def initialize_project_workflow(
 
 def get_project_workflow(project_id: str, owner_user_id: str) -> ProjectWorkflow:
     return ProjectWorkflowService(_DATABASE_REPOSITORY).get(project_id, owner_user_id)
+
+
+def get_latest_project_revision(project_id: str, owner_user_id: str) -> ProjectRevision:
+    """Read the latest immutable state through the canonical project boundary."""
+
+    return ProjectStateService(_DATABASE_REPOSITORY).get_latest(project_id, owner_user_id)
 
 
 def list_project_workflow_transitions(

--- a/blueprint_core/persistence/models.py
+++ b/blueprint_core/persistence/models.py
@@ -129,6 +129,25 @@ class DBWorkerExecutionPlan(Base):
     completed_at = Column(String, nullable=True)
 
 
+class DBProjectRevision(Base):
+    __tablename__ = "project_revisions"
+    __table_args__ = (
+        UniqueConstraint("project_id", "revision", name="uq_project_revisions_project_revision"),
+        UniqueConstraint("project_id", "source_job_id", name="uq_project_revisions_project_source_job"),
+    )
+
+    id = Column(String, primary_key=True)
+    project_id = Column(String, index=True, nullable=False)
+    owner_user_id = Column(String, index=True, nullable=False)
+    revision = Column(Integer, nullable=False)
+    parent_revision = Column(Integer, nullable=True)
+    design_brief_id = Column(String, index=True, nullable=False)
+    design_brief_version = Column(Integer, nullable=False)
+    source_job_id = Column(String, index=True, nullable=False)
+    payload_json = Column(JSON, nullable=False)
+    created_at = Column(String, index=True, nullable=False)
+
+
 class DBProjectContributionConsent(Base):
     __tablename__ = "project_contribution_consents"
     __table_args__ = (UniqueConstraint("project_id", "user_id", name="uq_project_contribution_consent_project_user"),)

--- a/blueprint_core/persistence/repositories/base.py
+++ b/blueprint_core/persistence/repositories/base.py
@@ -85,6 +85,17 @@ class ApplicationRepository(Protocol):
         updates: Dict[str, Any],
     ) -> Optional[Any]: ...
 
+    def get_latest_project_revision(self, project_id: str, owner_user_id: str) -> Optional[Any]: ...
+
+    def get_project_revision_by_source_job(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        source_job_id: str,
+    ) -> Optional[Any]: ...
+
+    def insert_initial_project_revision(self, record: Dict[str, Any]) -> Optional[Any]: ...
+
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]: ...
 
     def update_project_deletion_state(

--- a/blueprint_core/persistence/repositories/sqlite.py
+++ b/blueprint_core/persistence/repositories/sqlite.py
@@ -17,6 +17,7 @@ from blueprint_core.persistence.models import (
     DBProjectDeletionAudit,
     DBProjectWorkflow,
     DBProjectWorkflowTransition,
+    DBProjectRevision,
     DBWorkerExecutionPlan,
     DBUserSettings,
 )
@@ -303,6 +304,48 @@ class SqlAlchemyRepository:
             session.expunge(plan)
             return plan
 
+    def get_latest_project_revision(self, project_id: str, owner_user_id: str) -> Optional[Any]:
+        with self._session() as session:
+            return (
+                session.query(DBProjectRevision)
+                .filter(
+                    DBProjectRevision.project_id == project_id,
+                    DBProjectRevision.owner_user_id == owner_user_id,
+                )
+                .order_by(DBProjectRevision.revision.desc())
+                .first()
+            )
+
+    def get_project_revision_by_source_job(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        source_job_id: str,
+    ) -> Optional[Any]:
+        with self._session() as session:
+            return session.query(DBProjectRevision).filter(
+                DBProjectRevision.project_id == project_id,
+                DBProjectRevision.owner_user_id == owner_user_id,
+                DBProjectRevision.source_job_id == source_job_id,
+            ).first()
+
+    def insert_initial_project_revision(self, record: Dict[str, Any]) -> Optional[Any]:
+        try:
+            with self._session() as session, session.begin():
+                existing = session.query(DBProjectRevision).filter(
+                    DBProjectRevision.project_id == record["project_id"]
+                ).first()
+                if existing is not None or record["revision"] != 1 or record["parent_revision"] is not None:
+                    return None
+                revision = DBProjectRevision(**record)
+                session.add(revision)
+                session.flush()
+                session.refresh(revision)
+                session.expunge(revision)
+                return revision
+        except IntegrityError:
+            return None
+
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]:
         with self._session() as session:
             return (
@@ -354,6 +397,9 @@ class SqlAlchemyRepository:
                 return False
             chat_id = project.chat_id
             project_owner_user_id = project.owner_user_id
+            session.query(DBProjectRevision).filter(
+                DBProjectRevision.project_id == project_id
+            ).delete(synchronize_session=False)
             session.query(DBWorkerExecutionPlan).filter(
                 DBWorkerExecutionPlan.project_id == project_id
             ).delete(synchronize_session=False)
@@ -438,6 +484,9 @@ class SqlAlchemyRepository:
             ).first()
             if not project:
                 return False
+            session.query(DBProjectRevision).filter(
+                DBProjectRevision.project_id == project_id
+            ).delete(synchronize_session=False)
             session.query(DBWorkerExecutionPlan).filter(
                 DBWorkerExecutionPlan.project_id == project_id
             ).delete(synchronize_session=False)

--- a/blueprint_core/persistence/repositories/supabase.py
+++ b/blueprint_core/persistence/repositories/supabase.py
@@ -260,6 +260,44 @@ class SupabaseRepository:
         )
         return _record(rows[0]) if rows else None
 
+    def get_latest_project_revision(self, project_id: str, owner_user_id: str) -> Optional[Any]:
+        rows = (
+            self._client.table("project_revisions")
+            .select("*")
+            .eq("project_id", project_id)
+            .eq("owner_user_id", owner_user_id)
+            .order("revision", desc=True)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
+    def get_project_revision_by_source_job(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        source_job_id: str,
+    ) -> Optional[Any]:
+        rows = (
+            self._client.table("project_revisions")
+            .select("*")
+            .eq("project_id", project_id)
+            .eq("owner_user_id", owner_user_id)
+            .eq("source_job_id", source_job_id)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
+    def insert_initial_project_revision(self, record: Dict[str, Any]) -> Optional[Any]:
+        data = self._client.rpc("insert_initial_project_revision", {"p_revision": record}).execute().data
+        payload = data[0] if isinstance(data, list) and data else data
+        return _record(payload) if isinstance(payload, dict) else None
+
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]:
         rows = (
             self._client.table("generated_projects")
@@ -304,6 +342,7 @@ class SupabaseRepository:
             query = query.eq("owner_user_id", owner_user_id)
         deleted = bool(query.execute().data)
         if deleted:
+            self._client.table("project_revisions").delete().eq("project_id", project_id).execute()
             self._client.table("worker_execution_plans").delete().eq("project_id", project_id).execute()
             self._client.table("project_builds").delete().eq("project_id", project_id).execute()
             self._client.table("design_briefs").delete().eq("project_id", project_id).execute()
@@ -386,6 +425,7 @@ class SupabaseRepository:
         )
         deleted = bool(response.data)
         if deleted:
+            self._client.table("project_revisions").delete().eq("project_id", project_id).execute()
             self._client.table("worker_execution_plans").delete().eq("project_id", project_id).execute()
             self._client.table("project_builds").delete().eq("project_id", project_id).execute()
             self._client.table("design_briefs").delete().eq("project_id", project_id).execute()

--- a/blueprint_core/persistence/schema.py
+++ b/blueprint_core/persistence/schema.py
@@ -56,6 +56,13 @@ APPLICATION_SCHEMA: Tuple[TableContract, ...] = (
         ),
     ),
     TableContract(
+        "project_revisions",
+        (
+            "id", "project_id", "owner_user_id", "revision", "parent_revision", "design_brief_id",
+            "design_brief_version", "source_job_id", "payload_json", "created_at",
+        ),
+    ),
+    TableContract(
         "project_contribution_consents",
         (
             "id", "project_id", "user_id", "workspace_id", "consent_version", "permitted_purposes", "granted_at",

--- a/blueprint_core/workers/__init__.py
+++ b/blueprint_core/workers/__init__.py
@@ -29,10 +29,29 @@ from blueprint_core.workers.orchestration import (
     WorkerPlanStatus,
     WorkerPlanningError,
 )
+from blueprint_core.workers.generation import (
+    GENERATION_CAPABILITY_ID,
+    GENERATION_INPUT_VERSION,
+    GENERATION_OUTPUT_VERSION,
+    GENERATION_WORKER_ID,
+    GenerationEngine,
+    GenerationWorker,
+    GenerationWorkerPayload,
+    HardwareIRGenerationEngine,
+    build_generation_draft,
+)
 
 __all__ = [
     "WORKER_CONTRACT_VERSION",
     "WORKER_REGISTRY_VERSION",
+    "GENERATION_CAPABILITY_ID",
+    "GENERATION_INPUT_VERSION",
+    "GENERATION_OUTPUT_VERSION",
+    "GENERATION_WORKER_ID",
+    "GenerationEngine",
+    "GenerationWorker",
+    "GenerationWorkerPayload",
+    "HardwareIRGenerationEngine",
     "OrchestrationTaskState",
     "OrchestrationTaskStatus",
     "ProgressReporter",
@@ -56,4 +75,5 @@ __all__ = [
     "WorkerResolution",
     "WorkerResult",
     "WorkerResultStatus",
+    "build_generation_draft",
 ]

--- a/blueprint_core/workers/generation.py
+++ b/blueprint_core/workers/generation.py
@@ -1,0 +1,388 @@
+"""Generation worker that turns one frozen DesignBrief into canonical project revision 1."""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Protocol
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from blueprint_core.workers.contracts import (
+    WorkerArtifact,
+    WorkerError,
+    WorkerProgress,
+    WorkerRequest,
+    WorkerResult,
+    WorkerResultStatus,
+)
+from blueprint_core.workers.registry import WorkerCapability, WorkerDefinition
+from blueprint_core.workspaces.design_briefs import DesignBrief
+from blueprint_core.workspaces.projects import (
+    ProjectArtifact,
+    ProjectRevisionOutcome,
+    ProjectRevisionDraft,
+    ProjectStateError,
+    ProjectStateService,
+    ProjectSystem,
+)
+from blueprint_core.workspaces.projects.models import HardwareIR
+
+
+GENERATION_WORKER_ID = "generation-worker"
+GENERATION_CAPABILITY_ID = "project.generate"
+GENERATION_INPUT_VERSION = "design-brief.v1"
+GENERATION_OUTPUT_VERSION = "project-revision.v1"
+
+
+class GenerationWorkerPayload(BaseModel):
+    """The Generation worker accepts no conversational input outside the frozen brief."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    design_brief: DesignBrief
+
+
+class GenerationEngine(Protocol):
+    def generate(self, design_brief: DesignBrief) -> ProjectRevisionDraft | Awaitable[ProjectRevisionDraft]: ...
+
+
+class HardwareIRGenerationEngine:
+    """Adapter for the existing structured pipeline with legacy persistence disabled."""
+
+    def __init__(
+        self,
+        *,
+        provider_name: str | None = None,
+        model_name: str | None = None,
+        use_simulation: bool = False,
+    ) -> None:
+        self.provider_name = provider_name
+        self.model_name = model_name
+        self.use_simulation = use_simulation
+
+    def generate(self, design_brief: DesignBrief) -> ProjectRevisionDraft:
+        from blueprint_core.agents.orchestrator import HardwarePipelineOrchestrator
+
+        prompt = self._prompt(design_brief)
+        orchestrator = HardwarePipelineOrchestrator(
+            use_simulation=self.use_simulation,
+            provider_name=self.provider_name,
+            model_name=self.model_name,
+            persist_project=False,
+        )
+        state = orchestrator.generate_project(
+            prompt,
+            generation_metadata={
+                "project_id": str(design_brief.project_id),
+                "design_brief_id": str(design_brief.design_brief_id),
+                "design_brief_version": design_brief.brief_version,
+            },
+        )
+        generation_error = (state.assembly_metadata or {}).get("generation_error")
+        if generation_error or (state.assembly_metadata or {}).get("status") == "failed":
+            message = generation_error.get("message") if isinstance(generation_error, dict) else None
+            raise RuntimeError(str(message or "Structured hardware generation failed."))
+        return build_generation_draft(design_brief, state)
+
+    @staticmethod
+    def _prompt(design_brief: DesignBrief) -> str:
+        return (
+            "Generate an initial structured hardware project using only this frozen DesignBrief. "
+            "Treat only the references declared inside the brief as reference inputs. Do not infer context "
+            "from prior conversation or fetch undeclared sources.\n\n"
+            f"Frozen DesignBrief:\n{design_brief.model_dump_json(indent=2)}"
+        )
+
+
+def build_generation_draft(design_brief: DesignBrief, state: HardwareIR) -> ProjectRevisionDraft:
+    component_refs = [component.ref_des for component in state.components]
+    systems = [
+        ProjectSystem(
+            system_id="system-primary",
+            kind="hardware",
+            name=(state.overview.title if state.overview else design_brief.summary),
+            component_refs=component_refs,
+        )
+    ]
+    for rail in state.power_rails:
+        systems.append(ProjectSystem(
+            system_id=f"power-{rail.rail_id}",
+            kind="power",
+            name=rail.rail_id,
+            component_refs=[rail.source_component],
+            metadata={"voltage": rail.voltage, "max_current_capacity_ma": rail.max_current_capacity_ma},
+        ))
+    for bus in state.buses:
+        bus_components = sorted({
+            pin.ref_des
+            for net in state.nets
+            if net.net_id in bus.nets
+            for pin in net.pins
+        })
+        systems.append(ProjectSystem(
+            system_id=f"bus-{bus.bus_id}",
+            kind="bus",
+            name=bus.bus_id,
+            component_refs=bus_components,
+            metadata={"bus_type": bus.bus_type, "net_ids": list(bus.nets)},
+        ))
+
+    revision_base = f"forma://projects/{design_brief.project_id}/revisions/1"
+    artifacts = [
+        ProjectArtifact(
+            artifact_id="project-state",
+            kind="project-state",
+            uri=f"{revision_base}/state",
+            media_type="application/vnd.forma.hardware-ir+json",
+        )
+    ]
+    if state.components:
+        artifacts.append(ProjectArtifact(
+            artifact_id="bill-of-materials",
+            kind="bom",
+            uri=f"{revision_base}/bom",
+            media_type="application/json",
+        ))
+    if state.nets:
+        artifacts.append(ProjectArtifact(
+            artifact_id="wiring-netlist",
+            kind="wiring",
+            uri=f"{revision_base}/wiring",
+            media_type="application/json",
+        ))
+    if state.mechanical is not None:
+        artifacts.append(ProjectArtifact(
+            artifact_id="mechanical-plan",
+            kind="mechanical",
+            uri=f"{revision_base}/mechanical",
+            media_type="application/json",
+        ))
+    if state.assembly:
+        artifacts.append(ProjectArtifact(
+            artifact_id="assembly-guide",
+            kind="assembly",
+            uri=f"{revision_base}/assembly",
+            media_type="application/json",
+        ))
+
+    assumptions = list(dict.fromkeys([
+        *design_brief.assumptions,
+        "Generated component selections and topology remain provisional until validation.",
+    ]))
+    return ProjectRevisionDraft(
+        state=state,
+        components=list(state.components),
+        systems=systems,
+        artifacts=artifacts,
+        assumptions=assumptions,
+    )
+
+
+ProgressReporter = Callable[[WorkerProgress], Awaitable[None]]
+
+
+class GenerationWorker:
+    """Registered worker implementation for the `project.generate` capability."""
+
+    def __init__(
+        self,
+        state_service: ProjectStateService,
+        engine: GenerationEngine | None = None,
+    ) -> None:
+        self._state = state_service
+        self._engine = engine or HardwareIRGenerationEngine()
+
+    def worker_definition(self) -> WorkerDefinition:
+        return WorkerDefinition(
+            worker_id=GENERATION_WORKER_ID,
+            name="Forma Generation Worker",
+            worker_version="1.0.0",
+            capabilities=[
+                WorkerCapability(
+                    capability_id=GENERATION_CAPABILITY_ID,
+                    description="Create initial canonical project state from a frozen DesignBrief.",
+                    supported_input_versions=[GENERATION_INPUT_VERSION],
+                    supported_output_versions=[GENERATION_OUTPUT_VERSION],
+                )
+            ],
+        )
+
+    async def execute(self, request: WorkerRequest, report_progress: ProgressReporter) -> WorkerResult:
+        context = _worker_context(request)
+        try:
+            payload = GenerationWorkerPayload.model_validate(request.payload)
+            _validate_request_identity(request, payload.design_brief)
+            owner_user_id = str(request.metadata.get("execution_owner_user_id") or "").strip()
+            if not owner_user_id:
+                raise ProjectStateError(
+                    "generation_owner_missing",
+                    "Generation execution is missing its owner scope.",
+                )
+            payload.design_brief = self._state.require_frozen_design_brief(payload.design_brief, owner_user_id)
+        except ValidationError as exc:
+            return _failure_result(
+                request,
+                ProjectStateError("invalid_generation_request", "Generation payload is invalid.", context={
+                    "validation_errors": exc.errors(include_url=False),
+                }),
+                retryable=False,
+            )
+        except (ProjectStateError, ValueError) as exc:
+            return _failure_result(request, exc, retryable=False)
+
+        replay = self._state.get_by_source_job(request.project_id, owner_user_id, request.job_id)
+        if replay is not None:
+            if (
+                replay.design_brief_id != request.design_brief_id
+                or replay.design_brief_version != request.design_brief_version
+                or replay.revision != request.project_revision
+            ):
+                return _failure_result(
+                    request,
+                    ProjectStateError(
+                        "project_revision_idempotency_conflict",
+                        "The source job is already attached to a different project revision or DesignBrief.",
+                    ),
+                    retryable=False,
+                )
+            return _success_result(request, ProjectRevisionOutcome(revision=replay, idempotent_replay=True))
+
+        try:
+            await report_progress(WorkerProgress(
+                **context,
+                sequence=1,
+                status="running",
+                percent_complete=10,
+                message="Generating structured project state from the frozen DesignBrief.",
+            ))
+            candidate = self._engine.generate(payload.design_brief)
+            if hasattr(candidate, "__await__"):
+                candidate = await candidate
+            draft = ProjectRevisionDraft.model_validate(candidate)
+            await report_progress(WorkerProgress(
+                **context,
+                sequence=2,
+                status="running",
+                percent_complete=80,
+                message="Persisting initial project revision.",
+            ))
+            outcome = self._state.create_initial_revision(
+                draft,
+                project_id=request.project_id,
+                owner_user_id=owner_user_id,
+                design_brief_id=request.design_brief_id,
+                design_brief_version=request.design_brief_version,
+                source_job_id=request.job_id,
+            )
+        except ProjectStateError as exc:
+            return _failure_result(request, exc, retryable=exc.retryable)
+        except Exception as exc:
+            return _failure_result(request, exc, retryable=True)
+
+        return _success_result(request, outcome)
+
+
+def _success_result(request: WorkerRequest, outcome: ProjectRevisionOutcome) -> WorkerResult:
+    context = _worker_context(request)
+    revision = outcome.revision
+    artifacts = [
+        WorkerArtifact(
+            **context,
+            artifact_id=artifact.artifact_id,
+            kind=artifact.kind,
+            uri=artifact.uri,
+            media_type=artifact.media_type,
+            checksum=artifact.checksum,
+            metadata={
+                **artifact.metadata,
+                "project_revision": revision.revision,
+                "design_brief_version": revision.design_brief_version,
+            },
+        )
+        for artifact in revision.artifacts
+    ]
+    return WorkerResult(
+        **context,
+        output_contract_version=GENERATION_OUTPUT_VERSION,
+        status=WorkerResultStatus.SUCCEEDED,
+        output={
+            "project_revision": revision.model_dump(mode="json"),
+            "components": [item.model_dump(mode="json") for item in revision.components],
+            "systems": [item.model_dump(mode="json") for item in revision.systems],
+            "artifacts": [item.model_dump(mode="json") for item in revision.artifacts],
+            "assumptions": list(revision.assumptions),
+            "idempotent_replay": outcome.idempotent_replay,
+        },
+        artifacts=artifacts,
+    )
+
+
+def _validate_request_identity(request: WorkerRequest, brief: DesignBrief) -> None:
+    if (
+        brief.project_id != request.project_id
+        or brief.design_brief_id != request.design_brief_id
+        or brief.brief_version != request.design_brief_version
+        or request.project_revision != 1
+    ):
+        raise ProjectStateError(
+            "generation_context_mismatch",
+            "Generation request identity does not match its frozen DesignBrief or initial revision.",
+            context={
+                "request_project_id": str(request.project_id),
+                "brief_project_id": str(brief.project_id),
+                "request_design_brief_id": str(request.design_brief_id),
+                "brief_design_brief_id": str(brief.design_brief_id),
+                "request_design_brief_version": request.design_brief_version,
+                "brief_design_brief_version": brief.brief_version,
+                "request_project_revision": request.project_revision,
+            },
+        )
+
+
+def _worker_context(request: WorkerRequest) -> dict[str, Any]:
+    return request.model_dump(include={
+        "contract_version",
+        "project_id",
+        "project_revision",
+        "design_brief_id",
+        "design_brief_version",
+        "job_id",
+        "correlation_id",
+        "worker_id",
+        "capability_id",
+    })
+
+
+def _failure_result(request: WorkerRequest, exc: Exception, *, retryable: bool) -> WorkerResult:
+    context = _worker_context(request)
+    code = getattr(exc, "code", "generation_failed")
+    message = str(getattr(exc, "message", "") or str(exc) or exc.__class__.__name__)
+    details = {
+        "exception_type": exc.__class__.__name__,
+        "context": dict(getattr(exc, "context", {}) or {}),
+    }
+    error = WorkerError(
+        **context,
+        code=code,
+        message=message,
+        retryable=retryable,
+        details=details,
+    )
+    return WorkerResult(
+        **context,
+        output_contract_version=GENERATION_OUTPUT_VERSION,
+        status=WorkerResultStatus.FAILED,
+        error=error,
+    )
+
+
+__all__ = [
+    "GENERATION_CAPABILITY_ID",
+    "GENERATION_INPUT_VERSION",
+    "GENERATION_OUTPUT_VERSION",
+    "GENERATION_WORKER_ID",
+    "GenerationEngine",
+    "GenerationWorker",
+    "GenerationWorkerPayload",
+    "HardwareIRGenerationEngine",
+    "build_generation_draft",
+]

--- a/blueprint_core/workers/orchestration.py
+++ b/blueprint_core/workers/orchestration.py
@@ -411,8 +411,6 @@ class WorkerOrchestrator:
         plan: WorkerExecutionPlan,
         request: WorkerRequest,
     ) -> WorkerRequest:
-        if not request.dependencies:
-            return request
         dependency_results = {
             dependency.job_id: (
                 plan.jobs[dependency.job_id].result.model_dump(mode="json")
@@ -422,7 +420,12 @@ class WorkerOrchestrator:
             for dependency in request.dependencies
         }
         return request.model_copy(update={
-            "payload": {**request.payload, "dependency_results": dependency_results},
+            "payload": (
+                {**request.payload, "dependency_results": dependency_results}
+                if request.dependencies
+                else dict(request.payload)
+            ),
+            "metadata": {**request.metadata, "execution_owner_user_id": plan.owner_user_id},
         })
 
     def _failure_result(self, request: WorkerRequest, exc: Exception) -> WorkerResult:

--- a/blueprint_core/workspaces/projects/__init__.py
+++ b/blueprint_core/workspaces/projects/__init__.py
@@ -1,1 +1,23 @@
 """Project resources contained by a workspace."""
+
+from blueprint_core.workspaces.projects.state import (
+    PROJECT_REVISION_SCHEMA_VERSION,
+    ProjectArtifact,
+    ProjectRevision,
+    ProjectRevisionDraft,
+    ProjectRevisionOutcome,
+    ProjectStateError,
+    ProjectStateService,
+    ProjectSystem,
+)
+
+__all__ = [
+    "PROJECT_REVISION_SCHEMA_VERSION",
+    "ProjectArtifact",
+    "ProjectRevision",
+    "ProjectRevisionDraft",
+    "ProjectRevisionOutcome",
+    "ProjectStateError",
+    "ProjectStateService",
+    "ProjectSystem",
+]

--- a/blueprint_core/workspaces/projects/state.py
+++ b/blueprint_core/workspaces/projects/state.py
@@ -1,0 +1,360 @@
+"""Canonical, immutable project revision boundary shared by workers and workspace adapters."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Annotated, Any, Literal, Protocol
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+
+from blueprint_core.workspaces.design_briefs import DesignBrief
+from blueprint_core.workspaces.projects.models import ComponentInstance, HardwareIR
+
+
+PROJECT_REVISION_SCHEMA_VERSION = "1.0"
+NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ProjectSystem(BaseModel):
+    """A generated functional system composed from project components."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    system_id: NonEmptyString
+    kind: NonEmptyString
+    name: NonEmptyString
+    component_refs: list[NonEmptyString] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ProjectArtifact(BaseModel):
+    """A durable artifact reference owned by one canonical project revision."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    artifact_id: NonEmptyString
+    kind: NonEmptyString
+    uri: NonEmptyString
+    media_type: NonEmptyString | None = None
+    checksum: NonEmptyString | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ProjectRevisionDraft(BaseModel):
+    """Identity-free structured output produced by a worker before persistence."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    state: HardwareIR
+    components: list[ComponentInstance] = Field(default_factory=list)
+    systems: list[ProjectSystem] = Field(default_factory=list)
+    artifacts: list[ProjectArtifact] = Field(default_factory=list)
+    assumptions: list[NonEmptyString] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def require_consistent_unique_output(self) -> "ProjectRevisionDraft":
+        if self.components != self.state.components:
+            raise ValueError("Project revision components must match the canonical HardwareIR state.")
+        for values, label in (
+            ([item.system_id for item in self.systems], "system_id"),
+            ([item.artifact_id for item in self.artifacts], "artifact_id"),
+            (list(self.assumptions), "assumption"),
+        ):
+            if len(values) != len(set(values)):
+                raise ValueError(f"Project revision {label} values must be unique.")
+        component_refs = {item.ref_des for item in self.components}
+        dangling = sorted({
+            ref_des
+            for system in self.systems
+            for ref_des in system.component_refs
+            if ref_des not in component_refs
+        })
+        if dangling:
+            raise ValueError(f"Project systems reference unknown components: {', '.join(dangling)}.")
+        return self
+
+
+class ProjectRevision(ProjectRevisionDraft):
+    """An immutable revision committed through the shared project-state boundary."""
+
+    schema_version: Literal["1.0"] = PROJECT_REVISION_SCHEMA_VERSION
+    revision_id: UUID
+    project_id: UUID
+    owner_user_id: NonEmptyString
+    revision: int = Field(ge=1)
+    parent_revision: int | None = Field(default=None, ge=1)
+    design_brief_id: UUID
+    design_brief_version: int = Field(ge=1)
+    source_job_id: NonEmptyString
+    created_at: datetime = Field(default_factory=_utc_now)
+
+
+class ProjectRevisionOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    revision: ProjectRevision
+    idempotent_replay: bool = False
+
+
+class ProjectStateError(RuntimeError):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        retryable: bool = False,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.retryable = retryable
+        self.context = context or {}
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "retryable": self.retryable,
+            "context": dict(self.context),
+        }
+
+
+class ProjectStateRepository(Protocol):
+    def get_design_brief_version(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        brief_version: int,
+    ) -> Any | None: ...
+
+    def get_latest_project_revision(self, project_id: str, owner_user_id: str) -> Any | None: ...
+
+    def get_project_revision_by_source_job(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        source_job_id: str,
+    ) -> Any | None: ...
+
+    def insert_initial_project_revision(self, record: dict[str, Any]) -> Any | None: ...
+
+
+def _canonical_uuid(value: str | UUID, field_name: str) -> UUID:
+    try:
+        return UUID(str(value).strip())
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise ProjectStateError("invalid_project_revision_identity", f"{field_name} must be a UUID.") from exc
+
+
+def _revision_from_record(record: Any) -> ProjectRevision:
+    payload = getattr(record, "payload_json", None)
+    if not isinstance(payload, dict):
+        raise ProjectStateError(
+            "invalid_persisted_project_revision",
+            "Persisted project revision payload_json must be an object.",
+        )
+    return ProjectRevision.model_validate(payload)
+
+
+class ProjectStateService:
+    """Create and retrieve revisions without allowing cross-project or stale writes."""
+
+    def __init__(self, repository: ProjectStateRepository) -> None:
+        self._repository = repository
+
+    def get_latest(self, project_id: str | UUID, owner_user_id: str) -> ProjectRevision:
+        project = str(_canonical_uuid(project_id, "project_id"))
+        owner = str(owner_user_id or "").strip()
+        record = self._repository.get_latest_project_revision(project, owner)
+        if record is None:
+            raise ProjectStateError("project_revision_not_found", "Project revision not found.")
+        return _revision_from_record(record)
+
+    def get_by_source_job(
+        self,
+        project_id: str | UUID,
+        owner_user_id: str,
+        source_job_id: str,
+    ) -> ProjectRevision | None:
+        project = str(_canonical_uuid(project_id, "project_id"))
+        owner = str(owner_user_id or "").strip()
+        job_id = str(source_job_id or "").strip()
+        record = self._repository.get_project_revision_by_source_job(project, owner, job_id)
+        return _revision_from_record(record) if record is not None else None
+
+    def require_frozen_design_brief(
+        self,
+        design_brief: DesignBrief,
+        owner_user_id: str,
+    ) -> DesignBrief:
+        owner = str(owner_user_id or "").strip()
+        record = self._repository.get_design_brief_version(
+            str(design_brief.project_id),
+            owner,
+            design_brief.brief_version,
+        )
+        payload = getattr(record, "payload_json", None) if record is not None else None
+        if not isinstance(payload, dict):
+            raise ProjectStateError(
+                "frozen_design_brief_not_found",
+                "The exact frozen DesignBrief is not available to the project owner.",
+            )
+        persisted = DesignBrief.model_validate(payload)
+        if persisted != design_brief:
+            raise ProjectStateError(
+                "frozen_design_brief_mismatch",
+                "Generation input does not match the persisted frozen DesignBrief snapshot.",
+                context={
+                    "project_id": str(design_brief.project_id),
+                    "design_brief_id": str(design_brief.design_brief_id),
+                    "design_brief_version": design_brief.brief_version,
+                },
+            )
+        return persisted
+
+    def create_initial_revision(
+        self,
+        draft: ProjectRevisionDraft,
+        *,
+        project_id: str | UUID,
+        owner_user_id: str,
+        design_brief_id: str | UUID,
+        design_brief_version: int,
+        source_job_id: str,
+    ) -> ProjectRevisionOutcome:
+        project_uuid = _canonical_uuid(project_id, "project_id")
+        brief_uuid = _canonical_uuid(design_brief_id, "design_brief_id")
+        project = str(project_uuid)
+        owner = str(owner_user_id or "").strip()
+        job_id = str(source_job_id or "").strip()
+        if not owner or not job_id:
+            raise ProjectStateError(
+                "invalid_project_revision_identity",
+                "owner_user_id and source_job_id are required.",
+            )
+
+        replay = self._repository.get_project_revision_by_source_job(project, owner, job_id)
+        if replay is not None:
+            revision = _revision_from_record(replay)
+            self._require_identity(revision, project_uuid, brief_uuid, design_brief_version, job_id)
+            return ProjectRevisionOutcome(revision=revision, idempotent_replay=True)
+
+        brief_record = self._repository.get_design_brief_version(project, owner, design_brief_version)
+        if brief_record is None or str(getattr(brief_record, "design_brief_id", "")) != str(brief_uuid):
+            raise ProjectStateError(
+                "frozen_design_brief_not_found",
+                "The exact frozen DesignBrief is not available to the project owner.",
+                context={
+                    "project_id": project,
+                    "design_brief_id": str(brief_uuid),
+                    "design_brief_version": design_brief_version,
+                },
+            )
+        if self._repository.get_latest_project_revision(project, owner) is not None:
+            raise ProjectStateError(
+                "initial_project_revision_exists",
+                "The project already has an initial revision.",
+                context={"project_id": project},
+            )
+
+        state = draft.state.model_copy(deep=True)
+        metadata = dict(state.assembly_metadata or {})
+        supplied_project = str(metadata.get("project_id") or "").strip()
+        if supplied_project and supplied_project != project:
+            raise ProjectStateError(
+                "project_revision_identity_mismatch",
+                "Generated state targets a different project.",
+                context={"expected_project_id": project, "actual_project_id": supplied_project},
+            )
+        supplied_revision = metadata.get("revision")
+        if supplied_revision not in (None, 1, "1"):
+            raise ProjectStateError(
+                "project_revision_identity_mismatch",
+                "Generated state targets a different project revision.",
+                context={"expected_revision": 1, "actual_revision": supplied_revision},
+            )
+        state.assembly_metadata = {
+            **metadata,
+            "project_id": project,
+            "revision": 1,
+            "design_brief_id": str(brief_uuid),
+            "design_brief_version": design_brief_version,
+            "source_job_id": job_id,
+        }
+        normalized_draft = draft.model_copy(update={"state": state, "components": list(state.components)})
+        revision = ProjectRevision(
+            **normalized_draft.model_dump(),
+            revision_id=uuid4(),
+            project_id=project_uuid,
+            owner_user_id=owner,
+            revision=1,
+            parent_revision=None,
+            design_brief_id=brief_uuid,
+            design_brief_version=design_brief_version,
+            source_job_id=job_id,
+        )
+        record = {
+            "id": str(revision.revision_id),
+            "project_id": project,
+            "owner_user_id": owner,
+            "revision": revision.revision,
+            "parent_revision": revision.parent_revision,
+            "design_brief_id": str(brief_uuid),
+            "design_brief_version": design_brief_version,
+            "source_job_id": job_id,
+            "payload_json": revision.model_dump(mode="json"),
+            "created_at": revision.created_at.isoformat(),
+        }
+        saved = self._repository.insert_initial_project_revision(record)
+        if saved is not None:
+            return ProjectRevisionOutcome(revision=_revision_from_record(saved))
+
+        replay = self._repository.get_project_revision_by_source_job(project, owner, job_id)
+        if replay is not None:
+            persisted = _revision_from_record(replay)
+            self._require_identity(persisted, project_uuid, brief_uuid, design_brief_version, job_id)
+            return ProjectRevisionOutcome(revision=persisted, idempotent_replay=True)
+        raise ProjectStateError(
+            "project_revision_conflict",
+            "Project state changed before the initial revision could be committed.",
+            retryable=True,
+            context={"project_id": project},
+        )
+
+    @staticmethod
+    def _require_identity(
+        revision: ProjectRevision,
+        project_id: UUID,
+        design_brief_id: UUID,
+        design_brief_version: int,
+        source_job_id: str,
+    ) -> None:
+        if (
+            revision.project_id != project_id
+            or revision.design_brief_id != design_brief_id
+            or revision.design_brief_version != design_brief_version
+            or revision.source_job_id != source_job_id
+        ):
+            raise ProjectStateError(
+                "project_revision_idempotency_conflict",
+                "The source job is already attached to a different project or DesignBrief revision.",
+            )
+
+
+__all__ = [
+    "PROJECT_REVISION_SCHEMA_VERSION",
+    "ProjectArtifact",
+    "ProjectRevision",
+    "ProjectRevisionDraft",
+    "ProjectRevisionOutcome",
+    "ProjectStateError",
+    "ProjectStateRepository",
+    "ProjectStateService",
+    "ProjectSystem",
+]

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -72,3 +72,4 @@ flowchart LR
 - External agents can call or listen to Forma through the A2A layer documented in `docs/a2a.md`.
 - Specialized worker execution boundaries use the versioned contracts and capability registry documented in `docs/worker-contracts.md`.
 - Dependency-aware concurrent execution and restart recovery are documented in `docs/worker-orchestration.md`.
+- Frozen-brief generation and canonical revision persistence are documented in `docs/generation-worker.md`.

--- a/docs/generation-worker.md
+++ b/docs/generation-worker.md
@@ -1,0 +1,35 @@
+# Generation worker
+
+The Generation worker owns the `project.generate` capability. It converts one persisted, frozen `DesignBrief` into canonical project revision 1 and never reads raw conversation text.
+
+## Contract
+
+The worker accepts `design-brief.v1` with this payload:
+
+```json
+{
+  "design_brief": { "schema_version": "1.0" }
+}
+```
+
+The complete DesignBrief identity and payload must match the persisted snapshot selected by `WorkerRequest.project_id`, `design_brief_id`, and `design_brief_version`. Additional payload fields are rejected, so chat transcripts and undeclared research context cannot silently enter generation. Declared references remain part of the frozen brief.
+
+The `project-revision.v1` result identifies:
+
+- the complete canonical `HardwareIR` state;
+- structured components and functional systems;
+- every generated artifact reference;
+- every declared or generation-time assumption;
+- the exact project, revision, DesignBrief, and source job identities.
+
+## Shared project-state boundary
+
+`ProjectStateService` is the only write boundary used by the worker. Initial revisions are immutable, owner-scoped, and atomically inserted into `project_revisions`. A generated state that names another project or a revision other than 1 is rejected.
+
+The source worker job is an idempotency identity. Replaying a successful job returns the same revision instead of generating a duplicate. A conflicting source job or stale initial write fails before overwriting state.
+
+## Errors
+
+Failures use `WorkerError` inside a failed `WorkerResult`. Invalid payloads, mismatched frozen briefs, and cross-project writes are non-retryable. Provider and transient persistence failures are marked retryable. The orchestrator persists both shapes with the execution plan and advances the terminal workflow to `awaiting_feedback`.
+
+`HardwareIRGenerationEngine` adapts the existing structured generation pipeline with its legacy direct database write disabled. The engine receives only a prompt constructed from the frozen DesignBrief; the Generation worker commits the returned state through `ProjectStateService`.

--- a/docs/worker-orchestration.md
+++ b/docs/worker-orchestration.md
@@ -28,3 +28,5 @@ Successful outputs are aggregated by job ID from validated `WorkerResult` values
 The `worker_execution_plans` record contains the validated requests and every job's status, progress events, result, artifacts, and error, along with the aggregate output. A new orchestrator instance can reload and resume a plan after process restart. Completed jobs are retained; jobs that were running when the process stopped are safely requeued.
 
 When all jobs are terminal, the project workflow advances from `building` to `awaiting_feedback` with an idempotent system transition. Both successful and failed terminal plans preserve their results for feedback and diagnosis.
+
+The first production capability on this boundary is the [Generation worker](generation-worker.md), which persists canonical project revision 1 from a frozen DesignBrief.

--- a/supabase/migrations/20260801000500_project_revisions.sql
+++ b/supabase/migrations/20260801000500_project_revisions.sql
@@ -1,0 +1,76 @@
+-- Immutable canonical project revisions shared by workers and workspace adapters.
+
+create table if not exists public.project_revisions (
+  id text primary key,
+  project_id text not null,
+  owner_user_id text not null,
+  revision integer not null check (revision >= 1),
+  parent_revision integer,
+  design_brief_id text not null,
+  design_brief_version integer not null check (design_brief_version >= 1),
+  source_job_id text not null,
+  payload_json jsonb not null,
+  created_at text not null,
+  constraint project_revisions_parent_valid check (
+    (revision = 1 and parent_revision is null)
+    or (revision > 1 and parent_revision = revision - 1)
+  ),
+  constraint project_revisions_project_revision_unique unique (project_id, revision),
+  constraint project_revisions_project_source_job_unique unique (project_id, source_job_id)
+);
+
+create index if not exists idx_project_revisions_owner_project_revision
+  on public.project_revisions (owner_user_id, project_id, revision desc);
+
+create index if not exists idx_project_revisions_design_brief
+  on public.project_revisions (design_brief_id, design_brief_version);
+
+create or replace function public.insert_initial_project_revision(
+  p_revision jsonb
+) returns jsonb
+language plpgsql
+set search_path = public
+as $$
+declare
+  saved_revision public.project_revisions%rowtype;
+begin
+  if (p_revision->>'revision')::integer <> 1
+    or nullif(p_revision->>'parent_revision', '') is not null then
+    return null;
+  end if;
+
+  perform 1
+  from public.project_revisions
+  where project_id = p_revision->>'project_id'
+  for update;
+  if found then
+    return null;
+  end if;
+
+  insert into public.project_revisions (
+    id, project_id, owner_user_id, revision, parent_revision, design_brief_id,
+    design_brief_version, source_job_id, payload_json, created_at
+  ) values (
+    p_revision->>'id', p_revision->>'project_id', p_revision->>'owner_user_id',
+    (p_revision->>'revision')::integer, null, p_revision->>'design_brief_id',
+    (p_revision->>'design_brief_version')::integer, p_revision->>'source_job_id',
+    p_revision->'payload_json', p_revision->>'created_at'
+  ) returning * into saved_revision;
+
+  return to_jsonb(saved_revision);
+exception
+  when unique_violation then
+    return null;
+end;
+$$;
+
+alter table public.project_revisions enable row level security;
+
+revoke all on table public.project_revisions from anon, authenticated;
+grant select, insert, delete on table public.project_revisions to service_role;
+
+revoke all on function public.insert_initial_project_revision(jsonb) from public, anon, authenticated;
+grant execute on function public.insert_initial_project_revision(jsonb) to service_role;
+
+comment on table public.project_revisions is
+  'Immutable canonical project state revisions tied to exact frozen DesignBrief and source worker job identities.';

--- a/tests/agents/test_generation_worker.py
+++ b/tests/agents/test_generation_worker.py
@@ -1,0 +1,339 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+from blueprint_core.agents.orchestrator import HardwarePipelineOrchestrator
+from blueprint_core.persistence.providers import create_sqlite_provider
+from blueprint_core.persistence.repositories import SqlAlchemyRepository
+from blueprint_core.workers import (
+    GENERATION_CAPABILITY_ID,
+    GENERATION_INPUT_VERSION,
+    GENERATION_OUTPUT_VERSION,
+    GENERATION_WORKER_ID,
+    WORKER_CONTRACT_VERSION,
+    GenerationWorker,
+    OrchestrationTaskStatus,
+    WorkerOrchestrator,
+    WorkerPlanStatus,
+    WorkerRegistry,
+    WorkerRequest,
+)
+from blueprint_core.workspaces.design_briefs import (
+    DESIGN_BRIEF_SCHEMA_VERSION,
+    DesignBrief,
+    DesignBriefReference,
+)
+from blueprint_core.workspaces.projects import (
+    ProjectArtifact,
+    ProjectRevisionDraft,
+    ProjectStateError,
+    ProjectStateService,
+    ProjectSystem,
+)
+from blueprint_core.workspaces.projects.models import ComponentInstance, HardwareIR, ProjectOverview
+from blueprint_core.workspaces.workflow import (
+    ProjectWorkflowService,
+    ProjectWorkflowState,
+    WorkflowActorType,
+)
+
+
+OWNER = "generation-worker-user"
+
+
+class FakeGenerationEngine:
+    def __init__(self, *, fail: bool = False, target_project_id: str | None = None) -> None:
+        self.fail = fail
+        self.target_project_id = target_project_id
+        self.received: list[DesignBrief] = []
+
+    def generate(self, design_brief: DesignBrief) -> ProjectRevisionDraft:
+        self.received.append(design_brief)
+        if self.fail:
+            raise TimeoutError("generation provider timed out")
+        component = ComponentInstance(
+            ref_des="U1",
+            part_number="ESP32-DEVKIT",
+            name="ESP32 controller",
+            category="Microcontroller",
+            rationale="Provides processing and connectivity required by the frozen brief.",
+        )
+        state = HardwareIR(
+            overview=ProjectOverview(
+                title="Frozen Brief Controller",
+                description=design_brief.summary,
+                difficulty="Intermediate",
+                category="IoT",
+            ),
+            components=[component],
+            assembly_metadata={
+                "project_id": self.target_project_id or str(design_brief.project_id),
+                "revision": 1,
+            },
+        )
+        return ProjectRevisionDraft(
+            state=state,
+            components=[component],
+            systems=[
+                ProjectSystem(
+                    system_id="controller-system",
+                    kind="control",
+                    name="Main controller",
+                    component_refs=["U1"],
+                )
+            ],
+            artifacts=[
+                ProjectArtifact(
+                    artifact_id="initial-state",
+                    kind="project-state",
+                    uri=f"forma://projects/{design_brief.project_id}/revisions/1/state",
+                    media_type="application/vnd.forma.hardware-ir+json",
+                )
+            ],
+            assumptions=[*design_brief.assumptions, "Use the ESP32 development-board regulator."],
+        )
+
+
+class GenerationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.directory = tempfile.TemporaryDirectory()
+        provider = create_sqlite_provider(
+            source="generation worker test",
+            url=f"sqlite:///{Path(self.directory.name) / 'blueprint.db'}",
+            import_legacy_jobs=False,
+        )
+        provider.initialize()
+        self.repository = SqlAlchemyRepository(provider.session_factory)
+        self.state = ProjectStateService(self.repository)
+        self.workflow = ProjectWorkflowService(self.repository)
+        self.project_id = uuid.uuid4()
+        self.brief = self._persist_brief(self.project_id)
+        self.workflow.initialize(str(self.project_id), OWNER)
+        self.workflow.transition(
+            str(self.project_id),
+            OWNER,
+            ProjectWorkflowState.BUILDING,
+            actor_type=WorkflowActorType.USER,
+            actor_id=OWNER,
+            reason="Start Generation worker test.",
+        )
+
+    def tearDown(self) -> None:
+        self.directory.cleanup()
+
+    def _persist_brief(self, project_id: uuid.UUID) -> DesignBrief:
+        brief = DesignBrief(
+            schema_version=DESIGN_BRIEF_SCHEMA_VERSION,
+            conversation_id="conversation-generation",
+            intent="Build a compact sensor controller",
+            summary="A USB-powered sensor controller with a small display.",
+            requirements=["Read one digital sensor", "Show status on a display"],
+            constraints=["Use 5 V USB input"],
+            references=[
+                DesignBriefReference(
+                    reference_id="ref-datasheet",
+                    kind="datasheet",
+                    label="Declared controller datasheet",
+                    uri="https://example.test/declared-datasheet.pdf",
+                    media_type="application/pdf",
+                )
+            ],
+            requested_outputs=["wiring", "bom"],
+            validation_criteria=["Controller remains within input voltage limits"],
+            assumptions=["The display uses I2C"],
+            readiness="ready",
+            design_brief_id=uuid.uuid4(),
+            project_id=project_id,
+            brief_version=1,
+            created_at=datetime.now(timezone.utc),
+        )
+        self.repository.insert_design_brief_version({
+            "id": str(uuid.uuid4()),
+            "design_brief_id": str(brief.design_brief_id),
+            "project_id": str(brief.project_id),
+            "conversation_id": brief.conversation_id,
+            "owner_user_id": OWNER,
+            "brief_version": brief.brief_version,
+            "schema_version": brief.schema_version,
+            "previous_version": brief.previous_version,
+            "payload_json": brief.model_dump(mode="json"),
+            "created_at": brief.created_at.isoformat(),
+        })
+        return brief
+
+    def request(self, *, payload: dict[str, Any] | None = None, revision: int = 1) -> WorkerRequest:
+        return WorkerRequest(
+            contract_version=WORKER_CONTRACT_VERSION,
+            project_id=self.project_id,
+            project_revision=revision,
+            design_brief_id=self.brief.design_brief_id,
+            design_brief_version=self.brief.brief_version,
+            job_id="job-generation-initial",
+            correlation_id="corr-generation-build",
+            worker_id=GENERATION_WORKER_ID,
+            capability_id=GENERATION_CAPABILITY_ID,
+            input_contract_version=GENERATION_INPUT_VERSION,
+            payload=payload or {"design_brief": self.brief.model_dump(mode="json")},
+        )
+
+    async def test_registered_worker_persists_initial_revision_through_orchestrator(self) -> None:
+        engine = FakeGenerationEngine()
+        worker = GenerationWorker(self.state, engine)
+        registry = WorkerRegistry([worker])
+        orchestrator = WorkerOrchestrator(
+            self.repository,
+            [worker],
+            workflow_service=self.workflow,
+        )
+        plan = orchestrator.create_plan([self.request()], OWNER, max_concurrency=1)
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+        revision = self.state.get_latest(self.project_id, OWNER)
+        result = completed.jobs["job-generation-initial"].result
+
+        self.assertEqual(GENERATION_OUTPUT_VERSION, registry.resolve(
+            GENERATION_WORKER_ID, GENERATION_CAPABILITY_ID
+        ).capability.supported_output_versions[0])
+        self.assertEqual(WorkerPlanStatus.SUCCEEDED, completed.status)
+        self.assertEqual(OrchestrationTaskStatus.SUCCEEDED, completed.jobs["job-generation-initial"].status)
+        self.assertEqual(1, revision.revision)
+        self.assertEqual(self.brief.design_brief_id, revision.design_brief_id)
+        self.assertEqual(self.brief.brief_version, revision.design_brief_version)
+        self.assertEqual(["U1"], [item.ref_des for item in revision.components])
+        self.assertEqual(["controller-system"], [item.system_id for item in revision.systems])
+        self.assertEqual(["initial-state"], [item.artifact_id for item in revision.artifacts])
+        self.assertEqual(
+            ["The display uses I2C", "Use the ESP32 development-board regulator."],
+            revision.assumptions,
+        )
+        self.assertEqual(["initial-state"], [item.artifact_id for item in result.artifacts])
+        self.assertEqual(revision.model_dump(mode="json"), result.output["project_revision"])
+        self.assertEqual(ProjectWorkflowState.AWAITING_FEEDBACK, self.workflow.get(str(self.project_id), OWNER).state)
+        self.assertEqual(self.brief, engine.received[0])
+        self.assertEqual(["ref-datasheet"], [item.reference_id for item in engine.received[0].references])
+
+    async def test_provider_failure_is_structured_retryable_and_does_not_create_revision(self) -> None:
+        engine = FakeGenerationEngine(fail=True)
+        worker = GenerationWorker(self.state, engine)
+        orchestrator = WorkerOrchestrator(self.repository, [worker], workflow_service=self.workflow)
+        plan = orchestrator.create_plan([self.request()], OWNER)
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+        result = completed.jobs["job-generation-initial"].result
+
+        self.assertEqual(WorkerPlanStatus.FAILED, completed.status)
+        self.assertEqual("generation_failed", result.error.code)
+        self.assertTrue(result.error.retryable)
+        self.assertIn("timed out", result.error.message)
+        with self.assertRaises(ProjectStateError) as missing:
+            self.state.get_latest(self.project_id, OWNER)
+        self.assertEqual("project_revision_not_found", missing.exception.code)
+
+    async def test_extra_conversation_input_is_rejected_before_generation(self) -> None:
+        engine = FakeGenerationEngine()
+        worker = GenerationWorker(self.state, engine)
+        orchestrator = WorkerOrchestrator(self.repository, [worker], workflow_service=self.workflow)
+        request = self.request(payload={
+            "design_brief": self.brief.model_dump(mode="json"),
+            "conversation": "undeclared raw chat must not reach generation",
+        })
+        plan = orchestrator.create_plan([request], OWNER)
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+        result = completed.jobs["job-generation-initial"].result
+
+        self.assertEqual(WorkerPlanStatus.FAILED, completed.status)
+        self.assertEqual("invalid_generation_request", result.error.code)
+        self.assertFalse(result.error.retryable)
+        self.assertEqual([], engine.received)
+
+    async def test_modified_copy_of_frozen_brief_is_rejected_before_generation(self) -> None:
+        engine = FakeGenerationEngine()
+        worker = GenerationWorker(self.state, engine)
+        orchestrator = WorkerOrchestrator(self.repository, [worker], workflow_service=self.workflow)
+        modified = self.brief.model_copy(update={"summary": "Tampered summary"})
+        plan = orchestrator.create_plan(
+            [self.request(payload={"design_brief": modified.model_dump(mode="json")})],
+            OWNER,
+        )
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+        result = completed.jobs["job-generation-initial"].result
+
+        self.assertEqual(WorkerPlanStatus.FAILED, completed.status)
+        self.assertEqual("frozen_design_brief_mismatch", result.error.code)
+        self.assertFalse(result.error.retryable)
+        self.assertEqual([], engine.received)
+
+    async def test_generated_state_cannot_target_a_different_project(self) -> None:
+        other_project_id = str(uuid.uuid4())
+        engine = FakeGenerationEngine(target_project_id=other_project_id)
+        worker = GenerationWorker(self.state, engine)
+        orchestrator = WorkerOrchestrator(self.repository, [worker], workflow_service=self.workflow)
+        plan = orchestrator.create_plan([self.request()], OWNER)
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+        result = completed.jobs["job-generation-initial"].result
+
+        self.assertEqual(WorkerPlanStatus.FAILED, completed.status)
+        self.assertEqual("project_revision_identity_mismatch", result.error.code)
+        self.assertFalse(result.error.retryable)
+        with self.assertRaises(ProjectStateError):
+            self.state.get_latest(self.project_id, OWNER)
+        with self.assertRaises(ProjectStateError):
+            self.state.get_latest(other_project_id, OWNER)
+
+    async def test_source_job_replay_returns_the_same_revision_without_duplicate_write(self) -> None:
+        engine = FakeGenerationEngine()
+        worker = GenerationWorker(self.state, engine)
+        request = self.request().model_copy(update={"metadata": {"execution_owner_user_id": OWNER}})
+
+        async def progress(_: Any) -> None:
+            return None
+
+        first = await worker.execute(request, progress)
+        second = await worker.execute(request, progress)
+        persisted = self.state.get_latest(self.project_id, OWNER)
+
+        self.assertEqual("succeeded", first.status.value)
+        self.assertEqual("succeeded", second.status.value)
+        self.assertFalse(first.output["idempotent_replay"])
+        self.assertTrue(second.output["idempotent_replay"])
+        self.assertEqual(first.output["project_revision"]["revision_id"], second.output["project_revision"]["revision_id"])
+        self.assertEqual(str(persisted.revision_id), second.output["project_revision"]["revision_id"])
+        self.assertEqual(1, len(engine.received))
+
+    @patch("blueprint_core.agents.orchestrator.ensure_agent_pipeline_active")
+    @patch("blueprint_core.agents.orchestrator.save_generated_project")
+    def test_generation_engine_mode_disables_legacy_direct_project_write(
+        self,
+        save_generated_project: Any,
+        _ensure_pipeline: Any,
+    ) -> None:
+        pipeline = HardwarePipelineOrchestrator.__new__(HardwarePipelineOrchestrator)
+        pipeline.persist_project = False
+        pipeline._active_generation_metadata = {"project_id": str(self.project_id)}
+        state = HardwareIR(
+            overview=ProjectOverview(
+                title="Boundary-only generation",
+                description="Must be persisted by ProjectStateService.",
+                difficulty="Intermediate",
+                category="IoT",
+            )
+        )
+
+        project_id = pipeline.save_project_to_db("frozen brief prompt", state)
+
+        self.assertEqual(str(self.project_id), project_id)
+        self.assertEqual(str(self.project_id), state.assembly_metadata["project_id"])
+        save_generated_project.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #187

## Summary

- register the `project.generate` worker capability with versioned DesignBrief input and project-revision output contracts
- accept only the exact persisted frozen DesignBrief and its declared references; reject raw conversation or modified snapshots
- produce structured components, systems, artifact references, assumptions, and canonical HardwareIR state
- add an immutable, owner-scoped `ProjectStateService` boundary for initial project revisions
- atomically persist revision 1 against the exact project, DesignBrief version, and source worker job
- prevent cross-project and wrong-revision writes
- make source-job retries idempotent without rerunning successful generation
- return structured retryable provider/persistence errors and non-retryable contract/identity errors
- disable the legacy direct generated-project write when the pipeline runs behind the Generation worker
- add SQLite and Supabase persistence, migration, cleanup, and documentation

## Verification

- `CLOUDFLARE_ENABLE_THINKING=false ./scripts/quality/test.sh`
  - 416 passed, 1 skipped
- Generation worker integration covers registration, exact frozen-brief input, artifacts and assumptions, orchestrator persistence, cross-project rejection, structured provider failure, and idempotent replay
- migration `20260801000500_project_revisions.sql` applied successfully to local Supabase
- `supabase db lint --local --level error` passed
- atomic revision RPC passed a transactional rollback smoke test