### PR TITLE
Add Forma agent skill and five-view MCP PDF outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This repository is an **MVP and research prototype** focused on **low-voltage ma
 - Trace generation runs and structured LLM calls with **Langfuse** when project keys are configured
 - Let external agents integrate over **REST long-polling, WebSocket, optional TCP JSONL sockets, or MCP-style JSON-RPC tools**
 - Install the portable **Forma Agent Skill** for Claude Code and Codex
-- Return printable **PDF project reports** from MCP generation and export tools
+- Return five-view **PDF workspace captures** (`INFO`, `BOM`, `MECH`, `WIRE`, `DOCS`) from MCP compile, generation, and export tools
 
 ## How it works
 
@@ -354,7 +354,7 @@ Use the shared `LLM_API_KEY`, `LLM_MODEL`, and `LLM_BASE_URL` variables with `LL
 - `A2A_SOCKET_ENABLED`: Set to `true` to start the optional TCP JSONL A2A socket.
 - `A2A_SOCKET_HOST` / `A2A_SOCKET_PORT`: Host and port for the optional TCP JSONL listener.
 
-If no live LLM provider is configured or generation fails, the backend returns deterministic simulation outputs based on built-in example projects.
+If no live LLM provider is configured or generation fails, the backend returns an error. Simulation is never an automatic fallback; it requires an explicit `allow_simulation` request. Claude Code and Codex integrations normally author Hardware IR themselves and use `blueprint.compile_project` for deterministic validation and artifact generation.
 
 ### Frontend (Next.js)
 ```bash

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This repository is an **MVP and research prototype** focused on **low-voltage ma
 - Persist generated projects to **Supabase** through the Supabase client when configured, with an automatic **SQLite fallback** and `BLUEPRINT_DEV_MODE` for SQLite-only local work
 - Trace generation runs and structured LLM calls with **Langfuse** when project keys are configured
 - Let external agents integrate over **REST long-polling, WebSocket, optional TCP JSONL sockets, or MCP-style JSON-RPC tools**
+- Install the portable **Forma Agent Skill** for Claude Code and Codex
 
 ## How it works
 
