### PR TITLE
Implement the Validation worker and findings contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,7 @@ Tip: load an example directly with http://localhost:3000/?example=pocket_mp3_pla
 - [Worker contracts and capability registry](docs/worker-contracts.md)
 - [Dependency-aware worker orchestration](docs/worker-orchestration.md)
 - [Generation worker and canonical project revisions](docs/generation-worker.md)
+- [Validation worker and revision-bound findings](docs/validation-worker.md)
 - [Project workflow state machine](docs/project-workflow.md)
 - [Conversational context gathering](docs/context-gathering.md)
 - [Project readiness and build initiation](docs/project-readiness.md)

--- a/blueprint_core/persistence/models.py
+++ b/blueprint_core/persistence/models.py
@@ -148,6 +148,26 @@ class DBProjectRevision(Base):
     created_at = Column(String, index=True, nullable=False)
 
 
+class DBProjectValidationReport(Base):
+    __tablename__ = "project_validation_reports"
+    __table_args__ = (
+        UniqueConstraint(
+            "project_id", "source_job_id", name="uq_project_validation_reports_project_source_job"
+        ),
+    )
+
+    id = Column(String, primary_key=True)
+    project_id = Column(String, index=True, nullable=False)
+    owner_user_id = Column(String, index=True, nullable=False)
+    project_revision = Column(Integer, index=True, nullable=False)
+    design_brief_id = Column(String, index=True, nullable=False)
+    design_brief_version = Column(Integer, nullable=False)
+    source_job_id = Column(String, index=True, nullable=False)
+    revalidation_of_report_id = Column(String, index=True, nullable=True)
+    payload_json = Column(JSON, nullable=False)
+    created_at = Column(String, index=True, nullable=False)
+
+
 class DBProjectContributionConsent(Base):
     __tablename__ = "project_contribution_consents"
     __table_args__ = (UniqueConstraint("project_id", "user_id", name="uq_project_contribution_consent_project_user"),)

--- a/blueprint_core/persistence/repositories/base.py
+++ b/blueprint_core/persistence/repositories/base.py
@@ -87,6 +87,13 @@ class ApplicationRepository(Protocol):
 
     def get_latest_project_revision(self, project_id: str, owner_user_id: str) -> Optional[Any]: ...
 
+    def get_project_revision(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        revision: int,
+    ) -> Optional[Any]: ...
+
     def get_project_revision_by_source_job(
         self,
         project_id: str,
@@ -95,6 +102,17 @@ class ApplicationRepository(Protocol):
     ) -> Optional[Any]: ...
 
     def insert_initial_project_revision(self, record: Dict[str, Any]) -> Optional[Any]: ...
+
+    def get_validation_report(self, report_id: str, owner_user_id: str) -> Optional[Any]: ...
+
+    def get_validation_report_by_source_job(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        source_job_id: str,
+    ) -> Optional[Any]: ...
+
+    def insert_project_validation_report(self, record: Dict[str, Any]) -> Optional[Any]: ...
 
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]: ...
 

--- a/blueprint_core/persistence/repositories/sqlite.py
+++ b/blueprint_core/persistence/repositories/sqlite.py
@@ -18,6 +18,7 @@ from blueprint_core.persistence.models import (
     DBProjectWorkflow,
     DBProjectWorkflowTransition,
     DBProjectRevision,
+    DBProjectValidationReport,
     DBWorkerExecutionPlan,
     DBUserSettings,
 )
@@ -316,6 +317,19 @@ class SqlAlchemyRepository:
                 .first()
             )
 
+    def get_project_revision(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        revision: int,
+    ) -> Optional[Any]:
+        with self._session() as session:
+            return session.query(DBProjectRevision).filter(
+                DBProjectRevision.project_id == project_id,
+                DBProjectRevision.owner_user_id == owner_user_id,
+                DBProjectRevision.revision == revision,
+            ).first()
+
     def get_project_revision_by_source_job(
         self,
         project_id: str,
@@ -343,6 +357,57 @@ class SqlAlchemyRepository:
                 session.refresh(revision)
                 session.expunge(revision)
                 return revision
+        except IntegrityError:
+            return None
+
+    def get_validation_report(self, report_id: str, owner_user_id: str) -> Optional[Any]:
+        with self._session() as session:
+            return session.query(DBProjectValidationReport).filter(
+                DBProjectValidationReport.id == report_id,
+                DBProjectValidationReport.owner_user_id == owner_user_id,
+            ).first()
+
+    def get_validation_report_by_source_job(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        source_job_id: str,
+    ) -> Optional[Any]:
+        with self._session() as session:
+            return session.query(DBProjectValidationReport).filter(
+                DBProjectValidationReport.project_id == project_id,
+                DBProjectValidationReport.owner_user_id == owner_user_id,
+                DBProjectValidationReport.source_job_id == source_job_id,
+            ).first()
+
+    def insert_project_validation_report(self, record: Dict[str, Any]) -> Optional[Any]:
+        try:
+            with self._session() as session, session.begin():
+                revision = session.query(DBProjectRevision).filter(
+                    DBProjectRevision.project_id == record["project_id"],
+                    DBProjectRevision.owner_user_id == record["owner_user_id"],
+                    DBProjectRevision.revision == record["project_revision"],
+                    DBProjectRevision.design_brief_id == record["design_brief_id"],
+                    DBProjectRevision.design_brief_version == record["design_brief_version"],
+                ).first()
+                if revision is None:
+                    return None
+                parent_id = record.get("revalidation_of_report_id")
+                if parent_id:
+                    parent = session.query(DBProjectValidationReport).filter(
+                        DBProjectValidationReport.id == parent_id,
+                        DBProjectValidationReport.project_id == record["project_id"],
+                        DBProjectValidationReport.owner_user_id == record["owner_user_id"],
+                        DBProjectValidationReport.project_revision < record["project_revision"],
+                    ).first()
+                    if parent is None:
+                        return None
+                report = DBProjectValidationReport(**record)
+                session.add(report)
+                session.flush()
+                session.refresh(report)
+                session.expunge(report)
+                return report
         except IntegrityError:
             return None
 
@@ -397,6 +462,9 @@ class SqlAlchemyRepository:
                 return False
             chat_id = project.chat_id
             project_owner_user_id = project.owner_user_id
+            session.query(DBProjectValidationReport).filter(
+                DBProjectValidationReport.project_id == project_id
+            ).delete(synchronize_session=False)
             session.query(DBProjectRevision).filter(
                 DBProjectRevision.project_id == project_id
             ).delete(synchronize_session=False)
@@ -484,6 +552,9 @@ class SqlAlchemyRepository:
             ).first()
             if not project:
                 return False
+            session.query(DBProjectValidationReport).filter(
+                DBProjectValidationReport.project_id == project_id
+            ).delete(synchronize_session=False)
             session.query(DBProjectRevision).filter(
                 DBProjectRevision.project_id == project_id
             ).delete(synchronize_session=False)

--- a/blueprint_core/persistence/repositories/supabase.py
+++ b/blueprint_core/persistence/repositories/supabase.py
@@ -274,6 +274,25 @@ class SupabaseRepository:
         )
         return _record(rows[0]) if rows else None
 
