### PR TITLE
Add Google Vertex AI as an LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,18 +70,19 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 # and directs users without an active provider to Settings.
 # BLUEPRINT_DEPLOYMENT=true
 
-# LLM provider: openai, baseten, gmi, huggingface, cloudflare, nvidia, gemini, openai-compatible, runpod, runpod-serverless, or simulation.
+# LLM provider: vertex, openai, baseten, gmi, huggingface, cloudflare, nvidia, gemini, openai-compatible, runpod, runpod-serverless, or simulation.
 # Use runpod for Runpod OpenAI-compatible/vLLM endpoints and runpod-serverless for queue-style /runsync workers.
-LLM_PROVIDER=openai
-OPENAI_API_KEY=your_openai_api_key_here
-OPENAI_MODEL=gpt-4o-mini
+LLM_PROVIDER=vertex
+GOOGLE_CLOUD_PROJECT=your_google_cloud_project_id
+GOOGLE_CLOUD_LOCATION=global
+VERTEX_AI_MODEL=gemini-3.5-flash
 STRICT_LLM=true
 
 # Optional runtime provider/model switching.
 # Requests to /generate may include {"provider":"openai","model":"gpt-4o-mini"}.
 # If unset, allowed providers default to configured providers detected from env.
 # Runtime model overrides default to the configured model/fallback unless allowlists are set.
-# LLM_ALLOWED_PROVIDERS=openai,baseten,gmi,huggingface,cloudflare,nvidia,openai-compatible,gemini,runpod,runpod-serverless,simulation
+# LLM_ALLOWED_PROVIDERS=vertex,openai,baseten,gmi,huggingface,cloudflare,nvidia,openai-compatible,gemini,runpod,runpod-serverless,simulation
 # OPENAI_ALLOWED_MODELS=gpt-4o-mini,gpt-5.5
 # BASETEN_ALLOWED_MODELS=deepseek-ai/DeepSeek-V4-Pro
 # GMI_ALLOWED_MODELS=anthropic/claude-fable-5
@@ -90,6 +91,7 @@ STRICT_LLM=true
 # NVIDIA_ALLOWED_MODELS=qwen/qwen2.5-coder-32b-instruct,meta/llama-3.1-8b-instruct
 # OPENAI_COMPATIBLE_ALLOWED_MODELS=your-compatible-model
 # GEMINI_ALLOWED_MODELS=gemini-3.5-flash,gemini-2.5-flash
+# VERTEX_AI_ALLOWED_MODELS=gemini-3.5-flash,gemini-2.5-flash
 # RUNPOD_ALLOWED_MODELS=your-runpod-model-v1,your-runpod-model-v2
 
 # First-party OpenAI options.
@@ -273,7 +275,17 @@ SUPABASE_S3_BUCKET=contents
 # is json_object; switch to json_schema only after a live smoke test.
 # RUNPOD_RESPONSE_FORMAT=json_schema
 
-# Backward-compatible Gemini aliases are still supported.
+# Vertex AI uses Application Default Credentials. For local development, run
+# `gcloud auth application-default login`; in deployed environments, attach a
+# service account with Vertex AI access. A credential file can also be mounted
+# and selected with GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json.
+# VERTEX_AI_PROJECT=your_google_cloud_project_id
+# VERTEX_AI_LOCATION=global
+# VERTEX_AI_MODEL=gemini-3.5-flash
+# VERTEX_AI_FALLBACK_MODEL=gemini-2.5-flash
+# STRICT_VERTEX_AI=true
+
+# The Gemini Developer API remains available as a separate API-key provider.
 # GEMINI_API_KEY=your_gemini_api_key_here
 # GOOGLE_API_KEY=your_google_api_key_here
 # GEMINI_MODEL=gemini-3.5-flash

--- a/README.md
+++ b/README.md
@@ -168,9 +168,10 @@ primary SQLite database directly when the API server is not running. Job
 tables include the generation source when known: `Catalog`, `Web Research`, or
 both.
 
-To run with OpenAI:
+To run with Google Vertex AI as the primary LLM provider:
 ```bash
-LLM_PROVIDER=openai OPENAI_API_KEY=your_openai_api_key_here OPENAI_MODEL=gpt-4o-mini uvicorn apps.api.main:app --reload --port 8000
+gcloud auth application-default login
+LLM_PROVIDER=vertex GOOGLE_CLOUD_PROJECT=your-project-id GOOGLE_CLOUD_LOCATION=global VERTEX_AI_MODEL=gemini-3.5-flash uvicorn apps.api.main:app --reload --port 8000
 ```
 
 Environment variables (recommended via a repo-root `.env`; see `.env.example`):
@@ -197,9 +198,9 @@ Environment variables (recommended via a repo-root `.env`; see `.env.example`):
 
 The backend publishes the resolved, credential-safe client contract at `GET /api/runtime/config`. Its precedence is explicit request override, saved integration, environment, then provider default. The web application uses this response for provider/model choices, image behavior, workflow defaults, and BYOK prompts instead of repeating configuration logic.
 
-- `LLM_PROVIDER`: Live generation provider: `anthropic`, `baseten`, `gemini`, `gmi`, `huggingface`, `cloudflare`, `nvidia`, `openai`, `openai-compatible`, `runpod`, `runpod-serverless`, or `simulation`. Use `runpod` for Runpod OpenAI-compatible/vLLM endpoints and `runpod-serverless` for queue-style `/runsync` workers.
+- `LLM_PROVIDER`: Live generation provider: `vertex`, `anthropic`, `baseten`, `gemini`, `gmi`, `huggingface`, `cloudflare`, `nvidia`, `openai`, `openai-compatible`, `runpod`, `runpod-serverless`, or `simulation`. Use `runpod` for Runpod OpenAI-compatible/vLLM endpoints and `runpod-serverless` for queue-style `/runsync` workers.
 - `LLM_ALLOWED_PROVIDERS`: Optional comma-separated allowlist for per-request provider overrides.