@@ -117,6 +118,17 @@ blueprint-core validate project.json
 blueprint-core iterate project.json "Make the enclosure splash resistant" --namespace product.mech --output revised.json
 python -m blueprint_core --help
 ```
+
+**Claude Code and Codex Agent Skill:**
+
+Install the same portable Forma skill for both agents, then point it at a running Forma backend:
+
+```bash
+python scripts/operations/install-forma-skill.py
+export FORMA_MCP_URL=http://127.0.0.1:8000/mcp
+```
+
+Use `/forma-hardware` in Claude Code or `$forma-hardware` in Codex. Project-scoped installation, authentication, examples, and package details are documented in [Claude Code and Codex Agent Skill](docs/agent-skills.md).
 
 **Developer utilities:**
 
@@ -372,6 +384,7 @@ Tip: load an example directly with http://localhost:3000/?example=pocket_mp3_pla
 - [Validation](docs/validation.md)
 - [Database](docs/database.md)
 - [A2A](docs/a2a.md)
+- [Claude Code and Codex Agent Skill](docs/agent-skills.md)
 - [Backend](docs/backend.md)
 - [Frontend](docs/frontend.md)
 - [Setup](docs/setup.md)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This repository is an **MVP and research prototype** focused on **low-voltage ma
 - Trace generation runs and structured LLM calls with **Langfuse** when project keys are configured
 - Let external agents integrate over **REST long-polling, WebSocket, optional TCP JSONL sockets, or MCP-style JSON-RPC tools**
 - Install the portable **Forma Agent Skill** for Claude Code and Codex
+- Return printable **PDF project reports** from MCP generation and export tools
 
 ## How it works
 

--- a/apps/api/a2a.py
+++ b/apps/api/a2a.py
@@ -41,7 +41,7 @@ from blueprint_core.workspaces.projects.exports import (
     attach_project_output_artifacts,
     build_project_pdf_artifact,
 )
-from blueprint_core.workspaces.projects.models import ComponentInstance, ConnectionNet
+from blueprint_core.workspaces.projects.models import ComponentInstance, ConnectionNet, HardwareIR
 from blueprint_core.observability import (
     get_langfuse_debug_config,
     propagate_observation_attributes,
@@ -58,7 +58,7 @@ from blueprint_core.runtime import (
 from blueprint_core.user_integrations import UserIntegrationStore, apply_user_integrations_to_environment, default_integration_store
 from apps.api.storage import get_image_storage_config, upload_image_to_supabase_s3
 from blueprint_core.utils import generate_mermaid_chart, generate_svg_schematic
-from blueprint_core.validation import validate_circuit
+from blueprint_core.validation import build_validation_summary, check_safety_violations, validate_circuit
 
 
 logger = logging.getLogger(__name__)
@@ -86,6 +86,17 @@ def _payload_bool(value: Any, default: bool = False) -> bool:
     if isinstance(value, str):
         return value.strip().lower() in {"1", "true", "yes", "on"}
     return bool(value)
+
+
+def require_explicit_simulation(llm_config: Dict[str, Any], *, allow_simulation: bool) -> None:
+    runtime = llm_config.get("runtime") if isinstance(llm_config, dict) else None
+    runtime_provider = runtime.get("runtime_provider") if isinstance(runtime, dict) else None
+    provider = str(runtime_provider or llm_config.get("provider") or "").strip().lower()
+    if provider == "simulation" and not allow_simulation:
+        raise ValueError(
+            "Simulation generation is disabled unless allow_simulation=true is explicitly supplied. "
+            "Claude Code and Codex integrations should author Hardware IR and call blueprint.compile_project instead."
+        )
 
 
 class A2AAgentRegistration(BaseModel):
@@ -219,6 +230,7 @@ def get_a2a_capabilities() -> Dict[str, Any]:
                 "alias": "/api/a2a/mcp",
                 "tools": [
                     "blueprint.generate_project",
+                    "blueprint.compile_project",
                     "blueprint.debug_config",
                     "blueprint.validate_circuit",
                     "blueprint.export_project_pdf",
@@ -240,6 +252,7 @@ def get_a2a_capabilities() -> Dict[str, Any]:
         "data_sources": list_generation_data_sources(),
         "actions": [
             "blueprint.generate_project",
+            "blueprint.compile_project",
             "blueprint.debug_config",
             "blueprint.validate_circuit",
             "blueprint.export_project_pdf",
@@ -766,6 +779,7 @@ def build_generation_response(
     data_sources: Optional[List[str]] = None,
     past_job_context: Optional[PastJobContext] = None,
     project_id: Optional[str] = None,
+    allow_simulation: bool = False,
 ) -> Dict[str, Any]:
     _apply_owner_user_integrations(owner_user_id)
 
@@ -797,6 +811,7 @@ def build_generation_response(
         model_name=model,
         external_source_provider=external_source_provider,
     )
+    require_explicit_simulation(llm_config, allow_simulation=allow_simulation)
     if deployment_runtime_config(llm_config)["alpha_generation_gate_active"]:
         raise AlphaGenerationUnavailableError(generation_unavailable_message(llm_config))
 
@@ -991,7 +1006,57 @@ async def call_blueprint_action(action: str, payload: Dict[str, Any]) -> Dict[st
             data_sources,
             past_job_context,
             payload.get("project_id"),
+            _payload_bool(payload.get("allow_simulation"), default=False),
         )
+        return attach_project_output_artifacts(response, payload.get("output_formats"))
+
+    if normalized == "compile_project":
+        project_ir = payload.get("project_ir")
+        if not isinstance(project_ir, dict):
+            raise ValueError("project_ir must be a Forma Hardware IR object authored by Claude Code or Codex.")
+        authoring_agent = str(payload.get("authoring_agent") or "").strip().lower()
+        if authoring_agent not in {"claude", "codex"}:
+            raise ValueError("authoring_agent must be claude or codex.")
+        ir = HardwareIR.model_validate(project_ir)
+        safety_text = " ".join(
+            filter(
+                None,
+                [
+                    getattr(ir.overview, "title", None),
+                    getattr(ir.overview, "description", None),
+                    *((ir.requirements.requirements if ir.requirements else []) or []),
+                ],
+            )
+        )
+        safety_error = check_safety_violations(safety_text)
+        if safety_error:
+            raise ValueError(safety_error)
+        issues = validate_circuit(ir.components, ir.nets, ir.requirements)
+        ir.validation = build_validation_summary(issues)
+        ir.is_valid = not ir.validation.critical
+        if ir.overview:
+            ir.overview.estimated_cost = round(
+                sum(component.unit_price * component.quantity for component in ir.components),
+                2,
+            )
+        ir.assembly_metadata = {
+            **(ir.assembly_metadata or {}),
+            "generation_mode": "host_agent",
+            "authoring_agent": authoring_agent,
+            "simulation": False,
+            "pipeline": f"{authoring_agent}-authored Hardware IR + Forma deterministic compiler",
+        }
+        response = {
+            "project_id": payload.get("project_id") or ir.assembly_metadata.get("project_id"),
+            "project_ir": ir.model_dump(mode="json"),
+            "mermaid_code": generate_mermaid_chart(ir),
+            "svg_schematic": generate_svg_schematic(ir),
+            "generation": {
+                "mode": "host_agent",
+                "authoring_agent": authoring_agent,
+                "simulation": False,
+            },
+        }
         return attach_project_output_artifacts(response, payload.get("output_formats"))
 
     if normalized == "export_project_pdf":
@@ -1283,7 +1348,7 @@ def _mcp_tools() -> List[Dict[str, Any]]:
     return [
         {
             "name": "blueprint.generate_project",
-            "description": "Generate a Forma Hardware IR package, Mermaid diagram, SVG schematic, and optional PDF report.",
+            "description": "Run an explicitly configured server-side LLM to generate Hardware IR. Claude Code and Codex integrations should normally author IR themselves and use blueprint.compile_project.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -1295,6 +1360,16 @@ def _mcp_tools() -> List[Dict[str, Any]]:
                     },
                     "image_data": {"type": "string", "description": "Optional data URL or base64 image"},
                     "generate_image": {"type": "boolean", "default": False},
+                    "provider": {
+                        "type": "string",
+                        "description": "Explicit configured server LLM provider, such as anthropic or openai.",
+                    },
+                    "model": {"type": "string", "description": "Optional allowed server model override."},
+                    "allow_simulation": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": "Must be true to deliberately allow deterministic simulation output.",
+                    },
                     "external_source_provider": {
                         "type": "string",
                         "enum": ["firecrawl"],
@@ -1322,6 +1397,24 @@ def _mcp_tools() -> List[Dict[str, Any]]:
             },
         },
         {
+            "name": "blueprint.compile_project",
+            "description": "Compile Hardware IR authored by Claude Code or Codex, run deterministic validation, build diagrams, and optionally return the five-view PDF.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "project_ir": {"type": "object", "description": "Complete Forma Hardware IR authored by the host agent."},
+                    "authoring_agent": {"type": "string", "enum": ["claude", "codex"]},
+                    "project_id": {"type": "string"},
+                    "output_formats": {
+                        "type": "array",
+                        "items": {"type": "string", "enum": ["pdf"]},
+                        "uniqueItems": True,
+                    },
+                },
+                "required": ["project_ir", "authoring_agent"],
+            },
+        },
+        {
             "name": "blueprint.debug_config",
             "description": "Return configured LLM provider and model resolution details.",
             "inputSchema": {"type": "object", "properties": {}},
@@ -1340,7 +1433,7 @@ def _mcp_tools() -> List[Dict[str, Any]]:
         },
         {
             "name": "blueprint.export_project_pdf",
-            "description": "Render an existing Forma Hardware IR object as an embedded application/pdf project report.",
+            "description": "Render existing Hardware IR as a five-page INFO, BOM, MECH, WIRE, and DOCS workspace-capture PDF.",
             "inputSchema": {
                 "type": "object",
                 "properties": {

--- a/apps/api/a2a.py
+++ b/apps/api/a2a.py
@@ -37,6 +37,10 @@ from blueprint_core.jobs.context import (
 )
 from blueprint_core.jobs.source_usage import normalize_source_usage
 from blueprint_core.llm import get_llm_runtime_debug_config
+from blueprint_core.workspaces.projects.exports import (
+    attach_project_output_artifacts,
+    build_project_pdf_artifact,
+)
 from blueprint_core.workspaces.projects.models import ComponentInstance, ConnectionNet
 from blueprint_core.observability import (
     get_langfuse_debug_config,
@@ -217,6 +221,7 @@ def get_a2a_capabilities() -> Dict[str, Any]:
                     "blueprint.generate_project",
                     "blueprint.debug_config",
                     "blueprint.validate_circuit",
+                    "blueprint.export_project_pdf",
                     "blueprint.a2a.send_message",
                     "blueprint.a2a.poll_events",
                     "blueprint.a2a.get_job",
@@ -237,6 +242,7 @@ def get_a2a_capabilities() -> Dict[str, Any]:
             "blueprint.generate_project",
             "blueprint.debug_config",
             "blueprint.validate_circuit",
+            "blueprint.export_project_pdf",
             "blueprint.a2a.capabilities",
             "blueprint.a2a.get_job",
             "blueprint.a2a.list_jobs",
@@ -969,7 +975,7 @@ async def call_blueprint_action(action: str, payload: Dict[str, Any]) -> Dict[st
                 limit=int(payload.get("past_jobs_limit") or 3),
                 exclude_job_id=payload.get("client_job_id") or payload.get("frontend_job_id"),
             )
-        return await asyncio.to_thread(
+        response = await asyncio.to_thread(
             build_generation_response,
             payload.get("prompt", ""),
             payload.get("image_data"),
@@ -986,6 +992,21 @@ async def call_blueprint_action(action: str, payload: Dict[str, Any]) -> Dict[st
             past_job_context,
             payload.get("project_id"),
         )
+        return attach_project_output_artifacts(response, payload.get("output_formats"))
+
+    if normalized == "export_project_pdf":
+        project_ir = payload.get("project_ir")
+        if not isinstance(project_ir, dict):
+            raise ValueError("project_ir must be a Forma Hardware IR object.")
+        return {
+            "artifacts": [
+                build_project_pdf_artifact(
+                    project_ir,
+                    requested_filename=payload.get("filename"),
+                    project_id=payload.get("project_id"),
+                )
+            ]
+        }
 
     if normalized == "debug_config":
         orchestrator = HardwarePipelineOrchestrator(
@@ -1232,17 +1253,37 @@ def _jsonrpc_error(request_id: Any, code: int, message: str, data: Optional[Any]
 
 
 def _mcp_tool_result(result: Dict[str, Any]) -> Dict[str, Any]:
-    return {
-        "content": [{"type": "text", "text": json.dumps(result)}],
-        "structuredContent": result,
-    }
+    structured = json.loads(json.dumps(result))
+    content: List[Dict[str, Any]] = []
+    artifacts = structured.get("artifacts") if isinstance(structured, dict) else None
+    if isinstance(artifacts, list):
+        for artifact in artifacts:
+            if not isinstance(artifact, dict):
+                continue
+            encoded = artifact.pop("data_base64", None)
+            if not isinstance(encoded, str) or not encoded:
+                continue
+            artifact["delivery"] = "embedded_resource"
+            content.append(
+                {
+                    "type": "resource",
+                    "resource": {
+                        "uri": artifact.get("uri") or f"forma://artifacts/{artifact.get('filename', 'output.bin')}",
+                        "mimeType": artifact.get("mime_type") or "application/octet-stream",
+                        "blob": encoded,
+                    },
+                    "annotations": {"audience": ["user"], "priority": 1.0},
+                }
+            )
+    content.insert(0, {"type": "text", "text": json.dumps(structured)})
+    return {"content": content, "structuredContent": structured}
 
 
 def _mcp_tools() -> List[Dict[str, Any]]:
     return [
         {
             "name": "blueprint.generate_project",
-            "description": "Generate a Forma Hardware IR package, Mermaid diagram, and SVG schematic.",
+            "description": "Generate a Forma Hardware IR package, Mermaid diagram, SVG schematic, and optional PDF report.",
             "inputSchema": {
                 "type": "object",
                 "properties": {
@@ -1270,6 +1311,12 @@ def _mcp_tools() -> List[Dict[str, Any]]:
                         "maximum": 8,
                         "default": 3,
                     },
+                    "output_formats": {
+                        "type": "array",
+                        "items": {"type": "string", "enum": ["pdf"]},
+                        "uniqueItems": True,
+                        "description": "Optional additional output artifacts. Request pdf for an embedded application/pdf report.",
+                    },
                 },
                 "required": ["prompt"],
             },
@@ -1289,6 +1336,19 @@ def _mcp_tools() -> List[Dict[str, Any]]:
                     "nets": {"type": "array", "items": {"type": "object"}},
                 },
                 "required": ["components", "nets"],
+            },
+        },
+        {
+            "name": "blueprint.export_project_pdf",
+            "description": "Render an existing Forma Hardware IR object as an embedded application/pdf project report.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "project_ir": {"type": "object", "description": "Forma Hardware IR object to render."},
+                    "filename": {"type": "string", "description": "Optional output filename ending in .pdf."},
+                    "project_id": {"type": "string", "description": "Optional project id used in the resource URI."},
+                },
+                "required": ["project_ir"],
             },
         },
         {

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -112,6 +112,7 @@ from apps.api.a2a import (
     get_a2a_capabilities,
     handle_a2a_websocket,
     handle_mcp_json_rpc,
+    require_explicit_simulation,
     start_a2a_tcp_server,
     stop_a2a_tcp_server,
     submit_a2a_message,
@@ -520,7 +521,8 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
             model_name=request.model,
             external_source_provider=request.external_source_provider,
         )
-    except LLMProviderConfigError as e:
+        require_explicit_simulation(llm_config, allow_simulation=request.allow_simulation)
+    except (LLMProviderConfigError, ValueError) as e:
         raise HTTPException(
             status_code=400,
             detail=api_error_detail(
@@ -582,6 +584,7 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
         "workflow": request.workflow,
         "image_data": request.image_data,
         "generate_image": request.generate_image,
+        "allow_simulation": request.allow_simulation,
         "provider": request.provider,
         "model": request.model,
         "chat_id": request.chat_id,
@@ -634,6 +637,7 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
                 data_sources=request.data_sources,
                 past_job_context=past_job_context,
                 project_id=request.project_id,
+                allow_simulation=request.allow_simulation,
             )
         if JOB_STORE.is_cancelled(job_id):
             raise JobCancelledError(f"Job {job_id} was cancelled.")

--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -3227,66 +3227,18 @@ export function FormaWorkspace({
         });
         return;
       }
-      console.warn("Using local simulation fallback", error);
-      try {
-        const mockRes = await runMockCompilation(promptText, imageData);
-        mockRes.project_ir.assembly_metadata = {
-          ...(mockRes.project_ir.assembly_metadata || {}),
-          chat_id: requestChatId,
-          can_chat: true,
-        };
-        setProjectIR(mockRes.project_ir);
-        const fallbackProjectId = projectIdFromIR(mockRes.project_ir);
-        generatedProjectId = fallbackProjectId;
-        const fallbackMessage = `${mockRes.project_ir?.overview?.title || "Local example"} is loaded from local fallback because live generation failed.`;
-        rememberProjectRecord({
-          project_id: fallbackProjectId,
-          chat_id: requestChatId,
-          title: mockRes.project_ir?.overview?.title || rawPromptText,
-          prompt: promptText,
-          created_at: chatTimestamp(),
-          can_chat: true,
-          creator_display: "you",
-          creator_image_url: userImageUrl,
-          parts_count: Array.isArray(mockRes.project_ir?.components) ? mockRes.project_ir.components.length : 0,
-          star_count: 0,
-        });
-        rememberChatItem({
-          chatId: requestChatId,
-          title: mockRes.project_ir?.overview?.title || rawPromptText,
-          projectId: fallbackProjectId || "",
-          createdAt: chatTimestamp(),
-          projectCount: fallbackProjectId ? 1 : 0,
-        });
-        updateChatMessage(assistantMessageId, {
-          content: fallbackMessage,
-          status: "success",
-          projectId: fallbackProjectId,
-        });
-        if (fallbackProjectId) {
-          updateThreadMessage(requestChatId, userMessageId, {
-            projectId: fallbackProjectId,
-          });
-          updateThreadMessage(requestChatId, assistantMessageId, {
-            content: fallbackMessage,
-            status: "success",
-            projectId: fallbackProjectId,
-          });
-        }
-        generatedProject = true;
-      } catch (fallbackError) {
-        const message = fallbackError instanceof Error ? fallbackError.message : "Local example fallback failed.";
-        const errorMessage = generationFailureChatMessage(`Generation failed and local fallback was unavailable: ${message}`);
-        setGenerationInputNotice(errorMessage);
-        updateChatMessage(assistantMessageId, {
-          content: errorMessage,
-          status: "error",
-        });
-        updateThreadMessage(requestChatId, assistantMessageId, {
-          content: errorMessage,
-          status: "error",
-        });
-      }
+      console.error("Live generation failed", error);
+      const message = error instanceof Error ? error.message : "Live generation failed.";
+      const errorMessage = generationFailureChatMessage(message);
+      setGenerationInputNotice(errorMessage);
+      updateChatMessage(assistantMessageId, {
+        content: errorMessage,
+        status: "error",
+      });
+      updateThreadMessage(requestChatId, assistantMessageId, {
+        content: errorMessage,
+        status: "error",
+      });
     } finally {
       if (progressPollId !== null) window.clearInterval(progressPollId);
       if (generatedProject) {
@@ -3460,41 +3412,6 @@ export function FormaWorkspace({
     });
   }, []);
 
-
-  const runMockCompilation = async (userPrompt: string, imageData?: string | null): Promise<any> => {
-    const promptLower = userPrompt.toLowerCase();
-    let file = "biometric_deadbolt.json";
-
-    if (
-      imageData ||
-      promptLower.includes("mp3") ||
-      promptLower.includes("audio") ||
-      promptLower.includes("music") ||
-      promptLower.includes("player") ||
-      promptLower.includes("pocket")
-    ) {
-      file = "pocket_mp3_player.json";
-    } else if (promptLower.includes("water") || promptLower.includes("plant") || promptLower.includes("soil") || promptLower.includes("garden")) {
-      file = "plant_watering.json";
-    } else if (promptLower.includes("thermostat") || promptLower.includes("temperature") || promptLower.includes("weather")) {
-      file = "smart_thermostat.json";
-    }
-
-    const res = await fetch(`/examples/${file}`);
-    if (!res.ok) {
-      throw new Error(`Could not load local example ${file}.`);
-    }
-    const ir = await res.json();
-    ir.assembly_metadata = {
-      ...(ir.assembly_metadata || {}),
-      reference_image_data: imageData || ir.assembly_metadata?.reference_image_data || null,
-      input_mode: imageData ? "prompt_image" : "prompt",
-      image_features: ir.assembly_metadata?.image_features || ir.constraints || [],
-    };
-    return {
-      project_ir: ir,
-    };
-  };
 
   const loadOldProject = async (
     projectId: string,

--- a/blueprint_core/workspaces/projects/exports.py
+++ b/blueprint_core/workspaces/projects/exports.py
@@ -1,34 +1,19 @@
-"""Portable project report exports for Forma clients and MCP tools."""
+"""Portable project artifact exports for Forma clients and MCP tools."""
 
 from __future__ import annotations
 
 import base64
 import hashlib
 import re
-import textwrap
 import unicodedata
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import Any, Mapping
+
+from blueprint_core.workspaces.projects.report_views import render_project_screenshot_pdf
 
 
 PDF_MIME_TYPE = "application/pdf"
 SUPPORTED_PROJECT_OUTPUT_FORMATS = ("pdf",)
-
-_PAGE_WIDTH = 612.0
-_PAGE_HEIGHT = 792.0
-_MARGIN_X = 48.0
-_TOP_Y = 744.0
-_BOTTOM_Y = 52.0
-
-_STYLE = {
-    "title": ("F2", 20.0, 26.0, 10.0),
-    "heading": ("F2", 14.0, 19.0, 5.0),
-    "subheading": ("F2", 11.0, 15.0, 2.0),
-    "body": ("F1", 9.5, 13.0, 2.0),
-    "bullet": ("F1", 9.5, 13.0, 1.0),
-    "warning": ("F2", 9.5, 13.0, 2.0),
-    "small": ("F1", 8.0, 11.0, 1.0),
-}
 
 
 def _mapping(value: Any) -> dict[str, Any]:
@@ -38,260 +23,15 @@ def _mapping(value: Any) -> dict[str, Any]:
     return dict(value) if isinstance(value, Mapping) else {}
 
 
-def _items(value: Any) -> list[Any]:
-    return list(value) if isinstance(value, (list, tuple)) else []
-
-
 def _single_line(value: Any) -> str:
     if value is None:
         return ""
     return re.sub(r"\s+", " ", str(value)).strip()
 
 
-def _money(value: Any) -> str:
-    try:
-        return f"${float(value):,.2f}"
-    except (TypeError, ValueError):
-        return "$0.00"
-
-
-def _append_list(lines: list[tuple[str, str]], values: Iterable[Any], *, empty: str | None = None) -> None:
-    appended = False
-    for value in values:
-        text = _single_line(value)
-        if text:
-            lines.append(("bullet", f"- {text}"))
-            appended = True
-    if not appended and empty:
-        lines.append(("small", empty))
-
-
-def build_project_report_lines(project_ir: Any) -> list[tuple[str, str]]:
-    """Build deterministic styled text lines for a Forma project report."""
-    project = _mapping(project_ir)
-    overview = _mapping(project.get("overview"))
-    requirements = _mapping(project.get("requirements"))
-    validation = _mapping(project.get("validation"))
-    mechanical = _mapping(project.get("mechanical"))
-    title = _single_line(overview.get("title")) or "Untitled Forma Project"
-
-    lines: list[tuple[str, str]] = [
-        ("title", title),
-        ("small", "Forma Hardware Project Report"),
-        ("body", _single_line(overview.get("description")) or "No project description was provided."),
-        (
-            "small",
-            " | ".join(
-                part
-                for part in (
-                    f"Category: {_single_line(overview.get('category'))}" if overview.get("category") else "",
-                    f"Difficulty: {_single_line(overview.get('difficulty'))}" if overview.get("difficulty") else "",
-                    f"Estimated BOM: {_money(overview.get('estimated_cost'))}",
-                    f"IR version: {_single_line(project.get('hardware_ir_version')) or 'unknown'}",
-                )
-                if part
-            ),
-        ),
-        ("heading", "Requirements and Power"),
-    ]
-    power_parts = [
-        _single_line(requirements.get("power_needs")),
-        f"Operating voltage: {_single_line(requirements.get('operating_voltage'))} V"
-        if requirements.get("operating_voltage") is not None
-        else "",
-        f"Estimated peak current: {_single_line(project.get('estimated_current_draw_ma'))} mA"
-        if project.get("estimated_current_draw_ma") is not None
-        else "",
-    ]
-    lines.append(("body", " | ".join(part for part in power_parts if part) or "Power requirements were not provided."))
-    _append_list(lines, _items(requirements.get("requirements")), empty="No functional requirements were listed.")
-    _append_list(lines, _items(requirements.get("physical_constraints")))
-    for note in _items(requirements.get("safety_notes")):
-        text = _single_line(note)
-        if text:
-            lines.append(("warning", f"Safety: {text}"))
-    for missing in _items(requirements.get("missing_info")):
-        text = _single_line(missing)
-        if text:
-            lines.append(("warning", f"Open question: {text}"))
-
-    lines.append(("heading", "Bill of Materials"))
-    components = _items(project.get("components"))
-    if not components:
-        lines.append(("small", "No components were listed."))
-    for component_value in components:
-        component = _mapping(component_value)
-        ref_des = _single_line(component.get("ref_des")) or "UNREF"
-        name = _single_line(component.get("name")) or _single_line(component.get("part_number")) or "Unnamed component"
-        part_number = _single_line(component.get("part_number"))
-        quantity = component.get("quantity", 1)
-        unit_price = _money(component.get("unit_price"))
-        lines.append(("subheading", f"{ref_des} - {name}"))
-        lines.append(("small", f"Part: {part_number or 'unspecified'} | Qty: {quantity} | Unit estimate: {unit_price}"))
-        rationale = _single_line(component.get("rationale"))
-        if rationale:
-            lines.append(("body", rationale))
-
-    lines.append(("heading", "Electrical Connections"))
-    nets = _items(project.get("nets"))
-    if not nets:
-        lines.append(("small", "No connection nets were listed."))
-    for net_value in nets:
-        net = _mapping(net_value)
-        name = _single_line(net.get("name")) or _single_line(net.get("net_id")) or "Unnamed net"
-        details = [_single_line(net.get("net_type"))]
-        if net.get("voltage") is not None:
-            details.append(f"{_single_line(net.get('voltage'))} V")
-        pins = []
-        for pin_value in _items(net.get("pins")):
-            pin = _mapping(pin_value)
-            pin_text = ".".join(filter(None, (_single_line(pin.get("ref_des")), _single_line(pin.get("pin_id")))))
-            if pin_text:
-                pins.append(pin_text)
-        if pins:
-            details.append(", ".join(pins))
-        lines.append(("bullet", f"- {name}: {' | '.join(filter(None, details))}"))
-
-    lines.append(("heading", "Validation and Safety Audit"))
-    critical = _items(validation.get("critical"))
-    warnings = _items(validation.get("warning"))
-    info = _items(validation.get("info"))
-    lines.append(("warning" if critical else "subheading", "BLOCKED - critical issues remain" if critical else "PASS - no critical issues reported"))
-    issues = [*critical, *warnings, *info]
-    if not issues:
-        lines.append(("small", "No validation findings were reported."))
-    for issue_value in issues:
-        issue = _mapping(issue_value)
-        severity = _single_line(issue.get("severity")).upper() or "INFO"
-        category = _single_line(issue.get("category")) or "Validation note"
-        description = _single_line(issue.get("description"))
-        troubleshooting = _single_line(issue.get("troubleshooting"))
-        lines.append(("warning" if severity == "CRITICAL" else "subheading", f"{severity} - {category}"))
-        if description:
-            lines.append(("body", description))
-        if troubleshooting:
-            lines.append(("small", f"Suggested action: {troubleshooting}"))
-
-    lines.append(("heading", "Assembly Instructions"))
-    assembly = _items(project.get("assembly"))
-    if not assembly:
-        lines.append(("small", "No assembly instructions were listed."))
-    for index, step_value in enumerate(assembly, start=1):
-        step = _mapping(step_value)
-        step_number = step.get("step_num") or index
-        step_title = _single_line(step.get("title")) or f"Step {step_number}"
-        lines.append(("subheading", f"{step_number}. {step_title}"))
-        description = _single_line(step.get("description"))
-        if description:
-            lines.append(("body", description))
-        if step.get("danger_flag"):
-            warning = _single_line(step.get("danger_message")) or "Pay close attention to safety constraints during this step."
-            lines.append(("warning", f"WARNING: {warning}"))
-
-    if mechanical:
-        lines.append(("heading", "Mechanical and Fabrication Notes"))
-        enclosure_type = _single_line(mechanical.get("enclosure_type"))
-        rating = _single_line(mechanical.get("manufacturability_rating"))
-        if enclosure_type or rating:
-            lines.append(("body", " | ".join(filter(None, (enclosure_type, f"Manufacturability: {rating}" if rating else "")))))
-        mounting = _single_line(mechanical.get("mounting_guidance"))
-        if mounting:
-            lines.append(("body", mounting))
-        _append_list(lines, _items(mechanical.get("fabrication_details")))
-
-    lines.extend(
-        [
-            ("heading", "Prototype Disclaimer"),
-            (
-                "warning",
-                "This report is an AI-assisted low-voltage prototype plan. Verify component ratings, wiring, sourcing, mechanical clearances, and regulatory requirements before fabrication or power-up.",
-            ),
-        ]
-    )
-    return lines
-
-
-def _pdf_text_bytes(value: str) -> bytes:
-    normalized = unicodedata.normalize("NFKD", value).replace("\u2014", "-").replace("\u2013", "-")
-    return normalized.encode("cp1252", errors="replace")
-
-
-def _wrapped_lines(style: str, value: str) -> list[str]:
-    _font, font_size, _leading, _after = _STYLE[style]
-    usable_width = _PAGE_WIDTH - (2 * _MARGIN_X)
-    width = max(24, int(usable_width / (font_size * 0.52)))
-    return textwrap.wrap(_single_line(value), width=width, break_long_words=True, break_on_hyphens=True) or [""]
-
-
-def _paginate(lines: list[tuple[str, str]]) -> list[list[tuple[str, float, float, float, str]]]:
-    pages: list[list[tuple[str, float, float, float, str]]] = [[]]
-    y = _TOP_Y
-    for style, value in lines:
-        font, size, leading, after = _STYLE[style]
-        wrapped = _wrapped_lines(style, value)
-        for index, wrapped_line in enumerate(wrapped):
-            if y - leading < _BOTTOM_Y:
-                pages.append([])
-                y = _TOP_Y
-            prefix_indent = 10.0 if style == "bullet" and index > 0 else 0.0
-            pages[-1].append((font, size, _MARGIN_X + prefix_indent, y, wrapped_line))
-            y -= leading
-        y -= after
-    return pages
-
-
-def _content_stream(page: list[tuple[str, float, float, float, str]], page_number: int, page_count: int) -> bytes:
-    commands: list[bytes] = []
-    for font, size, x, y, value in page:
-        encoded = _pdf_text_bytes(value).hex().upper().encode("ascii")
-        commands.append(
-            b"BT /" + font.encode("ascii") + f" {size:.2f} Tf 1 0 0 1 {x:.2f} {y:.2f} Tm <".encode("ascii") + encoded + b"> Tj ET\n"
-        )
-    footer = f"Forma prototype report | Page {page_number} of {page_count}"
-    footer_hex = _pdf_text_bytes(footer).hex().upper().encode("ascii")
-    commands.append(b"BT /F1 7.50 Tf 1 0 0 1 48.00 28.00 Tm <" + footer_hex + b"> Tj ET\n")
-    return b"".join(commands)
-
-
 def render_project_pdf(project_ir: Any) -> bytes:
-    """Render a self-contained, text-based PDF report without optional dependencies."""
-    pages = _paginate(build_project_report_lines(project_ir))
-    objects: list[bytes] = [
-        b"<< /Type /Catalog /Pages 2 0 R >>",
-        b"",
-        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
-        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>",
-    ]
-    page_refs: list[str] = []
-    for index, page in enumerate(pages):
-        page_object_number = 5 + (index * 2)
-        content_object_number = page_object_number + 1
-        page_refs.append(f"{page_object_number} 0 R")
-        stream = _content_stream(page, index + 1, len(pages))
-        page_object = (
-            f"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {_PAGE_WIDTH:.0f} {_PAGE_HEIGHT:.0f}] "
-            f"/Resources << /Font << /F1 3 0 R /F2 4 0 R >> >> /Contents {content_object_number} 0 R >>"
-        ).encode("ascii")
-        content_object = f"<< /Length {len(stream)} >>\nstream\n".encode("ascii") + stream + b"endstream"
-        objects.extend((page_object, content_object))
-    objects[1] = f"<< /Type /Pages /Kids [{' '.join(page_refs)}] /Count {len(pages)} >>".encode("ascii")
-
-    document = bytearray(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
-    offsets = [0]
-    for number, payload in enumerate(objects, start=1):
-        offsets.append(len(document))
-        document.extend(f"{number} 0 obj\n".encode("ascii"))
-        document.extend(payload)
-        document.extend(b"\nendobj\n")
-    xref_offset = len(document)
-    document.extend(f"xref\n0 {len(objects) + 1}\n".encode("ascii"))
-    document.extend(b"0000000000 65535 f \n")
-    for offset in offsets[1:]:
-        document.extend(f"{offset:010d} 00000 n \n".encode("ascii"))
-    document.extend(
-        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n".encode("ascii")
-    )
-    return bytes(document)
+    """Render INFO, BOM, MECH, WIRE, and DOCS workspace captures as a PDF."""
+    return render_project_screenshot_pdf(project_ir)
 
 
 def project_pdf_filename(project_ir: Any, requested_filename: str | None = None) -> str:
@@ -318,7 +58,9 @@ def build_project_pdf_artifact(
     pdf = render_project_pdf(project_ir)
     digest = hashlib.sha256(pdf).hexdigest()
     filename = project_pdf_filename(project_ir, requested_filename)
-    resolved_project_id = _single_line(project_id) or _single_line(_mapping(_mapping(project_ir).get("assembly_metadata")).get("project_id"))
+    resolved_project_id = _single_line(project_id) or _single_line(
+        _mapping(_mapping(project_ir).get("assembly_metadata")).get("project_id")
+    )
     resource_id = re.sub(r"[^A-Za-z0-9_.-]+", "-", resolved_project_id).strip("-") or digest[:16]
     return {
         "format": "pdf",
@@ -328,6 +70,9 @@ def build_project_pdf_artifact(
         "sha256": digest,
         "uri": f"forma://artifacts/{resource_id}/{filename}",
         "data_base64": base64.b64encode(pdf).decode("ascii"),
+        "views": ["info", "bom", "mech", "wire", "docs"],
+        "page_count": 5,
+        "rendering": "workspace_screenshots",
     }
 
 
@@ -367,7 +112,6 @@ __all__ = [
     "SUPPORTED_PROJECT_OUTPUT_FORMATS",
     "attach_project_output_artifacts",
     "build_project_pdf_artifact",
-    "build_project_report_lines",
     "normalize_project_output_formats",
     "project_pdf_filename",
     "render_project_pdf",

--- a/blueprint_core/workspaces/projects/exports.py
+++ b/blueprint_core/workspaces/projects/exports.py
@@ -1,0 +1,374 @@
+"""Portable project report exports for Forma clients and MCP tools."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+import textwrap
+import unicodedata
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+PDF_MIME_TYPE = "application/pdf"
+SUPPORTED_PROJECT_OUTPUT_FORMATS = ("pdf",)
+
+_PAGE_WIDTH = 612.0
+_PAGE_HEIGHT = 792.0
+_MARGIN_X = 48.0
+_TOP_Y = 744.0
+_BOTTOM_Y = 52.0
+
+_STYLE = {
+    "title": ("F2", 20.0, 26.0, 10.0),
+    "heading": ("F2", 14.0, 19.0, 5.0),
+    "subheading": ("F2", 11.0, 15.0, 2.0),
+    "body": ("F1", 9.5, 13.0, 2.0),
+    "bullet": ("F1", 9.5, 13.0, 1.0),
+    "warning": ("F2", 9.5, 13.0, 2.0),
+    "small": ("F1", 8.0, 11.0, 1.0),
+}
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if hasattr(value, "model_dump"):
+        dumped = value.model_dump(mode="json")
+        return dumped if isinstance(dumped, dict) else {}
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _items(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, (list, tuple)) else []
+
+
+def _single_line(value: Any) -> str:
+    if value is None:
+        return ""
+    return re.sub(r"\s+", " ", str(value)).strip()
+
+
+def _money(value: Any) -> str:
+    try:
+        return f"${float(value):,.2f}"
+    except (TypeError, ValueError):
+        return "$0.00"
+
+
+def _append_list(lines: list[tuple[str, str]], values: Iterable[Any], *, empty: str | None = None) -> None:
+    appended = False
+    for value in values:
+        text = _single_line(value)
+        if text:
+            lines.append(("bullet", f"- {text}"))
+            appended = True
+    if not appended and empty:
+        lines.append(("small", empty))
+
+
+def build_project_report_lines(project_ir: Any) -> list[tuple[str, str]]:
+    """Build deterministic styled text lines for a Forma project report."""
+    project = _mapping(project_ir)
+    overview = _mapping(project.get("overview"))
+    requirements = _mapping(project.get("requirements"))
+    validation = _mapping(project.get("validation"))
+    mechanical = _mapping(project.get("mechanical"))
+    title = _single_line(overview.get("title")) or "Untitled Forma Project"
+
+    lines: list[tuple[str, str]] = [
+        ("title", title),
+        ("small", "Forma Hardware Project Report"),
+        ("body", _single_line(overview.get("description")) or "No project description was provided."),
+        (
+            "small",
+            " | ".join(
+                part
+                for part in (
+                    f"Category: {_single_line(overview.get('category'))}" if overview.get("category") else "",
+                    f"Difficulty: {_single_line(overview.get('difficulty'))}" if overview.get("difficulty") else "",
+                    f"Estimated BOM: {_money(overview.get('estimated_cost'))}",
+                    f"IR version: {_single_line(project.get('hardware_ir_version')) or 'unknown'}",
+                )
+                if part
+            ),
+        ),
+        ("heading", "Requirements and Power"),
+    ]
+    power_parts = [
+        _single_line(requirements.get("power_needs")),
+        f"Operating voltage: {_single_line(requirements.get('operating_voltage'))} V"
+        if requirements.get("operating_voltage") is not None
+        else "",
+        f"Estimated peak current: {_single_line(project.get('estimated_current_draw_ma'))} mA"
+        if project.get("estimated_current_draw_ma") is not None
+        else "",
+    ]
+    lines.append(("body", " | ".join(part for part in power_parts if part) or "Power requirements were not provided."))
+    _append_list(lines, _items(requirements.get("requirements")), empty="No functional requirements were listed.")
+    _append_list(lines, _items(requirements.get("physical_constraints")))
+    for note in _items(requirements.get("safety_notes")):
+        text = _single_line(note)
+        if text:
+            lines.append(("warning", f"Safety: {text}"))
+    for missing in _items(requirements.get("missing_info")):
+        text = _single_line(missing)
+        if text:
+            lines.append(("warning", f"Open question: {text}"))
+
+    lines.append(("heading", "Bill of Materials"))
+    components = _items(project.get("components"))
+    if not components:
+        lines.append(("small", "No components were listed."))
+    for component_value in components:
+        component = _mapping(component_value)
+        ref_des = _single_line(component.get("ref_des")) or "UNREF"
+        name = _single_line(component.get("name")) or _single_line(component.get("part_number")) or "Unnamed component"
+        part_number = _single_line(component.get("part_number"))
+        quantity = component.get("quantity", 1)
+        unit_price = _money(component.get("unit_price"))
+        lines.append(("subheading", f"{ref_des} - {name}"))
+        lines.append(("small", f"Part: {part_number or 'unspecified'} | Qty: {quantity} | Unit estimate: {unit_price}"))
+        rationale = _single_line(component.get("rationale"))
+        if rationale:
+            lines.append(("body", rationale))
+
+    lines.append(("heading", "Electrical Connections"))
+    nets = _items(project.get("nets"))
+    if not nets:
+        lines.append(("small", "No connection nets were listed."))
+    for net_value in nets:
+        net = _mapping(net_value)
+        name = _single_line(net.get("name")) or _single_line(net.get("net_id")) or "Unnamed net"
+        details = [_single_line(net.get("net_type"))]
+        if net.get("voltage") is not None:
+            details.append(f"{_single_line(net.get('voltage'))} V")
+        pins = []
+        for pin_value in _items(net.get("pins")):
+            pin = _mapping(pin_value)
+            pin_text = ".".join(filter(None, (_single_line(pin.get("ref_des")), _single_line(pin.get("pin_id")))))
+            if pin_text:
+                pins.append(pin_text)
+        if pins:
+            details.append(", ".join(pins))
+        lines.append(("bullet", f"- {name}: {' | '.join(filter(None, details))}"))
+
+    lines.append(("heading", "Validation and Safety Audit"))
+    critical = _items(validation.get("critical"))
+    warnings = _items(validation.get("warning"))
+    info = _items(validation.get("info"))
+    lines.append(("warning" if critical else "subheading", "BLOCKED - critical issues remain" if critical else "PASS - no critical issues reported"))
+    issues = [*critical, *warnings, *info]
+    if not issues:
+        lines.append(("small", "No validation findings were reported."))
+    for issue_value in issues:
+        issue = _mapping(issue_value)
+        severity = _single_line(issue.get("severity")).upper() or "INFO"
+        category = _single_line(issue.get("category")) or "Validation note"
+        description = _single_line(issue.get("description"))
+        troubleshooting = _single_line(issue.get("troubleshooting"))
+        lines.append(("warning" if severity == "CRITICAL" else "subheading", f"{severity} - {category}"))
+        if description:
+            lines.append(("body", description))
+        if troubleshooting:
+            lines.append(("small", f"Suggested action: {troubleshooting}"))
+
+    lines.append(("heading", "Assembly Instructions"))
+    assembly = _items(project.get("assembly"))
+    if not assembly:
+        lines.append(("small", "No assembly instructions were listed."))
+    for index, step_value in enumerate(assembly, start=1):
+        step = _mapping(step_value)
+        step_number = step.get("step_num") or index
+        step_title = _single_line(step.get("title")) or f"Step {step_number}"
+        lines.append(("subheading", f"{step_number}. {step_title}"))
+        description = _single_line(step.get("description"))
+        if description:
+            lines.append(("body", description))
+        if step.get("danger_flag"):
+            warning = _single_line(step.get("danger_message")) or "Pay close attention to safety constraints during this step."
+            lines.append(("warning", f"WARNING: {warning}"))
+
+    if mechanical:
+        lines.append(("heading", "Mechanical and Fabrication Notes"))
+        enclosure_type = _single_line(mechanical.get("enclosure_type"))
+        rating = _single_line(mechanical.get("manufacturability_rating"))
+        if enclosure_type or rating:
+            lines.append(("body", " | ".join(filter(None, (enclosure_type, f"Manufacturability: {rating}" if rating else "")))))
+        mounting = _single_line(mechanical.get("mounting_guidance"))
+        if mounting:
+            lines.append(("body", mounting))
+        _append_list(lines, _items(mechanical.get("fabrication_details")))
+
+    lines.extend(
+        [
+            ("heading", "Prototype Disclaimer"),
+            (
+                "warning",
+                "This report is an AI-assisted low-voltage prototype plan. Verify component ratings, wiring, sourcing, mechanical clearances, and regulatory requirements before fabrication or power-up.",
+            ),
+        ]
+    )
+    return lines
+
+
+def _pdf_text_bytes(value: str) -> bytes:
+    normalized = unicodedata.normalize("NFKD", value).replace("\u2014", "-").replace("\u2013", "-")
+    return normalized.encode("cp1252", errors="replace")
+
+
+def _wrapped_lines(style: str, value: str) -> list[str]:
+    _font, font_size, _leading, _after = _STYLE[style]
+    usable_width = _PAGE_WIDTH - (2 * _MARGIN_X)
+    width = max(24, int(usable_width / (font_size * 0.52)))
+    return textwrap.wrap(_single_line(value), width=width, break_long_words=True, break_on_hyphens=True) or [""]
+
+
+def _paginate(lines: list[tuple[str, str]]) -> list[list[tuple[str, float, float, float, str]]]:
+    pages: list[list[tuple[str, float, float, float, str]]] = [[]]
+    y = _TOP_Y
+    for style, value in lines:
+        font, size, leading, after = _STYLE[style]
+        wrapped = _wrapped_lines(style, value)
+        for index, wrapped_line in enumerate(wrapped):
+            if y - leading < _BOTTOM_Y:
+                pages.append([])
+                y = _TOP_Y
+            prefix_indent = 10.0 if style == "bullet" and index > 0 else 0.0
+            pages[-1].append((font, size, _MARGIN_X + prefix_indent, y, wrapped_line))
+            y -= leading
+        y -= after
+    return pages
+
+
+def _content_stream(page: list[tuple[str, float, float, float, str]], page_number: int, page_count: int) -> bytes:
+    commands: list[bytes] = []
+    for font, size, x, y, value in page:
+        encoded = _pdf_text_bytes(value).hex().upper().encode("ascii")
+        commands.append(
+            b"BT /" + font.encode("ascii") + f" {size:.2f} Tf 1 0 0 1 {x:.2f} {y:.2f} Tm <".encode("ascii") + encoded + b"> Tj ET\n"
+        )
+    footer = f"Forma prototype report | Page {page_number} of {page_count}"
+    footer_hex = _pdf_text_bytes(footer).hex().upper().encode("ascii")
+    commands.append(b"BT /F1 7.50 Tf 1 0 0 1 48.00 28.00 Tm <" + footer_hex + b"> Tj ET\n")
+    return b"".join(commands)
+
+
+def render_project_pdf(project_ir: Any) -> bytes:
+    """Render a self-contained, text-based PDF report without optional dependencies."""
+    pages = _paginate(build_project_report_lines(project_ir))
+    objects: list[bytes] = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding >>",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding >>",
+    ]
+    page_refs: list[str] = []
+    for index, page in enumerate(pages):
+        page_object_number = 5 + (index * 2)
+        content_object_number = page_object_number + 1
+        page_refs.append(f"{page_object_number} 0 R")
+        stream = _content_stream(page, index + 1, len(pages))
+        page_object = (
+            f"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {_PAGE_WIDTH:.0f} {_PAGE_HEIGHT:.0f}] "
+            f"/Resources << /Font << /F1 3 0 R /F2 4 0 R >> >> /Contents {content_object_number} 0 R >>"
+        ).encode("ascii")
+        content_object = f"<< /Length {len(stream)} >>\nstream\n".encode("ascii") + stream + b"endstream"
+        objects.extend((page_object, content_object))
+    objects[1] = f"<< /Type /Pages /Kids [{' '.join(page_refs)}] /Count {len(pages)} >>".encode("ascii")
+
+    document = bytearray(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
+    offsets = [0]
+    for number, payload in enumerate(objects, start=1):
+        offsets.append(len(document))
+        document.extend(f"{number} 0 obj\n".encode("ascii"))
+        document.extend(payload)
+        document.extend(b"\nendobj\n")
+    xref_offset = len(document)
+    document.extend(f"xref\n0 {len(objects) + 1}\n".encode("ascii"))
+    document.extend(b"0000000000 65535 f \n")
+    for offset in offsets[1:]:
+        document.extend(f"{offset:010d} 00000 n \n".encode("ascii"))
+    document.extend(
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n".encode("ascii")
+    )
+    return bytes(document)
+
+
+def project_pdf_filename(project_ir: Any, requested_filename: str | None = None) -> str:
+    """Return a safe PDF filename derived from the request or project title."""
+    if requested_filename:
+        source = re.sub(r"(?i)\.pdf$", "", Path(requested_filename).name)
+        suffix = ""
+    else:
+        overview = _mapping(_mapping(project_ir).get("overview"))
+        source = _single_line(overview.get("title")) or "forma_project"
+        suffix = "_report"
+    normalized = unicodedata.normalize("NFKD", source).encode("ascii", errors="ignore").decode("ascii")
+    basename = re.sub(r"[^a-z0-9]+", "_", normalized.lower()).strip("_")[:80] or "forma_project"
+    return f"{basename}{suffix}.pdf"
+
+
+def build_project_pdf_artifact(
+    project_ir: Any,
+    *,
+    requested_filename: str | None = None,
+    project_id: str | None = None,
+) -> dict[str, Any]:
+    """Build a base64 PDF artifact ready for MCP embedded-resource delivery."""
+    pdf = render_project_pdf(project_ir)
+    digest = hashlib.sha256(pdf).hexdigest()
+    filename = project_pdf_filename(project_ir, requested_filename)
+    resolved_project_id = _single_line(project_id) or _single_line(_mapping(_mapping(project_ir).get("assembly_metadata")).get("project_id"))
+    resource_id = re.sub(r"[^A-Za-z0-9_.-]+", "-", resolved_project_id).strip("-") or digest[:16]
+    return {
+        "format": "pdf",
+        "filename": filename,
+        "mime_type": PDF_MIME_TYPE,
+        "size_bytes": len(pdf),
+        "sha256": digest,
+        "uri": f"forma://artifacts/{resource_id}/{filename}",
+        "data_base64": base64.b64encode(pdf).decode("ascii"),
+    }
+
+
+def normalize_project_output_formats(value: Any) -> list[str]:
+    """Normalize and validate requested additional project output formats."""
+    if value is None:
+        return []
+    values = [value] if isinstance(value, str) else value
+    if not isinstance(values, (list, tuple, set)):
+        raise ValueError("output_formats must be a list of format names.")
+    normalized = []
+    for item in values:
+        output_format = _single_line(item).lower()
+        if output_format not in SUPPORTED_PROJECT_OUTPUT_FORMATS:
+            raise ValueError(f"Unsupported project output format: {output_format or item!r}.")
+        if output_format not in normalized:
+            normalized.append(output_format)
+    return normalized
+
+
+def attach_project_output_artifacts(result: dict[str, Any], output_formats: Any) -> dict[str, Any]:
+    """Attach explicitly requested output artifacts to a generation response."""
+    formats = normalize_project_output_formats(output_formats)
+    if not formats:
+        return result
+    project_ir = result.get("project_ir")
+    if not isinstance(project_ir, Mapping):
+        raise ValueError("A generated project_ir object is required for project exports.")
+    artifacts = list(result.get("artifacts") or [])
+    if "pdf" in formats:
+        artifacts.append(build_project_pdf_artifact(project_ir, project_id=result.get("project_id")))
+    return {**result, "artifacts": artifacts, "output_formats": formats}
+
+
+__all__ = [
+    "PDF_MIME_TYPE",
+    "SUPPORTED_PROJECT_OUTPUT_FORMATS",
+    "attach_project_output_artifacts",
+    "build_project_pdf_artifact",
+    "build_project_report_lines",
+    "normalize_project_output_formats",
+    "project_pdf_filename",
+    "render_project_pdf",
+]

--- a/blueprint_core/workspaces/projects/models.py
+++ b/blueprint_core/workspaces/projects/models.py
@@ -206,6 +206,10 @@ class GenerateProjectRequest(BaseModel):
         False,
         description="When true, generate a product concept image with the configured image provider"
     )
+    allow_simulation: bool = Field(
+        False,
+        description="Explicit opt-in required before the deterministic simulation provider may generate output.",
+    )
     provider: Optional[str] = Field(
         None,
         description="Optional runtime LLM provider override, for example openai, anthropic, baseten, gmi, huggingface, cloudflare, nvidia, openai-compatible, gemini, runpod, runpod-serverless, or simulation"

--- a/blueprint_core/workspaces/projects/report_views.py
+++ b/blueprint_core/workspaces/projects/report_views.py
@@ -1,0 +1,434 @@
+"""Deterministic screenshot-style project views used by PDF exports."""
+
+from __future__ import annotations
+
+import io
+import math
+import textwrap
+from functools import lru_cache
+from typing import Any, Mapping
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+VIEW_NAMES = ("INFO", "BOM", "MECH", "WIRE", "DOCS")
+VIEW_SIZE = (1600, 1000)
+
+BG = "#090d14"
+PANEL = "#101823"
+PANEL_ALT = "#0c131d"
+BORDER = "#26364a"
+TEXT = "#edf4fb"
+MUTED = "#8da0b5"
+CYAN = "#22d3ee"
+CYAN_DARK = "#0e7490"
+YELLOW = "#facc15"
+GREEN = "#34d399"
+RED = "#fb7185"
+BLUE = "#60a5fa"
+PURPLE = "#c084fc"
+NET_COLORS = (CYAN, YELLOW, GREEN, BLUE, PURPLE, RED)
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    if hasattr(value, "model_dump"):
+        dumped = value.model_dump(mode="json")
+        return dumped if isinstance(dumped, dict) else {}
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _items(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, (list, tuple)) else []
+
+
+def _text(value: Any, fallback: str = "") -> str:
+    value = str(value or " ").strip()
+    return value if value else fallback
+
+
+def _number(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+@lru_cache(maxsize=32)
+def _font(size: int, bold: bool = False) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    names = ("DejaVuSans-Bold.ttf", "DejaVuSans.ttf") if bold else ("DejaVuSans.ttf",)
+    for name in names:
+        try:
+            return ImageFont.truetype(name, size=size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def _rounded(draw: ImageDraw.ImageDraw, box: tuple[int, int, int, int], *, fill: str = PANEL, outline: str = BORDER, radius: int = 16, width: int = 2) -> None:
+    draw.rounded_rectangle(box, radius=radius, fill=fill, outline=outline, width=width)
+
+
+def _fit_lines(draw: ImageDraw.ImageDraw, value: Any, *, font: ImageFont.ImageFont, width: int, max_lines: int) -> list[str]:
+    text = " ".join(_text(value).split())
+    if not text:
+        return []
+    average = max(1, int(draw.textlength("ABCDEFGHIJKLMNOPQRSTUVWXYZ", font=font) / 26))
+    lines = textwrap.wrap(text, width=max(8, width // average), break_long_words=True)
+    if len(lines) > max_lines:
+        lines = lines[:max_lines]
+        lines[-1] = lines[-1].rstrip(" .") + "..."
+    return lines
+
+
+def _multiline(draw: ImageDraw.ImageDraw, xy: tuple[int, int], value: Any, *, font: ImageFont.ImageFont, fill: str = TEXT, width: int, max_lines: int = 4, spacing: int = 8) -> int:
+    lines = _fit_lines(draw, value, font=font, width=width, max_lines=max_lines)
+    if not lines:
+        return xy[1]
+    draw.multiline_text(xy, "\n".join(lines), font=font, fill=fill, spacing=spacing)
+    line_height = font.getbbox("Ag")[3] - font.getbbox("Ag")[1]
+    return xy[1] + (len(lines) * line_height) + ((len(lines) - 1) * spacing)
+
+
+def _base(project: dict[str, Any], active: str) -> tuple[Image.Image, ImageDraw.ImageDraw]:
+    image = Image.new("RGB", VIEW_SIZE, BG)
+    draw = ImageDraw.Draw(image)
+    overview = _mapping(project.get("overview"))
+    title = _text(overview.get("title"), "Untitled Forma Project")
+
+    draw.text((54, 35), "FORMA", font=_font(19, True), fill=CYAN)
+    draw.text((54, 67), title, font=_font(28, True), fill=TEXT)
+    draw.text((1545, 47), "PROJECT CAPTURE", font=_font(13, True), fill=MUTED, anchor="ra")
+    draw.text((1545, 76), "AI-assisted prototype", font=_font(12), fill="#60758c", anchor="ra")
+    draw.line((54, 112, 1546, 112), fill=BORDER, width=2)
+
+    x = 54
+    for name in VIEW_NAMES:
+        tab_width = 126
+        is_active = name == active
+        if is_active:
+            draw.rounded_rectangle((x, 126, x + tab_width, 172), radius=11, fill="#12303b", outline=CYAN_DARK, width=2)
+        draw.text((x + tab_width // 2, 149), name, font=_font(14, True), fill=CYAN if is_active else MUTED, anchor="mm")
+        x += tab_width + 10
+    return image, draw
+
+
+def _metric(draw: ImageDraw.ImageDraw, box: tuple[int, int, int, int], label: str, value: str, accent: str = CYAN) -> None:
+    _rounded(draw, box)
+    x1, y1, _x2, _y2 = box
+    draw.rectangle((x1, y1, x1 + 5, _y2), fill=accent)
+    draw.text((x1 + 25, y1 + 20), label.upper(), font=_font(12, True), fill=MUTED)
+    draw.text((x1 + 25, y1 + 55), value, font=_font(26, True), fill=TEXT)
+
+
+def _info_view(project: dict[str, Any]) -> Image.Image:
+    image, draw = _base(project, "INFO")
+    overview = _mapping(project.get("overview"))
+    requirements = _mapping(project.get("requirements"))
+    validation = _mapping(project.get("validation"))
+    components = _items(project.get("components"))
+    nets = _items(project.get("nets"))
+    critical_count = len(_items(validation.get("critical")))
+    warning_count = len(_items(validation.get("warning")))
+
+    _rounded(draw, (54, 194, 1546, 365), fill=PANEL_ALT)
+    draw.text((82, 220), _text(overview.get("category"), "HARDWARE PROJECT").upper(), font=_font(13, True), fill=CYAN)
+    draw.text((82, 253), _text(overview.get("title"), "Untitled Forma Project"), font=_font(34, True), fill=TEXT)
+    _multiline(draw, (82, 302), overview.get("description"), font=_font(17), fill=MUTED, width=1370, max_lines=2)
+
+    _metric(draw, (54, 389, 330, 508), "Estimated BOM", f"${_number(overview.get('estimated_cost')):,.2f}", YELLOW)
+    _metric(draw, (350, 389, 626, 508), "Components", str(len(components)), CYAN)
+    _metric(draw, (646, 389, 922, 508), "Electrical nets", str(len(nets)), BLUE)
+    _metric(draw, (942, 389, 1218, 508), "Peak current", f"{_number(project.get('estimated_current_draw_ma')):,.0f} mA", PURPLE)
+    status = "BLOCKED" if critical_count else ("REVIEW" if warning_count else "PASS")
+    _metric(draw, (1238, 389, 1546, 508), "Validation", status, RED if critical_count else YELLOW if warning_count else GREEN)
+
+    _rounded(draw, (54, 532, 982, 946))
+    draw.text((82, 558), "REQUIREMENTS", font=_font(15, True), fill=CYAN)
+    power = _text(requirements.get("power_needs"), "Power requirements not supplied")
+    voltage = requirements.get("operating_voltage")
+    if voltage is not None:
+        power += f"  /  {_number(voltage):g} V logic"
+    power_bottom = _multiline(
+        draw,
+        (82, 591),
+        power,
+        font=_font(18, True),
+        fill=TEXT,
+        width=820,
+        max_lines=2,
+        spacing=5,
+    )
+    y = power_bottom + 24
+    requirement_items = _items(requirements.get("requirements")) + _items(requirements.get("physical_constraints"))
+    for item in requirement_items[:8]:
+        draw.ellipse((84, y + 7, 92, y + 15), fill=CYAN)
+        y = _multiline(draw, (106, y), item, font=_font(15), fill=MUTED, width=820, max_lines=2) + 17
+
+    _rounded(draw, (1004, 532, 1546, 946))
+    draw.text((1032, 558), "SAFETY & OPEN ITEMS", font=_font(15, True), fill=YELLOW)
+    safety_items = _items(requirements.get("safety_notes")) + [f"Open: {_text(item)}" for item in _items(requirements.get("missing_info"))]
+    if not safety_items:
+        safety_items = ["No additional safety notes were reported."]
+    y = 600
+    for item in safety_items[:7]:
+        _rounded(draw, (1030, y, 1520, min(y + 64, 920)), fill="#171a1c", outline="#4b4521", radius=10, width=1)
+        _multiline(draw, (1048, y + 14), item, font=_font(14), fill="#d8cf9e", width=450, max_lines=2, spacing=5)
+        y += 76
+        if y > 900:
+            break
+    return image
+
+
+def _bom_view(project: dict[str, Any]) -> Image.Image:
+    image, draw = _base(project, "BOM")
+    components = [_mapping(item) for item in _items(project.get("components"))]
+    total = sum(_number(item.get("unit_price")) * max(1, int(_number(item.get("quantity"), 1))) for item in components)
+
+    draw.text((54, 206), "BILL OF MATERIALS", font=_font(24, True), fill=TEXT)
+    draw.text((1546, 212), f"{len(components)} line items   /   ${total:,.2f} estimated", font=_font(15, True), fill=YELLOW, anchor="ra")
+    _rounded(draw, (54, 250, 1546, 925), radius=12)
+    columns = ((76, "REF"), (174, "PART / DESCRIPTION"), (790, "CATEGORY"), (1060, "QTY"), (1160, "UNIT"), (1320, "EXTENDED"))
+    draw.rectangle((55, 251, 1545, 302), fill="#142131")
+    for x, label in columns:
+        draw.text((x, 268), label, font=_font(12, True), fill=CYAN)
+    row_y = 303
+    row_height = 57
+    for index, component in enumerate(components[:10]):
+        if index % 2:
+            draw.rectangle((56, row_y, 1544, row_y + row_height), fill="#0d151f")
+        ref = _text(component.get("ref_des"), "-")
+        part = _text(component.get("part_number"), "Unspecified")
+        name = _text(component.get("name"), "Unnamed component")
+        category = _text(component.get("category"), "Other")
+        quantity = max(1, int(_number(component.get("quantity"), 1)))
+        price = _number(component.get("unit_price"))
+        draw.text((76, row_y + 18), ref, font=_font(14, True), fill=CYAN)
+        draw.text((174, row_y + 10), part, font=_font(14, True), fill=TEXT)
+        draw.text((174, row_y + 32), name[:68], font=_font(12), fill=MUTED)
+        draw.text((790, row_y + 19), category[:26], font=_font(13), fill=MUTED)
+        draw.text((1076, row_y + 19), str(quantity), font=_font(13, True), fill=TEXT)
+        draw.text((1160, row_y + 19), f"${price:,.2f}", font=_font(13), fill=TEXT)
+        draw.text((1320, row_y + 19), f"${price * quantity:,.2f}", font=_font(13, True), fill=YELLOW)
+        row_y += row_height
+    if len(components) > 10:
+        draw.text((76, 886), f"+ {len(components) - 10} additional line items in Hardware IR", font=_font(13), fill=MUTED)
+    draw.text((1540, 950), "Pricing and availability require supplier verification.", font=_font(12), fill="#66788b", anchor="ra")
+    return image
+
+
+def _placement_values(project: dict[str, Any]) -> list[dict[str, Any]]:
+    mechanical = _mapping(project.get("mechanical"))
+    placements = [_mapping(item) for item in _items(mechanical.get("component_placements"))]
+    if placements:
+        return placements
+    generated = []
+    for index, item in enumerate(_items(project.get("components"))[:12]):
+        component = _mapping(item)
+        column = index % 4
+        row = index // 4
+        generated.append({
+            "ref_des": component.get("ref_des"),
+            "label": component.get("name"),
+            "category": component.get("category"),
+            "position": {"x_mm": (column - 1.5) * 28, "y_mm": (row - 1) * 23, "z_mm": 0},
+            "size": {"x_mm": 20, "y_mm": 14, "z_mm": 7},
+        })
+    return generated
+
+
+def _mech_view(project: dict[str, Any]) -> Image.Image:
+    image, draw = _base(project, "MECH")
+    mechanical = _mapping(project.get("mechanical"))
+    placements = _placement_values(project)
+    canvas = (54, 194, 1080, 946)
+    _rounded(draw, canvas, fill="#081019")
+    draw.text((82, 220), "MECHANICAL PLACEMENT", font=_font(15, True), fill=CYAN)
+    draw.text((1050, 220), "TOP / ISOMETRIC PLAN", font=_font(11, True), fill=MUTED, anchor="ra")
+
+    center_x, center_y = 565, 575
+    draw.polygon(((225, 680), (565, 400), (910, 650), (565, 865)), fill="#111c29", outline="#3a5069")
+    for offset in range(-240, 241, 80):
+        draw.line((center_x + offset, 410, center_x + offset, 855), fill="#17283a", width=1)
+        draw.line((230, center_y + offset // 2, 905, center_y + offset // 2), fill="#17283a", width=1)
+
+    positions = []
+    for placement in placements:
+        position = _mapping(placement.get("position"))
+        positions.append((_number(position.get("x_mm")), _number(position.get("y_mm"))))
+    max_extent = max([abs(value) for pair in positions for value in pair] or [50.0]) or 50.0
+    scale = min(5.2, 285 / max_extent)
+    for index, placement in enumerate(placements[:14]):
+        position = _mapping(placement.get("position"))
+        size = _mapping(placement.get("size"))
+        px = center_x + int((_number(position.get("x_mm")) - _number(position.get("y_mm")) * 0.45) * scale)
+        py = center_y + int((_number(position.get("y_mm")) * 0.48 + _number(position.get("x_mm")) * 0.08) * scale)
+        width = max(54, min(150, int(_number(size.get("x_mm"), 18) * scale * 0.55)))
+        height = max(34, min(90, int(_number(size.get("y_mm"), 12) * scale * 0.45)))
+        color = NET_COLORS[index % len(NET_COLORS)]
+        draw.rounded_rectangle((px - width // 2 + 8, py - height // 2 - 9, px + width // 2 + 8, py + height // 2 - 9), radius=7, fill="#182536", outline=color, width=2)
+        draw.line((px - width // 2, py + height // 2, px - width // 2 + 8, py + height // 2 - 9), fill=color, width=2)
+        label = _text(placement.get("ref_des"), f"P{index + 1}")
+        draw.text((px + 8, py - 9), label, font=_font(12, True), fill=TEXT, anchor="mm")
+
+    _rounded(draw, (1104, 194, 1546, 946))
+    draw.text((1132, 220), "FABRICATION NOTES", font=_font(15, True), fill=CYAN)
+    draw.text((1132, 260), _text(mechanical.get("enclosure_type"), "Enclosure not specified"), font=_font(20, True), fill=TEXT)
+    draw.text((1132, 296), _text(mechanical.get("manufacturability_rating"), "Unrated").upper(), font=_font(12, True), fill=YELLOW)
+    y = _multiline(draw, (1132, 338), mechanical.get("mounting_guidance"), font=_font(14), fill=MUTED, width=380, max_lines=7) + 28
+    for note in _items(mechanical.get("fabrication_details"))[:7]:
+        draw.rectangle((1134, y + 6, 1141, y + 13), fill=CYAN)
+        y = _multiline(draw, (1156, y), note, font=_font(13), fill=MUTED, width=350, max_lines=3, spacing=5) + 18
+        if y > 900:
+            break
+    return image
+
+
+def _wire_view(project: dict[str, Any]) -> Image.Image:
+    image, draw = _base(project, "WIRE")
+    components = [_mapping(item) for item in _items(project.get("components"))]
+    nets = [_mapping(item) for item in _items(project.get("nets"))]
+    diagram_box = (54, 194, 1110, 946)
+    _rounded(draw, diagram_box, fill="#081019")
+    draw.text((82, 220), "ELECTRICAL NET MAP", font=_font(15, True), fill=CYAN)
+
+    visible_components = components[:12]
+    centers: dict[str, tuple[int, int]] = {}
+    count = max(1, len(visible_components))
+    for index, component in enumerate(visible_components):
+        angle = (-math.pi / 2) + (index * 2 * math.pi / count)
+        cx = 580 + int(math.cos(angle) * 360)
+        cy = 570 + int(math.sin(angle) * 255)
+        centers[_text(component.get("ref_des"), f"C{index + 1}")] = (cx, cy)
+
+    for net_index, net in enumerate(nets[:12]):
+        color = NET_COLORS[net_index % len(NET_COLORS)]
+        points = []
+        for pin_value in _items(net.get("pins")):
+            pin = _mapping(pin_value)
+            center = centers.get(_text(pin.get("ref_des")))
+            if center:
+                points.append(center)
+        if len(points) >= 2:
+            for point in points[1:]:
+                draw.line((*points[0], *point), fill=color, width=5)
+        elif len(points) == 1:
+            draw.line((*points[0], points[0][0] + 55, points[0][1]), fill=color, width=5)
+
+    for index, component in enumerate(visible_components):
+        ref = _text(component.get("ref_des"), f"C{index + 1}")
+        cx, cy = centers[ref]
+        _rounded(draw, (cx - 82, cy - 37, cx + 82, cy + 37), fill="#142131", outline="#3d5874", radius=10, width=2)
+        draw.text((cx, cy - 11), ref, font=_font(14, True), fill=CYAN, anchor="mm")
+        draw.text((cx, cy + 14), _text(component.get("name"), "Component")[:22], font=_font(10), fill=TEXT, anchor="mm")
+
+    _rounded(draw, (1134, 194, 1546, 946))
+    draw.text((1162, 220), "NETS", font=_font(15, True), fill=CYAN)
+    y = 264
+    for index, net in enumerate(nets[:10]):
+        color = NET_COLORS[index % len(NET_COLORS)]
+        pins = []
+        for pin_value in _items(net.get("pins")):
+            pin = _mapping(pin_value)
+            pins.append(f"{_text(pin.get('ref_des'))}.{_text(pin.get('pin_id'))}")
+        _rounded(draw, (1160, y, 1520, y + 58), fill="#0d151f", outline="#23364b", radius=9, width=1)
+        draw.rectangle((1160, y, 1166, y + 58), fill=color)
+        draw.text((1182, y + 10), _text(net.get("name"), _text(net.get("net_id"), "Unnamed net"))[:35], font=_font(13, True), fill=TEXT)
+        draw.text((1182, y + 34), "  /  ".join(pins)[:48] or _text(net.get("net_type"), "No pins"), font=_font(10), fill=MUTED)
+        y += 67
+    if not nets:
+        draw.text((1162, 272), "No electrical nets supplied.", font=_font(14), fill=MUTED)
+    return image
+
+
+def _docs_view(project: dict[str, Any]) -> Image.Image:
+    image, draw = _base(project, "DOCS")
+    assembly = [_mapping(item) for item in _items(project.get("assembly"))]
+    validation = _mapping(project.get("validation"))
+    issues = [*_items(validation.get("critical")), *_items(validation.get("warning")), *_items(validation.get("info"))]
+
+    _rounded(draw, (54, 194, 1026, 946))
+    draw.text((82, 220), "ASSEMBLY PROCEDURE", font=_font(15, True), fill=CYAN)
+    y = 266
+    for index, step in enumerate(assembly[:6], start=1):
+        height = 96
+        danger = bool(step.get("danger_flag"))
+        _rounded(draw, (82, y, 998, y + height), fill="#0d151f", outline="#5a3038" if danger else BORDER, radius=11, width=2)
+        draw.ellipse((102, y + 18, 150, y + 66), fill="#12303b", outline=CYAN_DARK, width=2)
+        draw.text((126, y + 42), str(step.get("step_num") or index), font=_font(16, True), fill=CYAN, anchor="mm")
+        draw.text((168, y + 17), _text(step.get("title"), f"Step {index}")[:72], font=_font(15, True), fill=TEXT)
+        _multiline(draw, (168, y + 47), step.get("description"), font=_font(12), fill=MUTED, width=790, max_lines=2, spacing=4)
+        if danger:
+            draw.text((968, y + 19), "WARNING", font=_font(10, True), fill=RED, anchor="ra")
+        y += height + 14
+        if y > 920:
+            break
+    if not assembly:
+        draw.text((82, 276), "No assembly steps supplied.", font=_font(14), fill=MUTED)
+
+    _rounded(draw, (1050, 194, 1546, 946))
+    draw.text((1078, 220), "VALIDATION NOTES", font=_font(15, True), fill=CYAN)
+    if not issues:
+        draw.text((1078, 266), "PASS", font=_font(26, True), fill=GREEN)
+        draw.text((1078, 310), "No validation findings were reported.", font=_font(14), fill=MUTED)
+    y = 266
+    for issue_value in issues[:7]:
+        issue = _mapping(issue_value)
+        severity = _text(issue.get("severity"), "INFO").upper()
+        accent = RED if severity == "CRITICAL" else YELLOW if severity == "WARNING" else BLUE
+        draw.text((1078, y), severity, font=_font(11, True), fill=accent)
+        draw.text((1168, y), _text(issue.get("category"), "Validation note")[:34], font=_font(12, True), fill=TEXT)
+        y = _multiline(draw, (1078, y + 25), issue.get("description"), font=_font(12), fill=MUTED, width=430, max_lines=3, spacing=4) + 24
+        draw.line((1078, y - 10, 1518, y - 10), fill=BORDER, width=1)
+        if y > 900:
+            break
+    draw.text((1518, 916), "Verify all ratings before fabrication or power-up.", font=_font(10), fill="#66788b", anchor="ra")
+    return image
+
+
+def render_project_view_images(project_ir: Any) -> list[tuple[str, Image.Image]]:
+    """Render the five Forma workspace views as screenshot-like RGB images."""
+    project = _mapping(project_ir)
+    return [
+        ("info", _info_view(project)),
+        ("bom", _bom_view(project)),
+        ("mech", _mech_view(project)),
+        ("wire", _wire_view(project)),
+        ("docs", _docs_view(project)),
+    ]
+
+
+def render_project_view_screenshots(project_ir: Any) -> list[tuple[str, bytes]]:
+    """Return PNG screenshots for inspection, tests, or alternate delivery."""
+    screenshots: list[tuple[str, bytes]] = []
+    for name, image in render_project_view_images(project_ir):
+        output = io.BytesIO()
+        image.save(output, format="PNG", optimize=True)
+        screenshots.append((name, output.getvalue()))
+    return screenshots
+
+
+def render_project_screenshot_pdf(project_ir: Any) -> bytes:
+    """Assemble one landscape PDF page per Forma workspace screenshot."""
+    pages = [image for _name, image in render_project_view_images(project_ir)]
+    output = io.BytesIO()
+    pages[0].save(
+        output,
+        format="PDF",
+        save_all=True,
+        append_images=pages[1:],
+        resolution=144.0,
+        quality=88,
+        title=_text(_mapping(_mapping(project_ir).get("overview")).get("title"), "Forma Project Report"),
+        author="Forma",
+        subject="INFO, BOM, MECH, WIRE, and DOCS workspace captures",
+    )
+    return output.getvalue()
+
+
+__all__ = [
+    "VIEW_NAMES",
+    "VIEW_SIZE",
+    "render_project_screenshot_pdf",
+    "render_project_view_images",
+    "render_project_view_screenshots",
+]

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -84,7 +84,32 @@ Available tools:
 - `blueprint.generate_project`
 - `blueprint.debug_config`
 - `blueprint.validate_circuit`
+- `blueprint.export_project_pdf`
 - `blueprint.a2a.send_message`
 - `blueprint.a2a.poll_events`
 - `blueprint.a2a.get_job`
 - `blueprint.a2a.list_jobs`
+- `blueprint.lattice.list_agents`
+- `blueprint.lattice.get_agent_card`
+
+`blueprint.generate_project` accepts `output_formats: ["pdf"]` to add a printable project report. The PDF is returned as an MCP embedded binary resource with MIME type `application/pdf`; existing generation responses are unchanged when `output_formats` is omitted.
+
+To export existing Hardware IR without generating a new project, call `blueprint.export_project_pdf`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "pdf-1",
+  "method": "tools/call",
+  "params": {
+    "name": "blueprint.export_project_pdf",
+    "arguments": {
+      "project_ir": {
+        "overview": {"title": "Plant Monitor", "description": "A low-voltage sensor project"},
+        "components": [],
+        "nets": []
+      }
+    }
+  }
+}
+```

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -82,6 +82,7 @@ Each line sent to the socket is an `A2AMessage` JSON object. Each line returned 
 
 Available tools:
 - `blueprint.generate_project`
