### PR TITLE
Implement the Reverse-Engineering worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,7 @@ Tip: load an example directly with http://localhost:3000/?example=pocket_mp3_pla
 - [Dependency-aware worker orchestration](docs/worker-orchestration.md)
 - [Generation worker and canonical project revisions](docs/generation-worker.md)
 - [Validation worker and revision-bound findings](docs/validation-worker.md)
+- [Reverse-Engineering worker and artifact findings](docs/reverse-engineering-worker.md)
 - [Project workflow state machine](docs/project-workflow.md)
 - [Conversational context gathering](docs/context-gathering.md)
 - [Project readiness and build initiation](docs/project-readiness.md)

--- a/blueprint_core/workers/__init__.py
+++ b/blueprint_core/workers/__init__.py
@@ -51,6 +51,17 @@ from blueprint_core.workers.validation import (
     ValidationWorkerPayload,
     build_validation_request,
 )
+from blueprint_core.workers.reverse_engineering import (
+    REVERSE_ENGINEERING_CAPABILITY_ID,
+    REVERSE_ENGINEERING_INPUT_VERSION,
+    REVERSE_ENGINEERING_OUTPUT_VERSION,
+    REVERSE_ENGINEERING_WORKER_ID,
+    InlineImageInspectionEngine,
+    ReverseEngineeringEngine,
+    ReverseEngineeringWorker,
+    ReverseEngineeringWorkerPayload,
+    build_reverse_engineering_request,
+)
 
 __all__ = [
     "WORKER_CONTRACT_VERSION",
@@ -63,6 +74,14 @@ __all__ = [
     "GenerationWorker",
     "GenerationWorkerPayload",
     "HardwareIRGenerationEngine",
+    "InlineImageInspectionEngine",
+    "REVERSE_ENGINEERING_CAPABILITY_ID",
+    "REVERSE_ENGINEERING_INPUT_VERSION",
+    "REVERSE_ENGINEERING_OUTPUT_VERSION",
+    "REVERSE_ENGINEERING_WORKER_ID",
+    "ReverseEngineeringEngine",
+    "ReverseEngineeringWorker",
+    "ReverseEngineeringWorkerPayload",
     "RuleBasedValidationEngine",
     "VALIDATION_CAPABILITY_ID",
     "VALIDATION_INPUT_VERSION",
@@ -95,5 +114,6 @@ __all__ = [
     "WorkerResult",
     "WorkerResultStatus",
     "build_generation_draft",
+    "build_reverse_engineering_request",
     "build_validation_request",
 ]

--- a/blueprint_core/workers/reverse_engineering.py
+++ b/blueprint_core/workers/reverse_engineering.py
@@ -1,0 +1,272 @@
+"""Reverse-Engineering worker for bounded, non-mutating artifact inspection."""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Awaitable, Callable, Protocol
+
+from pydantic import BaseModel, ConfigDict, ValidationError
+
+from blueprint_core.workers.contracts import (
+    WORKER_CONTRACT_VERSION,
+    WorkerArtifact,
+    WorkerError,
+    WorkerProgress,
+    WorkerRequest,
+    WorkerResult,
+    WorkerResultStatus,
+)
+from blueprint_core.workers.registry import WorkerCapability, WorkerDefinition
+from blueprint_core.workspaces.design_briefs import DesignBrief
+from blueprint_core.workspaces.projects import ProjectStateError, ProjectStateService
+from blueprint_core.workspaces.reverse_engineering import (
+    SUPPORTED_IMAGE_MEDIA_TYPES,
+    ReverseEngineeringArtifactReference,
+    ReverseEngineeringError,
+    ReverseEngineeringReport,
+    ReverseEngineeringReportDraft,
+    inspect_inline_image,
+)
+
+
+REVERSE_ENGINEERING_WORKER_ID = "reverse-engineering-worker"
+REVERSE_ENGINEERING_CAPABILITY_ID = "artifact.reverse-engineer"
+REVERSE_ENGINEERING_INPUT_VERSION = "artifact-reference.v1"
+REVERSE_ENGINEERING_OUTPUT_VERSION = "reverse-engineering-findings.v1"
+
+
+class ReverseEngineeringWorkerPayload(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    artifact: ReverseEngineeringArtifactReference
+    design_brief: DesignBrief
+
+
+class ReverseEngineeringEngine(Protocol):
+    def inspect(
+        self,
+        artifact: ReverseEngineeringArtifactReference,
+        design_brief: DesignBrief,
+    ) -> ReverseEngineeringReportDraft | Awaitable[ReverseEngineeringReportDraft]: ...
+
+
+class InlineImageInspectionEngine:
+    """Local baseline that extracts defensible raster evidence without claiming semantic vision."""
+
+    def inspect(
+        self,
+        artifact: ReverseEngineeringArtifactReference,
+        design_brief: DesignBrief,
+    ) -> ReverseEngineeringReportDraft:
+        return inspect_inline_image(artifact, design_brief)
+
+
+ProgressReporter = Callable[[WorkerProgress], Awaitable[None]]
+
+
+class ReverseEngineeringWorker:
+    def __init__(
+        self,
+        project_state: ProjectStateService,
+        engine: ReverseEngineeringEngine | None = None,
+    ) -> None:
+        self._project_state = project_state
+        self._engine = engine or InlineImageInspectionEngine()
+
+    def worker_definition(self) -> WorkerDefinition:
+        return WorkerDefinition(
+            worker_id=REVERSE_ENGINEERING_WORKER_ID,
+            name="Forma Reverse-Engineering Worker",
+            worker_version="1.0.0",
+            capabilities=[WorkerCapability(
+                capability_id=REVERSE_ENGINEERING_CAPABILITY_ID,
+                description="Inspect a supplied artifact and return evidence-linked structured inferences.",
+                supported_input_versions=[REVERSE_ENGINEERING_INPUT_VERSION],
+                supported_output_versions=[REVERSE_ENGINEERING_OUTPUT_VERSION],
+                metadata={"supported_media_types": sorted(SUPPORTED_IMAGE_MEDIA_TYPES)},
+            )],
+        )
+
+    async def execute(self, request: WorkerRequest, report_progress: ProgressReporter) -> WorkerResult:
+        try:
+            payload = ReverseEngineeringWorkerPayload.model_validate(request.payload)
+            _require_request_identity(request, payload.design_brief)
+            owner = str(request.metadata.get("execution_owner_user_id") or "").strip()
+            if not owner:
+                raise ReverseEngineeringError(
+                    "reverse_engineering_owner_missing",
+                    "Reverse-engineering execution is missing its owner scope.",
+                )
+            payload.design_brief = self._project_state.require_frozen_design_brief(
+                payload.design_brief,
+                owner,
+            )
+        except ValidationError as exc:
+            errors = [
+                {"location": list(item["loc"]), "type": item["type"], "message": item["msg"]}
+                for item in exc.errors(include_url=False, include_input=False)
+            ]
+            return _failure_result(
+                request,
+                ReverseEngineeringError(
+                    "invalid_reverse_engineering_request",
+                    "Reverse-engineering payload is invalid.",
+                    context={"validation_errors": errors},
+                ),
+                retryable=False,
+            )
+        except (ProjectStateError, ReverseEngineeringError, ValueError) as exc:
+            return _failure_result(request, exc, retryable=False)
+
+        try:
+            await report_progress(WorkerProgress(
+                **_worker_context(request),
+                sequence=1,
+                status="running",
+                percent_complete=15,
+                message=f"Inspecting artifact {payload.artifact.artifact_id}.",
+            ))
+            candidate = self._engine.inspect(payload.artifact, payload.design_brief)
+            draft = await candidate if inspect.isawaitable(candidate) else candidate
+            try:
+                draft = ReverseEngineeringReportDraft.model_validate(draft)
+            except ValidationError as exc:
+                raise ReverseEngineeringError(
+                    "invalid_reverse_engineering_output",
+                    "Reverse-engineering engine returned an invalid findings contract.",
+                    retryable=True,
+                    context={"validation_error_count": exc.error_count()},
+                ) from exc
+            report = ReverseEngineeringReport(
+                **draft.model_dump(),
+                project_id=request.project_id,
+                project_revision=request.project_revision,
+                design_brief_id=request.design_brief_id,
+                design_brief_version=request.design_brief_version,
+            )
+            await report_progress(WorkerProgress(
+                **_worker_context(request),
+                sequence=2,
+                status="running",
+                percent_complete=90,
+                message="Validated evidence links and uncertainty declarations.",
+            ))
+        except ReverseEngineeringError as exc:
+            return _failure_result(request, exc, retryable=exc.retryable)
+        except Exception as exc:
+            return _failure_result(request, exc, retryable=True)
+        return _success_result(request, report)
+
+
+def build_reverse_engineering_request(
+    design_brief: DesignBrief,
+    artifact: ReverseEngineeringArtifactReference,
+    *,
+    project_revision: int,
+    job_id: str,
+    correlation_id: str,
+) -> WorkerRequest:
+    return WorkerRequest(
+        contract_version=WORKER_CONTRACT_VERSION,
+        project_id=design_brief.project_id,
+        project_revision=project_revision,
+        design_brief_id=design_brief.design_brief_id,
+        design_brief_version=design_brief.brief_version,
+        job_id=job_id,
+        correlation_id=correlation_id,
+        worker_id=REVERSE_ENGINEERING_WORKER_ID,
+        capability_id=REVERSE_ENGINEERING_CAPABILITY_ID,
+        input_contract_version=REVERSE_ENGINEERING_INPUT_VERSION,
+        payload=ReverseEngineeringWorkerPayload(
+            artifact=artifact,
+            design_brief=design_brief,
+        ).model_dump(mode="json"),
+    )
+
+
+def _require_request_identity(request: WorkerRequest, brief: DesignBrief) -> None:
+    if (
+        brief.project_id != request.project_id
+        or brief.design_brief_id != request.design_brief_id
+        or brief.brief_version != request.design_brief_version
+    ):
+        raise ReverseEngineeringError(
+            "reverse_engineering_context_mismatch",
+            "Reverse-engineering request identity does not match its frozen DesignBrief.",
+        )
+
+
+def _success_result(request: WorkerRequest, report: ReverseEngineeringReport) -> WorkerResult:
+    context = _worker_context(request)
+    artifact = WorkerArtifact(
+        **context,
+        artifact_id=f"reverse-engineering-{request.job_id}",
+        kind="reverse-engineering-findings",
+        uri=f"forma://worker-plans/{request.correlation_id}/jobs/{request.job_id}/result",
+        media_type="application/vnd.forma.reverse-engineering-findings+json",
+        checksum=report.artifact.content_sha256,
+        metadata={
+            "source_artifact_id": report.artifact.artifact_id,
+            "finding_count": len(report.findings),
+            "ambiguous": report.ambiguous,
+        },
+    )
+    return WorkerResult(
+        **context,
+        output_contract_version=REVERSE_ENGINEERING_OUTPUT_VERSION,
+        status=WorkerResultStatus.SUCCEEDED,
+        output={
+            "reverse_engineering_report": report.model_dump(mode="json"),
+            "evidence": [item.model_dump(mode="json") for item in report.evidence],
+            "findings": [item.model_dump(mode="json") for item in report.findings],
+            "ambiguous": report.ambiguous,
+        },
+        artifacts=[artifact],
+    )
+
+
+def _worker_context(request: WorkerRequest) -> dict[str, Any]:
+    return request.model_dump(include={
+        "contract_version",
+        "project_id",
+        "project_revision",
+        "design_brief_id",
+        "design_brief_version",
+        "job_id",
+        "correlation_id",
+        "worker_id",
+        "capability_id",
+    })
+
+
+def _failure_result(request: WorkerRequest, exc: Exception, *, retryable: bool) -> WorkerResult:
+    context = _worker_context(request)
+    error = WorkerError(
+        **context,
+        code=str(getattr(exc, "code", "reverse_engineering_failed")),
+        message=str(getattr(exc, "message", "") or str(exc) or exc.__class__.__name__),
+        retryable=retryable,
+        details={
+            "exception_type": exc.__class__.__name__,
+            "context": dict(getattr(exc, "context", {}) or {}),
+        },
+    )
+    return WorkerResult(
+        **context,
+        output_contract_version=REVERSE_ENGINEERING_OUTPUT_VERSION,
+        status=WorkerResultStatus.FAILED,
+        error=error,
+    )
+
+
+__all__ = [
+    "REVERSE_ENGINEERING_CAPABILITY_ID",
+    "REVERSE_ENGINEERING_INPUT_VERSION",
+    "REVERSE_ENGINEERING_OUTPUT_VERSION",
+    "REVERSE_ENGINEERING_WORKER_ID",
+    "InlineImageInspectionEngine",
+    "ReverseEngineeringEngine",
+    "ReverseEngineeringWorker",
+    "ReverseEngineeringWorkerPayload",
+    "build_reverse_engineering_request",
+]

--- a/blueprint_core/workspaces/reverse_engineering/__init__.py
+++ b/blueprint_core/workspaces/reverse_engineering/__init__.py
@@ -1,0 +1,37 @@
+from blueprint_core.workspaces.reverse_engineering.analyzer import (
+    MAX_ARTIFACT_BYTES,
+    MAX_IMAGE_PIXELS,
+    SUPPORTED_IMAGE_MEDIA_TYPES,
+    ReverseEngineeringError,
+    inspect_inline_image,
+)
+from blueprint_core.workspaces.reverse_engineering.models import (
+    REVERSE_ENGINEERING_REPORT_SCHEMA_VERSION,
+    AnalyzedArtifact,
+    ReverseEngineeringArtifactReference,
+    ReverseEngineeringConfidence,
+    ReverseEngineeringEvidence,
+    ReverseEngineeringEvidenceSource,
+    ReverseEngineeringFinding,
+    ReverseEngineeringFindingKind,
+    ReverseEngineeringReport,
+    ReverseEngineeringReportDraft,
+)
+
+__all__ = [
+    "MAX_ARTIFACT_BYTES",
+    "MAX_IMAGE_PIXELS",
+    "SUPPORTED_IMAGE_MEDIA_TYPES",
+    "REVERSE_ENGINEERING_REPORT_SCHEMA_VERSION",
+    "AnalyzedArtifact",
+    "ReverseEngineeringArtifactReference",
+    "ReverseEngineeringConfidence",
+    "ReverseEngineeringEvidence",
+    "ReverseEngineeringEvidenceSource",
+    "ReverseEngineeringFinding",
+    "ReverseEngineeringFindingKind",
+    "ReverseEngineeringReport",
+    "ReverseEngineeringReportDraft",
+    "ReverseEngineeringError",
+    "inspect_inline_image",
+]

--- a/blueprint_core/workspaces/reverse_engineering/analyzer.py
+++ b/blueprint_core/workspaces/reverse_engineering/analyzer.py
@@ -1,0 +1,246 @@
+"""Bounded local inspection for inline raster image artifacts."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import re
+from io import BytesIO
+
+from PIL import Image, ImageChops, UnidentifiedImageError
+
+from blueprint_core.workspaces.design_briefs import DesignBrief
+from blueprint_core.workspaces.reverse_engineering.models import (
+    AnalyzedArtifact,
+    ReverseEngineeringArtifactReference,
+    ReverseEngineeringConfidence,
+    ReverseEngineeringEvidence,
+    ReverseEngineeringEvidenceSource,
+    ReverseEngineeringFinding,
+    ReverseEngineeringFindingKind,
+    ReverseEngineeringReportDraft,
+)
+
+
+SUPPORTED_IMAGE_MEDIA_TYPES = frozenset({"image/jpeg", "image/png", "image/webp"})
+MAX_ARTIFACT_BYTES = 10 * 1024 * 1024
+MAX_IMAGE_PIXELS = 25_000_000
+_DATA_URI = re.compile(r"^data:(?P<media_type>[^;,]+);base64,(?P<data>.+)$", re.DOTALL)
+_FORMAT_MEDIA_TYPES = {"JPEG": "image/jpeg", "PNG": "image/png", "WEBP": "image/webp"}
+
+
+class ReverseEngineeringError(RuntimeError):
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        retryable: bool = False,
+        context: dict[str, object] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.retryable = retryable
+        self.context = context or {}
+
+
+def _decode_image(reference: ReverseEngineeringArtifactReference) -> tuple[bytes, Image.Image, str]:
+    claimed_media_type = reference.media_type.split(";", 1)[0].strip().lower()
+    if claimed_media_type not in SUPPORTED_IMAGE_MEDIA_TYPES:
+        raise ReverseEngineeringError(
+            "unsupported_reverse_engineering_artifact",
+            f"Artifact media type '{claimed_media_type}' is not supported.",
+            context={"supported_media_types": sorted(SUPPORTED_IMAGE_MEDIA_TYPES)},
+        )
+    match = _DATA_URI.fullmatch(reference.uri)
+    if match is None:
+        raise ReverseEngineeringError(
+            "artifact_content_unavailable",
+            "The baseline Reverse-Engineering worker requires an inline base64 image data URI.",
+            context={"artifact_id": reference.artifact_id},
+        )
+    data_media_type = match.group("media_type").strip().lower()
+    if data_media_type != claimed_media_type:
+        raise ReverseEngineeringError(
+            "artifact_media_type_mismatch",
+            "Artifact media type does not match its inline data URI.",
+            context={"claimed_media_type": claimed_media_type, "data_media_type": data_media_type},
+        )
+    encoded = match.group("data")
+    if len(encoded) > (MAX_ARTIFACT_BYTES * 4 // 3) + 8:
+        raise ReverseEngineeringError(
+            "reverse_engineering_artifact_too_large",
+            "Artifact exceeds the maximum supported inline image size.",
+            context={"max_bytes": MAX_ARTIFACT_BYTES},
+        )
+    try:
+        content = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ReverseEngineeringError(
+            "invalid_reverse_engineering_artifact",
+            "Artifact data URI does not contain valid base64 image data.",
+        ) from exc
+    if not content or len(content) > MAX_ARTIFACT_BYTES:
+        raise ReverseEngineeringError(
+            "reverse_engineering_artifact_too_large",
+            "Artifact is empty or exceeds the maximum supported inline image size.",
+            context={"max_bytes": MAX_ARTIFACT_BYTES},
+        )
+    try:
+        with Image.open(BytesIO(content)) as opened:
+            actual_media_type = _FORMAT_MEDIA_TYPES.get(str(opened.format or "").upper())
+            if actual_media_type is None or actual_media_type != claimed_media_type:
+                raise ReverseEngineeringError(
+                    "artifact_media_type_mismatch",
+                    "Decoded image format does not match the declared artifact media type.",
+                    context={
+                        "claimed_media_type": claimed_media_type,
+                        "decoded_media_type": actual_media_type,
+                    },
+                )
+            width, height = opened.size
+            if width <= 0 or height <= 0 or width * height > MAX_IMAGE_PIXELS:
+                raise ReverseEngineeringError(
+                    "reverse_engineering_artifact_too_large",
+                    "Decoded image dimensions exceed the supported inspection limit.",
+                    context={"max_pixels": MAX_IMAGE_PIXELS, "width": width, "height": height},
+                )
+            opened.load()
+            image = opened.convert("RGB")
+    except ReverseEngineeringError:
+        raise
+    except Image.DecompressionBombError as exc:
+        raise ReverseEngineeringError(
+            "reverse_engineering_artifact_too_large",
+            "Decoded image dimensions exceed the supported inspection limit.",
+            context={"max_pixels": MAX_IMAGE_PIXELS},
+        ) from exc
+    except (UnidentifiedImageError, OSError, ValueError) as exc:
+        raise ReverseEngineeringError(
+            "invalid_reverse_engineering_artifact",
+            "Artifact bytes could not be decoded as a supported image.",
+        ) from exc
+    return content, image, claimed_media_type
+
+
+def inspect_inline_image(
+    reference: ReverseEngineeringArtifactReference,
+    design_brief: DesignBrief,
+) -> ReverseEngineeringReportDraft:
+    content, image, media_type = _decode_image(reference)
+    width, height = image.size
+    grayscale = image.convert("L")
+    minimum, maximum = grayscale.getextrema()
+    tonal_span = maximum - minimum
+    background = Image.new("RGB", image.size, image.getpixel((0, 0)))
+    foreground_box = ImageChops.difference(image, background).getbbox()
+    ambiguous = foreground_box is None or tonal_span < 12
+
+    evidence = [
+        ReverseEngineeringEvidence(
+            evidence_id="artifact-format",
+            source=ReverseEngineeringEvidenceSource.ARTIFACT,
+            observation=f"Decoded {media_type} image is {width} by {height} pixels.",
+            method="Verified image decoder metadata.",
+        ),
+        ReverseEngineeringEvidence(
+            evidence_id="artifact-tonal-range",
+            source=ReverseEngineeringEvidenceSource.ARTIFACT,
+            observation=f"Grayscale tonal range spans {tonal_span} levels ({minimum} to {maximum}).",
+            method="Computed extrema after grayscale conversion.",
+        ),
+        ReverseEngineeringEvidence(
+            evidence_id="brief-intent",
+            source=ReverseEngineeringEvidenceSource.DESIGN_BRIEF,
+            observation=f"Frozen DesignBrief intent: {design_brief.intent}",
+            method="Read exact persisted DesignBrief context.",
+        ),
+    ]
+
+    orientation = "square" if width == height else ("landscape" if width > height else "portrait")
+    findings = [
+        ReverseEngineeringFinding(
+            finding_id="property-image-envelope",
+            kind=ReverseEngineeringFindingKind.PROPERTY,
+            inference=f"The supplied artifact is a {orientation} raster image with a {width}:{height} pixel envelope.",
+            evidence_ids=["artifact-format"],
+            confidence=ReverseEngineeringConfidence.HIGH,
+            uncertainties=["Pixel dimensions do not establish real-world physical dimensions or scale."],
+        )
+    ]
+    if ambiguous:
+        findings.append(ReverseEngineeringFinding(
+            finding_id="structure-foreground",
+            kind=ReverseEngineeringFindingKind.STRUCTURE,
+            inference="No distinct foreground structure can be resolved from the supplied raster evidence.",
+            evidence_ids=["artifact-tonal-range"],
+            confidence=ReverseEngineeringConfidence.LOW,
+            uncertainties=[
+                "Low contrast or a uniform background prevents reliable part, boundary, and connection inference."
+            ],
+        ))
+    else:
+        left, top, right, bottom = foreground_box
+        box_area = (right - left) * (bottom - top)
+        coverage = round(box_area / (width * height) * 100, 1)
+        evidence.append(ReverseEngineeringEvidence(
+            evidence_id="artifact-foreground-bounds",
+            source=ReverseEngineeringEvidenceSource.ARTIFACT,
+            observation=(
+                f"Foreground difference from the top-left background sample spans "
+                f"({left}, {top}) to ({right}, {bottom}), covering a {coverage}% bounding box."
+            ),
+            method="Compared RGB pixels with the top-left background color.",
+        ))
+        findings.append(ReverseEngineeringFinding(
+            finding_id="structure-foreground",
+            kind=ReverseEngineeringFindingKind.STRUCTURE,
+            inference="The artifact contains a visually distinct foreground region that may represent design structure.",
+            evidence_ids=["artifact-tonal-range", "artifact-foreground-bounds"],
+            confidence=ReverseEngineeringConfidence.MEDIUM,
+            uncertainties=[
+                "Pixel segmentation alone cannot identify components, connectivity, occlusion, or physical scale."
+            ],
+        ))
+    findings.append(ReverseEngineeringFinding(
+        finding_id="function-brief-alignment",
+        kind=ReverseEngineeringFindingKind.FUNCTION,
+        inference=f"The artifact may relate to the DesignBrief intent: {design_brief.intent}",
+        evidence_ids=["brief-intent", "artifact-format"],
+        confidence=ReverseEngineeringConfidence.LOW,
+        uncertainties=[
+            "The frozen brief supplies context, but this baseline pixel analysis cannot verify depicted function."
+        ],
+    ))
+
+    overall_uncertainties = [
+        "The baseline analyzer uses image metadata and pixel-level segmentation, not semantic object recognition.",
+        "No hidden geometry, electrical connectivity, materials, or physical scale can be established from this image alone.",
+    ]
+    if ambiguous:
+        overall_uncertainties.insert(0, "The image is visually ambiguous because it has no reliable foreground separation.")
+    return ReverseEngineeringReportDraft(
+        artifact=AnalyzedArtifact(
+            artifact_id=reference.artifact_id,
+            kind=reference.kind,
+            media_type=media_type,
+            content_sha256=hashlib.sha256(content).hexdigest(),
+            width_px=width,
+            height_px=height,
+        ),
+        evidence=evidence,
+        findings=findings,
+        ambiguous=ambiguous,
+        overall_uncertainties=overall_uncertainties,
+    )
+
+
+__all__ = [
+    "MAX_ARTIFACT_BYTES",
+    "MAX_IMAGE_PIXELS",
+    "SUPPORTED_IMAGE_MEDIA_TYPES",
+    "ReverseEngineeringError",
+    "inspect_inline_image",
+]

--- a/blueprint_core/workspaces/reverse_engineering/models.py
+++ b/blueprint_core/workspaces/reverse_engineering/models.py
@@ -1,0 +1,128 @@
+"""Structured evidence and inference contracts for artifact inspection."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Annotated, Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+
+
+REVERSE_ENGINEERING_REPORT_SCHEMA_VERSION = "1.0"
+NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+class ReverseEngineeringFindingKind(str, Enum):
+    STRUCTURE = "structure"
+    FUNCTION = "function"
+    PROPERTY = "property"
+
+
+class ReverseEngineeringEvidenceSource(str, Enum):
+    ARTIFACT = "artifact"
+    DESIGN_BRIEF = "design_brief"
+
+
+class ReverseEngineeringConfidence(str, Enum):
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class ReverseEngineeringArtifactReference(BaseModel):
+    """A bounded reference supplied to the worker; v1 supports inline raster images."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    artifact_id: NonEmptyString
+    kind: NonEmptyString
+    uri: NonEmptyString
+    media_type: NonEmptyString
+    label: NonEmptyString | None = None
+
+
+class ReverseEngineeringEvidence(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    evidence_id: NonEmptyString
+    source: ReverseEngineeringEvidenceSource
+    observation: NonEmptyString
+    method: NonEmptyString
+
+
+class ReverseEngineeringFinding(BaseModel):
+    """An inference linked to observations and explicit residual uncertainty."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    finding_id: NonEmptyString
+    kind: ReverseEngineeringFindingKind
+    inference: NonEmptyString
+    evidence_ids: list[NonEmptyString] = Field(min_length=1)
+    confidence: ReverseEngineeringConfidence
+    uncertainties: list[NonEmptyString] = Field(min_length=1)
+
+
+class AnalyzedArtifact(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    artifact_id: NonEmptyString
+    kind: NonEmptyString
+    media_type: NonEmptyString
+    content_sha256: NonEmptyString
+    width_px: int = Field(gt=0)
+    height_px: int = Field(gt=0)
+
+
+class ReverseEngineeringReportDraft(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    artifact: AnalyzedArtifact
+    evidence: list[ReverseEngineeringEvidence] = Field(min_length=1)
+    findings: list[ReverseEngineeringFinding] = Field(min_length=1)
+    ambiguous: bool
+    overall_uncertainties: list[NonEmptyString] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def require_linked_unique_findings(self) -> "ReverseEngineeringReportDraft":
+        evidence_ids = [item.evidence_id for item in self.evidence]
+        finding_ids = [item.finding_id for item in self.findings]
+        if len(evidence_ids) != len(set(evidence_ids)):
+            raise ValueError("Reverse-engineering evidence_id values must be unique.")
+        if len(finding_ids) != len(set(finding_ids)):
+            raise ValueError("Reverse-engineering finding_id values must be unique.")
+        available_evidence = set(evidence_ids)
+        dangling = sorted({
+            evidence_id
+            for finding in self.findings
+            for evidence_id in finding.evidence_ids
+            if evidence_id not in available_evidence
+        })
+        if dangling:
+            raise ValueError(
+                "Reverse-engineering findings reference unknown evidence: " + ", ".join(dangling)
+            )
+        return self
+
+
+class ReverseEngineeringReport(ReverseEngineeringReportDraft):
+    schema_version: Literal["1.0"] = REVERSE_ENGINEERING_REPORT_SCHEMA_VERSION
+    project_id: UUID
+    project_revision: int = Field(ge=1)
+    design_brief_id: UUID
+    design_brief_version: int = Field(ge=1)
+
+
+__all__ = [
+    "REVERSE_ENGINEERING_REPORT_SCHEMA_VERSION",
+    "AnalyzedArtifact",
+    "ReverseEngineeringArtifactReference",
+    "ReverseEngineeringConfidence",
+    "ReverseEngineeringEvidence",
+    "ReverseEngineeringEvidenceSource",
+    "ReverseEngineeringFinding",
+    "ReverseEngineeringFindingKind",
+    "ReverseEngineeringReport",
+    "ReverseEngineeringReportDraft",
+]

--- a/docs/reverse-engineering-worker.md
+++ b/docs/reverse-engineering-worker.md
@@ -1,0 +1,41 @@
+# Reverse-Engineering worker
+
+The Reverse-Engineering worker owns the `artifact.reverse-engineer` capability. It inspects one supplied artifact with exact frozen DesignBrief context and returns `reverse-engineering-findings.v1` without writing to canonical project state.
+
+## Contract
+
+The `artifact-reference.v1` payload contains a supported artifact reference and the frozen DesignBrief:
+
+```json
+{
+  "artifact": {
+    "artifact_id": "uploaded-reference",
+    "kind": "uploaded_image",
+    "uri": "data:image/png;base64,...",
+    "media_type": "image/png",
+    "label": "reference.png"
+  },
+  "design_brief": {
+    "schema_version": "1.0"
+  }
+}
+```
+
+The baseline `InlineImageInspectionEngine` accepts bounded inline PNG, JPEG, and WebP images. It verifies the declared type against decoded bytes, enforces byte and pixel limits, and extracts image properties, tonal range, and foreground bounds. A richer semantic or provider-backed vision engine can implement the same `ReverseEngineeringEngine` protocol later.
+
+## Findings
+
+The result deliberately separates:
+
+- `evidence`: observed artifact facts or exact DesignBrief context, including the observation method;
+- `findings`: structure, function, or property inferences linked to evidence IDs;
+- `confidence`: `high`, `medium`, or `low` for each inference;
+- `uncertainties`: unresolved limits on every inference and on the report overall.
+
+Visually uniform or low-contrast input succeeds as an ambiguous report instead of inventing structure. Unsupported media, invalid bytes, type mismatches, and unavailable content return stable structured worker errors.
+
+The worker result includes only an artifact summary and SHA-256 digest; it does not echo inline image content. The result is persisted by `WorkerOrchestrator`, so a dependent worker receives the validated report through its `dependency_results` payload.
+
+## State boundary
+
+The worker verifies that its DesignBrief matches the persisted owner-scoped snapshot. It never calls a project-state write method and does not replace components, systems, artifacts, or assumptions. Any downstream worker that proposes a state change must do so through its own explicit capability and revision boundary.

--- a/docs/worker-orchestration.md
+++ b/docs/worker-orchestration.md
@@ -29,4 +29,4 @@ The `worker_execution_plans` record contains the validated requests and every jo
 
 When all jobs are terminal, the project workflow advances from `building` to `awaiting_feedback` with an idempotent system transition. Both successful and failed terminal plans preserve their results for feedback and diagnosis.
 
-Production capabilities on this boundary include the [Generation worker](generation-worker.md), which persists canonical project revision 1 from a frozen DesignBrief, and the [Validation worker](validation-worker.md), which persists actionable findings against an exact revision.
+Production capabilities on this boundary include the [Generation worker](generation-worker.md), which persists canonical project revision 1 from a frozen DesignBrief; the [Validation worker](validation-worker.md), which persists actionable findings against an exact revision; and the [Reverse-Engineering worker](reverse-engineering-worker.md), which produces evidence-linked artifact findings without mutating project state.

--- a/tests/agents/test_reverse_engineering_worker.py
+++ b/tests/agents/test_reverse_engineering_worker.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+import base64
+import tempfile
+import unittest
+import uuid
+from datetime import datetime, timezone
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+
+from PIL import Image, ImageDraw
+
+from blueprint_core.persistence.providers import create_sqlite_provider
+from blueprint_core.persistence.repositories import SqlAlchemyRepository
+from blueprint_core.workers import (
+    REVERSE_ENGINEERING_CAPABILITY_ID,
+    REVERSE_ENGINEERING_INPUT_VERSION,
+    REVERSE_ENGINEERING_OUTPUT_VERSION,
+    REVERSE_ENGINEERING_WORKER_ID,
+    WORKER_CONTRACT_VERSION,
+    ReverseEngineeringWorker,
+    WorkerCapability,
+    WorkerDefinition,
+    WorkerDependency,
+    WorkerOrchestrator,
+    WorkerPlanStatus,
+    WorkerRegistry,
+    WorkerRequest,
+    WorkerResult,
+    WorkerResultStatus,
+    build_reverse_engineering_request,
+)
+from blueprint_core.workspaces.design_briefs import DESIGN_BRIEF_SCHEMA_VERSION, DesignBrief
+from blueprint_core.workspaces.projects import ProjectStateError, ProjectStateService
+from blueprint_core.workspaces.reverse_engineering import (
+    ReverseEngineeringArtifactReference,
+    ReverseEngineeringConfidence,
+    ReverseEngineeringEvidenceSource,
+    ReverseEngineeringFindingKind,
+    ReverseEngineeringReport,
+)
+from blueprint_core.workspaces.workflow import (
+    ProjectWorkflowService,
+    ProjectWorkflowState,
+    WorkflowActorType,
+)
+
+
+OWNER = "reverse-engineering-user"
+
+
+def _context(request: WorkerRequest) -> dict[str, Any]:
+    return request.model_dump(include={
+        "contract_version",
+        "project_id",
+        "project_revision",
+        "design_brief_id",
+        "design_brief_version",
+        "job_id",
+        "correlation_id",
+        "worker_id",
+        "capability_id",
+    })
+
+
+class FindingsConsumerWorker:
+    def worker_definition(self) -> WorkerDefinition:
+        return WorkerDefinition(
+            worker_id="findings-consumer-worker",
+            name="Findings consumer fixture",
+            worker_version="1.0.0",
+            capabilities=[WorkerCapability(
+                capability_id="findings.consume",
+                description="Consume reverse-engineering findings in a downstream fixture.",
+                supported_input_versions=[REVERSE_ENGINEERING_OUTPUT_VERSION],
+                supported_output_versions=["consumption-receipt.v1"],
+            )],
+        )
+
+    def execute(self, request: WorkerRequest, _report_progress: Any) -> WorkerResult:
+        dependency = request.payload["dependency_results"]["job-reverse-engineering"]
+        report = ReverseEngineeringReport.model_validate(
+            dependency["output"]["reverse_engineering_report"]
+        )
+        return WorkerResult(
+            **_context(request),
+            output_contract_version="consumption-receipt.v1",
+            status=WorkerResultStatus.SUCCEEDED,
+            output={
+                "consumed_artifact_id": report.artifact.artifact_id,
+                "consumed_finding_count": len(report.findings),
+                "evidence_links": sum(len(item.evidence_ids) for item in report.findings),
+            },
+        )
+
+
+class ReverseEngineeringWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.directory = tempfile.TemporaryDirectory()
+        provider = create_sqlite_provider(
+            source="reverse-engineering worker test",
+            url=f"sqlite:///{Path(self.directory.name) / 'blueprint.db'}",
+            import_legacy_jobs=False,
+        )
+        provider.initialize()
+        self.repository = SqlAlchemyRepository(provider.session_factory)
+        self.state = ProjectStateService(self.repository)
+        self.workflow = ProjectWorkflowService(self.repository)
+        self.project_id = uuid.uuid4()
+        self.brief = self._persist_brief()
+        self.workflow.initialize(str(self.project_id), OWNER)
+        self.workflow.transition(
+            str(self.project_id),
+            OWNER,
+            ProjectWorkflowState.BUILDING,
+            actor_type=WorkflowActorType.USER,
+            actor_id=OWNER,
+            reason="Start reverse-engineering worker test.",
+        )
+
+    def tearDown(self) -> None:
+        self.directory.cleanup()
+
+    def _persist_brief(self) -> DesignBrief:
+        brief = DesignBrief(
+            schema_version=DESIGN_BRIEF_SCHEMA_VERSION,
+            conversation_id="conversation-reverse-engineering",
+            intent="Recreate a compact controller shown in the uploaded reference",
+            summary="Inspect an uploaded product reference before generation.",
+            requirements=["Identify visible structural evidence"],
+            constraints=["Do not invent hidden connectivity"],
+            requested_outputs=["wiring", "bom"],
+            validation_criteria=["Every inference cites evidence"],
+            readiness="ready",
+            design_brief_id=uuid.uuid4(),
+            project_id=self.project_id,
+            brief_version=1,
+            created_at=datetime.now(timezone.utc),
+        )
+        self.repository.insert_design_brief_version({
+            "id": str(uuid.uuid4()),
+            "design_brief_id": str(brief.design_brief_id),
+            "project_id": str(brief.project_id),
+            "conversation_id": brief.conversation_id,
+            "owner_user_id": OWNER,
+            "brief_version": brief.brief_version,
+            "schema_version": brief.schema_version,
+            "previous_version": brief.previous_version,
+            "payload_json": brief.model_dump(mode="json"),
+            "created_at": brief.created_at.isoformat(),
+        })
+        return brief
+
+    @staticmethod
+    def _image_reference(*, ambiguous: bool = False) -> ReverseEngineeringArtifactReference:
+        image = Image.new("RGB", (96, 64), "white")
+        if not ambiguous:
+            drawing = ImageDraw.Draw(image)
+            drawing.rectangle((18, 14, 77, 49), fill="navy")
+            drawing.ellipse((38, 23, 57, 42), fill="orange")
+        output = BytesIO()
+        image.save(output, format="PNG")
+        encoded = base64.b64encode(output.getvalue()).decode("ascii")
+        return ReverseEngineeringArtifactReference(
+            artifact_id="uploaded-controller-reference",
+            kind="uploaded_image",
+            uri=f"data:image/png;base64,{encoded}",
+            media_type="image/png",
+            label="controller-reference.png",
+        )
+
+    def _request(
+        self,
+        artifact: ReverseEngineeringArtifactReference,
+        *,
+        job_id: str = "job-reverse-engineering",
+    ) -> WorkerRequest:
+        return build_reverse_engineering_request(
+            self.brief,
+            artifact,
+            project_revision=1,
+            job_id=job_id,
+            correlation_id="corr-reverse-engineering",
+        )
+
+    async def test_supported_image_returns_evidence_inference_and_uncertainty_without_state_write(self) -> None:
+        artifact = self._image_reference()
+        worker = ReverseEngineeringWorker(self.state)
+        registration = WorkerRegistry([worker]).resolve(
+            REVERSE_ENGINEERING_WORKER_ID,
+            REVERSE_ENGINEERING_CAPABILITY_ID,
+        )
+        orchestrator = WorkerOrchestrator(self.repository, [worker], workflow_service=self.workflow)
+        plan = orchestrator.create_plan([self._request(artifact)], OWNER)
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+        result = completed.jobs["job-reverse-engineering"].result
+        report = ReverseEngineeringReport.model_validate(result.output["reverse_engineering_report"])
+
+        self.assertEqual(WorkerPlanStatus.SUCCEEDED, completed.status)
+        self.assertEqual(REVERSE_ENGINEERING_INPUT_VERSION, registration.capability.supported_input_versions[0])
+        self.assertEqual(
+            ["image/jpeg", "image/png", "image/webp"],
+            registration.capability.metadata["supported_media_types"],
+        )
+        self.assertFalse(report.ambiguous)
+        self.assertEqual((96, 64), (report.artifact.width_px, report.artifact.height_px))
+        self.assertEqual(
+            {ReverseEngineeringEvidenceSource.ARTIFACT, ReverseEngineeringEvidenceSource.DESIGN_BRIEF},
+            {item.source for item in report.evidence},
+        )
+        self.assertEqual(
+            {
+                ReverseEngineeringFindingKind.STRUCTURE,
+                ReverseEngineeringFindingKind.FUNCTION,
+                ReverseEngineeringFindingKind.PROPERTY,
+            },
+            {item.kind for item in report.findings},
+        )
+        self.assertTrue(all(item.evidence_ids and item.uncertainties for item in report.findings))
+        self.assertNotIn(artifact.uri, result.model_dump_json())
+        with self.assertRaises(ProjectStateError):
+            self.state.get_latest(self.project_id, OWNER)
+
+    async def test_ambiguous_image_succeeds_with_low_confidence_uncertainty(self) -> None:
+        worker = ReverseEngineeringWorker(self.state)
+        orchestrator = WorkerOrchestrator(self.repository, [worker], workflow_service=self.workflow)
+        plan = orchestrator.create_plan([self._request(self._image_reference(ambiguous=True))], OWNER)
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+        report = ReverseEngineeringReport.model_validate(
+            completed.jobs["job-reverse-engineering"].result.output["reverse_engineering_report"]
+        )
+        structure = next(item for item in report.findings if item.kind == ReverseEngineeringFindingKind.STRUCTURE)
+
+        self.assertEqual(WorkerPlanStatus.SUCCEEDED, completed.status)
+        self.assertTrue(report.ambiguous)
+        self.assertEqual(ReverseEngineeringConfidence.LOW, structure.confidence)
+        self.assertIn("No distinct foreground", structure.inference)
+        self.assertGreaterEqual(len(report.overall_uncertainties), 3)
+
+    async def test_unsupported_artifact_returns_structured_nonretryable_error(self) -> None:
+        artifact = ReverseEngineeringArtifactReference(
+            artifact_id="uploaded-datasheet",
+            kind="uploaded_document",
+            uri="data:application/pdf;base64,JVBERi0xLjQ=",
+            media_type="application/pdf",
+        )
+        worker = ReverseEngineeringWorker(self.state)
+        orchestrator = WorkerOrchestrator(self.repository, [worker], workflow_service=self.workflow)
+        plan = orchestrator.create_plan([self._request(artifact)], OWNER)
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+        result = completed.jobs["job-reverse-engineering"].result
+
+        self.assertEqual(WorkerPlanStatus.FAILED, completed.status)
+        self.assertEqual("unsupported_reverse_engineering_artifact", result.error.code)
+        self.assertFalse(result.error.retryable)
+        self.assertEqual(
+            ["image/jpeg", "image/png", "image/webp"],
+            result.error.details["context"]["supported_media_types"],
+        )
+
+    async def test_downstream_worker_consumes_persisted_dependency_result(self) -> None:
+        reverse_worker = ReverseEngineeringWorker(self.state)
+        consumer = FindingsConsumerWorker()
+        reverse_request = self._request(self._image_reference())
+        consumer_request = WorkerRequest(
+            contract_version=WORKER_CONTRACT_VERSION,
+            project_id=self.project_id,
+            project_revision=1,
+            design_brief_id=self.brief.design_brief_id,
+            design_brief_version=1,
+            job_id="job-findings-consumer",
+            correlation_id="corr-reverse-engineering",
+            worker_id="findings-consumer-worker",
+            capability_id="findings.consume",
+            input_contract_version=REVERSE_ENGINEERING_OUTPUT_VERSION,
+            dependencies=[WorkerDependency(
+                job_id="job-reverse-engineering",
+                worker_id=REVERSE_ENGINEERING_WORKER_ID,
+                capability_id=REVERSE_ENGINEERING_CAPABILITY_ID,
+            )],
+        )
+        orchestrator = WorkerOrchestrator(
+            self.repository,
+            [reverse_worker, consumer],
+            workflow_service=self.workflow,
+        )
+        plan = orchestrator.create_plan([reverse_request, consumer_request], OWNER)
+
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+        receipt = completed.jobs["job-findings-consumer"].result.output
+
+        self.assertEqual(WorkerPlanStatus.SUCCEEDED, completed.status)
+        self.assertEqual("uploaded-controller-reference", receipt["consumed_artifact_id"])
+        self.assertEqual(3, receipt["consumed_finding_count"])
+        self.assertGreaterEqual(receipt["evidence_links"], 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #188

## Summary
- register the `artifact.reverse-engineer` capability and versioned findings contract
- inspect bounded inline PNG, JPEG, and WebP artifacts without mutating project state
- separate observed evidence, evidence-linked inference, confidence, and uncertainty
- return structured errors for unsupported, invalid, mismatched, oversized, or unavailable artifacts
- prove a downstream worker can consume the persisted dependency result
- document the worker contract, safety limits, and state boundary

## Verification
- `CLOUDFLARE_ENABLE_THINKING=false ./scripts/quality/test.sh` (426 passed, 1 skipped)
- `.venv/bin/python -m unittest tests.agents.test_reverse_engineering_worker` (4 passed)