-- `OPENAI_ALLOWED_MODELS` / `ANTHROPIC_ALLOWED_MODELS` / `BASETEN_ALLOWED_MODELS` / `GEMINI_ALLOWED_MODELS` / `GMI_ALLOWED_MODELS` / `HUGGINGFACE_ALLOWED_MODELS` / `CLOUDFLARE_ALLOWED_MODELS` / `NVIDIA_ALLOWED_MODELS` / `OPENAI_COMPATIBLE_ALLOWED_MODELS` / `RUNPOD_ALLOWED_MODELS`: Optional comma-separated allowlists for per-request model overrides. Without an explicit allowlist, runtime overrides are limited to the configured default/fallback model for that provider.
+- `VERTEX_AI_ALLOWED_MODELS` / `OPENAI_ALLOWED_MODELS` / `ANTHROPIC_ALLOWED_MODELS` / `BASETEN_ALLOWED_MODELS` / `GEMINI_ALLOWED_MODELS` / `GMI_ALLOWED_MODELS` / `HUGGINGFACE_ALLOWED_MODELS` / `CLOUDFLARE_ALLOWED_MODELS` / `NVIDIA_ALLOWED_MODELS` / `OPENAI_COMPATIBLE_ALLOWED_MODELS` / `RUNPOD_ALLOWED_MODELS`: Optional comma-separated allowlists for per-request model overrides. Without an explicit allowlist, runtime overrides are limited to the configured default/fallback model for that provider.
 - `/api/generate` also accepts optional `provider` and `model` fields for runtime switching. Each generated project records the requested provider/model and actual provider/model in `assembly_metadata`.
 - In the Keys UI, users can set Runtime Defaults → Preferred model as `provider/model` (for example `anthropic/claude-sonnet-5` or `huggingface/Qwen/Qwen2.5-Coder-3B-Instruct:nscale`). Forma derives the runtime provider, model, provider allowlist, and model allowlist from saved keys/models automatically.
 - `STRICT_LLM`: Set to `true` (default) to fail fast when model validation is enabled and the model is unavailable. Set to `false` to attempt fallback.