+- `blueprint.compile_project`
 - `blueprint.debug_config`
 - `blueprint.validate_circuit`
 - `blueprint.export_project_pdf`
@@ -92,9 +93,13 @@ Available tools:
 - `blueprint.lattice.list_agents`
 - `blueprint.lattice.get_agent_card`
 
-`blueprint.generate_project` accepts `output_formats: ["pdf"]` to add a printable project report. The PDF is returned as an MCP embedded binary resource with MIME type `application/pdf`; existing generation responses are unchanged when `output_formats` is omitted.
+`blueprint.compile_project` is the default Claude Code/Codex integration path. The host agent authors `project_ir`; Forma validates it, builds Mermaid and SVG diagrams, records `generation.mode: "host_agent"`, and optionally creates a PDF. Pass `authoring_agent: "claude"` or `"codex"` and `output_formats: ["pdf"]`.
 
-To export existing Hardware IR without generating a new project, call `blueprint.export_project_pdf`:
+The PDF is returned as an MCP embedded binary resource with MIME type `application/pdf`. Its five landscape pages capture the `INFO`, `BOM`, `MECH`, `WIRE`, and `DOCS` workspace views.
+
+`blueprint.generate_project` is reserved for an explicitly configured server-side LLM. It rejects the simulation provider unless the caller deliberately supplies `allow_simulation: true`.
+
+To export existing Hardware IR without compiling or generating a new project, call `blueprint.export_project_pdf`:
 
 ```json
 {

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -71,6 +71,14 @@ The bundled client can save an MCP PDF resource directly:
 python ~/.claude/skills/forma-hardware/scripts/forma.py export-pdf forma-project.json --pdf-output forma-project.pdf
 ```
 
