### PR TITLE
feat: add copy button to chat messages

### DIFF
--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -15,6 +15,7 @@ import {
   humanContextDefaultsChatSummary,
   humanContextDefaultsPromptSection,
 } from "../lib/human-context-defaults";
+import CopyButton from "../components/copy-button";
 import {
   useAdminSession,
   useBackendLogs,
@@ -5849,6 +5850,11 @@ function ChatWorkspace({
                             <span suppressHydrationWarning>{formatChatTimestamp(message.timestamp)}</span>
                             {message.status === "loading" && <RefreshCw className="h-3 w-3 animate-spin text-cyan-300" />}
                             {message.status === "cancelled" && <Square className="h-3 w-3 fill-current text-amber-300" />}
+                            <CopyButton
+                              value={message.content}
+                              label={isUser ? "Copy your message" : isSystem ? "Copy context message" : "Copy Forma's message"}
+                              className="ml-auto"
+                            />
                           </div>
                           <p className="break-anywhere whitespace-pre-wrap text-sm leading-6">{message.content}</p>
                           {!message.projectId && (

--- a/apps/web/app/blueprint-workspace/home-chat-view.tsx
+++ b/apps/web/app/blueprint-workspace/home-chat-view.tsx
@@ -17,6 +17,8 @@ import {
   X,
 } from "lucide-react";
 
+import CopyButton from "../../components/copy-button";
+
 type HomeChatMessage = {
   id: string;
   role: "assistant" | "user" | "system";
@@ -157,6 +159,11 @@ export default function HomeChatView({
                       <span>{isUser ? "You" : "Forma"}</span>
                       <span className="text-slate-700">/</span>
                       <span suppressHydrationWarning>{formatTimestamp(message.timestamp)}</span>
+                      <CopyButton
+                        value={message.content}
+                        label={isUser ? "Copy your message" : "Copy Forma's message"}
+                        className="ml-auto"
+                      />
                     </div>
                     <p className="break-anywhere whitespace-pre-wrap text-sm leading-6">{message.content}</p>
                     {message.imagePreview && (

--- a/apps/web/components/copy-button.tsx
+++ b/apps/web/components/copy-button.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { AlertTriangle, Check, Copy } from "lucide-react";
+
+import { copyText } from "../lib/clipboard";
+
+type CopyState = "idle" | "copied" | "error";
+
+const RESET_DELAY_MS = 2000;
+
+type CopyButtonProps = {
+  value: string;
+  /** Accessible name for the idle button. */
+  label?: string;
+  className?: string;
+};
+
+/** Icon button that copies `value` and reports the outcome to sighted and screen reader users. */
+export default function CopyButton({ value, label = "Copy message", className = "" }: CopyButtonProps) {
+  const [state, setState] = useState<CopyState>("idle");
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mounted = useRef(true);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+      if (resetTimer.current) clearTimeout(resetTimer.current);
+    };
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    const copied = await copyText(value);
+    if (!mounted.current) return;
+
+    setState(copied ? "copied" : "error");
+    if (resetTimer.current) clearTimeout(resetTimer.current);
+    resetTimer.current = setTimeout(() => {
+      if (mounted.current) setState("idle");
+    }, RESET_DELAY_MS);
+  }, [value]);
+
+  if (!value.trim()) return null;
+
+  const hint = state === "copied" ? "Copied" : state === "error" ? "Copy failed" : label;
+
+  return (
+    <span className={`inline-flex items-center ${className}`}>
+      <button
+        type="button"
+        onClick={handleCopy}
+        aria-label={label}
+        title={hint}
+        className="inline-flex h-6 w-6 shrink-0 items-center justify-center border border-transparent text-slate-500 transition hover:border-[#2c2f37] hover:bg-white/5 hover:text-white focus-visible:border-cyan-300 focus-visible:text-white focus-visible:outline-none"
+      >
+        {state === "copied" ? (
+          <Check className="h-3.5 w-3.5 text-emerald-300" />
+        ) : state === "error" ? (
+          <AlertTriangle className="h-3.5 w-3.5 text-rose-300" />
+        ) : (
+          <Copy className="h-3.5 w-3.5" />
+        )}
+      </button>
+      <span role="status" aria-live="polite" className="sr-only">
+        {state === "copied" ? "Message copied to clipboard" : state === "error" ? "Copying the message failed" : ""}
+      </span>
+    </span>
+  );
+}

--- a/apps/web/lib/clipboard.ts
+++ b/apps/web/lib/clipboard.ts
@@ -1,0 +1,87 @@
+export type ClipboardWriter = {
+  writeText: (text: string) => Promise<void>;
+};
+
+export type CopyEnvironment = {
+  /** The async clipboard API, when the browser exposes one. */
+  clipboard?: ClipboardWriter | null;
+  /** Async clipboard writes are rejected outside a secure context. */
+  isSecureContext?: boolean;
+  /** Synchronous `document.execCommand("copy")` path for older or non-secure contexts. */
+  legacyCopy?: ((text: string) => boolean) | null;
+};
+
+/**
+ * Copies `text` using the async clipboard API, falling back to the legacy
+ * selection-based command when it is unavailable or rejected. Returns whether
+ * the text actually made it to the clipboard so callers can surface a failure
+ * instead of silently pretending the copy worked.
+ */
+export async function copyTextToClipboard(text: string, environment: CopyEnvironment): Promise<boolean> {
+  if (!text) return false;
+
+  const { clipboard, isSecureContext = true, legacyCopy } = environment;
+
+  if (clipboard && isSecureContext) {
+    try {
+      await clipboard.writeText(text);
+      return true;
+    } catch {
+      // Permission denied, a detached document, or a browser that rejects
+      // writes outside a user gesture: fall through to the legacy path.
+    }
+  }
+
+  if (legacyCopy) {
+    try {
+      return legacyCopy(text);
+    } catch {
+      return false;
+    }
+  }
+
+  return false;
+}
+
+function legacyDocumentCopy(text: string): boolean {
+  const { body } = document;
+  if (!body) return false;
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.setAttribute("aria-hidden", "true");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+  body.appendChild(textarea);
+  textarea.select();
+  textarea.setSelectionRange(0, textarea.value.length);
+
+  try {
+    return document.execCommand("copy");
+  } finally {
+    body.removeChild(textarea);
+    previouslyFocused?.focus?.();
+  }
+}
+
+/** Reads the copy capabilities of the current browser. Server-safe: returns an empty environment. */
+export function browserCopyEnvironment(): CopyEnvironment {
+  if (typeof navigator === "undefined" || typeof document === "undefined") return {};
+
+  return {
+    clipboard: navigator.clipboard ?? null,
+    isSecureContext: typeof window === "undefined" ? true : window.isSecureContext !== false,
+    legacyCopy: typeof document.execCommand === "function" ? legacyDocumentCopy : null,
+  };
+}
+
+/** Convenience wrapper around {@link copyTextToClipboard} bound to the current browser. */
+export function copyText(text: string): Promise<boolean> {
+  return copyTextToClipboard(text, browserCopyEnvironment());
+}

--- a/apps/web/test/clipboard.test.ts
+++ b/apps/web/test/clipboard.test.ts
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { copyTextToClipboard, type CopyEnvironment } from "../lib/clipboard";
+
+function recordingEnvironment(overrides: Partial<CopyEnvironment> = {}) {
+  const writes: string[] = [];
+  const legacyWrites: string[] = [];
+
+  const environment: CopyEnvironment = {
+    clipboard: {
+      async writeText(text: string) {
+        writes.push(text);
+      },
+    },
+    isSecureContext: true,
+    legacyCopy: (text: string) => {
+      legacyWrites.push(text);
+      return true;
+    },
+    ...overrides,
+  };
+
+  return { environment, writes, legacyWrites };
+}
+
+test("the async clipboard API is used when it is available in a secure context", async () => {
+  const { environment, writes, legacyWrites } = recordingEnvironment();
+
+  assert.equal(await copyTextToClipboard("Forma build steps", environment), true);
+  assert.deepEqual(writes, ["Forma build steps"]);
+  assert.deepEqual(legacyWrites, []);
+});
+
+test("a rejected clipboard write falls back to the legacy copy command", async () => {
+  const { environment, legacyWrites } = recordingEnvironment({
+    clipboard: {
+      writeText: async () => {
+        throw new Error("NotAllowedError");
+      },
+    },
+  });
+
+  assert.equal(await copyTextToClipboard("Wiring notes", environment), true);
+  assert.deepEqual(legacyWrites, ["Wiring notes"]);
+});
+
+test("a non-secure context skips the async clipboard API entirely", async () => {
+  const { environment, writes, legacyWrites } = recordingEnvironment({ isSecureContext: false });
+
+  assert.equal(await copyTextToClipboard("Bill of materials", environment), true);
+  assert.deepEqual(writes, []);
+  assert.deepEqual(legacyWrites, ["Bill of materials"]);
+});
+
+test("a failing legacy copy is reported as a failure instead of a silent success", async () => {
+  const { environment } = recordingEnvironment({
+    clipboard: null,
+    legacyCopy: () => false,
+  });
+
+  assert.equal(await copyTextToClipboard("Bill of materials", environment), false);
+});
+
+test("a throwing legacy copy is reported as a failure", async () => {
+  const { environment } = recordingEnvironment({
+    clipboard: null,
+    legacyCopy: () => {
+      throw new Error("execCommand is not supported");
+    },
+  });
+
+  assert.equal(await copyTextToClipboard("Bill of materials", environment), false);
+});
+
+test("an environment with no copy capability reports failure", async () => {
+  assert.equal(await copyTextToClipboard("Bill of materials", {}), false);
+});
+
+test("empty text is never written to the clipboard", async () => {
+  const { environment, writes, legacyWrites } = recordingEnvironment();
+
+  assert.equal(await copyTextToClipboard("", environment), false);
+  assert.deepEqual(writes, []);
+  assert.deepEqual(legacyWrites, []);
+});


### PR DESCRIPTION
## Summary

Copying a generated plan out of Forma required a manual text selection, which is awkward for multi-line assistant output on desktop and close to unusable on touch.

This adds a copy button to the header row of every message bubble, in both chat surfaces:

- `apps/web/app/blueprint-workspace/home-chat-view.tsx` — the home chat
- `apps/web/app/blueprint-workspace.tsx` — the project chat

New pieces:

- `apps/web/lib/clipboard.ts` — `copyTextToClipboard(text, environment)`. Uses the async Clipboard API, and falls back to the legacy selection command when that API is missing, rejects (permission denied, no user gesture), or the page is not a secure context. Returns a boolean so a failed copy is reported rather than silently treated as success. The environment is injected, which keeps it testable without a DOM.
- `apps/web/components/copy-button.tsx` — icon button with an `idle → copied / failed → idle` state machine that resets after two seconds.

Behavior details:

- Accessible name per role: "Copy your message", "Copy Forma's message", "Copy context message".
- Outcome is exposed to sighted users through the icon and title, and to screen reader users through a polite live region.
- `type="button"`, so it cannot submit the surrounding chat form.
- Renders nothing for empty or whitespace-only messages, so streaming placeholders do not get a dead button.
- Reset timer is cleared on unmount, and post-unmount state updates are guarded.

## Related issue

Closes #95

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Test
- [ ] Refactor
- [ ] Chore or maintenance

## Verification

```text
# Type check
npx tsc --noEmit -p apps/web/tsconfig.json
  -> clean

# Lint
npx next lint            (run from apps/web)
  -> no errors; only the pre-existing @next/next/no-img-element warnings,
     none of them in the files touched here

# Production build
npx next build           (run from apps/web)
  -> compiled successfully, all 21 routes built

# Unit tests for the fallback chain (7 cases)
apps/web/test/clipboard.test.ts
  -> 7 pass, 0 fail
  Note: apps/web has no runner script for its node:test files, so these were run
  with `node --experimental-strip-types --test` against a copy with explicit .ts
  import extensions. Adding a runner script felt out of scope for this PR, but it
  is worth doing.

# Python suite
./scripts/quality/test.sh
  -> Ran 426 tests, OK (skipped=1)
  Run on a clean worktree of dev with this patch applied. In a working copy that
  still has the untracked legacy backend/ and fabricator/ directories left over
  from the apps/ restructure, tests/tooling/test_core_package.py reports 2
  unrelated failures asserting those directories are gone.
```

Behavior was also driven in headless Chromium against the real component, not just typechecked:

```text
idle:    title=Copy Forma's message  status=""
copied:  title=Copied                status="Message copied to clipboard"
clipboard received: ["Bill of materials: 1x ESP32"]
reset:   title=Copy Forma's message  status=""
blank message buttons: 0
chat bubble copy buttons: 2
```

The failure path was checked the same way: with clipboard permission denied in headless, both the async and legacy paths fail and the button correctly shows "Copy failed" and announces "Copying the message failed", instead of reporting a success that never happened.

## Configuration or migration requirements

None.

## Visual changes

The button sits at the end of the existing `ROLE / TIMESTAMP` meta row inside each bubble, right-aligned via `ml-auto`. It is muted slate by default and brightens on hover and keyboard focus, then turns into a green check for two seconds after a successful copy. Screenshots are attached in a follow-up comment.

## Safety and compatibility

No hardware, API, schema, or backend surface is touched. This is presentation-only and additive. No existing props, types, or exports changed, so nothing downstream breaks.

## AI assistance

Written with Claude Code.

## Checklist

- [x] This pull request targets `dev` and the branch started from an up-to-date `dev`.
- [x] The change addresses one logical concern and contains no unrelated cleanup.
- [x] Temporary, fixup, and unrelated commits were cleaned up where practical.
- [ ] Python code is typed and public classes and functions are documented where applicable. (No Python in this change.)
- [x] Relevant deterministic tests were added or updated.
- [x] `./scripts/quality/test.sh` passes, or failures are explained above.
- [x] Frontend lint and build checks pass when applicable.
- [ ] Documentation was updated when behavior changed. (No user-facing docs describe the chat message controls.)
- [x] No secrets, credentials, logs, databases, build artifacts, or generated temporary files were committed.
- [x] Hardware safety implications were considered.
- [x] Breaking changes are clearly identified. (None.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)