@@ -210,6 +211,15 @@ The backend publishes the resolved, credential-safe client contract at `GET /api
 - `LLM_TIMEOUT_SECONDS`: Generic read timeout. OpenAI-compatible endpoints default to `90`.
 - `LLM_REASONING_EFFORT`: Optional generic reasoning effort for compatible endpoints that support it.
 - `LLM_TEMPERATURE`: Optional generic sampling temperature. OpenAI-compatible endpoints default to `0.2`; set `default`, `none`, or `omit` to omit it.
+
+<details>
+<summary><strong>Google Vertex AI (primary)</strong></summary>
+
+- Set `LLM_PROVIDER=vertex`, `GOOGLE_CLOUD_PROJECT` (or `VERTEX_AI_PROJECT`), and `GOOGLE_CLOUD_LOCATION` (or `VERTEX_AI_LOCATION`, default `global`).
+- `VERTEX_AI_MODEL` selects the Gemini model and `VERTEX_AI_FALLBACK_MODEL` configures the optional non-strict fallback.
+- Authentication uses Google Cloud Application Default Credentials. Run `gcloud auth application-default login` locally; in production, attach a service account with Vertex AI access. `GOOGLE_APPLICATION_CREDENTIALS` may point to a mounted credential file.
+
+</details>
 
 <details>
 <summary><strong>OpenAI</strong></summary>

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -8,6 +8,7 @@ python-dotenv>=1.0.1
 PyJWT>=2.10.1
 cryptography>=42.0.0
 json-repair>=0.30.0
+google-genai>=1.0.0
 sqlalchemy==2.0.31
 supabase==2.31.0
 huggingface-hub>=0.34.0

--- a/apps/web/app/user/user-integrations-page.tsx
+++ b/apps/web/app/user/user-integrations-page.tsx
@@ -222,6 +222,7 @@ const INTEGRATION_NAV_GROUPS: Array<{ id: string; label: string; items: Integrat
       { integrationId: "openai", view: "llm", label: "OpenAI LLM" },
       { integrationId: "anthropic", view: "llm" },
       { integrationId: "gemini", view: "llm" },
+      { integrationId: "vertex", view: "llm" },
       { integrationId: "baseten", view: "llm" },
       { integrationId: "gmi", view: "llm", label: "GMI Cloud LLM" },
       { integrationId: "huggingface", view: "llm", label: "Hugging Face LLM" },

--- a/apps/web/lib/active-llms.ts
+++ b/apps/web/lib/active-llms.ts
@@ -11,7 +11,7 @@ export function generationLlmImageSupport(option: Pick<GenerationLlmOption, "pro
   const provider = option.provider.trim().toLowerCase();
   const model = option.model.trim().toLowerCase().replace(/^models\//, "");
 
-  if (provider === "gemini" || provider === "anthropic") return true;
+  if (provider === "gemini" || provider === "vertex" || provider === "anthropic") return true;
   if (provider === "cloudflare" && model === "@cf/google/gemma-4-26b-a4b-it") return true;
   if (["-vl", "_vl", "/vl", "vision", "llava"].some((marker) => model.includes(marker))) return true;
   if (provider === "openai" && ["gpt-4o", "gpt-4.1", "gpt-5"].some((prefix) => model.startsWith(prefix))) return true;

--- a/apps/web/lib/provider-model-catalog.ts
+++ b/apps/web/lib/provider-model-catalog.ts
@@ -32,6 +32,14 @@ export const LLM_MODEL_OPTIONS: Record<string, ProviderModelOption[]> = {
     model("gemini-2.5-pro", "Gemini 2.5 Pro", "Stable previous-generation pro model"),
     model("gemini-2.5-flash", "Gemini 2.5 Flash", "Stable previous-generation flash model"),
   ],
+  vertex: [
+    model("gemini-3.6-flash", "Gemini 3.6 Flash", "Vertex AI agentic and multimodal workloads"),
+    model("gemini-3.5-flash", "Gemini 3.5 Flash", "Vertex AI coding and sustained agentic tasks"),
+    model("gemini-3.5-flash-lite", "Gemini 3.5 Flash-Lite", "Vertex AI high-throughput workloads"),
+    model("gemini-3.1-flash-lite", "Gemini 3.1 Flash-Lite", "Vertex AI fast general-purpose model"),
+    model("gemini-2.5-pro", "Gemini 2.5 Pro", "Stable Vertex AI pro model"),
+    model("gemini-2.5-flash", "Gemini 2.5 Flash", "Stable Vertex AI flash model"),
+  ],
   baseten: [
     model("deepseek-ai/DeepSeek-V4-Pro", "DeepSeek V4 Pro"),
     model("zai-org/GLM-5.2", "GLM 5.2"),
@@ -271,6 +279,7 @@ function providerLabel(provider: string) {
     anthropic: "Anthropic",
     baseten: "Baseten",
     gemini: "Google Gemini",
+    vertex: "Google Vertex AI",
     gmi: "GMI Cloud",
     huggingface: "Hugging Face",
     cloudflare: "Cloudflare AI",

--- a/blueprint_core/config/contract.py
+++ b/blueprint_core/config/contract.py
@@ -32,6 +32,7 @@ _PROVIDER_LABELS = {
     "openai-compatible": "OpenAI Compatible",
     "runpod": "Runpod",
     "runpod-serverless": "Runpod Serverless",
+    "vertex": "Google Vertex AI",
 }
 
 _MODEL_LABELS = {

--- a/blueprint_core/llm_providers.py
+++ b/blueprint_core/llm_providers.py
@@ -28,6 +28,9 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_GEMINI_MODEL = "gemini-3.5-flash"
 DEFAULT_GEMINI_FALLBACK_MODEL = "gemini-2.5-flash"
+DEFAULT_VERTEX_MODEL = DEFAULT_GEMINI_MODEL
+DEFAULT_VERTEX_FALLBACK_MODEL = DEFAULT_GEMINI_FALLBACK_MODEL
+DEFAULT_VERTEX_LOCATION = "global"
 DEFAULT_ANTHROPIC_MODEL = "claude-sonnet-5"
 DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com/v1"
 DEFAULT_ANTHROPIC_VERSION = "2023-06-01"
@@ -86,7 +89,7 @@ def model_image_input_support(provider_name: str, model_name: str) -> Optional[b
     provider = normalize_llm_provider_name(provider_name) or provider_name.strip().lower()
     model = _normalize_model_name(model_name).lower()
 
-    if provider in {"gemini", "anthropic"}:
+    if provider in {"gemini", "vertex", "anthropic"}:
         return True
     if provider == "cloudflare" and model == DEFAULT_CLOUDFLARE_MODEL:
         return True
@@ -136,6 +139,7 @@ SUPPORTED_LLM_PROVIDERS = {
     "runpod",
     "runpod-serverless",
     "simulation",
+    "vertex",
 }
 SIMULATION_PROVIDER_ALIASES = {"simulation", "simulated", "offline", "none", "mock"}
 PROVIDER_ALIASES = {
@@ -149,6 +153,10 @@ PROVIDER_ALIASES = {
     "nim": "nvidia",
     "google": "gemini",
     "google-genai": "gemini",
+    "google-vertex": "vertex",
+    "google-vertex-ai": "vertex",
+    "vertex-ai": "vertex",
+    "vertexai": "vertex",
     "gmi-cloud": "gmi",
     "gmi_cloud": "gmi",
     "gmicloud": "gmi",
@@ -423,6 +431,8 @@ def _default_provider_name() -> str:
         return "runpod"
     if runpod_api_key and runpod_serverless_endpoint:
         return "runpod-serverless"
+    if _first_env(["VERTEX_AI_PROJECT", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID", "GCLOUD_PROJECT"]):
+        return "vertex"
     if _first_env(["GEMINI_API_KEY", "GOOGLE_API_KEY"]):
         return "gemini"
     if _first_env(["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"]):
@@ -482,6 +492,8 @@ def _configured_provider_names(default_provider: str) -> List[str]:
         providers.add("runpod-serverless")
     if _first_env(["GEMINI_API_KEY", "GOOGLE_API_KEY"]):
         providers.add("gemini")
+    if _first_env(["VERTEX_AI_PROJECT", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID", "GCLOUD_PROJECT"]):
+        providers.add("vertex")
     if _first_env(["OPENAI_API_KEY", "LLM_API_KEY"]):
         providers.add("openai")
     if _first_env(["LLM_BASE_URL", "OPENAI_BASE_URL"]):
@@ -509,6 +521,8 @@ def _default_model_for_provider(provider_name: str, *, include_runtime_override:
         return _first_env(["BASETEN_MODEL", *runtime_model], DEFAULT_BASETEN_MODEL) or DEFAULT_BASETEN_MODEL
     if provider_name == "gemini":
         return _first_env([*runtime_model, "GEMINI_MODEL"], DEFAULT_GEMINI_MODEL) or DEFAULT_GEMINI_MODEL
+    if provider_name == "vertex":
+        return _first_env([*runtime_model, "VERTEX_AI_MODEL", "VERTEX_MODEL"], DEFAULT_VERTEX_MODEL) or DEFAULT_VERTEX_MODEL
     if provider_name == "gmi":
         return _normalize_model_for_provider(
             provider_name,
@@ -541,6 +555,11 @@ def _fallback_model_for_provider(provider_name: str) -> Optional[str]:
         return _first_env(["BASETEN_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"])
     if provider_name == "gemini":
         return _first_env(["LLM_FALLBACK_MODEL", "GEMINI_FALLBACK_MODEL"], DEFAULT_GEMINI_FALLBACK_MODEL)
+    if provider_name == "vertex":
+        return _first_env(
+            ["LLM_FALLBACK_MODEL", "VERTEX_AI_FALLBACK_MODEL", "VERTEX_FALLBACK_MODEL"],
+            DEFAULT_VERTEX_FALLBACK_MODEL,
+        )
     if provider_name == "gmi":
         fallback = _first_env(["GMI_FALLBACK_MODEL", "GMI_CLOUD_FALLBACK_MODEL", "GMICLOUD_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"])
         return _normalize_model_for_provider(provider_name, fallback) if fallback else None
@@ -608,6 +627,8 @@ def _allowed_model_names(provider_name: str, default_model: str) -> Optional[Lis
         ]
     elif provider_name == "gemini":
         env_names = ["GEMINI_ALLOWED_MODELS", "ALLOWED_GEMINI_MODELS", *env_names]
+    elif provider_name == "vertex":
+        env_names = ["VERTEX_AI_ALLOWED_MODELS", "VERTEX_ALLOWED_MODELS", "ALLOWED_VERTEX_MODELS", *env_names]
     elif provider_name == "nvidia":
         env_names = ["NVIDIA_ALLOWED_MODELS", "NVIDIA_NIM_ALLOWED_MODELS", "NIM_ALLOWED_MODELS", *env_names]
     elif provider_name in {"runpod", "runpod-serverless"}:
@@ -689,7 +710,10 @@ def get_llm_runtime_debug_config() -> Dict[str, Any]:
 
 
 def _normalize_model_name(model_name: str) -> str:
-    return model_name.strip().removeprefix("models/")
+    normalized = model_name.strip().removeprefix("models/")
+    if "/models/" in normalized:
+        normalized = normalized.rsplit("/models/", 1)[-1]
+    return normalized
 
 
 def _model_is_available(model_name: str, available_models: List[str]) -> bool:
@@ -915,6 +939,7 @@ class SimulationProvider(StructuredLLMProvider):
 
 class GeminiProvider(StructuredLLMProvider):
     provider_name = "gemini"
+    provider_label = "Gemini"
 
     def __init__(self, model_name: Optional[str] = None):
         self.api_key = _first_env(["GEMINI_API_KEY", "GOOGLE_API_KEY", "LLM_API_KEY"])
@@ -932,16 +957,16 @@ class GeminiProvider(StructuredLLMProvider):
         if self.api_key and genai:
             try:
                 self.client = genai.Client(api_key=self.api_key)
-                logger.info("Gemini LLM provider initialized successfully.")
+                logger.info("%s LLM provider initialized successfully.", self.provider_label)
             except Exception as exc:
-                self.init_error = f"Error initializing Gemini provider: {exc}"
+                self.init_error = f"Error initializing {self.provider_label} provider: {exc}"
                 logger.error(self.init_error)
         elif self.api_key and not genai:
-            self.init_error = "Gemini API key is set, but google-genai is unavailable."
+            self.init_error = f"{self.provider_label} credentials are set, but google-genai is unavailable."
             logger.warning("%s Running in simulated/fallback mode.", self.init_error)
         else:
             self.init_error = "No Gemini API key found."
-            logger.warning("%s Live Gemini generation is disabled.", self.init_error)
+            logger.warning("%s Live %s generation is disabled.", self.init_error, self.provider_label)
 
         self.is_configured = self.client is not None
 
@@ -958,6 +983,11 @@ class GeminiProvider(StructuredLLMProvider):
             supported_actions = getattr(model, "supported_actions", None)
             if supported_actions is None and isinstance(model, dict):
                 supported_actions = model.get("supportedActions") or model.get("supported_actions")
+            if supported_actions is None and self.provider_name == "vertex":
+                # Vertex publisher-model listings currently omit capability
+                # metadata even for Gemini generateContent models.
+                available_models.append(name)
+                continue
             supported_actions = supported_actions or []
 
             if "generateContent" in supported_actions:
@@ -980,7 +1010,7 @@ class GeminiProvider(StructuredLLMProvider):
                 strict_mode=self.strict_mode,
                 fallback_active=False,
                 fallback_model=self.fallback_model,
-                validation_error=f"{self.init_error or 'Gemini provider is not configured'} Simulation mode is active.",
+                validation_error=f"{self.init_error or f'{self.provider_label} provider is not configured'} Simulation mode is active.",
                 live_generation_enabled=False,
             )
             return self._validation
@@ -988,7 +1018,7 @@ class GeminiProvider(StructuredLLMProvider):
         try:
             available_models = self._list_generate_content_models()
         except Exception as exc:
-            validation_error = f"Unable to validate Gemini model availability: {exc}"
+            validation_error = f"Unable to validate {self.provider_label} model availability: {exc}"
             actual_model = self.fallback_model if not self.strict_mode else None
             self._validation = LLMProviderValidation(
                 provider=self.provider_name,
@@ -1023,8 +1053,8 @@ class GeminiProvider(StructuredLLMProvider):
 
         if self.strict_mode:
             validation_error = (
-                f"Configured Gemini model {self.requested_model} is not available for this API key/provider. "
-                "Check available models or configure a valid Gemini model ID."
+                f"Configured {self.provider_label} model {self.requested_model} is not available for this account/provider. "
+                f"Check available models or configure a valid {self.provider_label} model ID."
             )
             self._validation = LLMProviderValidation(
                 provider=self.provider_name,
@@ -1044,7 +1074,7 @@ class GeminiProvider(StructuredLLMProvider):
         fallback_available = _model_is_available(self.fallback_model, available_models)
         if not fallback_available:
             validation_error = (
-                f"Configured Gemini model {self.requested_model} is not available, and fallback model "
+                f"Configured {self.provider_label} model {self.requested_model} is not available, and fallback model "
                 f"{self.fallback_model} is not available for this API key/provider."
             )
             self._validation = LLMProviderValidation(
@@ -1081,7 +1111,7 @@ class GeminiProvider(StructuredLLMProvider):
         image_mime_type: Optional[str] = None,
     ) -> Any:
         if self.client is None or genai_types is None:
-            raise RuntimeError("Gemini provider is not configured.")
+            raise RuntimeError(f"{self.provider_label} provider is not configured.")
 
         contents = []
         if image_bytes and image_mime_type:
@@ -1098,6 +1128,67 @@ class GeminiProvider(StructuredLLMProvider):
             ),
         )
         return _validate_structured_json(response.text, schema_class)
+
+
+class VertexAIProvider(GeminiProvider):
+    """Gemini on Vertex AI using Google Cloud Application Default Credentials."""
+
+    provider_name = "vertex"
+    provider_label = "Vertex AI"
+
+    def __init__(self, model_name: Optional[str] = None):
+        self.project = _first_env(
+            ["VERTEX_AI_PROJECT", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID", "GCLOUD_PROJECT"]
+        )
+        self.location = (
+            _first_env(["VERTEX_AI_LOCATION", "GOOGLE_CLOUD_LOCATION"], DEFAULT_VERTEX_LOCATION)
+            or DEFAULT_VERTEX_LOCATION
+        )
+        self.api_key = None
+        self.requested_model = (
+            model_name
+            or _first_env(["LLM_MODEL", "VERTEX_AI_MODEL", "VERTEX_MODEL"], DEFAULT_VERTEX_MODEL)
+            or DEFAULT_VERTEX_MODEL
+        )
+        self.fallback_model = (
+            _first_env(
+                ["LLM_FALLBACK_MODEL", "VERTEX_AI_FALLBACK_MODEL", "VERTEX_FALLBACK_MODEL"],
+                DEFAULT_VERTEX_FALLBACK_MODEL,
+            )
+            or DEFAULT_VERTEX_FALLBACK_MODEL
+        )
+        self.strict_mode = _first_env_bool(["STRICT_LLM", "STRICT_VERTEX_AI", "STRICT_VERTEX"], default=True)
+        self.model_name = self.requested_model
+        self.client = None
+        self.init_error: Optional[str] = None
+        self._validation: Optional[LLMProviderValidation] = None
+
+        if self.project and genai:
+            try:
+                self.client = genai.Client(
+                    vertexai=True,
+                    project=self.project,
+                    location=self.location,
+                )
+                logger.info(
+                    "Vertex AI LLM provider initialized for project %s in %s.",
+                    self.project,
+                    self.location,
+                )
+            except Exception as exc:
+                self.init_error = f"Error initializing Vertex AI provider: {exc}"
+                logger.error(self.init_error)
+        elif self.project and not genai:
+            self.init_error = "Vertex AI project is set, but google-genai is unavailable."
+            logger.warning("%s Running in simulated/fallback mode.", self.init_error)
+        else:
+            self.init_error = (
+                "No Vertex AI project found. Set VERTEX_AI_PROJECT or GOOGLE_CLOUD_PROJECT "
+                "and configure Application Default Credentials."
+            )
+            logger.warning("%s Live Vertex AI generation is disabled.", self.init_error)
+
+        self.is_configured = self.client is not None
 
 
 class AnthropicProvider(StructuredLLMProvider):
@@ -2382,6 +2473,8 @@ def build_llm_provider(
         return AnthropicProvider(model_name=runtime.model)
     if runtime.provider == "gemini":
         return GeminiProvider(model_name=runtime.model)
+    if runtime.provider == "vertex":
+        return VertexAIProvider(model_name=runtime.model)
     if runtime.provider in {"baseten", "gmi", "huggingface", "cloudflare", "nvidia", "openai", "openai-compatible"}:
         return OpenAICompatibleProvider(provider_name=runtime.provider, model_name=runtime.model)
     if runtime.provider == "runpod":
@@ -2393,7 +2486,8 @@ def build_llm_provider(
 
     message = (
         f"Unsupported LLM_PROVIDER '{runtime.provider}'. Supported providers are "
-        "anthropic, baseten, gemini, gmi, huggingface, cloudflare, nvidia, openai, openai-compatible, runpod, runpod-serverless, and simulation."
+        "anthropic, baseten, gemini, gmi, huggingface, cloudflare, nvidia, openai, openai-compatible, "
+        "runpod, runpod-serverless, simulation, and vertex."
     )
     logger.warning(message)
     return SimulationProvider(validation_error=message)

--- a/blueprint_core/user_integrations.py
+++ b/blueprint_core/user_integrations.py
@@ -494,6 +494,33 @@ INTEGRATION_DEFINITIONS: tuple[IntegrationDefinition, ...] = (
         ),
     ),
     IntegrationDefinition(
+        id="vertex",
+        label="Google Vertex AI",
+        description="Gemini models on Vertex AI using server-side Google Cloud Application Default Credentials.",
+        fields=(
+            IntegrationFieldDefinition(
+                "project",
+                "Google Cloud project",
+                ("VERTEX_AI_PROJECT", "GOOGLE_CLOUD_PROJECT"),
+                placeholder="your-gcp-project-id",
+                help="The backend must have Vertex AI access through Application Default Credentials.",
+            ),
+            IntegrationFieldDefinition(
+                "location",
+                "Vertex AI location",
+                ("VERTEX_AI_LOCATION", "GOOGLE_CLOUD_LOCATION"),
+                placeholder="global",
+            ),
+            IntegrationFieldDefinition("model", "Default model", ("VERTEX_AI_MODEL",), placeholder="gemini-3.5-flash"),
+            IntegrationFieldDefinition(
+                "fallback_model",
+                "Fallback model",
+                ("VERTEX_AI_FALLBACK_MODEL",),
+                placeholder="gemini-2.5-flash",
+            ),
+        ),
+    ),
+    IntegrationDefinition(
         id="firecrawl",
         label="Firecrawl",
         description="Firecrawl MCP search and page extraction.",
@@ -533,11 +560,13 @@ EXTRA_MANAGED_ENV_NAMES = {
     "NVIDIA_ALLOWED_MODELS",
     "OPENAI_ALLOWED_MODELS",
     "RUNPOD_ALLOWED_MODELS",
+    "VERTEX_AI_ALLOWED_MODELS",
 }
 LLM_PROVIDER_INTEGRATION_IDS = {
     "anthropic",
     "baseten",
     "gemini",
+    "vertex",
     "gmi",
     "huggingface",
     "cloudflare",
@@ -558,6 +587,10 @@ PROVIDER_ALIASES = {
     "nvidia-nim": "nvidia",
     "nim": "nvidia",
     "google": "gemini",
+    "google-vertex": "vertex",
+    "google-vertex-ai": "vertex",
+    "vertex-ai": "vertex",
+    "vertexai": "vertex",
 }
 MODEL_PREFIX_PROVIDERS = (
     ("claude-", "anthropic"),
@@ -573,6 +606,7 @@ PROVIDER_ALLOWED_MODEL_ENV = {
     "anthropic": "ANTHROPIC_ALLOWED_MODELS",
     "baseten": "BASETEN_ALLOWED_MODELS",
     "gemini": "GEMINI_ALLOWED_MODELS",
+    "vertex": "VERTEX_AI_ALLOWED_MODELS",
     "gmi": "GMI_ALLOWED_MODELS",
     "huggingface": "HUGGINGFACE_ALLOWED_MODELS",
     "cloudflare": "CLOUDFLARE_ALLOWED_MODELS",
@@ -1394,6 +1428,8 @@ def _environment_configures_integration(definition: IntegrationDefinition) -> bo
     ]
     if definition.id not in LLM_PROVIDER_INTEGRATION_IDS:
         return bool(configured_fields)
+    if definition.id == "vertex":
+        return any(field_definition.id == "project" for field_definition in configured_fields)
     if any(field_definition.secret for field_definition in configured_fields):
         return True
     runtime_provider = _normalize_provider_id(_ORIGINAL_ENV_VALUES.get("LLM_PROVIDER") or "")

--- a/blueprint_core/workspaces/projects/models.py
+++ b/blueprint_core/workspaces/projects/models.py
@@ -208,7 +208,7 @@ class GenerateProjectRequest(BaseModel):
     )
     provider: Optional[str] = Field(
         None,
-        description="Optional runtime LLM provider override, for example openai, anthropic, baseten, gmi, huggingface, cloudflare, nvidia, openai-compatible, gemini, runpod, runpod-serverless, or simulation"
+        description="Optional runtime LLM provider override, for example vertex, openai, anthropic, baseten, gmi, huggingface, cloudflare, nvidia, openai-compatible, gemini, runpod, runpod-serverless, or simulation"
     )
     model: Optional[str] = Field(
         None,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -24,7 +24,7 @@ Forma OSS turns prompts into structured hardware projects using a sequential, va
 - Live structured JSON output is routed through the reusable `blueprint_core.llm` package API.
 - Shared generation, provider, validation, model, and runtime utilities live under `blueprint_core` so the backend, CLI, smoke tests, and future workers use the same implementation.
 - External service adapters live under `blueprint_core/integrations/`; Hugging Face artifact packaging and uploads are grouped under `integrations/huggingface/`.
-- Supported providers are `anthropic`, `baseten`, `gemini`, `gmi`, `huggingface`, `cloudflare`, `nvidia`, `openai`, `openai-compatible`, `runpod`, `runpod-serverless`, and `simulation`.
+- Supported providers are `vertex`, `anthropic`, `baseten`, `gemini`, `gmi`, `huggingface`, `cloudflare`, `nvidia`, `openai`, `openai-compatible`, `runpod`, `runpod-serverless`, and `simulation`.
 - Generic configuration uses `LLM_PROVIDER`, `LLM_API_KEY`, `LLM_MODEL`, `STRICT_LLM`, and `LLM_FALLBACK_MODEL`.
 - `blueprint_core.config` is the dedicated configuration package. Its exported `config` singleton is the sole Python process-environment boundary; runtime resolution and the credential-safe client contract live in `blueprint_core.config.runtime` and `blueprint_core.config.contract`. Legacy runtime-config module paths are compatibility shims only.
 - Backend, core, CLI, example, evaluation, and maintenance modules use the config object's read, parse, snapshot, mutation, replacement, and temporary-override APIs instead of accessing `os.getenv` or `os.environ` directly.
@@ -33,6 +33,7 @@ Forma OSS turns prompts into structured hardware projects using a sequential, va
 - `blueprint_core.config.contract.resolve_runtime_contract()` is the single client-facing configuration authority. It resolves request/saved/environment/default precedence and publishes LLM options, image defaults, workflow defaults, generation readiness, and BYOK requirements through `GET /api/runtime/config`.
 - Environment variables and encrypted integration records are input adapters. The web application does not merge them or derive provider readiness independently.
 - Gemini-specific variables (`GEMINI_API_KEY`, `GOOGLE_API_KEY`, `GEMINI_MODEL`, `STRICT_GEMINI`, `GEMINI_FALLBACK_MODEL`) remain supported as compatibility aliases.
+- Vertex AI is the recommended primary provider and uses Google Cloud ADC with `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION`, and `VERTEX_AI_MODEL`.
 - If no API key is configured (or generation errors), the backend uses a deterministic simulation fallback backed by curated example projects.
 
 ## System diagram

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -60,12 +60,13 @@ LLM configuration behavior:
 - `PROJECTS_CACHE_TTL_SECONDS`: project-list cache lifetime in seconds, default `60`; successful project writes invalidate all list variants immediately.
 - `REDIS_CACHE_PREFIX`: Redis key namespace, required when `BLUEPRINT_DEV_MODE=false` and defaulting to `blueprint` only for development-mode cache usage.
 - `REDIS_SOCKET_TIMEOUT_SECONDS`: Redis connect/read timeout, default `0.25`; failures open a 30-second local circuit breaker.
-- `LLM_PROVIDER`: `anthropic`, `baseten`, `gemini`, `gmi`, `huggingface`, `cloudflare`, `nvidia`, `openai`, `openai-compatible`, `runpod`, `runpod-serverless`, or `simulation`. Use `runpod` for Runpod OpenAI-compatible/vLLM endpoints and `runpod-serverless` for queue-style `/runsync` workers.
+- `LLM_PROVIDER`: `vertex`, `anthropic`, `baseten`, `gemini`, `gmi`, `huggingface`, `cloudflare`, `nvidia`, `openai`, `openai-compatible`, `runpod`, `runpod-serverless`, or `simulation`. Use `runpod` for Runpod OpenAI-compatible/vLLM endpoints and `runpod-serverless` for queue-style `/runsync` workers.
 - `LLM_MODEL`: provider model ID
 - `/api/generate` accepts optional `provider` and `model` fields for runtime switching. The backend validates them before generation and records requested/actual provider/model metadata on the project.
 - `/api/generate` accepts `data_sources: ["past_jobs"]` and an optional `past_jobs_limit` (1-8, default 3). This retrieves the signed-in owner's relevant completed generation jobs, compacts their stored project outputs into bounded prompt context, and requires no embedding model or vector database. The current request always takes precedence over historical examples.
 - `LLM_ALLOWED_PROVIDERS`: optional comma-separated allowlist for runtime provider overrides. If unset, configured providers detected from env plus `simulation` are allowed.
-- `OPENAI_ALLOWED_MODELS` / `BASETEN_ALLOWED_MODELS` / `HUGGINGFACE_ALLOWED_MODELS` / `CLOUDFLARE_ALLOWED_MODELS` / `NVIDIA_ALLOWED_MODELS` / `OPENAI_COMPATIBLE_ALLOWED_MODELS` / `GEMINI_ALLOWED_MODELS` / `RUNPOD_ALLOWED_MODELS`: optional comma-separated allowlists for runtime model overrides. If unset, runtime model overrides are limited to configured default/fallback models for the selected provider.
+- `VERTEX_AI_ALLOWED_MODELS` / `OPENAI_ALLOWED_MODELS` / `BASETEN_ALLOWED_MODELS` / `HUGGINGFACE_ALLOWED_MODELS` / `CLOUDFLARE_ALLOWED_MODELS` / `NVIDIA_ALLOWED_MODELS` / `OPENAI_COMPATIBLE_ALLOWED_MODELS` / `GEMINI_ALLOWED_MODELS` / `RUNPOD_ALLOWED_MODELS`: optional comma-separated allowlists for runtime model overrides. If unset, runtime model overrides are limited to configured default/fallback models for the selected provider.
+- `GOOGLE_CLOUD_PROJECT` / `VERTEX_AI_PROJECT`, `GOOGLE_CLOUD_LOCATION` / `VERTEX_AI_LOCATION`, and `VERTEX_AI_MODEL`: Vertex AI routing when `LLM_PROVIDER=vertex`; authentication uses Google Cloud Application Default Credentials.
 - `OPENAI_API_KEY`: first-party OpenAI API key when `LLM_PROVIDER=openai`
 - `OPENAI_MODEL`: first-party OpenAI model alias for `LLM_MODEL`
 - `OPENAI_RESPONSE_FORMAT`: OpenAI response format, defaulting to `json_schema`; `json_object` and `none` are also supported
@@ -171,5 +172,5 @@ Saved smoke-test reports are written to `.logs/llm-smoke/` by default, with `.lo
 Run against first-party OpenAI:
 
 ```bash
-LLM_PROVIDER=openai OPENAI_API_KEY=your_openai_api_key_here OPENAI_MODEL=gpt-4o-mini uvicorn apps.api.main:app --reload --port 8000
+LLM_PROVIDER=vertex GOOGLE_CLOUD_PROJECT=your-project-id GOOGLE_CLOUD_LOCATION=global VERTEX_AI_MODEL=gemini-3.5-flash uvicorn apps.api.main:app --reload --port 8000
 ```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -174,9 +174,10 @@ Notes:
 - Provider availability is `environment configured OR (BYOK enabled AND BYOK configured)`. Environment variables remain workspace/platform defaults, saved BYOK values overlay matching fields, and clearing or disabling BYOK reveals the environment fallback. Generated provider/model allowlists include both sources, so either source can make a provider available without suppressing the other.
 - After those inputs are applied, `GET /api/runtime/config` is authoritative for the frontend. Resolution precedence is request override, saved integration, environment, then provider default; the browser does not repeat this merge.
 - `BLUEPRINT_DEPLOYMENT=true` requires a configured deployment provider or signed-in user's BYOK provider for generation. The frontend keeps the composer visible and directs users without an active provider to Settings.