+Claude Code and Codex author Hardware IR themselves, then ask Forma to compile it:
+
+```bash
+python ~/.claude/skills/forma-hardware/scripts/forma.py compile forma-project.json --authoring-agent claude --pdf-output forma-project.pdf --output compiled-project.json
+```
+
+The PDF contains five screenshot-style pages matching the `INFO`, `BOM`, `MECH`, `WIRE`, and `DOCS` workspace views. Forma's server-side prompt generator is optional and must be selected explicitly with `generate --use-configured-provider`. Simulation additionally requires `--provider simulation --allow-simulation`; it is never used as a failure fallback.
+
 The skill preserves Forma's safety boundary. Its output is a prototype plan and does not replace electrical review, compliance testing, or physical verification.
 
 ## Package layout

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -63,6 +63,13 @@ Example requests:
 - `Use Forma to design a 5V ESP32 soil monitor and save the Hardware IR.`
 - `Validate the components and nets in forma-project.json.`
 - `Generate a low-voltage weather station with sourced component research.`
+- `Generate a printable PDF report for this Forma project.`
+
+The bundled client can save an MCP PDF resource directly:
+
+```bash
+python ~/.claude/skills/forma-hardware/scripts/forma.py export-pdf forma-project.json --pdf-output forma-project.pdf
+```
 
 The skill preserves Forma's safety boundary. Its output is a prototype plan and does not replace electrical review, compliance testing, or physical verification.
 

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -45,6 +45,15 @@ The skill includes a standard-library Python client, so the agent does not need 
 python integrations/agent-skills/forma-hardware/scripts/forma.py tools
 ```
 
+Optionally register Forma as a native Claude Code MCP server so its tools are available outside the skill too:
+
+```bash
+claude mcp add --scope user --transport http forma http://127.0.0.1:8000/mcp
+claude mcp list
+```
+
+Use the full hosted `/api/mcp` URL instead when Forma is deployed behind that route. A protected endpoint also needs an authorization header configured through the agent host. The skill's client remains the portable fallback for both Claude Code and Codex.
+
 ## Use
 
 In Claude Code, ask for a Forma hardware design naturally or invoke `/forma-hardware`. In Codex, ask naturally or invoke `$forma-hardware`.

--- a/docs/agent-skills.md
+++ b/docs/agent-skills.md
@@ -1,0 +1,64 @@
+# Claude Code and Codex Agent Skill
+
+Forma ships one portable [`forma-hardware`](../integrations/agent-skills/forma-hardware/SKILL.md) Agent Skill for Claude Code and Codex. It teaches either agent how to generate and validate safe, low-voltage hardware projects through a running Forma MCP endpoint.
+
+## Install
+
+Install for both agents at user scope:
+
+```bash
+python scripts/operations/install-forma-skill.py
+```
+
+This copies the skill to:
+
+- Claude Code: `~/.claude/skills/forma-hardware`
+- Codex: `~/.agents/skills/forma-hardware`
+
+Install into a repository instead:
+
+```bash
+python scripts/operations/install-forma-skill.py --scope project --project-dir /path/to/project
+```
+
+Use `--agent claude` or `--agent codex` to install only one target. Re-run with `--force` to update an existing copy. The installer never writes credentials or agent settings.
+
+## Connect to Forma
+
+Start the Forma backend, then configure the endpoint if it is not the local default:
+
+```bash
+export FORMA_MCP_URL=http://127.0.0.1:8000/mcp
+```
+
+For a protected deployment, export an access token without placing it in a prompt or checked-in file:
+
+```bash
+export FORMA_AUTH_TOKEN=your_access_token
+```
+
+`FORMA_TIMEOUT_SECONDS` defaults to `600`. Increase it when the selected provider has a long cold start.
+
+The skill includes a standard-library Python client, so the agent does not need a separate MCP client package. Verify the connection directly:
+
+```bash
+python integrations/agent-skills/forma-hardware/scripts/forma.py tools
+```
+
+## Use
+
+In Claude Code, ask for a Forma hardware design naturally or invoke `/forma-hardware`. In Codex, ask naturally or invoke `$forma-hardware`.
+
+Example requests:
+
+- `Use Forma to design a 5V ESP32 soil monitor and save the Hardware IR.`
+- `Validate the components and nets in forma-project.json.`
+- `Generate a low-voltage weather station with sourced component research.`
+
+The skill preserves Forma's safety boundary. Its output is a prototype plan and does not replace electrical review, compliance testing, or physical verification.
+
+## Package layout
+
+The canonical, product-neutral skill lives under `integrations/agent-skills/forma-hardware`. Both installations receive the same `SKILL.md`, client script, and connection reference. Codex also reads the optional `agents/openai.yaml` UI metadata; Claude safely ignores that product-specific file.
+
+Agent Skills are an open folder format based on `SKILL.md`. See the [Agent Skills specification](https://agentskills.io/specification), [Claude Agent Skills documentation](https://docs.claude.com/en/docs/agents-and-tools/agent-skills/overview), and [Codex skill documentation](https://developers.openai.com/codex/skills) for host-specific behavior.

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -67,7 +67,7 @@ flowchart LR
 ## Notes
 - Agents run **sequentially** for determinism and traceability.
 - Validation can trigger a **repair loop** that re-invokes the wiring agent.
-- If a live LLM provider isn’t configured (or generation fails), the backend uses a deterministic **simulation fallback** backed by the example projects.
+- If a live LLM provider is not configured or generation fails, the backend returns an error. Deterministic simulation requires an explicit `allow_simulation: true` request.
 - The pipeline is designed to swap models or add agents without rewriting the core IR schema.
 - External agents can call or listen to Forma through the A2A layer documented in `docs/a2a.md`.
 - Specialized worker execution boundaries use the versioned contracts and capability registry documented in `docs/worker-contracts.md`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Forma OSS turns prompts into structured hardware projects using a sequential, va
 ## System pipeline
 1. **Prompt + optional image** enters the system.
 2. **Safety guardrails** block high-risk domains early (weapons, medical, mains AC, etc.).
-3. **Model resolution** determines whether live LLM generation runs or a deterministic simulation fallback is used.
+3. **Model resolution** selects an explicitly configured live LLM; simulation requires a separate caller opt-in.
 4. **Intent Parser Agent** produces a high-level `ProjectOverview`.
 5. **Requirements Agent** extracts functional requirements and constraints.
 6. **Component Selection Agent** chooses parts from the seed database.
@@ -33,13 +33,13 @@ Forma OSS turns prompts into structured hardware projects using a sequential, va
 - `blueprint_core.config.contract.resolve_runtime_contract()` is the single client-facing configuration authority. It resolves request/saved/environment/default precedence and publishes LLM options, image defaults, workflow defaults, generation readiness, and BYOK requirements through `GET /api/runtime/config`.
 - Environment variables and encrypted integration records are input adapters. The web application does not merge them or derive provider readiness independently.
 - Gemini-specific variables (`GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_MODEL`, `STRICT_GEMINI`, `GEMINI_FALLBACK_MODEL`) remain supported as compatibility aliases.
-- If no API key is configured (or generation errors), the backend uses a deterministic simulation fallback backed by curated example projects.
+- If no API key is configured or generation errors, the backend returns an error. Curated simulation output is available only through explicit `allow_simulation: true` requests.
 
 ## System diagram
 ```mermaid
 flowchart TD
   A[Prompt + optional image] --> S[Safety guardrails]