+    def get_project_revision(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        revision: int,
+    ) -> Optional[Any]:
+        rows = (
+            self._client.table("project_revisions")
+            .select("*")
+            .eq("project_id", project_id)
+            .eq("owner_user_id", owner_user_id)
+            .eq("revision", revision)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
     def get_project_revision_by_source_job(
         self,
         project_id: str,
@@ -295,6 +314,43 @@ class SupabaseRepository:
 
     def insert_initial_project_revision(self, record: Dict[str, Any]) -> Optional[Any]:
         data = self._client.rpc("insert_initial_project_revision", {"p_revision": record}).execute().data
+        payload = data[0] if isinstance(data, list) and data else data
+        return _record(payload) if isinstance(payload, dict) else None
+
+    def get_validation_report(self, report_id: str, owner_user_id: str) -> Optional[Any]:
+        rows = (
+            self._client.table("project_validation_reports")
+            .select("*")
+            .eq("id", report_id)
+            .eq("owner_user_id", owner_user_id)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
+    def get_validation_report_by_source_job(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        source_job_id: str,
+    ) -> Optional[Any]:
+        rows = (
+            self._client.table("project_validation_reports")
+            .select("*")
+            .eq("project_id", project_id)
+            .eq("owner_user_id", owner_user_id)
+            .eq("source_job_id", source_job_id)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
+    def insert_project_validation_report(self, record: Dict[str, Any]) -> Optional[Any]:
+        data = self._client.rpc("insert_project_validation_report", {"p_report": record}).execute().data
         payload = data[0] if isinstance(data, list) and data else data
         return _record(payload) if isinstance(payload, dict) else None
 
@@ -342,6 +398,7 @@ class SupabaseRepository:
             query = query.eq("owner_user_id", owner_user_id)
         deleted = bool(query.execute().data)
         if deleted:
+            self._client.table("project_validation_reports").delete().eq("project_id", project_id).execute()
             self._client.table("project_revisions").delete().eq("project_id", project_id).execute()
             self._client.table("worker_execution_plans").delete().eq("project_id", project_id).execute()
             self._client.table("project_builds").delete().eq("project_id", project_id).execute()
@@ -425,6 +482,7 @@ class SupabaseRepository:
         )
         deleted = bool(response.data)
         if deleted:
+            self._client.table("project_validation_reports").delete().eq("project_id", project_id).execute()
             self._client.table("project_revisions").delete().eq("project_id", project_id).execute()
             self._client.table("worker_execution_plans").delete().eq("project_id", project_id).execute()
             self._client.table("project_builds").delete().eq("project_id", project_id).execute()

--- a/blueprint_core/persistence/schema.py
+++ b/blueprint_core/persistence/schema.py
@@ -63,6 +63,13 @@ APPLICATION_SCHEMA: Tuple[TableContract, ...] = (
         ),
     ),
     TableContract(
+        "project_validation_reports",
+        (
+            "id", "project_id", "owner_user_id", "project_revision", "design_brief_id",
+            "design_brief_version", "source_job_id", "revalidation_of_report_id", "payload_json", "created_at",
+        ),
+    ),
+    TableContract(
         "project_contribution_consents",
         (
             "id", "project_id", "user_id", "workspace_id", "consent_version", "permitted_purposes", "granted_at",

--- a/blueprint_core/workers/__init__.py
+++ b/blueprint_core/workers/__init__.py
@@ -40,6 +40,17 @@ from blueprint_core.workers.generation import (
     HardwareIRGenerationEngine,
     build_generation_draft,
 )
+from blueprint_core.workers.validation import (
+    VALIDATION_CAPABILITY_ID,
+    VALIDATION_INPUT_VERSION,
+    VALIDATION_OUTPUT_VERSION,
+    VALIDATION_WORKER_ID,
+    RuleBasedValidationEngine,
+    ValidationEngine,
+    ValidationWorker,
+    ValidationWorkerPayload,
+    build_validation_request,
+)
 
 __all__ = [
     "WORKER_CONTRACT_VERSION",
@@ -52,6 +63,14 @@ __all__ = [
     "GenerationWorker",
     "GenerationWorkerPayload",
     "HardwareIRGenerationEngine",
+    "RuleBasedValidationEngine",
+    "VALIDATION_CAPABILITY_ID",
+    "VALIDATION_INPUT_VERSION",
+    "VALIDATION_OUTPUT_VERSION",
+    "VALIDATION_WORKER_ID",
+    "ValidationEngine",
+    "ValidationWorker",
+    "ValidationWorkerPayload",
     "OrchestrationTaskState",
     "OrchestrationTaskStatus",
     "ProgressReporter",
@@ -76,4 +95,5 @@ __all__ = [
     "WorkerResult",
     "WorkerResultStatus",
     "build_generation_draft",
+    "build_validation_request",
 ]

--- a/blueprint_core/workers/validation.py
+++ b/blueprint_core/workers/validation.py
@@ -1,0 +1,291 @@
+"""Validation worker for exact canonical project revisions."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Awaitable, Callable, Protocol
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from blueprint_core.workers.contracts import (
+    WORKER_CONTRACT_VERSION,
+    NonEmptyString,
+    WorkerArtifact,
+    WorkerError,
+    WorkerProgress,
+    WorkerRequest,
+    WorkerResult,
+    WorkerResultStatus,
+)
+from blueprint_core.workers.registry import WorkerCapability, WorkerDefinition
+from blueprint_core.workspaces.design_briefs import DesignBrief
+from blueprint_core.workspaces.projects import ProjectRevision, ProjectStateError, ProjectStateService
+from blueprint_core.workspaces.validation import (
+    ValidationReport,
+    ValidationReportDraft,
+    ValidationReportError,
+    ValidationReportOutcome,
+    ValidationReportService,
+    evaluate_project_revision,
+)
+
+
+VALIDATION_WORKER_ID = "validation-worker"
+VALIDATION_CAPABILITY_ID = "project.validate"
+VALIDATION_INPUT_VERSION = "project-revision.v1"
+VALIDATION_OUTPUT_VERSION = "validation-findings.v1"
+
+
+class ValidationWorkerPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    requested_checks: list[NonEmptyString] = Field(default_factory=list)
+    revalidation_of_report_id: UUID | None = None
+
+
+class ValidationEngine(Protocol):
+    def validate(
+        self,
+        revision: ProjectRevision,
+        design_brief: DesignBrief,
+        requested_checks: list[str],
+    ) -> ValidationReportDraft | Awaitable[ValidationReportDraft]: ...
+
+
+class RuleBasedValidationEngine:
+    def validate(
+        self,
+        revision: ProjectRevision,
+        design_brief: DesignBrief,
+        requested_checks: list[str],
+    ) -> ValidationReportDraft:
+        return evaluate_project_revision(revision, design_brief, requested_checks or None)
+
+
+ProgressReporter = Callable[[WorkerProgress], Awaitable[None]]
+
+
+class ValidationWorker:
+    def __init__(
+        self,
+        project_state: ProjectStateService,
+        reports: ValidationReportService,
+        engine: ValidationEngine | None = None,
+    ) -> None:
+        self._project_state = project_state
+        self._reports = reports
+        self._engine = engine or RuleBasedValidationEngine()
+
+    def worker_definition(self) -> WorkerDefinition:
+        return WorkerDefinition(
+            worker_id=VALIDATION_WORKER_ID,
+            name="Forma Validation Worker",
+            worker_version="1.0.0",
+            capabilities=[
+                WorkerCapability(
+                    capability_id=VALIDATION_CAPABILITY_ID,
+                    description="Evaluate and persist actionable findings for an exact project revision.",
+                    supported_input_versions=[VALIDATION_INPUT_VERSION],
+                    supported_output_versions=[VALIDATION_OUTPUT_VERSION],
+                )
+            ],
+        )
+
+    async def execute(self, request: WorkerRequest, report_progress: ProgressReporter) -> WorkerResult:
+        try:
+            payload = ValidationWorkerPayload.model_validate(request.payload)
+            owner = str(request.metadata.get("execution_owner_user_id") or "").strip()
+            if not owner:
+                raise ValidationReportError(
+                    "validation_owner_missing",
+                    "Validation execution is missing its owner scope.",
+                )
+            revision = self._project_state.get_revision(request.project_id, owner, request.project_revision)
+            self._require_request_identity(request, revision)
+            brief = self._project_state.get_frozen_design_brief(
+                request.project_id,
+                owner,
+                request.design_brief_id,
+                request.design_brief_version,
+            )
+        except ValidationError as exc:
+            return _failure_result(
+                request,
+                ValidationReportError(
+                    "invalid_validation_request",
+                    "Validation payload is invalid.",
+                    context={"validation_errors": exc.errors(include_url=False)},
+                ),
+                retryable=False,
+            )
+        except (ProjectStateError, ValidationReportError, ValueError) as exc:
+            return _failure_result(request, exc, retryable=False)
+
+        replay = self._reports.get_by_source_job(revision.project_id, owner, request.job_id)
+        if replay is not None:
+            if not _report_matches_request(replay, request):
+                return _failure_result(
+                    request,
+                    ValidationReportError(
+                        "validation_report_idempotency_conflict",
+                        "The source job is already attached to a different project revision or DesignBrief.",
+                    ),
+                    retryable=False,
+                )
+            return _success_result(request, ValidationReportOutcome(report=replay, idempotent_replay=True))
+
+        try:
+            await report_progress(WorkerProgress(
+                **_worker_context(request),
+                sequence=1,
+                status="running",
+                percent_complete=20,
+                message=f"Evaluating canonical project revision {revision.revision}.",
+            ))
+            candidate = self._engine.validate(revision, brief, payload.requested_checks)
+            draft = await candidate if inspect.isawaitable(candidate) else candidate
+            draft = ValidationReportDraft.model_validate(draft)
+            await report_progress(WorkerProgress(
+                **_worker_context(request),
+                sequence=2,
+                status="running",
+                percent_complete=85,
+                message="Persisting revision-bound validation findings.",
+            ))
+            outcome = self._reports.create_report(
+                draft,
+                revision,
+                owner_user_id=owner,
+                source_job_id=request.job_id,
+                revalidation_of_report_id=payload.revalidation_of_report_id,
+            )
+        except ValidationReportError as exc:
+            return _failure_result(request, exc, retryable=exc.retryable)
+        except Exception as exc:
+            return _failure_result(request, exc, retryable=True)
+        return _success_result(request, outcome)
+
+    @staticmethod
+    def _require_request_identity(request: WorkerRequest, revision: ProjectRevision) -> None:
+        if (
+            revision.project_id != request.project_id
+            or revision.revision != request.project_revision
+            or revision.design_brief_id != request.design_brief_id
+            or revision.design_brief_version != request.design_brief_version
+        ):
+            raise ValidationReportError(
+                "validation_context_mismatch",
+                "Validation request does not match the persisted project revision and DesignBrief identity.",
+            )
+
+
+def build_validation_request(
+    revision: ProjectRevision,
+    *,
+    job_id: str,
+    correlation_id: str,
+    requested_checks: list[str] | None = None,
+    revalidation_of_report_id: str | UUID | None = None,
+) -> WorkerRequest:
+    """Build a downstream validation or revalidation request without copying project state."""
+
+    return WorkerRequest(
+        contract_version=WORKER_CONTRACT_VERSION,
+        project_id=revision.project_id,
+        project_revision=revision.revision,
+        design_brief_id=revision.design_brief_id,
+        design_brief_version=revision.design_brief_version,
+        job_id=job_id,
+        correlation_id=correlation_id,
+        worker_id=VALIDATION_WORKER_ID,
+        capability_id=VALIDATION_CAPABILITY_ID,
+        input_contract_version=VALIDATION_INPUT_VERSION,
+        payload=ValidationWorkerPayload(
+            requested_checks=requested_checks or [],
+            revalidation_of_report_id=revalidation_of_report_id,
+        ).model_dump(mode="json"),
+    )
+
+
+def _report_matches_request(report: ValidationReport, request: WorkerRequest) -> bool:
+    return (
+        report.project_id == request.project_id
+        and report.project_revision == request.project_revision
+        and report.design_brief_id == request.design_brief_id
+        and report.design_brief_version == request.design_brief_version
+    )
+
+
+def _success_result(request: WorkerRequest, outcome: ValidationReportOutcome) -> WorkerResult:
+    report = outcome.report
+    artifact = WorkerArtifact(
+        **_worker_context(request),
+        artifact_id=f"validation-report-{report.report_id}",
+        kind="validation-report",
+        uri=f"forma://projects/{report.project_id}/revisions/{report.project_revision}/validation/{report.report_id}",
+        media_type="application/vnd.forma.validation-report+json",
+        metadata={
+            "project_revision": report.project_revision,
+            "finding_count": report.summary.total,
+        },
+    )
+    return WorkerResult(
+        **_worker_context(request),
+        output_contract_version=VALIDATION_OUTPUT_VERSION,
+        status=WorkerResultStatus.SUCCEEDED,
+        output={
+            "validation_report": report.model_dump(mode="json"),
+            "findings": [item.model_dump(mode="json") for item in report.findings],
+            "summary": report.summary.model_dump(mode="json"),
+            "idempotent_replay": outcome.idempotent_replay,
+        },
+        artifacts=[artifact],
+    )
+
+
+def _worker_context(request: WorkerRequest) -> dict[str, Any]:
+    return request.model_dump(include={
+        "contract_version",
+        "project_id",
+        "project_revision",
+        "design_brief_id",
+        "design_brief_version",
+        "job_id",
+        "correlation_id",
+        "worker_id",
+        "capability_id",
+    })
+
+
+def _failure_result(request: WorkerRequest, exc: Exception, *, retryable: bool) -> WorkerResult:
+    context = _worker_context(request)
+    error = WorkerError(
+        **context,
+        code=str(getattr(exc, "code", "validation_failed")),
+        message=str(getattr(exc, "message", "") or str(exc) or exc.__class__.__name__),
+        retryable=retryable,
+        details={
+            "exception_type": exc.__class__.__name__,
+            "context": dict(getattr(exc, "context", {}) or {}),
+        },
+    )
+    return WorkerResult(
+        **context,
+        output_contract_version=VALIDATION_OUTPUT_VERSION,
+        status=WorkerResultStatus.FAILED,
+        error=error,
+    )
+
+
+__all__ = [
+    "VALIDATION_CAPABILITY_ID",
+    "VALIDATION_INPUT_VERSION",
+    "VALIDATION_OUTPUT_VERSION",
+    "VALIDATION_WORKER_ID",
+    "RuleBasedValidationEngine",
+    "ValidationEngine",
+    "ValidationWorker",
+    "ValidationWorkerPayload",
+    "build_validation_request",
+]

--- a/blueprint_core/workspaces/projects/state.py
+++ b/blueprint_core/workspaces/projects/state.py
@@ -135,6 +135,13 @@ class ProjectStateRepository(Protocol):
 
     def get_latest_project_revision(self, project_id: str, owner_user_id: str) -> Any | None: ...
 
+    def get_project_revision(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        revision: int,
+    ) -> Any | None: ...
+
     def get_project_revision_by_source_job(
         self,
         project_id: str,
@@ -174,6 +181,23 @@ class ProjectStateService:
         record = self._repository.get_latest_project_revision(project, owner)
         if record is None:
             raise ProjectStateError("project_revision_not_found", "Project revision not found.")
+        return _revision_from_record(record)
+
+    def get_revision(
+        self,
+        project_id: str | UUID,
+        owner_user_id: str,
+        revision: int,
+    ) -> ProjectRevision:
+        project = str(_canonical_uuid(project_id, "project_id"))
+        owner = str(owner_user_id or "").strip()
+        record = self._repository.get_project_revision(project, owner, revision)
+        if record is None:
+            raise ProjectStateError(
+                "project_revision_not_found",
+                "The exact project revision is not available to the project owner.",
+                context={"project_id": project, "revision": revision},
+            )
         return _revision_from_record(record)
 
     def get_by_source_job(
@@ -217,6 +241,31 @@ class ProjectStateService:
                 },
             )
         return persisted
+
+    def get_frozen_design_brief(
+        self,
+        project_id: str | UUID,
+        owner_user_id: str,
+        design_brief_id: str | UUID,
+        design_brief_version: int,
+    ) -> DesignBrief:
+        project = str(_canonical_uuid(project_id, "project_id"))
+        brief_id = _canonical_uuid(design_brief_id, "design_brief_id")
+        owner = str(owner_user_id or "").strip()
+        record = self._repository.get_design_brief_version(project, owner, design_brief_version)
+        payload = getattr(record, "payload_json", None) if record is not None else None
+        if not isinstance(payload, dict):
+            raise ProjectStateError(
+                "frozen_design_brief_not_found",
+                "The exact frozen DesignBrief is not available to the project owner.",
+            )
+        brief = DesignBrief.model_validate(payload)
+        if brief.design_brief_id != brief_id or brief.project_id != UUID(project):
+            raise ProjectStateError(
+                "frozen_design_brief_not_found",
+                "The exact frozen DesignBrief is not available to the project owner.",
+            )
+        return brief
 
     def create_initial_revision(
         self,

--- a/blueprint_core/workspaces/validation/__init__.py
+++ b/blueprint_core/workspaces/validation/__init__.py
@@ -1,0 +1,37 @@
+from blueprint_core.workspaces.validation.evaluator import (
+    SUPPORTED_VALIDATION_CHECKS,
+    evaluate_project_revision,
+)
+from blueprint_core.workspaces.validation.models import (
+    VALIDATION_REPORT_SCHEMA_VERSION,
+    ValidationCheckStatus,
+    ValidationFinding,
+    ValidationFindingDraft,
+    ValidationFindingKind,
+    ValidationReport,
+    ValidationReportDraft,
+    ValidationReportOutcome,
+    ValidationReportSummary,
+    ValidationSeverity,
+)
+from blueprint_core.workspaces.validation.service import (
+    ValidationReportError,
+    ValidationReportService,
+)
+
+__all__ = [
+    "SUPPORTED_VALIDATION_CHECKS",
+    "VALIDATION_REPORT_SCHEMA_VERSION",
+    "ValidationCheckStatus",
+    "ValidationFinding",
+    "ValidationFindingDraft",
+    "ValidationFindingKind",
+    "ValidationReport",
+    "ValidationReportDraft",
+    "ValidationReportError",
+    "ValidationReportOutcome",
+    "ValidationReportService",
+    "ValidationReportSummary",
+    "ValidationSeverity",
+    "evaluate_project_revision",
+]

--- a/blueprint_core/workspaces/validation/evaluator.py
+++ b/blueprint_core/workspaces/validation/evaluator.py
@@ -1,0 +1,295 @@
+"""Deterministic baseline checks for canonical project revisions."""
+
+from __future__ import annotations
+
+import re
+
+from blueprint_core.workspaces.design_briefs import DesignBrief
+from blueprint_core.workspaces.projects import ProjectRevision
+from blueprint_core.workspaces.validation.models import (
+    ValidationCheckStatus,
+    ValidationFindingDraft,
+    ValidationFindingKind,
+    ValidationReportDraft,
+    ValidationSeverity,
+)
+
+
+SUPPORTED_VALIDATION_CHECKS = frozenset({"constraints", "consistency", "assumptions", "criteria"})
+
+
+def _slug(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
+    return normalized[:64] or "check"
+
+
+def _artifact_for(revision: ProjectRevision, *kinds: str) -> str | None:
+    for kind in kinds:
+        artifact = next((item for item in revision.artifacts if item.kind == kind), None)
+        if artifact is not None:
+            return artifact.artifact_id
+    return revision.artifacts[0].artifact_id if revision.artifacts else None
+
+
+def _finding(
+    *,
+    criterion_id: str,
+    criterion: str,
+    kind: ValidationFindingKind,
+    status: ValidationCheckStatus,
+    evidence: list[str],
+    remediation: str,
+    artifact_id: str | None,
+) -> ValidationFindingDraft:
+    severity = {
+        ValidationCheckStatus.PASSED: ValidationSeverity.INFO,
+        ValidationCheckStatus.WARNING: ValidationSeverity.WARNING,
+        ValidationCheckStatus.FAILED: ValidationSeverity.ERROR,
+        ValidationCheckStatus.SKIPPED: ValidationSeverity.INFO,
+    }[status]
+    return ValidationFindingDraft(
+        criterion_id=criterion_id,
+        criterion=criterion,
+        kind=kind,
+        status=status,
+        severity=severity,
+        affected_artifact_id=artifact_id,
+        evidence=evidence,
+        remediation=remediation,
+    )
+
+
+def _constraint_findings(revision: ProjectRevision, brief: DesignBrief) -> list[ValidationFindingDraft]:
+    available = {
+        value.strip().casefold()
+        for value in [
+            *revision.state.constraints,
+            *(revision.state.requirements.physical_constraints if revision.state.requirements else []),
+        ]
+        if value.strip()
+    }
+    if not brief.constraints:
+        return [_finding(
+            criterion_id="constraints:none-declared",
+            criterion="DesignBrief constraints are represented in project state",
+            kind=ValidationFindingKind.CONSTRAINT,
+            status=ValidationCheckStatus.SKIPPED,
+            evidence=["The frozen DesignBrief declares no explicit constraints."],
+            remediation="Declare constraints in a new DesignBrief version before revalidation.",
+            artifact_id=_artifact_for(revision, "project-state"),
+        )]
+    findings: list[ValidationFindingDraft] = []
+    for index, constraint in enumerate(brief.constraints, start=1):
+        present = constraint.strip().casefold() in available
+        findings.append(_finding(
+            criterion_id=f"constraint:{index}:{_slug(constraint)}",
+            criterion=constraint,
+            kind=ValidationFindingKind.CONSTRAINT,
+            status=ValidationCheckStatus.PASSED if present else ValidationCheckStatus.WARNING,
+            evidence=(
+                [f"Constraint is present in canonical project state: {constraint}"]
+                if present
+                else [f"Constraint is declared by DesignBrief but not represented verbatim in project state: {constraint}"]
+            ),
+            remediation=(
+                "No action required."
+                if present
+                else "Represent the constraint explicitly in the next project revision or document an equivalent mapping."
+            ),
+            artifact_id=_artifact_for(revision, "project-state"),
+        ))
+    return findings
+
+
+def _consistency_findings(revision: ProjectRevision) -> list[ValidationFindingDraft]:
+    component_refs = [item.ref_des for item in revision.components]
+    duplicates = sorted({value for value in component_refs if component_refs.count(value) > 1})
+    known = set(component_refs)
+    dangling = sorted({
+        pin.ref_des
+        for net in revision.state.nets
+        for pin in net.pins
+        if pin.ref_des not in known
+    })
+    if duplicates or dangling:
+        evidence = []
+        if duplicates:
+            evidence.append(f"Duplicate component references: {', '.join(duplicates)}.")
+        if dangling:
+            evidence.append(f"Net pins reference unknown components: {', '.join(dangling)}.")
+        return [_finding(
+            criterion_id="consistency:component-references",
+            criterion="Component and net references are internally consistent",
+            kind=ValidationFindingKind.CONSISTENCY,
+            status=ValidationCheckStatus.FAILED,
+            evidence=evidence,
+            remediation="Resolve duplicate or dangling component references in a new project revision.",
+            artifact_id=_artifact_for(revision, "wiring", "project-state"),
+        )]
+    return [_finding(
+        criterion_id="consistency:component-references",
+        criterion="Component and net references are internally consistent",
+        kind=ValidationFindingKind.CONSISTENCY,
+        status=ValidationCheckStatus.PASSED,
+        evidence=[f"Validated {len(component_refs)} component references and {len(revision.state.nets)} nets."],
+        remediation="No action required.",
+        artifact_id=_artifact_for(revision, "wiring", "project-state"),
+    )]
+
+
+def _assumption_findings(revision: ProjectRevision, brief: DesignBrief) -> list[ValidationFindingDraft]:
+    findings: list[ValidationFindingDraft] = []
+    for index, question in enumerate(brief.unresolved_questions, start=1):
+        findings.append(_finding(
+            criterion_id=f"assumption:unresolved:{index}:{_slug(question)}",
+            criterion=question,
+            kind=ValidationFindingKind.ASSUMPTION,
+            status=ValidationCheckStatus.FAILED,
+            evidence=[f"The frozen DesignBrief still marks this question unresolved: {question}"],
+            remediation="Resolve the question in a new DesignBrief and regenerate or revise the project.",
+            artifact_id=_artifact_for(revision, "project-state"),
+        ))
+    for index, assumption in enumerate(revision.assumptions, start=1):
+        findings.append(_finding(
+            criterion_id=f"assumption:declared:{index}:{_slug(assumption)}",
+            criterion=assumption,
+            kind=ValidationFindingKind.ASSUMPTION,
+            status=ValidationCheckStatus.WARNING,
+            evidence=[f"Project revision {revision.revision} depends on this recorded assumption: {assumption}"],
+            remediation="Confirm the assumption with evidence or replace it in a new project revision.",
+            artifact_id=_artifact_for(revision, "project-state"),
+        ))
+    if findings:
+        return findings
+    return [_finding(
+        criterion_id="assumption:none-unresolved",
+        criterion="No unresolved assumptions remain",
+        kind=ValidationFindingKind.ASSUMPTION,
+        status=ValidationCheckStatus.PASSED,
+        evidence=["The revision and frozen DesignBrief contain no unresolved assumptions or questions."],
+        remediation="No action required.",
+        artifact_id=_artifact_for(revision, "project-state"),
+    )]
+
+
+def _criterion_finding(
+    revision: ProjectRevision,
+    criterion: str,
+    index: int,
+) -> ValidationFindingDraft:
+    lowered = criterion.casefold()
+    critical = list(revision.state.validation.critical or [])
+    criterion_id = f"criterion:{index}:{_slug(criterion)}"
+    if "critical" in lowered or "valid" in lowered:
+        passed = revision.state.is_valid and not critical
+        return _finding(
+            criterion_id=criterion_id,
+            criterion=criterion,
+            kind=ValidationFindingKind.CRITERION,
+            status=ValidationCheckStatus.PASSED if passed else ValidationCheckStatus.FAILED,
+            evidence=(
+                ["Project state is valid and contains no critical validation issues."]
+                if passed
+                else [f"Project state is_valid={revision.state.is_valid} with {len(critical)} critical issues."]
+            ),
+            remediation="No action required." if passed else "Resolve every critical validation issue and request revalidation.",
+            artifact_id=_artifact_for(revision, "validation", "project-state"),
+        )
+    if "component" in lowered:
+        passed = bool(revision.components)
+        return _finding(
+            criterion_id=criterion_id,
+            criterion=criterion,
+            kind=ValidationFindingKind.CRITERION,
+            status=ValidationCheckStatus.PASSED if passed else ValidationCheckStatus.FAILED,
+            evidence=[f"Canonical revision contains {len(revision.components)} components."],
+            remediation="No action required." if passed else "Add the required components in a new project revision.",
+            artifact_id=_artifact_for(revision, "bom", "project-state"),
+        )
+    if "voltage" in lowered or "power" in lowered:
+        voltages = [item.voltage for item in revision.state.power_rails]
+        if revision.state.requirements and revision.state.requirements.operating_voltage:
+            voltages.append(revision.state.requirements.operating_voltage)
+        if not voltages:
+            return _finding(
+                criterion_id=criterion_id,
+                criterion=criterion,
+                kind=ValidationFindingKind.CRITERION,
+                status=ValidationCheckStatus.SKIPPED,
+                evidence=["No structured power rail or operating voltage is available for this check."],
+                remediation="Add structured voltage data or use a domain-specific electrical validator.",
+                artifact_id=_artifact_for(revision, "wiring", "project-state"),
+            )
+        voltage_issues = [item for item in critical if "voltage" in item.category.casefold()]
+        passed = not voltage_issues
+        return _finding(
+            criterion_id=criterion_id,
+            criterion=criterion,
+            kind=ValidationFindingKind.CRITERION,
+            status=ValidationCheckStatus.PASSED if passed else ValidationCheckStatus.FAILED,
+            evidence=[f"Structured voltages: {', '.join(str(value) for value in voltages)}; critical voltage issues: {len(voltage_issues)}."],
+            remediation="No action required." if passed else "Resolve critical voltage findings and request revalidation.",
+            artifact_id=_artifact_for(revision, "wiring", "project-state"),
+        )
+    return _finding(
+        criterion_id=criterion_id,
+        criterion=criterion,
+        kind=ValidationFindingKind.CRITERION,
+        status=ValidationCheckStatus.SKIPPED,
+        evidence=["The baseline Validation worker does not implement this domain-specific criterion."],
+        remediation="Route this criterion to a compatible domain validator or perform documented manual review.",
+        artifact_id=_artifact_for(revision, "project-state"),
+    )
+
+
+def evaluate_project_revision(
+    revision: ProjectRevision,
+    design_brief: DesignBrief,
+    requested_checks: list[str] | None = None,
+) -> ValidationReportDraft:
+    checks: list[str] = []
+    seen_checks: set[str] = set()
+    for requested in requested_checks or ["constraints", "consistency", "assumptions", "criteria"]:
+        normalized = requested.strip().lower()
+        if normalized not in seen_checks:
+            checks.append(requested)
+            seen_checks.add(normalized)
+    findings: list[ValidationFindingDraft] = []
+    for check in checks:
+        normalized = check.strip().lower()
+        if normalized == "constraints":
+            findings.extend(_constraint_findings(revision, design_brief))
+        elif normalized == "consistency":
+            findings.extend(_consistency_findings(revision))
+        elif normalized == "assumptions":
+            findings.extend(_assumption_findings(revision, design_brief))
+        elif normalized == "criteria":
+            if design_brief.validation_criteria:
+                findings.extend(
+                    _criterion_finding(revision, criterion, index)
+                    for index, criterion in enumerate(design_brief.validation_criteria, start=1)
+                )
+            else:
+                findings.append(_finding(
+                    criterion_id="criteria:none-declared",
+                    criterion="Declared DesignBrief validation criteria",
+                    kind=ValidationFindingKind.CRITERION,
+                    status=ValidationCheckStatus.SKIPPED,
+                    evidence=["The frozen DesignBrief declares no validation criteria."],
+                    remediation="Declare validation criteria in a new DesignBrief version.",
+                    artifact_id=_artifact_for(revision, "project-state"),
+                ))
+        else:
+            findings.append(_finding(
+                criterion_id=f"requested-check:{_slug(check)}",
+                criterion=check,
+                kind=ValidationFindingKind.REQUESTED_CHECK,
+                status=ValidationCheckStatus.SKIPPED,
+                evidence=[f"Requested check '{check}' is not supported by this Validation worker version."],
+                remediation=f"Use one of the supported checks: {', '.join(sorted(SUPPORTED_VALIDATION_CHECKS))}.",
+                artifact_id=_artifact_for(revision, "project-state"),
+            ))
+    return ValidationReportDraft(findings=findings)
+
+
+__all__ = ["SUPPORTED_VALIDATION_CHECKS", "evaluate_project_revision"]

--- a/blueprint_core/workspaces/validation/models.py
+++ b/blueprint_core/workspaces/validation/models.py
@@ -1,0 +1,146 @@
+"""Versioned findings emitted by revision-bound validation workers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Annotated, Any, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+
+
+VALIDATION_REPORT_SCHEMA_VERSION = "1.0"
+NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class ValidationCheckStatus(str, Enum):
+    PASSED = "passed"
+    WARNING = "warning"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+class ValidationSeverity(str, Enum):
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+class ValidationFindingKind(str, Enum):
+    CONSTRAINT = "constraint"
+    CONSISTENCY = "consistency"
+    ASSUMPTION = "assumption"
+    CRITERION = "criterion"
+    REQUESTED_CHECK = "requested_check"
+
+
+class ValidationFindingDraft(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    criterion_id: NonEmptyString
+    criterion: NonEmptyString
+    kind: ValidationFindingKind
+    status: ValidationCheckStatus
+    severity: ValidationSeverity
+    affected_artifact_id: NonEmptyString | None = None
+    evidence: list[NonEmptyString] = Field(min_length=1)
+    remediation: NonEmptyString
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+
+class ValidationReportDraft(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    findings: list[ValidationFindingDraft] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_unique_criteria(self) -> "ValidationReportDraft":
+        criterion_ids = [item.criterion_id for item in self.findings]
+        if len(criterion_ids) != len(set(criterion_ids)):
+            raise ValueError("Validation finding criterion_id values must be unique within a report.")
+        return self
+
+
+class ValidationFinding(ValidationFindingDraft):
+    finding_id: UUID
+    report_id: UUID
+    project_id: UUID
+    project_revision: int = Field(ge=1)
+    design_brief_id: UUID
+    design_brief_version: int = Field(ge=1)
+    created_at: datetime
+
+
+class ValidationReportSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    total: int = Field(ge=1)
+    passed: int = Field(ge=0)
+    warnings: int = Field(ge=0)
+    failed: int = Field(ge=0)
+    skipped: int = Field(ge=0)
+
+
+class ValidationReport(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["1.0"] = VALIDATION_REPORT_SCHEMA_VERSION
+    report_id: UUID
+    project_id: UUID
+    owner_user_id: NonEmptyString
+    project_revision: int = Field(ge=1)
+    design_brief_id: UUID
+    design_brief_version: int = Field(ge=1)
+    source_job_id: NonEmptyString
+    revalidation_of_report_id: UUID | None = None
+    findings: list[ValidationFinding] = Field(min_length=1)
+    summary: ValidationReportSummary
+    created_at: datetime
+
+    @model_validator(mode="after")
+    def require_matching_findings_and_summary(self) -> "ValidationReport":
+        finding_ids = [item.finding_id for item in self.findings]
+        criterion_ids = [item.criterion_id for item in self.findings]
+        if len(finding_ids) != len(set(finding_ids)) or len(criterion_ids) != len(set(criterion_ids)):
+            raise ValueError("Validation report finding and criterion identities must be unique.")
+        for finding in self.findings:
+            if (
+                finding.report_id != self.report_id
+                or finding.project_id != self.project_id
+                or finding.project_revision != self.project_revision
+                or finding.design_brief_id != self.design_brief_id
+                or finding.design_brief_version != self.design_brief_version
+            ):
+                raise ValueError("Validation finding identity must match its report.")
+        counts = {
+            "total": len(self.findings),
+            "passed": sum(item.status == ValidationCheckStatus.PASSED for item in self.findings),
+            "warnings": sum(item.status == ValidationCheckStatus.WARNING for item in self.findings),
+            "failed": sum(item.status == ValidationCheckStatus.FAILED for item in self.findings),
+            "skipped": sum(item.status == ValidationCheckStatus.SKIPPED for item in self.findings),
+        }
+        if self.summary.model_dump() != counts:
+            raise ValueError("Validation report summary must match its findings.")
+        return self
+
+
+class ValidationReportOutcome(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    report: ValidationReport
+    idempotent_replay: bool = False
+
+
+__all__ = [
+    "VALIDATION_REPORT_SCHEMA_VERSION",
+    "ValidationCheckStatus",
+    "ValidationFinding",
+    "ValidationFindingDraft",
+    "ValidationFindingKind",
+    "ValidationReport",
+    "ValidationReportDraft",
+    "ValidationReportOutcome",
+    "ValidationReportSummary",
+    "ValidationSeverity",
+]

--- a/blueprint_core/workspaces/validation/service.py
+++ b/blueprint_core/workspaces/validation/service.py
@@ -1,0 +1,212 @@
+"""Atomic persistence boundary for revision-bound validation findings."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Protocol
+from uuid import UUID, uuid4
+
+from blueprint_core.workspaces.projects import ProjectRevision
+from blueprint_core.workspaces.validation.models import (
+    ValidationCheckStatus,
+    ValidationFinding,
+    ValidationReport,
+    ValidationReportDraft,
+    ValidationReportOutcome,
+    ValidationReportSummary,
+)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class ValidationReportRepository(Protocol):
+    def get_project_revision(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        revision: int,
+    ) -> Any | None: ...
+
+    def get_validation_report(self, report_id: str, owner_user_id: str) -> Any | None: ...
+
+    def get_validation_report_by_source_job(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        source_job_id: str,
+    ) -> Any | None: ...
+
+    def insert_project_validation_report(self, record: dict[str, Any]) -> Any | None: ...
+
+
+class ValidationReportError(RuntimeError):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        retryable: bool = False,
+        context: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.retryable = retryable
+        self.context = context or {}
+
+
+def _report_from_record(record: Any) -> ValidationReport:
+    payload = getattr(record, "payload_json", None)
+    if not isinstance(payload, dict):
+        raise ValidationReportError(
+            "invalid_persisted_validation_report",
+            "Persisted validation report payload_json must be an object.",
+        )
+    return ValidationReport.model_validate(payload)
+
+
+class ValidationReportService:
+    def __init__(self, repository: ValidationReportRepository) -> None:
+        self._repository = repository
+
+    def get(self, report_id: str | UUID, owner_user_id: str) -> ValidationReport:
+        record = self._repository.get_validation_report(str(report_id), owner_user_id)
+        if record is None:
+            raise ValidationReportError("validation_report_not_found", "Validation report not found.")
+        return _report_from_record(record)
+
+    def get_by_source_job(
+        self,
+        project_id: str | UUID,
+        owner_user_id: str,
+        source_job_id: str,
+    ) -> ValidationReport | None:
+        record = self._repository.get_validation_report_by_source_job(
+            str(project_id), owner_user_id, source_job_id
+        )
+        return _report_from_record(record) if record is not None else None
+
+    def create_report(
+        self,
+        draft: ValidationReportDraft,
+        revision: ProjectRevision,
+        *,
+        owner_user_id: str,
+        source_job_id: str,
+        revalidation_of_report_id: str | UUID | None = None,
+    ) -> ValidationReportOutcome:
+        owner = str(owner_user_id or "").strip()
+        source_job = str(source_job_id or "").strip()
+        if owner != revision.owner_user_id or not source_job:
+            raise ValidationReportError(
+                "validation_report_identity_mismatch",
+                "Validation report owner and source job must match the project revision execution context.",
+            )
+
+        replay = self.get_by_source_job(revision.project_id, owner, source_job)
+        if replay is not None:
+            self._require_revision_identity(replay, revision)
+            return ValidationReportOutcome(report=replay, idempotent_replay=True)
+
+        parent_report_id: UUID | None = None
+        if revalidation_of_report_id is not None:
+            parent = self.get(revalidation_of_report_id, owner)
+            if parent.project_id != revision.project_id or parent.project_revision >= revision.revision:
+                raise ValidationReportError(
+                    "invalid_revalidation_parent",
+                    "Revalidation must reference an older report for the same project.",
+                )
+            parent_report_id = parent.report_id
+
+        exact_revision = self._repository.get_project_revision(
+            str(revision.project_id), owner, revision.revision
+        )
+        if exact_revision is None:
+            raise ValidationReportError(
+                "project_revision_not_found",
+                "The exact project revision is not available for validation.",
+            )
+
+        now = _utc_now()
+        report_id = uuid4()
+        findings = [
+            ValidationFinding(
+                **finding.model_dump(),
+                finding_id=uuid4(),
+                report_id=report_id,
+                project_id=revision.project_id,
+                project_revision=revision.revision,
+                design_brief_id=revision.design_brief_id,
+                design_brief_version=revision.design_brief_version,
+                created_at=now,
+            )
+            for finding in draft.findings
+        ]
+        summary = ValidationReportSummary(
+            total=len(findings),
+            passed=sum(item.status == ValidationCheckStatus.PASSED for item in findings),
+            warnings=sum(item.status == ValidationCheckStatus.WARNING for item in findings),
+            failed=sum(item.status == ValidationCheckStatus.FAILED for item in findings),
+            skipped=sum(item.status == ValidationCheckStatus.SKIPPED for item in findings),
+        )
+        report = ValidationReport(
+            report_id=report_id,
+            project_id=revision.project_id,
+            owner_user_id=owner,
+            project_revision=revision.revision,
+            design_brief_id=revision.design_brief_id,
+            design_brief_version=revision.design_brief_version,
+            source_job_id=source_job,
+            revalidation_of_report_id=parent_report_id,
+            findings=findings,
+            summary=summary,
+            created_at=now,
+        )
+        record = {
+            "id": str(report.report_id),
+            "project_id": str(report.project_id),
+            "owner_user_id": owner,
+            "project_revision": report.project_revision,
+            "design_brief_id": str(report.design_brief_id),
+            "design_brief_version": report.design_brief_version,
+            "source_job_id": source_job,
+            "revalidation_of_report_id": str(parent_report_id) if parent_report_id else None,
+            "payload_json": report.model_dump(mode="json"),
+            "created_at": now.isoformat(),
+        }
+        saved = self._repository.insert_project_validation_report(record)
+        if saved is not None:
+            return ValidationReportOutcome(report=_report_from_record(saved))
+
+        replay = self.get_by_source_job(revision.project_id, owner, source_job)
+        if replay is not None:
+            self._require_revision_identity(replay, revision)
+            return ValidationReportOutcome(report=replay, idempotent_replay=True)
+        raise ValidationReportError(
+            "validation_report_conflict",
+            "Project revision changed before validation findings could be persisted.",
+            retryable=True,
+            context={"project_id": str(revision.project_id), "revision": revision.revision},
+        )
+
+    @staticmethod
+    def _require_revision_identity(report: ValidationReport, revision: ProjectRevision) -> None:
+        if (
+            report.project_id != revision.project_id
+            or report.project_revision != revision.revision
+            or report.design_brief_id != revision.design_brief_id
+            or report.design_brief_version != revision.design_brief_version
+        ):
+            raise ValidationReportError(
+                "validation_report_idempotency_conflict",
+                "The source job is already attached to a different project revision or DesignBrief.",
+            )
+
+
+__all__ = [
+    "ValidationReportError",
+    "ValidationReportRepository",
+    "ValidationReportService",
+]

--- a/docs/validation-worker.md
+++ b/docs/validation-worker.md
@@ -1,0 +1,28 @@
+# Validation worker
+
+The Validation worker owns the `project.validate` capability. It evaluates one exact canonical project revision against its frozen DesignBrief and persists an immutable `validation-findings.v1` report.
+
+## Contract
+
+The worker accepts `project-revision.v1`. Its optional payload selects baseline checks or links a revalidation to an older report:
+
+```json
+{
+  "requested_checks": ["constraints", "consistency", "assumptions", "criteria"],
+  "revalidation_of_report_id": null
+}
+```
+
+The default rule-based engine checks declared constraints, internal component/net consistency, unresolved questions and assumptions, and DesignBrief validation criteria. An unknown or unsupported check produces a `skipped` finding instead of being treated as a pass.
+
+Each finding carries the exact project revision and DesignBrief identity, criterion, status, severity, affected artifact when available, evidence, and suggested remediation. Status is one of `passed`, `warning`, `failed`, or `skipped`; severity is independently represented as `info`, `warning`, or `error`.
+
+## Revision safety and persistence
+
+`ProjectStateService.get_revision()` loads the requested revision rather than substituting the latest project state. `ValidationReportService` atomically stores findings in `project_validation_reports`, whose `(project_id, project_revision)` foreign key targets `project_revisions`. The insert also verifies the owner and frozen DesignBrief identity.
+
+Reports are immutable and source-job idempotent. Replaying a completed job returns the same report. A revalidation request may reference an older report for the same project, but its new findings attach only to the changed revision; the earlier report remains on its original revision.
+
+`build_validation_request()` is the downstream workflow boundary for requesting validation or revalidation without copying mutable project state into the worker payload.
+
+The baseline evaluator is intentionally not a complete engineering simulator. Domain-specific criteria it cannot support are explicitly skipped and include routing or manual-review remediation.

--- a/docs/worker-orchestration.md
+++ b/docs/worker-orchestration.md
@@ -29,4 +29,4 @@ The `worker_execution_plans` record contains the validated requests and every jo
 
 When all jobs are terminal, the project workflow advances from `building` to `awaiting_feedback` with an idempotent system transition. Both successful and failed terminal plans preserve their results for feedback and diagnosis.
 
-The first production capability on this boundary is the [Generation worker](generation-worker.md), which persists canonical project revision 1 from a frozen DesignBrief.
+Production capabilities on this boundary include the [Generation worker](generation-worker.md), which persists canonical project revision 1 from a frozen DesignBrief, and the [Validation worker](validation-worker.md), which persists actionable findings against an exact revision.

--- a/supabase/migrations/20260801000600_project_validation_reports.sql
+++ b/supabase/migrations/20260801000600_project_validation_reports.sql
@@ -1,0 +1,86 @@
+-- Persist actionable validation findings against exact canonical project revisions.
+
+create table if not exists public.project_validation_reports (
+  id text primary key,
+  project_id text not null,
+  owner_user_id text not null,
+  project_revision integer not null check (project_revision >= 1),
+  design_brief_id text not null,
+  design_brief_version integer not null check (design_brief_version >= 1),
+  source_job_id text not null,
+  revalidation_of_report_id text references public.project_validation_reports(id) on delete set null,
+  payload_json jsonb not null,
+  created_at text not null,
+  constraint project_validation_reports_project_source_job_unique unique (project_id, source_job_id),
+  constraint project_validation_reports_revision_fk foreign key (project_id, project_revision)
+    references public.project_revisions(project_id, revision) on delete cascade
+);
+
+create index if not exists idx_project_validation_reports_owner_project_revision
+  on public.project_validation_reports (owner_user_id, project_id, project_revision desc, created_at desc);
+
+create index if not exists idx_project_validation_reports_design_brief
+  on public.project_validation_reports (design_brief_id, design_brief_version);
+
+create or replace function public.insert_project_validation_report(
+  p_report jsonb
+) returns jsonb
+language plpgsql
+set search_path = public
+as $$
+declare
+  exact_revision public.project_revisions%rowtype;
+  parent_report public.project_validation_reports%rowtype;
+  saved_report public.project_validation_reports%rowtype;
+begin
+  select * into exact_revision
+  from public.project_revisions
+  where project_id = p_report->>'project_id'
+    and owner_user_id = p_report->>'owner_user_id'
+    and revision = (p_report->>'project_revision')::integer
+    and design_brief_id = p_report->>'design_brief_id'
+    and design_brief_version = (p_report->>'design_brief_version')::integer;
+
+  if not found then
+    return null;
+  end if;
+
+  if nullif(p_report->>'revalidation_of_report_id', '') is not null then
+    select * into parent_report
+    from public.project_validation_reports
+    where id = p_report->>'revalidation_of_report_id'
+      and project_id = p_report->>'project_id'
+      and owner_user_id = p_report->>'owner_user_id'
+      and project_revision < (p_report->>'project_revision')::integer;
+    if not found then
+      return null;
+    end if;
+  end if;
+
+  insert into public.project_validation_reports (
+    id, project_id, owner_user_id, project_revision, design_brief_id,
+    design_brief_version, source_job_id, revalidation_of_report_id, payload_json, created_at
+  ) values (
+    p_report->>'id', p_report->>'project_id', p_report->>'owner_user_id',
+    (p_report->>'project_revision')::integer, p_report->>'design_brief_id',
+    (p_report->>'design_brief_version')::integer, p_report->>'source_job_id',
+    nullif(p_report->>'revalidation_of_report_id', ''), p_report->'payload_json', p_report->>'created_at'
+  ) returning * into saved_report;
+
+  return to_jsonb(saved_report);
+exception
+  when unique_violation or foreign_key_violation then
+    return null;
+end;
+$$;
+
+alter table public.project_validation_reports enable row level security;
+
+revoke all on table public.project_validation_reports from anon, authenticated;
+grant select, insert, delete on table public.project_validation_reports to service_role;
+
+revoke all on function public.insert_project_validation_report(jsonb) from public, anon, authenticated;
+grant execute on function public.insert_project_validation_report(jsonb) to service_role;
+
+comment on table public.project_validation_reports is
+  'Immutable actionable validation findings bound to exact canonical project and DesignBrief revisions.';

--- a/tests/agents/test_validation_worker.py
+++ b/tests/agents/test_validation_worker.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from blueprint_core.persistence.models import DBProjectRevision
+from blueprint_core.persistence.providers import create_sqlite_provider
+from blueprint_core.persistence.repositories import SqlAlchemyRepository
+from blueprint_core.workers import (
+    VALIDATION_CAPABILITY_ID,
+    VALIDATION_INPUT_VERSION,
+    VALIDATION_WORKER_ID,
+    WORKER_CONTRACT_VERSION,
+    ValidationWorker,
+    WorkerOrchestrator,
+    WorkerPlanStatus,
+    WorkerRegistry,
+    WorkerRequest,
+    build_validation_request,
+)
+from blueprint_core.workspaces.design_briefs import DESIGN_BRIEF_SCHEMA_VERSION, DesignBrief
+from blueprint_core.workspaces.projects import (
+    ProjectArtifact,
+    ProjectRevision,
+    ProjectRevisionDraft,
+    ProjectStateService,
+)
+from blueprint_core.workspaces.projects.models import (
+    ComponentInstance,
+    HardwareIR,
+    ProjectOverview,
+    ValidationIssue,
+    ValidationSummary,
+)
+from blueprint_core.workspaces.validation import (
+    ValidationCheckStatus,
+    ValidationFindingDraft,
+    ValidationFindingKind,
+    ValidationReportDraft,
+    ValidationReportService,
+    ValidationSeverity,
+)
+from blueprint_core.workspaces.workflow import (
+    ProjectWorkflowService,
+    ProjectWorkflowState,
+    WorkflowActorType,
+)
+
+
+OWNER = "validation-worker-user"
+
+
+class CountingValidationEngine:
+    def __init__(self, draft: ValidationReportDraft | None = None, *, fail: bool = False) -> None:
+        self.draft = draft
+        self.fail = fail
+        self.calls = 0
+
+    def validate(
+        self,
+        revision: ProjectRevision,
+        design_brief: DesignBrief,
+        requested_checks: list[str],
+    ) -> ValidationReportDraft:
+        self.calls += 1
+        if self.fail:
+            raise TimeoutError("validation provider timed out")
+        if self.draft is not None:
+            return self.draft
+        raise AssertionError("CountingValidationEngine requires a draft")
+
+
+class ValidationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.directory = tempfile.TemporaryDirectory()
+        provider = create_sqlite_provider(
+            source="validation worker test",
+            url=f"sqlite:///{Path(self.directory.name) / 'blueprint.db'}",
+            import_legacy_jobs=False,
+        )
+        provider.initialize()
+        self.session_factory = provider.session_factory
+        self.repository = SqlAlchemyRepository(provider.session_factory)
+        self.state = ProjectStateService(self.repository)
+        self.reports = ValidationReportService(self.repository)
+        self.workflow = ProjectWorkflowService(self.repository)
+        self.project_id = uuid.uuid4()
+        self.brief = self._persist_brief()
+        self.revision = self._persist_initial_revision()
+        self.workflow.initialize(str(self.project_id), OWNER)
+        self.workflow.transition(
+            str(self.project_id),
+            OWNER,
+            ProjectWorkflowState.BUILDING,
+            actor_type=WorkflowActorType.USER,
+            actor_id=OWNER,
+            reason="Start Validation worker test.",
+        )
+
+    def tearDown(self) -> None:
+        self.directory.cleanup()
+
+    def _persist_brief(self) -> DesignBrief:
+        brief = DesignBrief(
+            schema_version=DESIGN_BRIEF_SCHEMA_VERSION,
+            conversation_id="conversation-validation",
+            intent="Build a safe USB controller",
+            summary="A USB-powered controller with one component.",
+            requirements=["Control one output"],
+            constraints=["Use 5 V USB input"],
+            requested_outputs=["wiring", "bom"],
+            validation_criteria=[
+                "At least one component is selected",
+                "No critical validation issues remain",
+                "Enclosure survives a lunar dust cyclone",
+            ],
+            unresolved_questions=[],
+            assumptions=[],
+            readiness="ready",
+            design_brief_id=uuid.uuid4(),
+            project_id=self.project_id,
+            brief_version=1,
+            created_at=datetime.now(timezone.utc),
+        )
+        self.repository.insert_design_brief_version({
+            "id": str(uuid.uuid4()),
+            "design_brief_id": str(brief.design_brief_id),
+            "project_id": str(brief.project_id),
+            "conversation_id": brief.conversation_id,
+            "owner_user_id": OWNER,
+            "brief_version": brief.brief_version,
+            "schema_version": brief.schema_version,
+            "previous_version": brief.previous_version,
+            "payload_json": brief.model_dump(mode="json"),
+            "created_at": brief.created_at.isoformat(),
+        })
+        return brief
+
+    def _draft(self) -> ProjectRevisionDraft:
+        component = ComponentInstance(
+            ref_des="U1",
+            part_number="TEST-MCU",
+            name="Test controller",
+            category="Microcontroller",
+            rationale="Provides the requested control function.",
+        )
+        state = HardwareIR(
+            overview=ProjectOverview(
+                title="Validation fixture",
+                description="Fixture with deliberately mixed validation results.",
+                difficulty="Intermediate",
+                category="IoT",
+            ),
+            components=[component],
+            constraints=["Use 5 V USB input"],
+            validation=ValidationSummary(critical=[ValidationIssue(
+                severity="CRITICAL",
+                category="Safety Block",
+                description="Output protection has not been selected.",
+                troubleshooting="Add output protection.",
+            )]),
+            is_valid=False,
+        )
+        return ProjectRevisionDraft(
+            state=state,
+            components=[component],
+            artifacts=[ProjectArtifact(
+                artifact_id="state-r1",
+                kind="project-state",
+                uri=f"forma://projects/{self.project_id}/revisions/1/state",
+            )],
+            assumptions=["The actuator draws less than 500 mA."],
+        )
+
+    def _persist_initial_revision(self) -> ProjectRevision:
+        return self.state.create_initial_revision(
+            self._draft(),
+            project_id=self.project_id,
+            owner_user_id=OWNER,
+            design_brief_id=self.brief.design_brief_id,
+            design_brief_version=1,
+            source_job_id="job-generation-r1",
+        ).revision
+
+    def _request(
+        self,
+        *,
+        job_id: str = "job-validation-r1",
+        revision: int = 1,
+        payload: dict[str, Any] | None = None,
+    ) -> WorkerRequest:
+        return WorkerRequest(
+            contract_version=WORKER_CONTRACT_VERSION,
+            project_id=self.project_id,
+            project_revision=revision,
+            design_brief_id=self.brief.design_brief_id,
+            design_brief_version=1,
+            job_id=job_id,
+            correlation_id="corr-validation",
+            worker_id=VALIDATION_WORKER_ID,
+            capability_id=VALIDATION_CAPABILITY_ID,
+            input_contract_version=VALIDATION_INPUT_VERSION,
+            payload=payload or {},
+        )
+
+    def _persist_revision_two(self) -> ProjectRevision:
+        payload = self.revision.model_dump(mode="json")
+        payload.update({
+            "revision_id": str(uuid.uuid4()),
+            "revision": 2,
+            "parent_revision": 1,
+            "source_job_id": "job-edit-r2",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        })
+        payload["state"]["assembly_metadata"].update({"revision": 2, "source_job_id": "job-edit-r2"})
+        payload["assumptions"] = []
+        revision = ProjectRevision.model_validate(payload)
+        with self.session_factory() as session:
+            session.add(DBProjectRevision(
+                id=str(revision.revision_id),
+                project_id=str(revision.project_id),
+                owner_user_id=OWNER,
+                revision=2,
+                parent_revision=1,
+                design_brief_id=str(revision.design_brief_id),
+                design_brief_version=revision.design_brief_version,
+                source_job_id=revision.source_job_id,
+                payload_json=revision.model_dump(mode="json"),
+                created_at=revision.created_at.isoformat(),
+            ))
+            session.commit()
+        return revision
+
+    async def test_worker_persists_revision_bound_pass_warning_failure_and_skipped_findings(self) -> None:
+        worker = ValidationWorker(self.state, self.reports)
+        registration = WorkerRegistry([worker]).resolve(VALIDATION_WORKER_ID, VALIDATION_CAPABILITY_ID)
+        orchestrator = WorkerOrchestrator(self.repository, [worker], workflow_service=self.workflow)
+        plan = orchestrator.create_plan([self._request()], OWNER)
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+        result = completed.jobs["job-validation-r1"].result
+        report = self.reports.get_by_source_job(self.project_id, OWNER, "job-validation-r1")
+
+        self.assertEqual(WorkerPlanStatus.SUCCEEDED, completed.status)
+        self.assertEqual(VALIDATION_INPUT_VERSION, registration.capability.supported_input_versions[0])
+        self.assertIsNotNone(report)
+        self.assertEqual(1, report.project_revision)
+        self.assertEqual(self.brief.design_brief_id, report.design_brief_id)
+        self.assertGreater(report.summary.passed, 0)
+        self.assertGreater(report.summary.warnings, 0)
+        self.assertGreater(report.summary.failed, 0)
+        self.assertGreater(report.summary.skipped, 0)
+        self.assertEqual(str(report.report_id), result.output["validation_report"]["report_id"])
+        self.assertEqual("validation-report", result.artifacts[0].kind)
+        for finding in report.findings:
+            self.assertEqual(1, finding.project_revision)
+            self.assertTrue(finding.criterion)
+            self.assertTrue(finding.evidence)
+            self.assertTrue(finding.remediation)
+            self.assertIn(finding.severity, list(ValidationSeverity))
+
+    async def test_exact_missing_revision_fails_without_attaching_to_latest(self) -> None:
+        worker = ValidationWorker(self.state, self.reports)
+        orchestrator = WorkerOrchestrator(self.repository, [worker], workflow_service=self.workflow)
+        plan = orchestrator.create_plan([self._request(revision=2)], OWNER)
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+        result = completed.jobs["job-validation-r1"].result
+
+        self.assertEqual(WorkerPlanStatus.FAILED, completed.status)
+        self.assertEqual("project_revision_not_found", result.error.code)
+        self.assertIsNone(self.reports.get_by_source_job(self.project_id, OWNER, "job-validation-r1"))
+
+    async def test_source_job_replay_returns_same_report_without_rerunning_engine(self) -> None:
+        draft = ValidationReportDraft(findings=[ValidationFindingDraft(
+            criterion_id="fixture:pass",
+            criterion="Fixture check passes",
+            kind=ValidationFindingKind.REQUESTED_CHECK,
+            status=ValidationCheckStatus.PASSED,
+            severity=ValidationSeverity.INFO,
+            evidence=["The fixture passed."],
+            remediation="No action required.",
+        )])
+        engine = CountingValidationEngine(draft)
+        worker = ValidationWorker(self.state, self.reports, engine)
+        request = self._request().model_copy(update={"metadata": {"execution_owner_user_id": OWNER}})
+
+        async def progress(_: Any) -> None:
+            return None
+
+        first = await worker.execute(request, progress)
+        second = await worker.execute(request, progress)
+
+        self.assertEqual("succeeded", first.status.value)
+        self.assertEqual("succeeded", second.status.value)
+        self.assertFalse(first.output["idempotent_replay"])
+        self.assertTrue(second.output["idempotent_replay"])
+        self.assertEqual(first.output["validation_report"]["report_id"], second.output["validation_report"]["report_id"])
+        self.assertEqual(1, engine.calls)
+
+    async def test_downstream_request_revalidates_changed_revision_without_moving_old_report(self) -> None:
+        worker = ValidationWorker(self.state, self.reports)
+        orchestrator = WorkerOrchestrator(self.repository, [worker], workflow_service=self.workflow)
+        first_plan = orchestrator.create_plan([self._request()], OWNER)
+        await orchestrator.execute(first_plan.plan_id, OWNER)
+        first_report = self.reports.get_by_source_job(self.project_id, OWNER, "job-validation-r1")
+        revision_two = self._persist_revision_two()
+        request = build_validation_request(
+            revision_two,
+            job_id="job-validation-r2",
+            correlation_id="corr-revalidation",
+            revalidation_of_report_id=first_report.report_id,
+        )
+        second_plan = orchestrator.create_plan([request], OWNER)
+
+        completed = await orchestrator.execute(second_plan.plan_id, OWNER)
+        second_report = self.reports.get_by_source_job(self.project_id, OWNER, "job-validation-r2")
+        unchanged_first = self.reports.get(first_report.report_id, OWNER)
+
+        self.assertEqual(WorkerPlanStatus.SUCCEEDED, completed.status)
+        self.assertEqual(2, second_report.project_revision)
+        self.assertEqual(first_report.report_id, second_report.revalidation_of_report_id)
+        self.assertEqual(1, unchanged_first.project_revision)
+        self.assertNotEqual(first_report.report_id, second_report.report_id)
+
+    async def test_unsupported_requested_check_is_explicitly_skipped(self) -> None:
+        worker = ValidationWorker(self.state, self.reports)
+        orchestrator = WorkerOrchestrator(self.repository, [worker], workflow_service=self.workflow)
+        plan = orchestrator.create_plan([
+            self._request(payload={"requested_checks": ["thermal-vacuum"]})
+        ], OWNER)
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+        report = self.reports.get_by_source_job(self.project_id, OWNER, "job-validation-r1")
+
+        self.assertEqual(WorkerPlanStatus.SUCCEEDED, completed.status)
+        self.assertEqual(1, report.summary.skipped)
+        self.assertEqual(ValidationCheckStatus.SKIPPED, report.findings[0].status)
+        self.assertIn("not supported", report.findings[0].evidence[0])
+
+    async def test_engine_failure_is_structured_and_retryable(self) -> None:
+        worker = ValidationWorker(self.state, self.reports, CountingValidationEngine(fail=True))
+        orchestrator = WorkerOrchestrator(self.repository, [worker], workflow_service=self.workflow)
+        plan = orchestrator.create_plan([self._request()], OWNER)
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+        result = completed.jobs["job-validation-r1"].result
+
+        self.assertEqual(WorkerPlanStatus.FAILED, completed.status)
+        self.assertEqual("validation_failed", result.error.code)
+        self.assertTrue(result.error.retryable)
+        self.assertIn("timed out", result.error.message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #189

## Summary
- register the `project.validate` capability with revision-bound worker request/result contracts
- evaluate constraints, consistency, assumptions, criteria, and explicit unsupported checks
- persist immutable actionable findings against the exact project and DesignBrief revision
- support idempotent execution and downstream revalidation linked to an older report
- add SQLite/Supabase repository support, migration, documentation, and integration coverage

## Verification
- `CLOUDFLARE_ENABLE_THINKING=false ./scripts/quality/test.sh` (422 passed, 1 skipped)
- `supabase migration up --local`
- `supabase db lint --local --level error`