-- `LLM_PROVIDER` can be `anthropic`, `baseten`, `gemini`, `gmi`, `huggingface`, `cloudflare`, `nvidia`, `openai`, `openai-compatible`, `runpod`, `runpod-serverless`, or `simulation`. Use `runpod` for Runpod OpenAI-compatible/vLLM endpoints and `runpod-serverless` for queue-style `/runsync` workers.
+- `LLM_PROVIDER` can be `vertex`, `anthropic`, `baseten`, `gemini`, `gmi`, `huggingface`, `cloudflare`, `nvidia`, `openai`, `openai-compatible`, `runpod`, `runpod-serverless`, or `simulation`. Use `runpod` for Runpod OpenAI-compatible/vLLM endpoints and `runpod-serverless` for queue-style `/runsync` workers.
 - `/api/generate` accepts optional `provider` and `model` fields for runtime switching, for example `{"provider":"openai","model":"gpt-4o-mini"}`.
-- Use `LLM_ALLOWED_PROVIDERS` plus provider-specific model allowlists (`OPENAI_ALLOWED_MODELS`, `BASETEN_ALLOWED_MODELS`, `HUGGINGFACE_ALLOWED_MODELS`, `CLOUDFLARE_ALLOWED_MODELS`, `NVIDIA_ALLOWED_MODELS`, `OPENAI_COMPATIBLE_ALLOWED_MODELS`, `GEMINI_ALLOWED_MODELS`, `RUNPOD_ALLOWED_MODELS`) to control what clients can select at runtime.
+- Use `LLM_ALLOWED_PROVIDERS` plus provider-specific model allowlists (`VERTEX_AI_ALLOWED_MODELS`, `OPENAI_ALLOWED_MODELS`, `BASETEN_ALLOWED_MODELS`, `HUGGINGFACE_ALLOWED_MODELS`, `CLOUDFLARE_ALLOWED_MODELS`, `NVIDIA_ALLOWED_MODELS`, `OPENAI_COMPATIBLE_ALLOWED_MODELS`, `GEMINI_ALLOWED_MODELS`, `RUNPOD_ALLOWED_MODELS`) to control what clients can select at runtime.
+- `GOOGLE_CLOUD_PROJECT` (or `VERTEX_AI_PROJECT`), `GOOGLE_CLOUD_LOCATION` (or `VERTEX_AI_LOCATION`), and `VERTEX_AI_MODEL` configure Vertex AI. It authenticates with Application Default Credentials; use `gcloud auth application-default login` locally or an attached service account in production.
 - `OPENAI_API_KEY` enables first-party OpenAI live structured generation when `LLM_PROVIDER=openai`.
 - `OPENAI_RESPONSE_FORMAT` defaults to `json_schema` for OpenAI. You can set it to `json_object` for older JSON mode or `none` to omit `response_format`.
 - `OPENAI_TIMEOUT_SECONDS` controls the per-request OpenAI read timeout and defaults to `300`.