-  S --> M[Model resolution\n(live LLM vs simulation)]
+  S --> M[Model resolution\nconfigured live LLM or explicit simulation]
   M --> B[Intent Parser Agent]
   B --> C[Requirements Agent]
   C --> D[Component Selection Agent]

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -26,6 +26,8 @@ SQLITE_DATABASE_URL=sqlite:////data/blueprint.db
 LLM_PROVIDER=simulation
 ```
 
+This Compose value makes the simulation provider available for local demos; it does not opt requests into simulated generation. A caller must still send `allow_simulation: true`. Claude Code and Codex skills instead author Hardware IR with their host model and call `blueprint.compile_project`.
+
 Compose also starts an ephemeral Redis service and configures the backend to
 cache project gallery responses for 60 seconds. Project writes invalidate the
 cache immediately; Redis outages fall back to the primary database.

--- a/integrations/agent-skills/forma-hardware/SKILL.md
+++ b/integrations/agent-skills/forma-hardware/SKILL.md
@@ -9,7 +9,7 @@ Use Forma as the hardware compiler. Do not invent a successful generation or val
 
 ## Connect
 
-Use the bundled dependency-free client. Resolve `<skill-directory>` to the directory containing this `SKILL.md`; do not assume the current working directory is the skill directory. The client reads `FORMA_MCP_URL` and defaults to `http://127.0.0.1:8000/mcp`.
+Prefer the host's native Forma MCP tools when they are available. Otherwise use the bundled dependency-free client. Resolve `<skill-directory>` to the directory containing this `SKILL.md`; do not assume the current working directory is the skill directory. The client reads `FORMA_MCP_URL` and defaults to `http://127.0.0.1:8000/mcp`.
 
 ```bash
 python <skill-directory>/scripts/forma.py tools

--- a/integrations/agent-skills/forma-hardware/SKILL.md
+++ b/integrations/agent-skills/forma-hardware/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: forma-hardware
+description: Generates and validates structured low-voltage maker-electronics projects with Forma, including Hardware IR, BOMs, wiring nets, diagrams, assembly steps, and optional concept images. Use when a user asks to design, compile, inspect, or electrically validate a safe 3.3V-5V hardware prototype with Forma.
+---
+
+# Forma Hardware
+
+Use Forma as the hardware compiler. Do not invent a successful generation or validation result when Forma is unavailable.
+
+## Connect
+
+Use the bundled dependency-free client. Resolve `<skill-directory>` to the directory containing this `SKILL.md`; do not assume the current working directory is the skill directory. The client reads `FORMA_MCP_URL` and defaults to `http://127.0.0.1:8000/mcp`.
+
+```bash
+python <skill-directory>/scripts/forma.py tools
+```
+
+If the server requires authentication, have the user set `FORMA_AUTH_TOKEN`; never place the token in a command or output. Read [references/configuration.md](references/configuration.md) when connection, authentication, or server startup fails.
+
+## Generate a project
+
+1. Confirm the request is a low-voltage educational or maker project. Decline requests involving weapons, critical medical or life-support devices, mains AC, automotive control, or unsafe high-power batteries.
+2. Ask a follow-up question only when a missing constraint would materially change the design. Otherwise preserve the user's stated power, size, budget, environment, interfaces, and component preferences in the prompt.
+3. Run:
+
+```bash
+python <skill-directory>/scripts/forma.py generate "<complete hardware brief>" --output forma-project.json
+```
+
+Use `--workflow web_research` only when the user needs sourced component research and the Forma server has Firecrawl configured. Add `--generate-image` only when the user explicitly wants a concept image. Add `--image-file <path>` when a reference image is part of the request.
+
+4. Inspect the returned `project_ir`, especially `overview`, `requirements`, `components`, `nets`, `validation`, `bom`, `assembly_steps`, and `assembly_metadata`.
+5. Report the artifact path, the design summary, unresolved warnings, and whether electrical validation passed. Clearly label the output as a prototype plan, not fabrication-ready engineering approval.
+
+## Validate an existing project
+
+Run validation after changing components or nets and before presenting the result as complete:
+
+```bash
+python <skill-directory>/scripts/forma.py validate forma-project.json --output validation.json
+```
+
+Treat every `CRITICAL` issue as blocking. Report warnings rather than silently discarding them. If the input is not a Forma response or Hardware IR object, explain the schema problem and ask for components and nets.
+
+## Inspect server state and jobs
+
+Use these only when they help answer the user's request:
+
+```bash
+python <skill-directory>/scripts/forma.py config
+python <skill-directory>/scripts/forma.py job <job-id>
+python <skill-directory>/scripts/forma.py jobs --status succeeded --limit 10
+```
+
+Do not expose provider credentials, authorization headers, or unredacted debug secrets. Prefer the returned structured JSON over parsing the human-readable text content.
+
+## Output contract
+
+Keep Forma output intact when saving JSON. In the user-facing response include:
+
+- Project title and goal
+- Power assumptions and major components
+- Validation status and remaining issues
+- Saved artifact paths
+- Any unavailable optional outputs, such as product imagery or web research
+
+Do not claim that generated diagrams, BOM availability, pricing, or component compatibility have been physically verified unless the returned data explicitly establishes it.

--- a/integrations/agent-skills/forma-hardware/SKILL.md
+++ b/integrations/agent-skills/forma-hardware/SKILL.md
@@ -29,6 +29,12 @@ python <skill-directory>/scripts/forma.py generate "<complete hardware brief>" -
 
 Use `--workflow web_research` only when the user needs sourced component research and the Forma server has Firecrawl configured. Add `--generate-image` only when the user explicitly wants a concept image. Add `--image-file <path>` when a reference image is part of the request.
 
+When the user requests a printable report, request PDF output and save the embedded MCP resource:
+
+```bash
+python <skill-directory>/scripts/forma.py generate "<complete hardware brief>" --output forma-project.json --pdf-output forma-project.pdf
+```
+
 4. Inspect the returned `project_ir`, especially `overview`, `requirements`, `components`, `nets`, `validation`, `bom`, `assembly_steps`, and `assembly_metadata`.
 5. Report the artifact path, the design summary, unresolved warnings, and whether electrical validation passed. Clearly label the output as a prototype plan, not fabrication-ready engineering approval.
 
@@ -41,6 +47,12 @@ python <skill-directory>/scripts/forma.py validate forma-project.json --output v
 ```
 
 Treat every `CRITICAL` issue as blocking. Report warnings rather than silently discarding them. If the input is not a Forma response or Hardware IR object, explain the schema problem and ask for components and nets.
+
+To create a PDF later from existing Forma project JSON, run:
+
+```bash
+python <skill-directory>/scripts/forma.py export-pdf forma-project.json --pdf-output forma-project.pdf
+```
 
 ## Inspect server state and jobs
 
@@ -62,6 +74,7 @@ Keep Forma output intact when saving JSON. In the user-facing response include:
 - Power assumptions and major components
 - Validation status and remaining issues
 - Saved artifact paths
+- Requested PDF report filename and path
 - Any unavailable optional outputs, such as product imagery or web research
 
 Do not claim that generated diagrams, BOM availability, pricing, or component compatibility have been physically verified unless the returned data explicitly establishes it.

--- a/integrations/agent-skills/forma-hardware/SKILL.md
+++ b/integrations/agent-skills/forma-hardware/SKILL.md
@@ -1,80 +1,63 @@
 ---
 name: forma-hardware
-description: Generates and validates structured low-voltage maker-electronics projects with Forma, including Hardware IR, BOMs, wiring nets, diagrams, assembly steps, and optional concept images. Use when a user asks to design, compile, inspect, or electrically validate a safe 3.3V-5V hardware prototype with Forma.
+description: Authors, compiles, validates, and exports structured low-voltage maker-electronics projects with Forma, including Hardware IR, BOMs, wiring, mechanical layouts, build docs, and five-view PDFs. Use when a user asks Claude Code or Codex to design, compile, inspect, document, or electrically validate a safe 3.3V-12V hardware prototype with Forma.
 ---
 
 # Forma Hardware
 
-Use Forma as the hardware compiler. Do not invent a successful generation or validation result when Forma is unavailable.
+Use the current host agent—Claude Code or Codex—to author the design. Use Forma as the deterministic hardware compiler, validator, diagrammer, and exporter. Never substitute a simulated example for failed generation.
 
 ## Connect
 
-Prefer the host's native Forma MCP tools when they are available. Otherwise use the bundled dependency-free client. Resolve `<skill-directory>` to the directory containing this `SKILL.md`; do not assume the current working directory is the skill directory. The client reads `FORMA_MCP_URL` and defaults to `http://127.0.0.1:8000/mcp`.
+Prefer native Forma MCP tools. Otherwise run the bundled client from this skill directory:
 
 ```bash
 python <skill-directory>/scripts/forma.py tools
 ```
 
-If the server requires authentication, have the user set `FORMA_AUTH_TOKEN`; never place the token in a command or output. Read [references/configuration.md](references/configuration.md) when connection, authentication, or server startup fails.
+The client reads `FORMA_MCP_URL` and defaults to `http://127.0.0.1:8000/mcp`. For connection or authentication failures, read [references/configuration.md](references/configuration.md).
 
-## Generate a project
+## Author and compile a project
 
-1. Confirm the request is a low-voltage educational or maker project. Decline requests involving weapons, critical medical or life-support devices, mains AC, automotive control, or unsafe high-power batteries.
-2. Ask a follow-up question only when a missing constraint would materially change the design. Otherwise preserve the user's stated power, size, budget, environment, interfaces, and component preferences in the prompt.
-3. Run:
-
-```bash
-python <skill-directory>/scripts/forma.py generate "<complete hardware brief>" --output forma-project.json
-```
-
-Use `--workflow web_research` only when the user needs sourced component research and the Forma server has Firecrawl configured. Add `--generate-image` only when the user explicitly wants a concept image. Add `--image-file <path>` when a reference image is part of the request.
-
-When the user requests a printable report, request PDF output and save the embedded MCP resource:
+1. Keep the project within safe low-voltage educational or maker scope. Decline weapons, critical medical or life-support devices, mains AC, automotive control, and unsafe high-power battery requests.
+2. Read [references/hardware-ir.md](references/hardware-ir.md), then author complete Forma Hardware IR from the user's brief. Preserve stated power, size, budget, environment, interfaces, and component preferences. Do not copy a bundled example or claim unavailable supplier facts.
+3. Save the IR as `forma-project.json`.
+4. Compile it with the current host identity:
 
 ```bash
-python <skill-directory>/scripts/forma.py generate "<complete hardware brief>" --output forma-project.json --pdf-output forma-project.pdf
+# Claude Code
+python <skill-directory>/scripts/forma.py compile forma-project.json --authoring-agent claude --output compiled-project.json
+
+# Codex
+python <skill-directory>/scripts/forma.py compile forma-project.json --authoring-agent codex --output compiled-project.json
 ```
 
-4. Inspect the returned `project_ir`, especially `overview`, `requirements`, `components`, `nets`, `validation`, `bom`, `assembly_steps`, and `assembly_metadata`.
-5. Report the artifact path, the design summary, unresolved warnings, and whether electrical validation passed. Clearly label the output as a prototype plan, not fabrication-ready engineering approval.
+When the user requests a PDF, add `--pdf-output forma-project.pdf`. The PDF contains five landscape workspace captures: INFO, BOM, MECH, WIRE, and DOCS.
 
-## Validate an existing project
+5. Inspect deterministic validation findings. Fix agent-authored components or nets and compile again when practical. Treat every `CRITICAL` issue as blocking.
+6. Report the authoring agent, artifact paths, design summary, power assumptions, major components, and remaining validation issues. Label the result as an AI-assisted prototype plan.
 
-Run validation after changing components or nets and before presenting the result as complete:
+When using native MCP, call `blueprint.compile_project` with `project_ir`, `authoring_agent` set to `claude` or `codex`, and optional `output_formats: ["pdf"]`.
+
+## Validate or export existing IR
 
 ```bash
 python <skill-directory>/scripts/forma.py validate forma-project.json --output validation.json
-```
-
-Treat every `CRITICAL` issue as blocking. Report warnings rather than silently discarding them. If the input is not a Forma response or Hardware IR object, explain the schema problem and ask for components and nets.
-
-To create a PDF later from existing Forma project JSON, run:
-
-```bash
 python <skill-directory>/scripts/forma.py export-pdf forma-project.json --pdf-output forma-project.pdf
 ```
 
-## Inspect server state and jobs
+Use export-only mode when the IR is already complete. It does not assert who authored the project.
 
-Use these only when they help answer the user's request:
+## Optional server-side generation
+
+Do not use `blueprint.generate_project` by default. Use it only when the user deliberately wants the separately configured Forma server LLM described in [references/configuration.md](references/configuration.md).
 
 ```bash
-python <skill-directory>/scripts/forma.py config
-python <skill-directory>/scripts/forma.py job <job-id>
-python <skill-directory>/scripts/forma.py jobs --status succeeded --limit 10
+python <skill-directory>/scripts/forma.py generate "<brief>" --use-configured-provider --output forma-project.json
 ```
 
-Do not expose provider credentials, authorization headers, or unredacted debug secrets. Prefer the returned structured JSON over parsing the human-readable text content.
+Simulation is never an automatic fallback. It requires explicit user acceptance and both `--provider simulation --allow-simulation`.
 
-## Output contract
+## Output integrity
 
-Keep Forma output intact when saving JSON. In the user-facing response include:
-
-- Project title and goal
-- Power assumptions and major components
-- Validation status and remaining issues
-- Saved artifact paths
-- Requested PDF report filename and path
-- Any unavailable optional outputs, such as product imagery or web research
-
-Do not claim that generated diagrams, BOM availability, pricing, or component compatibility have been physically verified unless the returned data explicitly establishes it.
+Keep compiled JSON intact. Do not expose provider credentials or authorization headers. Do not claim that diagrams, prices, availability, compatibility, or mechanical clearances were physically verified unless returned evidence establishes that.

