### PR TITLE
Fix dev server process cleanup

### DIFF
--- a/scripts/development/dev-core-logs.sh
+++ b/scripts/development/dev-core-logs.sh
@@ -14,6 +14,9 @@ FRONTEND_LOG_FILE="${FRONTEND_LOG_FILE:-$ROOT_DIR/.logs/frontend-dev.log}"
 UVICORN_LOG_LEVEL="${UVICORN_LOG_LEVEL:-warning}"
 UVICORN_ACCESS_LOG="${UVICORN_ACCESS_LOG:-false}"
 
+# shellcheck source=scripts/development/dev-processes.sh
+source "$ROOT_DIR/scripts/development/dev-processes.sh"
+
 backend_pid=""
 frontend_pid=""
 cleaned_up="false"
@@ -80,20 +83,22 @@ cleanup() {
   cleaned_up="true"
 
   log "Stopping services..."
-  if [ -n "$frontend_pid" ] && kill -0 "$frontend_pid" >/dev/null 2>&1; then
-    kill "$frontend_pid" >/dev/null 2>&1 || true
+  if [ -n "$frontend_pid" ]; then
+    dev_stop_process_group "$frontend_pid" "frontend" "$DEV_FRONTEND_PID_FILE" || true
   fi
-  if [ -n "$backend_pid" ] && kill -0 "$backend_pid" >/dev/null 2>&1; then
-    kill "$backend_pid" >/dev/null 2>&1 || true
+  if [ -n "$backend_pid" ]; then
+    dev_stop_process_group "$backend_pid" "backend" "$DEV_BACKEND_PID_FILE" || true
   fi
   if [ -n "$frontend_pid" ] || [ -n "$backend_pid" ]; then
     wait ${frontend_pid:+"$frontend_pid"} ${backend_pid:+"$backend_pid"} >/dev/null 2>&1 || true
   fi
 }
 
-trap cleanup EXIT INT TERM
+trap cleanup EXIT INT TERM HUP
 
 cd "$ROOT_DIR"
+
+dev_cleanup_previous_session
 
 if [ ! -x "$VENV_DIR/bin/python" ]; then
   log "Creating Python virtualenv at $VENV_DIR"
@@ -133,8 +138,8 @@ else
   if ! is_truthy "$UVICORN_ACCESS_LOG"; then
     uvicorn_args+=(--no-access-log)
   fi
-  "$VENV_DIR/bin/python" -m uvicorn "${uvicorn_args[@]}" &
-  backend_pid="$!"
+  dev_start_process_group backend_pid "$DEV_BACKEND_PID_FILE" "" \
+    "$VENV_DIR/bin/python" -m uvicorn "${uvicorn_args[@]}"
   wait_for_url "http://$BACKEND_HOST:$BACKEND_PORT/api" "Backend" 60 "$backend_pid" "$BACKEND_LOG_FILE"
 fi
 
@@ -142,8 +147,9 @@ FRONTEND_PORT="$(first_free_port "$FRONTEND_PORT")"
 mkdir -p "$(dirname "$FRONTEND_LOG_FILE")"
 log "Starting frontend at http://$FRONTEND_HOST:$FRONTEND_PORT"
 log "Frontend log file: $FRONTEND_LOG_FILE"
-(cd "$ROOT_DIR/apps/web" && npm run dev -- --hostname "$FRONTEND_HOST" --port "$FRONTEND_PORT" >"$FRONTEND_LOG_FILE" 2>&1) &
-frontend_pid="$!"
+dev_start_process_group frontend_pid "$DEV_FRONTEND_PID_FILE" "$FRONTEND_LOG_FILE" \
+  bash -c 'cd "$1" && shift && exec "$@"' bash "$ROOT_DIR/apps/web" \
+  npm run dev -- --hostname "$FRONTEND_HOST" --port "$FRONTEND_PORT"
 
 wait_for_url "http://$FRONTEND_HOST:$FRONTEND_PORT/" "Frontend"
 