@@ -241,7 +242,7 @@ uvicorn apps.api.main:app --reload --port 8000
 
 OpenAI one-liner:
 ```bash
-LLM_PROVIDER=openai OPENAI_API_KEY=your_openai_api_key_here OPENAI_MODEL=gpt-4o-mini uvicorn apps.api.main:app --reload --port 8000
+LLM_PROVIDER=vertex GOOGLE_CLOUD_PROJECT=your-project-id GOOGLE_CLOUD_LOCATION=global VERTEX_AI_MODEL=gemini-3.5-flash uvicorn apps.api.main:app --reload --port 8000
 ```
 
 API docs: http://localhost:8000/api/docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ fabricator = "blueprint_core.fabricator.main:main"
 entrypoint = "apps.api.main:app"
 
 [project.optional-dependencies]
-gemini = ["google-genai>=0.1.0"]
+gemini = ["google-genai>=1.0.0"]
+vertex = ["google-genai>=1.0.0"]
 huggingface = ["huggingface-hub>=0.34.0"]
 observability = ["langfuse>=4.0.0"]
 supabase = ["supabase==2.31.0"]
@@ -60,7 +61,7 @@ backend = [
 ]
 s3 = ["boto3==1.35.99"]
 all = [
-    "google-genai>=0.1.0",
+    "google-genai>=1.0.0",
     "boto3==1.35.99",
     "cryptography>=42.0.0",
     "fastapi>=0.124.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ python-dotenv>=1.0.1
 PyJWT>=2.10.1
 cryptography>=42.0.0
 json-repair>=0.30.0
+google-genai>=1.0.0
 sqlalchemy==2.0.31
 supabase==2.31.0
 huggingface-hub>=0.34.0

--- a/tests/providers/test_llm_runtime.py
+++ b/tests/providers/test_llm_runtime.py
@@ -55,6 +55,7 @@ LLM_ENV_KEYS = {
     "GEMINI_ALLOWED_MODELS",
     "GEMINI_API_KEY",
     "GEMINI_MODEL",
+    "GCLOUD_PROJECT",
     "GMI_ALLOWED_MODELS",
     "GMI_API_KEY",
     "GMI_BASE_URL",
@@ -81,6 +82,11 @@ LLM_ENV_KEYS = {
     "GMICLOUD_TIMEOUT_SECONDS",
     "GMICLOUD_VALIDATE_MODELS",
     "GOOGLE_API_KEY",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "GOOGLE_CLOUD_LOCATION",
+    "GOOGLE_CLOUD_PROJECT",
+    "GOOGLE_CLOUD_PROJECT_ID",
+    "GOOGLE_GENAI_USE_VERTEXAI",
     "HF_ALLOWED_MODELS",
     "HF_API_TOKEN",
     "HF_BASE_URL",
@@ -155,6 +161,16 @@ LLM_ENV_KEYS = {
     "STRICT_GMICLOUD",
     "STRICT_LLM",
     "STRICT_CLOUDFLARE",
+    "STRICT_VERTEX",
+    "STRICT_VERTEX_AI",
+    "VERTEX_AI_ALLOWED_MODELS",
+    "VERTEX_AI_FALLBACK_MODEL",
+    "VERTEX_AI_LOCATION",
+    "VERTEX_AI_MODEL",
+    "VERTEX_AI_PROJECT",
+    "VERTEX_ALLOWED_MODELS",
+    "VERTEX_FALLBACK_MODEL",
+    "VERTEX_MODEL",
 }
 
 
@@ -226,6 +242,57 @@ class LLMRuntimeTests(unittest.TestCase):
         self.assertTrue(model_image_input_support("cloudflare", "@cf/google/gemma-4-26b-a4b-it"))
         self.assertTrue(model_image_input_support("openai", "gpt-5.5"))
         self.assertIsNone(model_image_input_support("cloudflare", "some-new-model"))
+
+    def test_vertex_is_primary_google_cloud_provider_and_uses_adc_client(self) -> None:
+        client_calls = []
+
+        class FakeModel:
+            name = "publishers/google/models/gemini-3.5-flash"
+            supported_actions = None
+
+        class FakeClient:
+            def __init__(self):
+                self.models = self
+
+            def list(self):
+                return [FakeModel()]
+
+        class FakeGenAI:
+            @staticmethod
+            def Client(**kwargs):
+                client_calls.append(kwargs)
+                return FakeClient()
+
+        with isolated_llm_env(
+            GOOGLE_CLOUD_PROJECT="forma-vertex-test",
+            GOOGLE_CLOUD_LOCATION="us-central1",
+            VERTEX_AI_MODEL="gemini-3.5-flash",
+        ), patch("blueprint_core.llm_providers.genai", FakeGenAI):
+            runtime = resolve_llm_runtime_config()
+            provider = build_llm_provider(runtime_config=runtime)
+            validation = provider.validate_configured_model()
+
+        self.assertEqual("vertex", runtime.provider)
+        self.assertEqual("gemini-3.5-flash", runtime.model)
+        self.assertEqual(
+            [{"vertexai": True, "project": "forma-vertex-test", "location": "us-central1"}],
+            client_calls,
+        )
+        self.assertTrue(provider.is_configured)
+        self.assertTrue(validation.requested_model_available)
+        self.assertEqual("vertex", validation.provider)
+
+    def test_vertex_alias_and_provider_specific_allowlist_are_supported(self) -> None:
+        with isolated_llm_env(
+            LLM_PROVIDER="google-vertex-ai",
+            VERTEX_AI_PROJECT="forma-vertex-test",
+            VERTEX_AI_ALLOWED_MODELS="gemini-2.5-flash,gemini-3.5-flash",
+        ):
+            runtime = resolve_llm_runtime_config(model_name="gemini-2.5-flash")
+
+        self.assertEqual("vertex", runtime.provider)
+        self.assertEqual("gemini-2.5-flash", runtime.model)
+        self.assertEqual(["gemini-2.5-flash", "gemini-3.5-flash"], runtime.allowed_models)
 
     def test_parse_provider_model_selector(self) -> None:
         selector = parse_llm_selector("runpod/caid-technologies/parti-base")


### PR DESCRIPTION
## Summary
- add a first-class Vertex AI provider using Google Cloud Application Default Credentials
- expose Vertex project, location, model, fallback, allowlist, and runtime/UI configuration
- make Vertex the documented default while keeping the Gemini Developer API separate
- include google-genai in backend runtime dependencies

## Verification
- live Vertex AI structured generation smoke test with gemini-3.5-flash
- 82 focused backend tests pass
- frontend TypeScript check passes