--- a/integrations/agent-skills/forma-hardware/agents/openai.yaml
+++ b/integrations/agent-skills/forma-hardware/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Forma Hardware"
-  short_description: "Generate and validate low-voltage hardware"
-  default_prompt: "Use $forma-hardware to turn my hardware idea into a validated Forma project."
+  short_description: "Author and compile safe hardware projects"
+  default_prompt: "Use $forma-hardware to author, validate, and compile my hardware idea with a five-view PDF."

--- a/integrations/agent-skills/forma-hardware/agents/openai.yaml
+++ b/integrations/agent-skills/forma-hardware/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Forma Hardware"
+  short_description: "Generate and validate low-voltage hardware"
+  default_prompt: "Use $forma-hardware to turn my hardware idea into a validated Forma project."

--- a/integrations/agent-skills/forma-hardware/references/configuration.md
+++ b/integrations/agent-skills/forma-hardware/references/configuration.md
@@ -1,0 +1,44 @@
+# Forma connection reference
+
+The bundled client uses only the Python standard library.
+
+## Environment
+
+- `FORMA_MCP_URL`: Forma MCP endpoint. Defaults to `http://127.0.0.1:8000/mcp`. A bare server origin is normalized by appending `/mcp`.
+- `FORMA_AUTH_TOKEN`: Optional bearer token for a protected deployment.
+- `FORMA_TIMEOUT_SECONDS`: HTTP timeout. Defaults to `600` because hardware generation can take several minutes.
+
+Keep secrets in the environment. Do not write tokens into skill files, shell history, generated projects, or chat responses.
+
+## Start a local server
+
+From a Forma OSS checkout, run either:
+
+```bash
+./scripts/development/dev.sh
+```
+
+or:
+
+```bash
+uvicorn apps.api.main:app --reload --port 8000
+```
+
+The server must have `BLUEPRINT_USER_SECRETS_KEY` and a configured generation provider. Deterministic simulation is suitable only when the user explicitly accepts simulated output.
+
+## Common failures
+
+- `Connection refused`: start Forma or correct `FORMA_MCP_URL`.
+- `401` or `403`: obtain an authorized token and export `FORMA_AUTH_TOKEN`.
+- JSON-RPC `Method not found`: the server is not a compatible Forma MCP endpoint or is outdated.
+- Generation timeout: increase `FORMA_TIMEOUT_SECONDS` and check the selected model provider.
+- Generation error: run the bundled `scripts/forma.py config` from the skill directory and report the credential-safe runtime details; never request that credentials be pasted into chat.
+
+## Supported tool workflow
+
+- `blueprint.generate_project`: generate Hardware IR and diagrams.
+- `blueprint.validate_circuit`: validate components and connection nets.
+- `blueprint.debug_config`: inspect credential-safe runtime configuration.
+- `blueprint.a2a.get_job` and `blueprint.a2a.list_jobs`: inspect persisted job metadata.
+
+Use the bundled `scripts/forma.py tools` to discover the live server's complete tool list instead of assuming optional tools exist.

--- a/integrations/agent-skills/forma-hardware/references/configuration.md
+++ b/integrations/agent-skills/forma-hardware/references/configuration.md
@@ -24,7 +24,9 @@ or:
 uvicorn apps.api.main:app --reload --port 8000
 ```
 
-The server must have `BLUEPRINT_USER_SECRETS_KEY` and a configured generation provider. Deterministic simulation is suitable only when the user explicitly accepts simulated output.
+The server must have `BLUEPRINT_USER_SECRETS_KEY`. Normal Claude Code/Codex usage does not require a server LLM: the host agent authors Hardware IR and `blueprint.compile_project` performs deterministic compilation.
+
+Server-side prompt generation is optional. Configure a live provider such as Anthropic or OpenAI before using `blueprint.generate_project`. A missing provider never authorizes simulation. Deterministic simulation is suitable only when the user explicitly accepts it and the request supplies `allow_simulation: true` (the client requires `--provider simulation --allow-simulation`).
 
 ## Common failures
 
@@ -36,7 +38,8 @@ The server must have `BLUEPRINT_USER_SECRETS_KEY` and a configured generation pr
 
 ## Supported tool workflow
 
-- `blueprint.generate_project`: generate Hardware IR and diagrams.
+- `blueprint.compile_project`: compile host-agent-authored Hardware IR, validate it, and build diagrams or PDF captures.
+- `blueprint.generate_project`: optional explicitly configured server-side LLM generation; never the default agent-skill path.
 - `blueprint.validate_circuit`: validate components and connection nets.
 - `blueprint.export_project_pdf`: render existing Hardware IR as an embedded `application/pdf` report.
 - `blueprint.debug_config`: inspect credential-safe runtime configuration.

--- a/integrations/agent-skills/forma-hardware/references/configuration.md
+++ b/integrations/agent-skills/forma-hardware/references/configuration.md
@@ -38,6 +38,7 @@ The server must have `BLUEPRINT_USER_SECRETS_KEY` and a configured generation pr
 
 - `blueprint.generate_project`: generate Hardware IR and diagrams.
 - `blueprint.validate_circuit`: validate components and connection nets.
+- `blueprint.export_project_pdf`: render existing Hardware IR as an embedded `application/pdf` report.
 - `blueprint.debug_config`: inspect credential-safe runtime configuration.
 - `blueprint.a2a.get_job` and `blueprint.a2a.list_jobs`: inspect persisted job metadata.
 

--- a/integrations/agent-skills/forma-hardware/references/hardware-ir.md
+++ b/integrations/agent-skills/forma-hardware/references/hardware-ir.md
@@ -1,0 +1,93 @@
+# Agent-authored Forma Hardware IR
+
+Author a concrete, internally consistent project. Use real reference designators and pin IDs. Every net pin must point to a declared component pin. Include enough pin definitions for deterministic voltage, short-circuit, and conflict checks.
+
+Start from this shape:
+
+```json
+{
+  "hardware_ir_version": "0.1",
+  "overview": {
+    "title": "Project title",
+    "description": "What the prototype does and its safe scope",
+    "difficulty": "Beginner",
+    "estimated_cost": 0,
+    "category": "IoT"
+  },
+  "requirements": {
+    "requirements": ["Measurable functional requirement"],
+    "power_needs": "5V USB",
+    "operating_voltage": 3.3,
+    "physical_constraints": [],
+    "safety_notes": ["Disconnect power before rewiring."],
+    "missing_info": []
+  },
+  "components": [
+    {
+      "ref_des": "U1",
+      "part_number": "ESP32-DEVKIT",
+      "name": "ESP32 development board",
+      "category": "Microcontroller",
+      "quantity": 1,
+      "unit_price": 9.5,
+      "sourcing_url": null,
+      "rationale": "Controls the prototype.",
+      "pins": [
+        {"pin_id": "3V3", "name": "3V3", "pin_type": "Power", "voltage": 3.3, "description": "Regulated output"},
+        {"pin_id": "GND", "name": "GND", "pin_type": "Ground", "voltage": 0, "description": "Ground"}
+      ]
+    }
+  ],
+  "nets": [
+    {
+      "net_id": "NET_3V3",
+      "name": "3.3V rail",
+      "net_type": "Power",
+      "voltage": 3.3,
+      "pins": [{"ref_des": "U1", "pin_id": "3V3"}]
+    }
+  ],
+  "buses": [],
+  "pin_mappings": [],
+  "assembly": [
+    {
+      "step_num": 1,
+      "title": "Wire power while disconnected",
+      "description": "Connect the declared low-voltage rails and inspect polarity before power-up.",
+      "danger_flag": false,
+      "danger_message": null,
+      "affected_components": ["U1"]
+    }
+  ],
+  "mechanical": {
+    "enclosure_type": "3D printed",
+    "mounting_guidance": "Use insulated standoffs and preserve connector access.",
+    "fabrication_details": ["Verify dimensions against physical parts."],
+    "fabrication_cost_estimate_usd": 5,
+    "cad_sources": [],
+    "manufacturability_rating": "Easy",
+    "render_dimensions": {"x_mm": 80, "y_mm": 55, "z_mm": 25},
+    "component_placements": [],
+    "spatial_relationships": []
+  },
+  "constraints": ["Low-voltage DC only"],
+  "power_rails": [],
+  "estimated_current_draw_ma": 250,
+  "fabrication_notes": [],
+  "assembly_metadata": {},
+  "project_version_history": [],
+  "validation": {"critical": [], "warning": [], "info": []},
+  "is_valid": true
+}
+```
+
+Use these `pin_type` values where applicable: `Power`, `Ground`, `Digital`, `Analog`, `I2C`, `SPI`, `UART`, `PWM`, or `Passive`.
+
+Before compiling, check:
+
+- Reference designators and net IDs are unique.
+- Every connected `ref_des.pin_id` exists in `components[].pins`.
+- Power and signal voltages are compatible.
+- BOM quantities, unit prices, and rationale are present.
+- Assembly steps explain wiring, inspection, initial current-limited power-up, and testing.
+- Mechanical notes describe clearances as estimates unless verified against real CAD.

--- a/integrations/agent-skills/forma-hardware/scripts/forma.py
+++ b/integrations/agent-skills/forma-hardware/scripts/forma.py
@@ -231,11 +231,34 @@ def build_parser() -> argparse.ArgumentParser:
     generate.add_argument("--past-jobs", action="store_true", help="Use relevant completed jobs as context.")
     generate.add_argument("--past-jobs-limit", type=int, choices=range(1, 9), default=3)
     generate.add_argument("--pdf-output", help="Request and save an additional PDF project report.")
+    generation_source = generate.add_mutually_exclusive_group(required=True)
+    generation_source.add_argument("--provider", help="Explicit configured server-side LLM provider.")
+    generation_source.add_argument(
+        "--use-configured-provider",
+        action="store_true",
+        help="Use the server's configured live provider; simulation remains blocked by default.",
+    )
+    generate.add_argument("--model", help="Optional allowed model override for server-side generation.")
+    generate.add_argument(
+        "--allow-simulation",
+        action="store_true",
+        help="Explicitly permit deterministic simulation output.",
+    )
     _shared_options(generate)
 
     validate = subparsers.add_parser("validate", help="Validate components and nets from Forma project JSON.")
     validate.add_argument("project", help="Project JSON path, or - for stdin.")
     _shared_options(validate)
+
+    compile_project = subparsers.add_parser(
+        "compile",
+        help="Compile and validate Hardware IR authored by Claude Code or Codex.",
+    )
+    compile_project.add_argument("project", help="Agent-authored Hardware IR JSON path, or - for stdin.")
+    compile_project.add_argument("--authoring-agent", required=True, choices=("claude", "codex"))
+    compile_project.add_argument("--project-id")
+    compile_project.add_argument("--pdf-output", help="Request and save the five-view PDF report.")
+    _shared_options(compile_project)
 
     export_pdf = subparsers.add_parser("export-pdf", help="Render existing Forma project JSON as PDF.")
     export_pdf.add_argument("project", help="Project JSON path, or - for stdin.")
@@ -284,6 +307,14 @@ def run(args: argparse.Namespace) -> Any:
             arguments["data_sources"] = ["past_jobs"]
         if args.pdf_output:
             arguments["output_formats"] = ["pdf"]
+        if args.provider:
+            arguments["provider"] = args.provider
+        if args.model:
+            arguments["model"] = args.model
+        if args.allow_simulation:
+            arguments["allow_simulation"] = True
+        if args.provider and args.provider.strip().lower() == "simulation" and not args.allow_simulation:
+            raise FormaClientError("--provider simulation requires the explicit --allow-simulation flag.")
         return call_tool("blueprint.generate_project", arguments, **options)
     if args.command == "validate":
         project = _project_ir(_load_json(args.project))
@@ -292,6 +323,17 @@ def run(args: argparse.Namespace) -> Any:
         if not isinstance(components, list) or not isinstance(nets, list):
             raise FormaClientError("The project JSON must contain components and nets arrays.")
         return call_tool("blueprint.validate_circuit", {"components": components, "nets": nets}, **options)
+    if args.command == "compile":
+        project = _project_ir(_load_json(args.project))
+        arguments = {
+            "project_ir": project,
+            "authoring_agent": args.authoring_agent,
+        }
+        if args.project_id:
+            arguments["project_id"] = args.project_id
+        if args.pdf_output:
+            arguments["output_formats"] = ["pdf"]
+        return call_tool("blueprint.compile_project", arguments, **options)
     if args.command == "export-pdf":
         project = _project_ir(_load_json(args.project))
         arguments: dict[str, Any] = {"project_ir": project}

--- a/integrations/agent-skills/forma-hardware/scripts/forma.py
+++ b/integrations/agent-skills/forma-hardware/scripts/forma.py
@@ -129,7 +129,14 @@ def call_tool(
 ) -> Any:
     result = request("tools/call", {"name": name, "arguments": arguments}, url=url, timeout=timeout)
     if isinstance(result, dict) and "structuredContent" in result:
-        return result["structuredContent"]
+        structured = dict(result["structuredContent"])
+        resources = []
+        for block in result.get("content") or []:
+            if isinstance(block, dict) and block.get("type") == "resource" and isinstance(block.get("resource"), dict):
+                resources.append(dict(block["resource"]))
+        if resources:
+            structured["_embedded_resources"] = resources
+        return structured
     return result
 
 
@@ -170,6 +177,35 @@ def _image_data_url(path_value: str) -> str:
     return f"data:{mime_type};base64,{encoded}"
 
 
+def _write_embedded_pdf(value: Any, output: str) -> Path:
+    if not isinstance(value, dict):
+        raise FormaClientError("Forma did not return structured PDF output.")
+    resources = value.get("_embedded_resources")
+    if not isinstance(resources, list):
+        raise FormaClientError("Forma did not return an embedded PDF resource.")
+    for resource in resources:
+        if not isinstance(resource, dict) or resource.get("mimeType") != "application/pdf":
+            continue
+        encoded = resource.get("blob")
+        if not isinstance(encoded, str) or not encoded:
+            continue
+        try:
+            pdf = base64.b64decode(encoded, validate=True)
+        except ValueError as exc:
+            raise FormaClientError("Forma returned invalid base64 PDF data.") from exc
+        if not pdf.startswith(b"%PDF-"):
+            raise FormaClientError("Forma returned application/pdf data without a PDF signature.")
+        path = Path(output)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(pdf)
+        resource.pop("blob", None)
+        resource["saved_path"] = str(path)
+        resource["size_bytes"] = len(pdf)
+        print(str(path))
+        return path
+    raise FormaClientError("Forma did not return an embedded application/pdf resource.")
+
+
 def _shared_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--url", help="Forma MCP URL; overrides FORMA_MCP_URL.")
     parser.add_argument("--timeout", type=float, help="HTTP timeout in seconds.")
@@ -194,11 +230,19 @@ def build_parser() -> argparse.ArgumentParser:
     generate.add_argument("--external-source-provider", choices=("firecrawl",))
     generate.add_argument("--past-jobs", action="store_true", help="Use relevant completed jobs as context.")
     generate.add_argument("--past-jobs-limit", type=int, choices=range(1, 9), default=3)
+    generate.add_argument("--pdf-output", help="Request and save an additional PDF project report.")
     _shared_options(generate)
 
     validate = subparsers.add_parser("validate", help="Validate components and nets from Forma project JSON.")
     validate.add_argument("project", help="Project JSON path, or - for stdin.")
     _shared_options(validate)
+
+    export_pdf = subparsers.add_parser("export-pdf", help="Render existing Forma project JSON as PDF.")
+    export_pdf.add_argument("project", help="Project JSON path, or - for stdin.")
+    export_pdf.add_argument("--pdf-output", required=True, help="Destination PDF path.")
+    export_pdf.add_argument("--filename", help="Optional artifact filename reported by Forma.")
+    export_pdf.add_argument("--project-id", help="Optional project id for the embedded resource URI.")
+    _shared_options(export_pdf)
 
     job = subparsers.add_parser("job", help="Fetch one persisted A2A job.")
     job.add_argument("job_id")
@@ -238,6 +282,8 @@ def run(args: argparse.Namespace) -> Any:
             arguments["external_source_provider"] = args.external_source_provider
         if args.past_jobs:
             arguments["data_sources"] = ["past_jobs"]
+        if args.pdf_output:
+            arguments["output_formats"] = ["pdf"]
         return call_tool("blueprint.generate_project", arguments, **options)
     if args.command == "validate":
         project = _project_ir(_load_json(args.project))
@@ -246,6 +292,14 @@ def run(args: argparse.Namespace) -> Any:
         if not isinstance(components, list) or not isinstance(nets, list):
             raise FormaClientError("The project JSON must contain components and nets arrays.")
         return call_tool("blueprint.validate_circuit", {"components": components, "nets": nets}, **options)
+    if args.command == "export-pdf":
+        project = _project_ir(_load_json(args.project))
+        arguments: dict[str, Any] = {"project_ir": project}
+        if args.filename:
+            arguments["filename"] = args.filename
+        if args.project_id:
+            arguments["project_id"] = args.project_id
+        return call_tool("blueprint.export_project_pdf", arguments, **options)
     if args.command == "job":
         return call_tool("blueprint.a2a.get_job", {"job_id": args.job_id}, **options)
     if args.command == "jobs":
@@ -268,6 +322,9 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         result = run(args)
+        pdf_output = getattr(args, "pdf_output", None)
+        if pdf_output:
+            _write_embedded_pdf(result, pdf_output)
         _write_json(result, args.output)
         return 0
     except (FormaClientError, OSError, ValueError, json.JSONDecodeError) as exc:

--- a/integrations/agent-skills/forma-hardware/scripts/forma.py
+++ b/integrations/agent-skills/forma-hardware/scripts/forma.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Small MCP JSON-RPC client for the Forma Agent Skill."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import mimetypes
+import os
+from pathlib import Path
+import sys
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlparse, urlunparse
+from urllib.request import Request, urlopen
+import uuid
+
+
+DEFAULT_MCP_URL = "http://127.0.0.1:8000/mcp"
+DEFAULT_TIMEOUT_SECONDS = 600.0
+
+
+class FormaClientError(RuntimeError):
+    """A connection, protocol, or Forma tool error."""
+
+
+def _mcp_url(value: str | None) -> str:
+    url = (value or os.environ.get("FORMA_MCP_URL") or DEFAULT_MCP_URL).strip()
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise FormaClientError("FORMA_MCP_URL must be an http:// or https:// URL.")
+    if parsed.path in {"", "/"}:
+        parsed = parsed._replace(path="/mcp")
+    return urlunparse(parsed)
+
+
+def _timeout(value: float | None) -> float:
+    if value is not None:
+        timeout = value
+    else:
+        raw = os.environ.get("FORMA_TIMEOUT_SECONDS", str(DEFAULT_TIMEOUT_SECONDS))
+        try:
+            timeout = float(raw)
+        except ValueError as exc:
+            raise FormaClientError("FORMA_TIMEOUT_SECONDS must be a number.") from exc
+    if timeout <= 0:
+        raise FormaClientError("The Forma timeout must be greater than zero.")
+    return timeout
+
+
+def _decode_response(raw: bytes, content_type: str) -> Any:
+    text = raw.decode("utf-8")
+    if "text/event-stream" not in content_type.lower():
+        return json.loads(text)
+
+    events: list[Any] = []
+    for line in text.splitlines():
+        if not line.startswith("data:"):
+            continue
+        data = line[5:].strip()
+        if data and data != "[DONE]":
+            events.append(json.loads(data))
+    if not events:
+        raise FormaClientError("Forma returned an empty event stream.")
+    return events[-1]
+
+
+def request(
+    method: str,
+    params: dict[str, Any] | None = None,
+    *,
+    url: str | None = None,
+    timeout: float | None = None,
+) -> Any:
+    payload = {
+        "jsonrpc": "2.0",
+        "id": f"forma-skill-{uuid.uuid4().hex}",
+        "method": method,
+        "params": params or {},
+    }
+    headers = {
+        "Accept": "application/json, text/event-stream",
+        "Content-Type": "application/json",
+        "User-Agent": "Forma-Agent-Skill/1.0",
+    }
+    token = os.environ.get("FORMA_AUTH_TOKEN", "").strip()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    http_request = Request(
+        _mcp_url(url),
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urlopen(http_request, timeout=_timeout(timeout)) as response:
+            result = _decode_response(response.read(), response.headers.get("Content-Type", "application/json"))
+    except HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace").strip()
+        suffix = f": {detail}" if detail else ""
+        raise FormaClientError(f"Forma returned HTTP {exc.code}{suffix}") from exc
+    except URLError as exc:
+        raise FormaClientError(f"Could not reach Forma at {_mcp_url(url)}: {exc.reason}") from exc
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise FormaClientError("Forma returned a response that was not valid JSON.") from exc
+
+    if not isinstance(result, dict):
+        raise FormaClientError("Forma returned an invalid JSON-RPC response.")
+    if result.get("error"):
+        error = result["error"]
+        if isinstance(error, dict):
+            message = error.get("message") or json.dumps(error, sort_keys=True)
+        else:
+            message = str(error)
+        raise FormaClientError(f"Forma JSON-RPC error: {message}")
+    if "result" not in result:
+        raise FormaClientError("Forma JSON-RPC response did not include a result.")
+    return result["result"]
+
+
+def call_tool(
+    name: str,
+    arguments: dict[str, Any],
+    *,
+    url: str | None = None,
+    timeout: float | None = None,
+) -> Any:
+    result = request("tools/call", {"name": name, "arguments": arguments}, url=url, timeout=timeout)
+    if isinstance(result, dict) and "structuredContent" in result:
+        return result["structuredContent"]
+    return result
+
+
+def _load_json(path_value: str) -> Any:
+    if path_value == "-":
+        return json.load(sys.stdin)
+    return json.loads(Path(path_value).read_text(encoding="utf-8"))
+
+
+def _write_json(value: Any, output: str | None) -> None:
+    rendered = json.dumps(value, indent=2, sort_keys=True) + "\n"
+    if not output or output == "-":
+        sys.stdout.write(rendered)
+        return
+    path = Path(output)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(rendered, encoding="utf-8")
+    print(str(path))
+
+
+def _project_ir(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise FormaClientError("The project JSON must contain an object.")
+    for key in ("project_ir", "hardware_ir"):
+        nested = value.get(key)
+        if isinstance(nested, dict):
+            return nested
+    response = value.get("response")
+    if isinstance(response, dict) and isinstance(response.get("project_ir"), dict):
+        return response["project_ir"]
+    return value
+
+
+def _image_data_url(path_value: str) -> str:
+    path = Path(path_value)
+    mime_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+    encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+    return f"data:{mime_type};base64,{encoded}"
+
+
+def _shared_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--url", help="Forma MCP URL; overrides FORMA_MCP_URL.")
+    parser.add_argument("--timeout", type=float, help="HTTP timeout in seconds.")
+    parser.add_argument("--output", help="Write JSON to this path instead of stdout.")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Call Forma from Claude, Codex, or another Agent Skills host.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    tools = subparsers.add_parser("tools", help="List Forma MCP tools.")
+    _shared_options(tools)
+
+    config = subparsers.add_parser("config", help="Show credential-safe Forma runtime configuration.")
+    _shared_options(config)
+
+    generate = subparsers.add_parser("generate", help="Generate a structured Forma hardware project.")
+    generate.add_argument("prompt", help="Complete hardware brief.")
+    generate.add_argument("--workflow", choices=("default", "web_research"), default="default")
+    generate.add_argument("--generate-image", action="store_true")
+    generate.add_argument("--image-file", help="Optional reference image path.")
+    generate.add_argument("--external-source-provider", choices=("firecrawl",))
+    generate.add_argument("--past-jobs", action="store_true", help="Use relevant completed jobs as context.")
+    generate.add_argument("--past-jobs-limit", type=int, choices=range(1, 9), default=3)
+    _shared_options(generate)
+
+    validate = subparsers.add_parser("validate", help="Validate components and nets from Forma project JSON.")
+    validate.add_argument("project", help="Project JSON path, or - for stdin.")
+    _shared_options(validate)
+
+    job = subparsers.add_parser("job", help="Fetch one persisted A2A job.")
+    job.add_argument("job_id")
+    _shared_options(job)
+
+    jobs = subparsers.add_parser("jobs", help="List persisted A2A jobs.")
+    jobs.add_argument("--sender")
+    jobs.add_argument("--status")
+    jobs.add_argument("--limit", type=int, default=50)
+    _shared_options(jobs)
+
+    call = subparsers.add_parser("call", help="Call any discovered Forma MCP tool.")
+    call.add_argument("tool")
+    argument_source = call.add_mutually_exclusive_group()
+    argument_source.add_argument("--arguments", default="{}", help="Tool arguments as a JSON object.")
+    argument_source.add_argument("--arguments-file", help="Tool arguments JSON path, or - for stdin.")
+    _shared_options(call)
+    return parser
+
+
+def run(args: argparse.Namespace) -> Any:
+    options = {"url": args.url, "timeout": args.timeout}
+    if args.command == "tools":
+        return request("tools/list", **options)
+    if args.command == "config":
+        return call_tool("blueprint.debug_config", {}, **options)
+    if args.command == "generate":
+        arguments: dict[str, Any] = {
+            "prompt": args.prompt,
+            "workflow": args.workflow,
+            "generate_image": args.generate_image,
+            "past_jobs_limit": args.past_jobs_limit,
+        }
+        if args.image_file:
+            arguments["image_data"] = _image_data_url(args.image_file)
+        if args.external_source_provider:
+            arguments["external_source_provider"] = args.external_source_provider
+        if args.past_jobs:
+            arguments["data_sources"] = ["past_jobs"]
+        return call_tool("blueprint.generate_project", arguments, **options)
+    if args.command == "validate":
+        project = _project_ir(_load_json(args.project))
+        components = project.get("components")
+        nets = project.get("nets")
+        if not isinstance(components, list) or not isinstance(nets, list):
+            raise FormaClientError("The project JSON must contain components and nets arrays.")
+        return call_tool("blueprint.validate_circuit", {"components": components, "nets": nets}, **options)
+    if args.command == "job":
+        return call_tool("blueprint.a2a.get_job", {"job_id": args.job_id}, **options)
+    if args.command == "jobs":
+        arguments = {"limit": args.limit}
+        if args.sender:
+            arguments["sender"] = args.sender
+        if args.status:
+            arguments["status"] = args.status
+        return call_tool("blueprint.a2a.list_jobs", arguments, **options)
+    if args.command == "call":
+        arguments = _load_json(args.arguments_file) if args.arguments_file else json.loads(args.arguments)
+        if not isinstance(arguments, dict):
+            raise FormaClientError("Tool arguments must be a JSON object.")
+        return call_tool(args.tool, arguments, **options)
+    raise FormaClientError(f"Unknown command: {args.command}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        result = run(args)
+        _write_json(result, args.output)
+        return 0
+    except (FormaClientError, OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"forma: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,6 +16,7 @@ Common entrypoints:
 ./scripts/quality/test.sh
 ./scripts/models/verify-llm-providers.py --list
 ./scripts/quality/benchmark.sh
+python scripts/operations/install-forma-skill.py
 ```
 
 Scripts should stay thin and call reusable implementations from `blueprint_core` or `evals` instead of accumulating application logic.

