### PR TITLE
release: enable Vertex AI authentication on staging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,13 @@ GOOGLE_CLOUD_LOCATION=global
 VERTEX_AI_MODEL=gemini-3.5-flash
 STRICT_LLM=true
 
+# Optional keyless Vertex authentication for Vercel deployments. Configure a
+# Google Workload Identity Pool/provider that trusts Vercel OIDC, then set:
+# GCP_PROJECT_NUMBER=123456789012
+# GCP_SERVICE_ACCOUNT_EMAIL=vertex-runner@example.iam.gserviceaccount.com
+# GCP_WORKLOAD_IDENTITY_POOL_ID=vercel
+# GCP_WORKLOAD_IDENTITY_POOL_PROVIDER_ID=vercel
+
 # Optional runtime provider/model switching.
 # Requests to /generate may include {"provider":"openai","model":"gpt-5.6-sol"}.
 # If unset, allowed providers default to configured providers detected from env.

--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ The backend publishes the resolved, credential-safe client contract at `GET /api
 - Set `LLM_PROVIDER=vertex`, `GOOGLE_CLOUD_PROJECT` (or `VERTEX_AI_PROJECT`), and `GOOGLE_CLOUD_LOCATION` (or `VERTEX_AI_LOCATION`, default `global`).
 - `VERTEX_AI_MODEL` selects the Gemini model and `VERTEX_AI_FALLBACK_MODEL` configures the optional non-strict fallback.
 - Authentication uses Google Cloud Application Default Credentials. Run `gcloud auth application-default login` locally; in production, attach a service account with Vertex AI access. `GOOGLE_APPLICATION_CREDENTIALS` may point to a mounted credential file.
+- Vercel deployments can use keyless workload identity federation. Configure Vercel OIDC in a Google Workload Identity Pool, then set `GCP_PROJECT_NUMBER`, `GCP_SERVICE_ACCOUNT_EMAIL`, `GCP_WORKLOAD_IDENTITY_POOL_ID`, and `GCP_WORKLOAD_IDENTITY_POOL_PROVIDER_ID`. Forma exchanges the request's short-lived Vercel OIDC token and does not store a service-account key.
 
 </details>
 

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -60,6 +60,7 @@ load_dotenv(REPO_ROOT / ".env")
 load_dotenv(Path(__file__).resolve().parent / ".env", override=False)
 
 from blueprint_core.user_integrations import UserIntegrationStore, apply_user_integrations_to_environment, require_user_secrets_key
+from blueprint_core.vertex_auth import VercelOidcContextMiddleware
 
 apply_user_integrations_to_environment()
 
@@ -276,6 +277,7 @@ class ApiPrefixCompatibilityMiddleware:
 
 
 app.add_middleware(ApiPrefixCompatibilityMiddleware)
+app.add_middleware(VercelOidcContextMiddleware)
 
 # Enable CORS for Next.js frontend
 app.add_middleware(

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "pyjwt>=2.10.1",
     "cryptography>=42.0.0",
     "json-repair>=0.30.0",
+    "google-auth>=2.29.0",
+    "google-genai>=1.0.0",
     "sqlalchemy==2.0.31",
     "supabase==2.31.0",
     "huggingface-hub>=0.34.0",

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -8,6 +8,7 @@ python-dotenv>=1.0.1
 PyJWT>=2.10.1
 cryptography>=42.0.0
 json-repair>=0.30.0
+google-auth>=2.29.0
 google-genai>=1.0.0
 sqlalchemy==2.0.31
 supabase==2.31.0

--- a/apps/api/uv.lock
+++ b/apps/api/uv.lock
@@ -40,6 +40,8 @@ source = { virtual = "." }
 dependencies = [
     { name = "cryptography" },
     { name = "fastapi" },
+    { name = "google-auth" },
+    { name = "google-genai" },
     { name = "huggingface-hub" },
     { name = "json-repair" },
     { name = "pillow" },
@@ -57,6 +59,8 @@ dependencies = [
 requires-dist = [
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "fastapi", specifier = ">=0.124.1" },
+    { name = "google-auth", specifier = ">=2.29.0" },
+    { name = "google-genai", specifier = ">=1.0.0" },
     { name = "huggingface-hub", specifier = ">=0.34.0" },
     { name = "json-repair", specifier = ">=0.30.0" },
     { name = "pillow", specifier = ">=10.0.0" },
@@ -100,6 +104,28 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/80/c138990aa2a70b1a269f6e06348729836d733d6f970867943f61d367f8cc/cffi-2.1.0-cp312-cp312-win32.whl", hash = "sha256:9b8f0f26ca4e7513c534d351eca551947d053fac438f2a04ac96d882909b0d3a", size = 175269, upload-time = "2026-07-06T21:32:57.777Z" },
     { url = "https://files.pythonhosted.org/packages/a8/eb/f636456ff21a83fc13c032b58cc5dde061691546ac79efa284b2989b7982/cffi-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97f080ea627e2863524c5af3836e2270b5f5dfff1f104392b959f8df0c5d384", size = 185881, upload-time = "2026-07-06T21:32:59.253Z" },
     { url = "https://files.pythonhosted.org/packages/dd/2c/400ea43e721727dca8a65c4521390e9196757caba4a45643acb2b63271b8/cffi-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:6d194185eabd279f1c05ebe3504265ddfc5ad2b58d0714f7db9f01da592e9eb6", size = 180088, upload-time = "2026-07-06T21:33:02.278Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:45b0cc4e3556cd875e09102988d1ab8356c998b596c9fced84547c8138b487a0", size = 319300, upload-time = "2026-07-07T14:33:15.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9b2aff1c7b3884512b9512c3eaadd9bab39fb45042ffaaa1dd08ff2b9f8109d9", size = 215802, upload-time = "2026-07-07T14:33:17.031Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4c/5361f9aa7f2cb58d94f2ab831b3d493f69efb1d239654b4744e3c09527cb/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9104ed0bd76a429d46f9ec0dbc9b08ad1d2dcdf2b00a5a0daa1c145329b35b44", size = 237171, upload-time = "2026-07-07T14:33:18.576Z" },
+    { url = "https://files.pythonhosted.org/packages/50/78/ce342ca4ff30b2eb49fe6d9578df85974f90c67d294113e94efdd9664cbd/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7b86a2b16095d250c6f58b3d9b2eee6f4147754344f3dab0922f7c9bf7d226c9", size = 233075, upload-time = "2026-07-07T14:33:20.084Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e226f6218febc71f6c1fc2fafb91c226f75bdc1d8fb12d66823716e891608fd", size = 224256, upload-time = "2026-07-07T14:33:21.747Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3a/ad914516df7e358a81aae018caa5e0470ba827fa6d763b1d2e87d920a5f6/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:90c44bc373b7687f6948b693cceaea1348ae0975d7474746559494468e3c1d84", size = 208784, upload-time = "2026-07-07T14:33:23.313Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/74/3c12f9755717dfe5c5c87da63f35d765fa0c00382ec26bf23f7fae34f2ba/charset_normalizer-3.4.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9cdef90ae47919cae358d8ab15797a800ed41da7aba5d72419fb510729e2ed4b", size = 219928, upload-time = "2026-07-07T14:33:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/33/9a/895095b83e7907abd6d3d99aad3a38ad0d9686cc186cb0c94c24320fe63e/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:60f44ade2cf573dad7a277e6f8ca9a51a21dda572b13bd7d8539bb3cd5dbedde", size = 218489, upload-time = "2026-07-07T14:33:26.42Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/34/ef5c05f412f42520d7709b7d3784d19640839eb7366ded1755511585429f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:a1786910334ed46ab1dd73222f2cd1e05c2c3bb39f6dddb4f8b36fc382058a39", size = 210267, upload-time = "2026-07-07T14:33:27.952Z" },
+    { url = "https://files.pythonhosted.org/packages/83/dc/9b29fa4412b318bf3bfea985c35d67eb55e04b59a7c3f2237168b0e0be6f/charset_normalizer-3.4.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:03d07803992c6c7bbc976327f34b18b6160327fc81cb82c9d504720ac0be3b62", size = 226030, upload-time = "2026-07-07T14:33:29.397Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/42/6dbc00b8cd16011691203e33570fa42ed5746599a2e878112d16eab403a3/charset_normalizer-3.4.9-cp312-cp312-win32.whl", hash = "sha256:78841cccf1af7b40f6f716338d50c0902dbe88d9f800b3c973b7a9a0a693a642", size = 151185, upload-time = "2026-07-07T14:33:30.781Z" },
+    { url = "https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl", hash = "sha256:4b3dac63058cc36820b0dd072f89898604e2d39686fe05321729d00d8ac185a0", size = 162557, upload-time = "2026-07-07T14:33:32.176Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/e6/0386d43a261ff4e4b30c5857af7df877254b46bec7b9d1b74b6bf969a90b/charset_normalizer-3.4.9-cp312-cp312-win_arm64.whl", hash = "sha256:78fa18e436a1a0e58dbd7e02fc4473f3f32cceb12df9dfca542d075961c307d2", size = 152665, upload-time = "2026-07-07T14:33:33.711Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
 ]
 
 [[package]]
@@ -173,6 +199,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.139.0"
 source = { registry = "https://pypi.org/simple" }
@@ -204,6 +239,45 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/10/a1/ae4e3e5003468d6391d2c77b6fa1cd73bd5d13511d81c642d7b28ac90ed4/fsspec-2026.6.0.tar.gz", hash = "sha256:f5bac145310fe30e16e1471bd6840b2d990d609e872251d7e674241822abf01a", size = 313646, upload-time = "2026-06-16T01:57:28.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/22/4222d7ddf3da30f363edaa98e329c2bce6c65497c9cb2810931c8b2c0fbc/fsspec-2026.6.0-py3-none-any.whl", hash = "sha256:02e0b71817df9b2169dc30a16832045764def1191b43dcff5bb85bdee212d2a1", size = 203949, upload-time = "2026-06-16T01:57:26.358Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.56.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/4c/fa42116a48bab3f7a143cf5042ecff7df9c8b73f8a376203cd534d1dc966/google_auth-2.56.3.tar.gz", hash = "sha256:40e229fc901f0a305b553050e5fce562d509bee0435be053abfa91582b51b90c", size = 367110, upload-time = "2026-08-06T06:24:01.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b3/6117b2f24065cd7e2c4f140e9a193e215f089ca8ba314cf91eb9d0b7fe0a/google_auth-2.56.3-py3-none-any.whl", hash = "sha256:8ec438808f813ad034535000261eed1067475d229d05bbf4216e78c3f2362e53", size = 259116, upload-time = "2026-08-06T06:22:51.788Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "2.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/2e/03a0486e192cde27f7ffbb20c63fa934a132396a667b1a0e1b7e5f606ad7/google_genai-2.17.0.tar.gz", hash = "sha256:6b640a2390c82b4a240873eddb9f518c6d2c33244b2de16ed3d14526a6da7f57", size = 648676, upload-time = "2026-08-06T05:10:41.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/37/71e397a5b93d9a3c139e95acdcb00b4169ed59ae20e16616f2875170abb7/google_genai-2.17.0-py3-none-any.whl", hash = "sha256:a4835563c60aee646c9c4b261c507aa4a624710d25017012d20dc65abf3d9a54", size = 1044950, upload-time = "2026-08-06T05:10:39.308Z" },
 ]
 
 [[package]]
@@ -444,6 +518,27 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -562,6 +657,30 @@ wheels = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "sqlalchemy"
 version = "2.0.31"
 source = { registry = "https://pypi.org/simple" }
@@ -666,6 +785,15 @@ wheels = [
 ]
 
 [[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.69.0"
 source = { registry = "https://pypi.org/simple" }
@@ -696,6 +824,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/blueprint_core/image_providers.py
+++ b/blueprint_core/image_providers.py
@@ -4,6 +4,7 @@ import io
 import json
 import logging
 from blueprint_core.config import config
+from blueprint_core.vertex_auth import build_vertex_credentials
 import time
 import uuid
 import urllib.error
@@ -610,12 +611,16 @@ class VertexAIImageProvider(OpenAIImageProvider):
 
         if self.enabled and self.project and genai:
             try:
-                self.client = genai.Client(
-                    vertexai=True,
-                    project=self.project,
-                    location=self.location,
-                    http_options=genai_types.HttpOptions(timeout=int(self.timeout_seconds * 1000)),
-                )
+                client_config: Dict[str, Any] = {
+                    "vertexai": True,
+                    "project": self.project,
+                    "location": self.location,
+                    "http_options": genai_types.HttpOptions(timeout=int(self.timeout_seconds * 1000)),
+                }
+                credentials = build_vertex_credentials()
+                if credentials is not None:
+                    client_config["credentials"] = credentials
+                self.client = genai.Client(**client_config)
             except Exception as exc:
                 self.init_error = f"Error initializing Vertex AI image provider: {exc}"
                 logger.error(self.init_error)

--- a/blueprint_core/llm_providers.py
+++ b/blueprint_core/llm_providers.py
@@ -2,6 +2,7 @@ import base64
 import json
 import logging
 from blueprint_core.config import config
+from blueprint_core.vertex_auth import build_vertex_credentials
 import socket
 import time
 import urllib.error
@@ -1165,10 +1166,16 @@ class VertexAIProvider(GeminiProvider):
 
         if self.project and genai:
             try:
+                client_config: Dict[str, Any] = {
+                    "vertexai": True,
+                    "project": self.project,
+                    "location": self.location,
+                }
+                credentials = build_vertex_credentials()
+                if credentials is not None:
+                    client_config["credentials"] = credentials
                 self.client = genai.Client(
-                    vertexai=True,
-                    project=self.project,
-                    location=self.location,
+                    **client_config,
                 )
                 logger.info(
                     "Vertex AI LLM provider initialized for project %s in %s.",

--- a/blueprint_core/vertex_auth.py
+++ b/blueprint_core/vertex_auth.py
@@ -1,0 +1,91 @@
+"""Google Cloud credentials for Vertex AI across local ADC and Vercel OIDC."""
+
+from __future__ import annotations
+
+import os
+from contextvars import ContextVar, Token
+from typing import Any
+
+from google.auth import identity_pool
+from google.auth.exceptions import RefreshError
+
+
+_VERTEX_OIDC_TOKEN: ContextVar[str | None] = ContextVar("vertex_oidc_token", default=None)
+_CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
+_SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:jwt"
+
+
+def bind_vertex_oidc_token(token: str | None) -> Token[str | None]:
+    """Bind the Vercel-issued request token for provider construction in this context."""
+
+    return _VERTEX_OIDC_TOKEN.set(str(token or "").strip() or None)
+
+
+def reset_vertex_oidc_token(token: Token[str | None]) -> None:
+    _VERTEX_OIDC_TOKEN.reset(token)
+
+
+def current_vertex_oidc_token() -> str | None:
+    """Return a request token, falling back to Vercel's local/build-time variable."""
+
+    return _VERTEX_OIDC_TOKEN.get() or str(os.getenv("VERCEL_OIDC_TOKEN") or "").strip() or None
+
+
+class VercelOidcContextMiddleware:
+    """Expose Vercel's runtime OIDC header through the active async context."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+
+    async def __call__(self, scope: dict[str, Any], receive: Any, send: Any) -> None:
+        oidc_token = None
+        if scope.get("type") in {"http", "websocket"}:
+            headers = {
+                key.lower(): value
+                for key, value in scope.get("headers", [])
+                if isinstance(key, bytes) and isinstance(value, bytes)
+            }
+            raw_token = headers.get(b"x-vercel-oidc-token")
+            oidc_token = raw_token.decode("utf-8", errors="ignore") if raw_token else None
+
+        context_token = bind_vertex_oidc_token(oidc_token)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            reset_vertex_oidc_token(context_token)
+
+
+class _VercelOidcTokenSupplier(identity_pool.SubjectTokenSupplier):
+    def get_subject_token(self, context: Any, request: Any) -> str:
+        del context, request
+        token = current_vertex_oidc_token()
+        if not token:
+            raise RefreshError("Vercel OIDC token is unavailable for Vertex AI authentication.")
+        return token
+
+
+def build_vertex_credentials() -> identity_pool.Credentials | None:
+    """Build short-lived GCP credentials when Vercel workload identity is configured."""
+
+    project_number = str(os.getenv("GCP_PROJECT_NUMBER") or "").strip()
+    service_account_email = str(os.getenv("GCP_SERVICE_ACCOUNT_EMAIL") or "").strip()
+    pool_id = str(os.getenv("GCP_WORKLOAD_IDENTITY_POOL_ID") or "").strip()
+    provider_id = str(os.getenv("GCP_WORKLOAD_IDENTITY_POOL_PROVIDER_ID") or "").strip()
+    if not all((project_number, service_account_email, pool_id, provider_id, current_vertex_oidc_token())):
+        return None
+
+    audience = (
+        f"//iam.googleapis.com/projects/{project_number}/locations/global/"
+        f"workloadIdentityPools/{pool_id}/providers/{provider_id}"
+    )
+    impersonation_url = (
+        "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/"
+        f"{service_account_email}:generateAccessToken"
+    )
+    return identity_pool.Credentials(
+        audience=audience,
+        subject_token_type=_SUBJECT_TOKEN_TYPE,
+        subject_token_supplier=_VercelOidcTokenSupplier(),
+        service_account_impersonation_url=impersonation_url,
+        scopes=[_CLOUD_PLATFORM_SCOPE],
+    )

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -67,6 +67,7 @@ LLM configuration behavior:
 - `LLM_ALLOWED_PROVIDERS`: optional comma-separated allowlist for runtime provider overrides. If unset, configured providers detected from env plus `simulation` are allowed.
 - `VERTEX_AI_ALLOWED_MODELS` / `OPENAI_ALLOWED_MODELS` / `BASETEN_ALLOWED_MODELS` / `HUGGINGFACE_ALLOWED_MODELS` / `CLOUDFLARE_ALLOWED_MODELS` / `NVIDIA_ALLOWED_MODELS` / `OPENAI_COMPATIBLE_ALLOWED_MODELS` / `GEMINI_ALLOWED_MODELS` / `RUNPOD_ALLOWED_MODELS`: optional comma-separated allowlists for runtime model overrides. If unset, runtime model overrides are limited to configured default/fallback models for the selected provider.
 - `GOOGLE_CLOUD_PROJECT` / `VERTEX_AI_PROJECT`, `GOOGLE_CLOUD_LOCATION` / `VERTEX_AI_LOCATION`, and `VERTEX_AI_MODEL`: Vertex AI routing when `LLM_PROVIDER=vertex`; authentication uses Google Cloud Application Default Credentials.
+- `GCP_PROJECT_NUMBER`, `GCP_SERVICE_ACCOUNT_EMAIL`, `GCP_WORKLOAD_IDENTITY_POOL_ID`, and `GCP_WORKLOAD_IDENTITY_POOL_PROVIDER_ID`: optional keyless Vertex authentication for Vercel through workload identity federation. The runtime exchanges Vercel's per-request OIDC token for short-lived Google credentials.
 - `OPENAI_API_KEY`: first-party OpenAI API key when `LLM_PROVIDER=openai`
 - `OPENAI_MODEL`: first-party OpenAI model alias for `LLM_MODEL`
 - `OPENAI_RESPONSE_FORMAT`: OpenAI response format, defaulting to `json_schema`; `json_object` and `none` are also supported

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
     "Typing :: Typed",
 ]
 dependencies = [
+    "google-auth>=2.29.0",
     "json-repair>=0.30.0",
     "pydantic>=2.12.0",
     "python-dotenv>=1.0.1",
@@ -45,7 +46,7 @@ entrypoint = "apps.api.main:app"
 
 [project.optional-dependencies]
 gemini = ["google-genai>=1.0.0"]
-vertex = ["google-genai>=1.0.0"]
+vertex = ["google-auth>=2.29.0", "google-genai>=1.0.0"]
 huggingface = ["huggingface-hub>=0.34.0"]
 observability = ["langfuse>=4.0.0"]
 supabase = ["supabase==2.31.0"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ python-dotenv>=1.0.1
 PyJWT>=2.10.1
 cryptography>=42.0.0
 json-repair>=0.30.0
+google-auth>=2.29.0
 google-genai>=1.0.0
 sqlalchemy==2.0.31
 supabase==2.31.0

--- a/tests/providers/test_image_providers.py
+++ b/tests/providers/test_image_providers.py
@@ -118,6 +118,25 @@ class ImageProviderRoutingTests(unittest.TestCase):
         self.assertEqual("gemini-3.1-flash-image", provider.model_name)
         self.assertTrue(provider.is_configured)
 
+    def test_vertex_image_provider_uses_vercel_workload_identity_credentials(self) -> None:
+        credentials = object()
+        fake_genai = SimpleNamespace(Client=Mock(return_value=Mock()))
+        with patch.dict(
+            os.environ,
+            {
+                "IMAGE_PROVIDER": "vertex",
+                "GOOGLE_CLOUD_PROJECT": "forma-image-test",
+            },
+            clear=True,
+        ), patch("blueprint_core.image_providers.genai", fake_genai), patch(
+            "blueprint_core.image_providers.build_vertex_credentials",
+            return_value=credentials,
+        ):
+            provider = build_image_provider(force_enabled=True)
+
+        self.assertTrue(provider.is_configured)
+        self.assertIs(credentials, fake_genai.Client.call_args.kwargs["credentials"])
+
     def test_gmi_image_provider_routes_from_image_provider(self) -> None:
         with patch.dict(
             os.environ,

--- a/tests/providers/test_llm_runtime.py
+++ b/tests/providers/test_llm_runtime.py
@@ -294,6 +294,28 @@ class LLMRuntimeTests(unittest.TestCase):
         self.assertEqual("gemini-2.5-flash", runtime.model)
         self.assertEqual(["gemini-2.5-flash", "gemini-3.5-flash"], runtime.allowed_models)
 
+    def test_vertex_passes_vercel_workload_identity_credentials_to_client(self) -> None:
+        credentials = object()
+        client_calls = []
+
+        class FakeGenAI:
+            @staticmethod
+            def Client(**kwargs):
+                client_calls.append(kwargs)
+                return object()
+
+        with isolated_llm_env(
+            GOOGLE_CLOUD_PROJECT="forma-vertex-test",
+            VERTEX_AI_MODEL="gemini-3.5-flash",
+        ), patch("blueprint_core.llm_providers.genai", FakeGenAI), patch(
+            "blueprint_core.llm_providers.build_vertex_credentials",
+            return_value=credentials,
+        ):
+            provider = build_llm_provider()
+
+        self.assertTrue(provider.is_configured)
+        self.assertIs(credentials, client_calls[0]["credentials"])
+
     def test_parse_provider_model_selector(self) -> None:
         selector = parse_llm_selector("runpod/caid-technologies/parti-base")
 

--- a/tests/providers/test_vertex_auth.py
+++ b/tests/providers/test_vertex_auth.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import unittest
+from unittest.mock import patch
+
+from google.auth import identity_pool
+
+from blueprint_core.vertex_auth import (
+    VercelOidcContextMiddleware,
+    _VercelOidcTokenSupplier,
+    bind_vertex_oidc_token,
+    build_vertex_credentials,
+    current_vertex_oidc_token,
+    reset_vertex_oidc_token,
+)
+
+
+class VertexAuthTests(unittest.TestCase):
+    def test_builds_workload_identity_credentials_from_vercel_configuration(self) -> None:
+        environment = {
+            "GCP_PROJECT_NUMBER": "123456789",
+            "GCP_SERVICE_ACCOUNT_EMAIL": "vertex@example.iam.gserviceaccount.com",
+            "GCP_WORKLOAD_IDENTITY_POOL_ID": "vercel",
+            "GCP_WORKLOAD_IDENTITY_POOL_PROVIDER_ID": "vercel",
+        }
+        context_token = bind_vertex_oidc_token("signed-vercel-token")
+        try:
+            with patch.dict(os.environ, environment, clear=True):
+                credentials = build_vertex_credentials()
+        finally:
+            reset_vertex_oidc_token(context_token)
+
+        self.assertIsInstance(credentials, identity_pool.Credentials)
+        assert credentials is not None
+        self.assertEqual("vertex@example.iam.gserviceaccount.com", credentials.service_account_email)
+
+    def test_missing_workload_identity_configuration_keeps_adc_fallback(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(build_vertex_credentials())
+
+    def test_subject_supplier_reads_the_request_context(self) -> None:
+        context_token = bind_vertex_oidc_token("request-token")
+        try:
+            token = _VercelOidcTokenSupplier().get_subject_token(None, None)
+        finally:
+            reset_vertex_oidc_token(context_token)
+
+        self.assertEqual("request-token", token)
+        self.assertIsNone(current_vertex_oidc_token())
+
+    def test_middleware_binds_and_resets_vercel_header(self) -> None:
+        observed: list[str | None] = []
+
+        async def inner(scope, receive, send):
+            del scope, receive, send
+            observed.append(current_vertex_oidc_token())
+
+        middleware = VercelOidcContextMiddleware(inner)
+
+        async def invoke() -> None:
+            await middleware(
+                {
+                    "type": "http",
+                    "headers": [(b"x-vercel-oidc-token", b"runtime-token")],
+                },
+                None,
+                None,
+            )
+
+        asyncio.run(invoke())
+
+        self.assertEqual(["runtime-token"], observed)
+        self.assertIsNone(current_vertex_oidc_token())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- authenticate the Vercel backend to Google Vertex AI through Workload Identity Federation/OIDC
- bundle `google-auth` and `google-genai` in the actual `apps/api` Vercel dependency graph
- update the locked backend dependencies so Vertex LLM and image providers load at runtime

## Staging configuration already applied
- Vertex project, location, models, and Workload Identity settings
- `LLM_ALLOWED_PROVIDERS` includes `vertex`

## Verification
- local `uv lock --check` passed
- isolated `google-genai` import passed
- Vercel preview deployment passed
- Cloudflare Workers build passed

This promotion resolves: `Vertex AI project is set, but google-genai is unavailable. Running in simulated/fallback mode.`