--- a/scripts/development/dev-processes.sh
+++ b/scripts/development/dev-processes.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+# Shared lifecycle helpers for the local development launchers.
+# The caller must define ROOT_DIR and may override DEV_RUNTIME_DIR.
+
+DEV_RUNTIME_DIR="${DEV_RUNTIME_DIR:-$ROOT_DIR/.tmp/development}"
+DEV_BACKEND_PID_FILE="${DEV_BACKEND_PID_FILE:-$DEV_RUNTIME_DIR/backend.pgid}"
+DEV_FRONTEND_PID_FILE="${DEV_FRONTEND_PID_FILE:-$DEV_RUNTIME_DIR/frontend.pgid}"
+
+dev_group_is_running() {
+  local pgid="$1"
+  ps -eo pgid=,stat= | awk -v target="$pgid" \
+    '$1 == target && $2 !~ /^Z/ { found=1 } END { exit !found }'
+}
+
+dev_group_belongs_to_repo() {
+  local pgid="$1"
+  local pid cwd
+
+  while read -r pid; do
+    [ -n "$pid" ] || continue
+    cwd="$(readlink -f "/proc/$pid/cwd" 2>/dev/null || true)"
+    case "$cwd" in
+      "$ROOT_DIR"|"$ROOT_DIR"/*) return 0 ;;
+    esac
+  done < <(ps -eo pid=,pgid= | awk -v target="$pgid" '$2 == target { print $1 }')
+
+  return 1
+}
+
+dev_remove_pid_file() {
+  local pid_file="$1"
+  local expected_pgid="$2"
+  local recorded_pgid=""
+
+  if [ -f "$pid_file" ]; then
+    read -r recorded_pgid <"$pid_file" || true
+    if [ "$recorded_pgid" = "$expected_pgid" ]; then
+      rm -f -- "$pid_file"
+    fi
+  fi
+}
+
+dev_stop_process_group() {
+  local pgid="$1"
+  local label="$2"
+  local pid_file="${3:-}"
+  local attempt
+
+  if ! [[ "$pgid" =~ ^[0-9]+$ ]] || [ "$pgid" -le 1 ]; then
+    return 0
+  fi
+  if ! dev_group_is_running "$pgid"; then
+    [ -n "$pid_file" ] && dev_remove_pid_file "$pid_file" "$pgid"
+    return 0
+  fi
+  if ! dev_group_belongs_to_repo "$pgid"; then
+    printf '[blueprint-dev] Refusing to stop %s process group %s; it is not owned by %s.\n' \
+      "$label" "$pgid" "$ROOT_DIR" >&2
+    [ -n "$pid_file" ] && dev_remove_pid_file "$pid_file" "$pgid"
+    return 1
+  fi
+
+  printf '[blueprint-dev] Stopping prior %s process group %s...\n' "$label" "$pgid"
+  kill -TERM -- "-$pgid" >/dev/null 2>&1 || true
+  for attempt in $(seq 1 20); do
+    if ! dev_group_is_running "$pgid"; then
+      break
+    fi
+    sleep 0.1
+  done
+  if dev_group_is_running "$pgid"; then
+    printf '[blueprint-dev] Force-stopping %s process group %s...\n' "$label" "$pgid"
+    kill -KILL -- "-$pgid" >/dev/null 2>&1 || true
+  fi
+  [ -n "$pid_file" ] && dev_remove_pid_file "$pid_file" "$pgid"
+}
+
+dev_stop_recorded_process() {
+  local pid_file="$1"
+  local label="$2"
+  local pgid=""
+
+  [ -f "$pid_file" ] || return 0
+  read -r pgid <"$pid_file" || true
+  dev_stop_process_group "$pgid" "$label" "$pid_file"
+}
+
+dev_cleanup_previous_session() {
+  mkdir -p "$DEV_RUNTIME_DIR"
+  dev_stop_recorded_process "$DEV_FRONTEND_PID_FILE" "frontend"
+  dev_stop_recorded_process "$DEV_BACKEND_PID_FILE" "backend"
+}
+
+dev_start_process_group() {
+  local output_variable="$1"
+  local pid_file="$2"
+  local log_file="$3"
+  shift 3
+  local child_pid
+
+  mkdir -p "$DEV_RUNTIME_DIR"
+  if [ -n "$log_file" ]; then
+    setsid "$@" >"$log_file" 2>&1 &
+  else
+    setsid "$@" &
+  fi
+  child_pid="$!"
+  printf '%s\n' "$child_pid" >"$pid_file"
+  printf -v "$output_variable" '%s' "$child_pid"
+}

--- a/scripts/development/dev.sh
+++ b/scripts/development/dev.sh
@@ -10,6 +10,9 @@ PYTHON_BIN="${PYTHON_BIN:-python3}"
 VENV_DIR="${VENV_DIR:-$ROOT_DIR/.venv}"
 BACKEND_LOG_FILE="${BACKEND_LOG_FILE:-$ROOT_DIR/.logs/backend-dev.log}"
 
+# shellcheck source=scripts/development/dev-processes.sh
+source "$ROOT_DIR/scripts/development/dev-processes.sh"
+
 backend_pid=""
 frontend_pid=""
 cleaned_up="false"
@@ -68,20 +71,22 @@ cleanup() {
   cleaned_up="true"
 
   log "Stopping services..."
-  if [ -n "$frontend_pid" ] && kill -0 "$frontend_pid" >/dev/null 2>&1; then
-    kill "$frontend_pid" >/dev/null 2>&1 || true
+  if [ -n "$frontend_pid" ]; then
+    dev_stop_process_group "$frontend_pid" "frontend" "$DEV_FRONTEND_PID_FILE" || true
   fi
-  if [ -n "$backend_pid" ] && kill -0 "$backend_pid" >/dev/null 2>&1; then
-    kill "$backend_pid" >/dev/null 2>&1 || true
+  if [ -n "$backend_pid" ]; then
+    dev_stop_process_group "$backend_pid" "backend" "$DEV_BACKEND_PID_FILE" || true
   fi
   if [ -n "$frontend_pid" ] || [ -n "$backend_pid" ]; then
     wait ${frontend_pid:+"$frontend_pid"} ${backend_pid:+"$backend_pid"} >/dev/null 2>&1 || true
   fi
 }
 
-trap cleanup EXIT INT TERM
+trap cleanup EXIT INT TERM HUP
 
 cd "$ROOT_DIR"
+
+dev_cleanup_previous_session
 
 if [ ! -x "$VENV_DIR/bin/python" ]; then
   log "Creating Python virtualenv at $VENV_DIR"
@@ -111,15 +116,16 @@ else
   export BACKEND_LOG_FILE
   log "Starting backend at http://$BACKEND_HOST:$BACKEND_PORT"
   log "Backend log file: $BACKEND_LOG_FILE"
-  "$VENV_DIR/bin/python" -m uvicorn apps.api.main:app --host "$BACKEND_HOST" --port "$BACKEND_PORT" &
-  backend_pid="$!"
+  dev_start_process_group backend_pid "$DEV_BACKEND_PID_FILE" "" \
+    "$VENV_DIR/bin/python" -m uvicorn apps.api.main:app --host "$BACKEND_HOST" --port "$BACKEND_PORT"
   wait_for_url "http://$BACKEND_HOST:$BACKEND_PORT/api" "Backend" 60 "$backend_pid"
 fi
 
 FRONTEND_PORT="$(first_free_port "$FRONTEND_PORT")"
 log "Starting frontend at http://$FRONTEND_HOST:$FRONTEND_PORT"
-(cd "$ROOT_DIR/apps/web" && npm run dev -- --hostname "$FRONTEND_HOST" --port "$FRONTEND_PORT") &
-frontend_pid="$!"
+dev_start_process_group frontend_pid "$DEV_FRONTEND_PID_FILE" "" \
+  bash -c 'cd "$1" && shift && exec "$@"' bash "$ROOT_DIR/apps/web" \
+  npm run dev -- --hostname "$FRONTEND_HOST" --port "$FRONTEND_PORT"
 
 wait_for_url "http://$FRONTEND_HOST:$FRONTEND_PORT/" "Frontend"
 


### PR DESCRIPTION
## Summary
- launch backend and frontend in dedicated process groups
- track managed groups with shared PID files and replace stale dev sessions on startup
- terminate full process trees on EXIT, INT, TERM, and HUP with repository ownership checks

## Verification
- bash syntax checks for all three scripts
- started dev-core-logs.sh twice; second launch replaced the first and reused ports 3000/8000
- stopped dev-core-logs.sh and dev.sh with Ctrl+C; verified no listeners, descendants, or PID files remained

Targets dev and contains only the process lifecycle fix.