--- a/scripts/operations/install-forma-skill.py
+++ b/scripts/operations/install-forma-skill.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Install the portable Forma Agent Skill for Claude Code and/or Codex."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import shutil
+import sys
+
+
+SKILL_NAME = "forma-hardware"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_SOURCE = REPO_ROOT / "integrations" / "agent-skills" / SKILL_NAME
+AGENT_PATHS = {
+    "claude": Path(".claude") / "skills" / SKILL_NAME,
+    "codex": Path(".agents") / "skills" / SKILL_NAME,
+}
+
+
+def install_skill(source: Path, destination: Path, *, force: bool = False) -> Path:
+    if not (source / "SKILL.md").is_file():
+        raise ValueError(f"Forma skill source is invalid: {source}")
+    if destination.exists() and not force:
+        raise FileExistsError(f"Skill already exists at {destination}; pass --force to update it.")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source, destination, dirs_exist_ok=force)
+    return destination
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--agent", choices=("claude", "codex", "both"), default="both")
+    parser.add_argument("--scope", choices=("user", "project"), default="user")
+    parser.add_argument("--project-dir", type=Path, default=Path.cwd())
+    parser.add_argument("--home", type=Path, default=Path.home(), help=argparse.SUPPRESS)
+    parser.add_argument("--source", type=Path, default=DEFAULT_SOURCE, help=argparse.SUPPRESS)
+    parser.add_argument("--force", action="store_true", help="Update an existing installed skill.")
+    parser.add_argument("--dry-run", action="store_true", help="Print destinations without copying files.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    agents = tuple(AGENT_PATHS) if args.agent == "both" else (args.agent,)
+    base = args.home.expanduser() if args.scope == "user" else args.project_dir.expanduser().resolve()
+
+    try:
+        for agent in agents:
+            destination = base / AGENT_PATHS[agent]
+            if not args.dry_run:
+                install_skill(args.source.resolve(), destination, force=args.force)
+            print(f"{agent}: {destination}")
+    except (OSError, ValueError) as exc:
+        print(f"install-forma-skill: {exc}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/operations/install-forma-skill.py
+++ b/scripts/operations/install-forma-skill.py
@@ -24,7 +24,12 @@ def install_skill(source: Path, destination: Path, *, force: bool = False) -> Pa
     if destination.exists() and not force:
         raise FileExistsError(f"Skill already exists at {destination}; pass --force to update it.")
     destination.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(source, destination, dirs_exist_ok=force)
+    shutil.copytree(
+        source,
+        destination,
+        dirs_exist_ok=force,
+        ignore=shutil.ignore_patterns("__pycache__", "*.py[cod]"),
+    )
     return destination
 
 

--- a/tests/api/test_mcp_pdf_output.py
+++ b/tests/api/test_mcp_pdf_output.py
@@ -15,7 +15,12 @@ class McpPdfOutputTests(unittest.TestCase):
         tools = {tool["name"]: tool for tool in a2a._mcp_tools()}
 
         self.assertIn("blueprint.export_project_pdf", tools)
+        self.assertIn("blueprint.compile_project", tools)
         self.assertEqual(["project_ir"], tools["blueprint.export_project_pdf"]["inputSchema"]["required"])
+        self.assertEqual(
+            ["project_ir", "authoring_agent"],
+            tools["blueprint.compile_project"]["inputSchema"]["required"],
+        )
         output_formats = tools["blueprint.generate_project"]["inputSchema"]["properties"]["output_formats"]
         self.assertEqual(["pdf"], output_formats["items"]["enum"])
 
@@ -43,6 +48,31 @@ class McpPdfOutputTests(unittest.TestCase):
         artifact = result["structuredContent"]["artifacts"][0]
         self.assertEqual("embedded_resource", artifact["delivery"])
         self.assertNotIn("data_base64", artifact)
+
+    def test_compile_tool_marks_host_agent_and_returns_five_view_pdf(self) -> None:
+        response = asyncio.run(
+            a2a.call_blueprint_action(
+                "blueprint.compile_project",
+                {
+                    "project_ir": SAMPLE_PROJECT,
+                    "authoring_agent": "codex",
+                    "output_formats": ["pdf"],
+                },
+            )
+        )
+
+        self.assertEqual("host_agent", response["generation"]["mode"])
+        self.assertEqual("codex", response["generation"]["authoring_agent"])
+        self.assertFalse(response["generation"]["simulation"])
+        self.assertEqual("codex", response["project_ir"]["assembly_metadata"]["authoring_agent"])
+        self.assertEqual(["info", "bom", "mech", "wire", "docs"], response["artifacts"][0]["views"])
+
+    def test_simulation_requires_an_explicit_opt_in(self) -> None:
+        config = {"provider": "simulation", "runtime": {"runtime_provider": "simulation"}}
+
+        with self.assertRaisesRegex(ValueError, "allow_simulation=true"):
+            a2a.require_explicit_simulation(config, allow_simulation=False)
+        a2a.require_explicit_simulation(config, allow_simulation=True)
 
     def test_generate_project_only_attaches_pdf_when_requested(self) -> None:
         generated = {"project_id": "project-123", "project_ir": SAMPLE_PROJECT}

--- a/tests/api/test_mcp_pdf_output.py
+++ b/tests/api/test_mcp_pdf_output.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import unittest
+from unittest.mock import patch
+
+from apps.api import a2a
+
+from tests.projects.test_project_exports import SAMPLE_PROJECT
+
+
+class McpPdfOutputTests(unittest.TestCase):
+    def test_pdf_export_tool_is_discoverable(self) -> None:
+        tools = {tool["name"]: tool for tool in a2a._mcp_tools()}
+
+        self.assertIn("blueprint.export_project_pdf", tools)
+        self.assertEqual(["project_ir"], tools["blueprint.export_project_pdf"]["inputSchema"]["required"])
+        output_formats = tools["blueprint.generate_project"]["inputSchema"]["properties"]["output_formats"]
+        self.assertEqual(["pdf"], output_formats["items"]["enum"])
+
+    def test_export_tool_returns_an_embedded_pdf_resource(self) -> None:
+        response = asyncio.run(
+            a2a.handle_mcp_json_rpc(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "pdf-test",
+                    "method": "tools/call",
+                    "params": {
+                        "name": "blueprint.export_project_pdf",
+                        "arguments": {"project_ir": SAMPLE_PROJECT},
+                    },
+                }
+            )
+        )
+
+        result = response["result"]
+        resource_blocks = [block for block in result["content"] if block.get("type") == "resource"]
+        self.assertEqual(1, len(resource_blocks))
+        resource = resource_blocks[0]["resource"]
+        self.assertEqual("application/pdf", resource["mimeType"])
+        self.assertTrue(base64.b64decode(resource["blob"], validate=True).startswith(b"%PDF-"))
+        artifact = result["structuredContent"]["artifacts"][0]
+        self.assertEqual("embedded_resource", artifact["delivery"])
+        self.assertNotIn("data_base64", artifact)
+
+    def test_generate_project_only_attaches_pdf_when_requested(self) -> None:
+        generated = {"project_id": "project-123", "project_ir": SAMPLE_PROJECT}
+
+        async def run_to_thread_inline(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch.object(a2a, "_apply_owner_user_integrations"), patch.object(
+            a2a, "build_generation_response", return_value=generated
+        ), patch.object(a2a.asyncio, "to_thread", side_effect=run_to_thread_inline):
+            normal = asyncio.run(a2a.call_blueprint_action("blueprint.generate_project", {"prompt": "test"}))
+            with_pdf = asyncio.run(
+                a2a.call_blueprint_action(
+                    "blueprint.generate_project",
+                    {"prompt": "test", "output_formats": ["pdf"]},
+                )
+            )
+
+        self.assertNotIn("artifacts", normal)
+        self.assertEqual("pdf", with_pdf["artifacts"][0]["format"])
+        self.assertTrue(base64.b64decode(with_pdf["artifacts"][0]["data_base64"]).startswith(b"%PDF-"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/projects/test_project_exports.py
+++ b/tests/projects/test_project_exports.py
@@ -11,6 +11,7 @@ from blueprint_core.workspaces.projects.exports import (
     normalize_project_output_formats,
     render_project_pdf,
 )
+from blueprint_core.workspaces.projects.report_views import render_project_view_screenshots
 
 
 SAMPLE_PROJECT = {
@@ -35,9 +36,19 @@ SAMPLE_PROJECT = {
             "ref_des": "U1",
             "part_number": "ESP32-DEVKIT",
             "name": "ESP32 development board",
+            "category": "Microcontroller",
             "quantity": 1,
             "unit_price": 9.5,
             "rationale": "Provides Wi-Fi and analog input.",
+            "pins": [
+                {
+                    "pin_id": "3V3",
+                    "name": "3V3",
+                    "pin_type": "Power",
+                    "voltage": 3.3,
+                    "description": "Regulated 3.3V output",
+                }
+            ],
         }
     ],
     "nets": [
@@ -69,14 +80,15 @@ class ProjectPdfExportTests(unittest.TestCase):
         pdf = render_project_pdf(SAMPLE_PROJECT)
 
         self.assertTrue(pdf.startswith(b"%PDF-1.4"))
-        self.assertTrue(pdf.endswith(b"%%EOF\n"))
+        self.assertTrue(pdf.rstrip().endswith(b"%%EOF"))
         self.assertIn(b"/Type /Catalog", pdf)
         self.assertIn(b"/Type /Pages", pdf)
-        self.assertIn(b"/BaseFont /Helvetica", pdf)
+        self.assertEqual(5, len(re.findall(rb"/Type /Page\b", pdf)))
+        self.assertEqual(5, len(re.findall(rb"/Subtype /Image\b", pdf)))
         startxref = int(re.search(rb"startxref\n(\d+)\n%%EOF", pdf).group(1))
         self.assertEqual(b"xref", pdf[startxref:startxref + 4])
 
-    def test_large_report_is_paginated(self) -> None:
+    def test_report_always_has_one_page_per_workspace_view(self) -> None:
         project = {**SAMPLE_PROJECT, "assembly": [
             {
                 "step_num": index,
@@ -88,10 +100,13 @@ class ProjectPdfExportTests(unittest.TestCase):
         ]}
 
         pdf = render_project_pdf(project)
-        page_count = int(re.search(rb"/Type /Pages /Kids \[[^]]+\] /Count (\d+)", pdf).group(1))
+        self.assertEqual(5, len(re.findall(rb"/Type /Page\b", pdf)))
 
-        self.assertGreater(page_count, 1)
-        self.assertEqual(page_count, len(re.findall(rb"/Type /Page ", pdf)))
+    def test_workspace_screenshots_cover_expected_views(self) -> None:
+        screenshots = render_project_view_screenshots(SAMPLE_PROJECT)
+
+        self.assertEqual(["info", "bom", "mech", "wire", "docs"], [name for name, _data in screenshots])
+        self.assertTrue(all(data.startswith(b"\x89PNG\r\n\x1a\n") for _name, data in screenshots))
 
     def test_artifact_has_integrity_metadata_and_base64_pdf(self) -> None:
         artifact = build_project_pdf_artifact(SAMPLE_PROJECT)
@@ -102,6 +117,8 @@ class ProjectPdfExportTests(unittest.TestCase):
         self.assertEqual(len(pdf), artifact["size_bytes"])
         self.assertEqual(hashlib.sha256(pdf).hexdigest(), artifact["sha256"])
         self.assertEqual("forma://artifacts/project-123/esp32_soil_monitor_report.pdf", artifact["uri"])
+        self.assertEqual(["info", "bom", "mech", "wire", "docs"], artifact["views"])
+        self.assertEqual("workspace_screenshots", artifact["rendering"])
 
     def test_requested_filename_is_sanitized_without_adding_a_suffix(self) -> None:
         artifact = build_project_pdf_artifact(SAMPLE_PROJECT, requested_filename="../Customer Report.PDF")

--- a/tests/projects/test_project_exports.py
+++ b/tests/projects/test_project_exports.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import re
+import unittest
+
+from blueprint_core.workspaces.projects.exports import (
+    attach_project_output_artifacts,
+    build_project_pdf_artifact,
+    normalize_project_output_formats,
+    render_project_pdf,
+)
+
+
+SAMPLE_PROJECT = {
+    "hardware_ir_version": "0.1",
+    "overview": {
+        "title": "ESP32 Soil Monitor",
+        "description": "A 5V USB-powered plant monitor with a moisture sensor and OLED.",
+        "difficulty": "Beginner",
+        "estimated_cost": 24.5,
+        "category": "IoT",
+    },
+    "requirements": {
+        "requirements": ["Measure soil moisture", "Show status locally"],
+        "power_needs": "5V USB",
+        "operating_voltage": 3.3,
+        "physical_constraints": ["Indoor enclosure"],
+        "safety_notes": ["Disconnect USB power before rewiring."],
+        "missing_info": [],
+    },
+    "components": [
+        {
+            "ref_des": "U1",
+            "part_number": "ESP32-DEVKIT",
+            "name": "ESP32 development board",
+            "quantity": 1,
+            "unit_price": 9.5,
+            "rationale": "Provides Wi-Fi and analog input.",
+        }
+    ],
+    "nets": [
+        {
+            "net_id": "NET_3V3",
+            "name": "3.3V rail",
+            "net_type": "Power",
+            "voltage": 3.3,
+            "pins": [{"ref_des": "U1", "pin_id": "3V3"}],
+        }
+    ],
+    "assembly": [
+        {
+            "step_num": 1,
+            "title": "Wire power",
+            "description": "Connect the sensor to the regulated 3.3V output.",
+            "danger_flag": False,
+        }
+    ],
+    "validation": {"critical": [], "warning": [], "info": []},
+    "is_valid": True,
+    "estimated_current_draw_ma": 180,
+    "assembly_metadata": {"project_id": "project-123"},
+}
+
+
+class ProjectPdfExportTests(unittest.TestCase):
+    def test_renderer_produces_a_structurally_complete_pdf(self) -> None:
+        pdf = render_project_pdf(SAMPLE_PROJECT)
+
+        self.assertTrue(pdf.startswith(b"%PDF-1.4"))
+        self.assertTrue(pdf.endswith(b"%%EOF\n"))
+        self.assertIn(b"/Type /Catalog", pdf)
+        self.assertIn(b"/Type /Pages", pdf)
+        self.assertIn(b"/BaseFont /Helvetica", pdf)
+        startxref = int(re.search(rb"startxref\n(\d+)\n%%EOF", pdf).group(1))
+        self.assertEqual(b"xref", pdf[startxref:startxref + 4])
+
+    def test_large_report_is_paginated(self) -> None:
+        project = {**SAMPLE_PROJECT, "assembly": [
+            {
+                "step_num": index,
+                "title": f"Assembly step {index}",
+                "description": "Connect and verify the low-voltage wiring before proceeding. " * 4,
+                "danger_flag": False,
+            }
+            for index in range(1, 80)
+        ]}
+
+        pdf = render_project_pdf(project)
+        page_count = int(re.search(rb"/Type /Pages /Kids \[[^]]+\] /Count (\d+)", pdf).group(1))
+
+        self.assertGreater(page_count, 1)
+        self.assertEqual(page_count, len(re.findall(rb"/Type /Page ", pdf)))
+
+    def test_artifact_has_integrity_metadata_and_base64_pdf(self) -> None:
+        artifact = build_project_pdf_artifact(SAMPLE_PROJECT)
+        pdf = base64.b64decode(artifact["data_base64"], validate=True)
+
+        self.assertEqual("application/pdf", artifact["mime_type"])
+        self.assertEqual("esp32_soil_monitor_report.pdf", artifact["filename"])
+        self.assertEqual(len(pdf), artifact["size_bytes"])
+        self.assertEqual(hashlib.sha256(pdf).hexdigest(), artifact["sha256"])
+        self.assertEqual("forma://artifacts/project-123/esp32_soil_monitor_report.pdf", artifact["uri"])
+
+    def test_requested_filename_is_sanitized_without_adding_a_suffix(self) -> None:
+        artifact = build_project_pdf_artifact(SAMPLE_PROJECT, requested_filename="../Customer Report.PDF")
+
+        self.assertEqual("customer_report.pdf", artifact["filename"])
+        self.assertNotIn("..", artifact["uri"])
+
+    def test_generation_artifacts_are_only_added_when_requested(self) -> None:
+        response = {"project_id": "project-123", "project_ir": SAMPLE_PROJECT}
+
+        self.assertIs(response, attach_project_output_artifacts(response, None))
+        exported = attach_project_output_artifacts(response, ["PDF", "pdf"])
+
+        self.assertEqual(["pdf"], exported["output_formats"])
+        self.assertEqual(1, len(exported["artifacts"]))
+        self.assertNotIn("artifacts", response)
+
+    def test_unknown_output_format_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "Unsupported project output format"):
+            normalize_project_output_formats(["docx"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tooling/test_forma_agent_skill.py
+++ b/tests/tooling/test_forma_agent_skill.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import importlib.util
+import json
+from pathlib import Path
+import threading
+import tempfile
+import unittest
+from unittest.mock import patch
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+SKILL_DIR = ROOT_DIR / "integrations" / "agent-skills" / "forma-hardware"
+CLIENT_PATH = SKILL_DIR / "scripts" / "forma.py"
+INSTALLER_PATH = ROOT_DIR / "scripts" / "operations" / "install-forma-skill.py"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+forma_client = _load_module("forma_skill_client", CLIENT_PATH)
+forma_installer = _load_module("forma_skill_installer", INSTALLER_PATH)
+
+
+class _MCPHandler(BaseHTTPRequestHandler):
+    requests: list[dict] = []
+    authorization: str | None = None
+    rpc_error: dict | None = None
+
+    def do_POST(self) -> None:  # noqa: N802 - stdlib handler API
+        length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(length))
+        type(self).requests.append(payload)
+        type(self).authorization = self.headers.get("Authorization")
+
+        if type(self).rpc_error:
+            response = {"jsonrpc": "2.0", "id": payload["id"], "error": type(self).rpc_error}
+        elif payload["method"] == "tools/list":
+            response = {
+                "jsonrpc": "2.0",
+                "id": payload["id"],
+                "result": {"tools": [{"name": "blueprint.generate_project"}]},
+            }
+        else:
+            arguments = payload["params"]["arguments"]
+            response = {
+                "jsonrpc": "2.0",
+                "id": payload["id"],
+                "result": {
+                    "content": [{"type": "text", "text": "ignored"}],
+                    "structuredContent": {"received": arguments},
+                },
+            }
+
+        rendered = json.dumps(response).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(rendered)))
+        self.end_headers()
+        self.wfile.write(rendered)
+
+    def log_message(self, format: str, *args) -> None:
+        return
+
+
+@contextmanager
+def _mcp_server():
+    _MCPHandler.requests = []
+    _MCPHandler.authorization = None
+    _MCPHandler.rpc_error = None
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _MCPHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+class FormaSkillClientTests(unittest.TestCase):
+    def test_lists_tools_and_normalizes_bare_origin(self) -> None:
+        with _mcp_server() as url:
+            result = forma_client.request("tools/list", url=url, timeout=2)
+
+        self.assertEqual("blueprint.generate_project", result["tools"][0]["name"])
+        self.assertEqual("tools/list", _MCPHandler.requests[0]["method"])
+
+    def test_generate_uses_structured_content_and_bearer_token(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir, _mcp_server() as url:
+            output = Path(temp_dir) / "project.json"
+            with patch.dict("os.environ", {"FORMA_AUTH_TOKEN": "test-token"}, clear=False):
+                exit_code = forma_client.main([
+                    "generate",
+                    "ESP32 soil monitor",
+                    "--workflow",
+                    "web_research",
+                    "--past-jobs",
+                    "--url",
+                    url,
+                    "--timeout",
+                    "2",
+                    "--output",
+                    str(output),
+                ])
+
+            saved = json.loads(output.read_text(encoding="utf-8"))
+
+        self.assertEqual(0, exit_code)
+        self.assertEqual("ESP32 soil monitor", saved["received"]["prompt"])
+        self.assertEqual(["past_jobs"], saved["received"]["data_sources"])
+        self.assertEqual("Bearer test-token", _MCPHandler.authorization)
+        self.assertEqual("blueprint.generate_project", _MCPHandler.requests[0]["params"]["name"])
+
+    def test_validate_extracts_project_ir(self) -> None:
+        project = {"project_ir": {"components": [{"id": "mcu"}], "nets": [{"id": "power"}]}}
+        with tempfile.TemporaryDirectory() as temp_dir, _mcp_server() as url:
+            project_path = Path(temp_dir) / "project.json"
+            output_path = Path(temp_dir) / "validation.json"
+            project_path.write_text(json.dumps(project), encoding="utf-8")
+            exit_code = forma_client.main([
+                "validate",
+                str(project_path),
+                "--url",
+                url,
+                "--output",
+                str(output_path),
+            ])
+            saved = json.loads(output_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(0, exit_code)
+        self.assertEqual([{"id": "mcu"}], saved["received"]["components"])
+        self.assertEqual([{"id": "power"}], saved["received"]["nets"])
+
+    def test_surfaces_json_rpc_errors(self) -> None:
+        with _mcp_server() as url:
+            _MCPHandler.rpc_error = {"code": -32000, "message": "provider unavailable"}
+            with self.assertRaisesRegex(forma_client.FormaClientError, "provider unavailable"):
+                forma_client.request("tools/list", url=url, timeout=2)
+
+
+class FormaSkillInstallerTests(unittest.TestCase):
+    def test_installs_for_claude_and_codex_at_user_scope(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            home = Path(temp_dir)
+            exit_code = forma_installer.main(["--home", str(home), "--source", str(SKILL_DIR)])
+
+            claude_skill = home / ".claude" / "skills" / "forma-hardware"
+            codex_skill = home / ".agents" / "skills" / "forma-hardware"
+            self.assertEqual(0, exit_code)
+            self.assertTrue((claude_skill / "SKILL.md").is_file())
+            self.assertTrue((codex_skill / "scripts" / "forma.py").is_file())
+            self.assertEqual(
+                (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8"),
+                (claude_skill / "SKILL.md").read_text(encoding="utf-8"),
+            )
+
+    def test_requires_force_to_update_an_existing_skill(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            home = Path(temp_dir)
+            first = forma_installer.main([
+                "--agent",
+                "codex",
+                "--home",
+                str(home),
+                "--source",
+                str(SKILL_DIR),
+            ])
+            second = forma_installer.main([
+                "--agent",
+                "codex",
+                "--home",
+                str(home),
+                "--source",
+                str(SKILL_DIR),
+            ])
+            updated = forma_installer.main([
+                "--agent",
+                "codex",
+                "--home",
+                str(home),
+                "--source",
+                str(SKILL_DIR),
+                "--force",
+            ])
+
+        self.assertEqual(0, first)
+        self.assertEqual(2, second)
+        self.assertEqual(0, updated)
+
+
+class FormaSkillPackageTests(unittest.TestCase):
+    def test_skill_has_cross_agent_metadata_and_docs(self) -> None:
+        skill = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+        openai_metadata = (SKILL_DIR / "agents" / "openai.yaml").read_text(encoding="utf-8")
+
+        self.assertIn("name: forma-hardware", skill)
+        self.assertIn("description:", skill)
+        self.assertNotIn("TODO", skill)
+        self.assertIn("$forma-hardware", openai_metadata)
+        self.assertTrue((SKILL_DIR / "references" / "configuration.md").is_file())
+        self.assertTrue((ROOT_DIR / "docs" / "agent-skills.md").is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tooling/test_forma_agent_skill.py
+++ b/tests/tooling/test_forma_agent_skill.py
@@ -159,6 +159,8 @@ class FormaSkillInstallerTests(unittest.TestCase):
             self.assertEqual(0, exit_code)
             self.assertTrue((claude_skill / "SKILL.md").is_file())
             self.assertTrue((codex_skill / "scripts" / "forma.py").is_file())
+            self.assertFalse(any(path.name == "__pycache__" for path in claude_skill.rglob("*")))
+            self.assertFalse(any(path.suffix == ".pyc" for path in codex_skill.rglob("*")))
             self.assertEqual(
                 (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8"),
                 (claude_skill / "SKILL.md").read_text(encoding="utf-8"),

--- a/tests/tooling/test_forma_agent_skill.py
+++ b/tests/tooling/test_forma_agent_skill.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 import importlib.util
@@ -48,6 +49,39 @@ class _MCPHandler(BaseHTTPRequestHandler):
                 "jsonrpc": "2.0",
                 "id": payload["id"],
                 "result": {"tools": [{"name": "blueprint.generate_project"}]},
+            }
+        elif (
+            payload["params"]["name"] == "blueprint.export_project_pdf"
+            or "pdf" in payload["params"]["arguments"].get("output_formats", [])
+        ):
+            encoded_pdf = base64.b64encode(b"%PDF-1.4\n%%EOF\n").decode("ascii")
+            response = {
+                "jsonrpc": "2.0",
+                "id": payload["id"],
+                "result": {
+                    "content": [
+                        {"type": "text", "text": "pdf"},
+                        {
+                            "type": "resource",
+                            "resource": {
+                                "uri": "forma://artifacts/test/report.pdf",
+                                "mimeType": "application/pdf",
+                                "blob": encoded_pdf,
+                            },
+                        },
+                    ],
+                    "structuredContent": {
+                        "received": payload["params"]["arguments"],
+                        "artifacts": [
+                            {
+                                "format": "pdf",
+                                "filename": "report.pdf",
+                                "mime_type": "application/pdf",
+                                "delivery": "embedded_resource",
+                            }
+                        ]
+                    },
+                },
             }
         else:
             arguments = payload["params"]["arguments"]
@@ -140,6 +174,55 @@ class FormaSkillClientTests(unittest.TestCase):
         self.assertEqual(0, exit_code)
         self.assertEqual([{"id": "mcu"}], saved["received"]["components"])
         self.assertEqual([{"id": "power"}], saved["received"]["nets"])
+
+    def test_generate_can_save_requested_pdf_output(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir, _mcp_server() as url:
+            pdf_path = Path(temp_dir) / "generated-report.pdf"
+            metadata_path = Path(temp_dir) / "project.json"
+
+            exit_code = forma_client.main([
+                "generate",
+                "ESP32 soil monitor",
+                "--url",
+                url,
+                "--pdf-output",
+                str(pdf_path),
+                "--output",
+                str(metadata_path),
+            ])
+            saved_pdf = pdf_path.read_bytes()
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(0, exit_code)
+        self.assertTrue(saved_pdf.startswith(b"%PDF-"))
+        self.assertEqual(["pdf"], metadata["received"]["output_formats"])
+
+    def test_export_pdf_saves_embedded_resource(self) -> None:
+        project = {"project_ir": {"overview": {"title": "Test"}, "components": [], "nets": []}}
+        with tempfile.TemporaryDirectory() as temp_dir, _mcp_server() as url:
+            project_path = Path(temp_dir) / "project.json"
+            pdf_path = Path(temp_dir) / "report.pdf"
+            metadata_path = Path(temp_dir) / "metadata.json"
+            project_path.write_text(json.dumps(project), encoding="utf-8")
+
+            exit_code = forma_client.main([
+                "export-pdf",
+                str(project_path),
+                "--url",
+                url,
+                "--pdf-output",
+                str(pdf_path),
+                "--output",
+                str(metadata_path),
+            ])
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            saved_pdf = pdf_path.read_bytes()
+
+        self.assertEqual(0, exit_code)
+        self.assertEqual(b"%PDF-1.4\n%%EOF\n", saved_pdf)
+        resource = metadata["_embedded_resources"][0]
+        self.assertEqual(str(pdf_path), resource["saved_path"])
+        self.assertNotIn("blob", resource)
 
     def test_surfaces_json_rpc_errors(self) -> None:
         with _mcp_server() as url:

--- a/tests/tooling/test_forma_agent_skill.py
+++ b/tests/tooling/test_forma_agent_skill.py
@@ -136,6 +136,7 @@ class FormaSkillClientTests(unittest.TestCase):
                 exit_code = forma_client.main([
                     "generate",
                     "ESP32 soil monitor",
+                    "--use-configured-provider",
                     "--workflow",
                     "web_research",
                     "--past-jobs",
@@ -183,6 +184,7 @@ class FormaSkillClientTests(unittest.TestCase):
             exit_code = forma_client.main([
                 "generate",
                 "ESP32 soil monitor",
+                "--use-configured-provider",
                 "--url",
                 url,
                 "--pdf-output",
@@ -223,6 +225,41 @@ class FormaSkillClientTests(unittest.TestCase):
         resource = metadata["_embedded_resources"][0]
         self.assertEqual(str(pdf_path), resource["saved_path"])
         self.assertNotIn("blob", resource)
+
+    def test_compile_uses_host_agent_and_saves_pdf(self) -> None:
+        project = {"overview": {"title": "Agent project"}, "components": [], "nets": []}
+        with tempfile.TemporaryDirectory() as temp_dir, _mcp_server() as url:
+            project_path = Path(temp_dir) / "agent-project.json"
+            pdf_path = Path(temp_dir) / "agent-project.pdf"
+            metadata_path = Path(temp_dir) / "compiled.json"
+            project_path.write_text(json.dumps(project), encoding="utf-8")
+
+            exit_code = forma_client.main([
+                "compile",
+                str(project_path),
+                "--authoring-agent",
+                "codex",
+                "--pdf-output",
+                str(pdf_path),
+                "--url",
+                url,
+                "--output",
+                str(metadata_path),
+            ])
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+            saved_pdf = pdf_path.read_bytes()
+
+        self.assertEqual(0, exit_code)
+        self.assertTrue(saved_pdf.startswith(b"%PDF-"))
+        self.assertEqual("codex", metadata["received"]["authoring_agent"])
+        self.assertEqual(["pdf"], metadata["received"]["output_formats"])
+
+    def test_simulation_generation_requires_double_opt_in(self) -> None:
+        parser = forma_client.build_parser()
+        args = parser.parse_args(["generate", "test", "--provider", "simulation"])
+
+        with self.assertRaisesRegex(forma_client.FormaClientError, "--allow-simulation"):
+            forma_client.run(args)
 
     def test_surfaces_json_rpc_errors(self) -> None:
         with _mcp_server() as url:


### PR DESCRIPTION
## Summary

- add one portable `forma-hardware` Agent Skill shared by Claude Code and Codex
- make the host Claude/Codex agent author Hardware IR by default
- add `blueprint.compile_project` for deterministic validation, Mermaid/SVG generation, and PDF export of host-authored IR
- render PDFs as five landscape workspace captures: `INFO`, `BOM`, `MECH`, `WIRE`, and `DOCS`
- return PDFs as MCP embedded `application/pdf` resources
- require explicit opt-in for server-side generation and a second explicit `allow_simulation` opt-in for simulation
- remove the web app's silent local-example fallback when live generation fails
- include client commands, Hardware IR authoring reference, setup docs, and deterministic coverage

## Related issue

None.

## Change type

- [ ] Bug fix
- [x] Feature
- [x] Documentation
- [x] Test
- [ ] Refactor
- [ ] Chore or maintenance

## Verification

```text
python /home/isayah/.codex/skills/.system/skill-creator/scripts/quick_validate.py integrations/agent-skills/forma-hardware
# Skill is valid!

CLOUDFLARE_ENABLE_THINKING=false ./scripts/quality/test.sh
# 449 passed; 1 distribution-metadata check skipped

npm run lint --prefix apps/web
# Passed with seven existing no-img-element warnings.

npm run build --prefix apps/web
# Production build passed.

# Live isolated MCP server:
python integrations/agent-skills/forma-hardware/scripts/forma.py compile apps/web/public/examples/smart_thermostat.json --authoring-agent codex --url http://127.0.0.1:8013/mcp --pdf-output /tmp/forma-codex-five-views.pdf --output /tmp/forma-codex-compiled.json
# 11 tools discovered; host-agent compilation returned simulation=false.
# Exported a valid 602,341-byte PDF with five pages and five embedded images.
# Ghostscript validated the PDF successfully.

python integrations/agent-skills/forma-hardware/scripts/forma.py call blueprint.generate_project --arguments '{"prompt":"test monitor","provider":"simulation"}' --url http://127.0.0.1:8013/mcp
# Rejected because allow_simulation=true was not supplied.

git diff --check
# Passed
```

## Configuration or migration requirements

No migration. Claude Code and Codex normally need only the Forma MCP URL and optional auth token; the host agent authors IR. Optional server-side prompt generation requires a configured live provider. Simulation requires explicit caller acceptance through `allow_simulation: true` or `--provider simulation --allow-simulation`.

Existing Forma servers must be restarted after deploying this update before the new MCP tool appears.

## Visual changes

PDF exports now contain five screenshot-style workspace pages matching INFO, BOM, MECH, WIRE, and DOCS.

## Safety and compatibility

The skill and compiler preserve Forma's low-voltage maker-electronics boundary and prototype disclaimer. Existing export and validation tools remain available. Server simulation can no longer be reached implicitly, and frontend generation failures now surface as errors instead of successful-looking local examples.

## AI assistance

Codex substantially assisted with implementation, documentation, visual inspection, deterministic tests, and live MCP verification. A clean-context skill forward-test selected host-agent authoring and the compile path without choosing server generation or simulation.

## Checklist

- [x] This pull request targets `dev` and the branch started from an up-to-date `dev`.
- [x] The change addresses one logical concern and contains no unrelated cleanup.
- [x] Python code is typed and public classes and functions are documented where applicable.
- [x] Relevant deterministic tests were added or updated.
- [x] The full Python suite, frontend lint, and frontend build pass.
- [x] Documentation was updated when behavior changed.
- [x] No secrets, credentials, logs, databases, build artifacts, or generated temporary files were committed.
- [x] Hardware safety implications were considered.
- [x] Breaking behavior changes are documented.
