### PR TITLE
Fix Vertex build lifecycle on Vercel

### DIFF
--- a/apps/api/context_builds.py
+++ b/apps/api/context_builds.py
@@ -8,8 +8,10 @@ from blueprint_core.database import (
     create_project_generation_plan,
     evaluate_project_readiness,
     execute_project_generation_plan,
+    get_project_generation_plan,
     initiate_project_build,
 )
+from blueprint_core.config import config
 from blueprint_core.workspaces.context import ContextBuildExecution
 from blueprint_core.workspaces.readiness import BuildMode, ReadinessStatus
 from blueprint_core.workspaces.workflow import ProjectWorkflow
@@ -55,7 +57,7 @@ class ContextBuildDispatcher:
         )
         plan = create_project_generation_plan(outcome.build, owner_user_id)
         job_id = next(iter(plan.jobs))
-        if plan.status.value == "planned":
+        if plan.status.value == "planned" and not self.requires_request_bound_execution():
             self._launch(plan.plan_id, owner_user_id)
         return (
             ContextBuildExecution(
@@ -66,6 +68,33 @@ class ContextBuildDispatcher:
             ),
             outcome.workflow,
         )
+
+    @staticmethod
+    def requires_request_bound_execution() -> bool:
+        """Return whether the runtime can discard work after an HTTP response."""
+
+        return str(config.get("VERCEL") or "").strip() == "1"
+
+    @classmethod
+    async def execute(cls, plan_id: str, owner_user_id: str):
+        """Keep a build attached to an HTTP invocation on serverless runtimes."""
+
+        cancellation_event = Event()
+        with cls._cancellation_lock:
+            if plan_id in cls._cancellation_events:
+                return get_project_generation_plan(plan_id, owner_user_id)
+            cls._cancellation_events[plan_id] = cancellation_event
+
+        try:
+            return await execute_project_generation_plan(
+                plan_id,
+                owner_user_id,
+                cancellation_check=cancellation_event.is_set,
+            )
+        finally:
+            with cls._cancellation_lock:
+                if cls._cancellation_events.get(plan_id) is cancellation_event:
+                    cls._cancellation_events.pop(plan_id, None)
 
     @classmethod
     def _launch(cls, plan_id: str, owner_user_id: str) -> None:

--- a/apps/api/worker_plans_api.py
+++ b/apps/api/worker_plans_api.py
@@ -35,6 +35,24 @@ def get_build_plan_endpoint(
     return plan
 
 
+@router.post("/plans/{plan_id}/execute", response_model=WorkerExecutionPlan)
+async def execute_build_plan_endpoint(
+    project_id: UUID,
+    plan_id: str,
+    user: UserContext = Depends(require_user_context),
+) -> WorkerExecutionPlan:
+    """Execute a plan inside this request so serverless runtimes keep it alive."""
+
+    owner = _owner(user)
+    try:
+        plan = get_project_generation_plan(plan_id, owner)
+    except WorkerPlanningError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.as_dict()) from exc
+    if str(plan.project_id) != str(project_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Build execution not found.")
+    return await ContextBuildDispatcher.execute(plan_id, owner)
+
+
 @router.post("/plans/{plan_id}/cancel", response_model=WorkerExecutionPlan)
 async def cancel_build_plan_endpoint(
     project_id: UUID,

--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -2962,6 +2962,30 @@ export function FormaWorkspace({
     }
   };
 
+  const executeContextBuild = async (
+    projectId: string,
+    planId: string,
+    run?: ActiveGenerationRun,
+  ) => {
+    try {
+      const response = await fetch(
+        `${API_URL}/projects/${encodeURIComponent(projectId)}/build/plans/${encodeURIComponent(planId)}/execute`,
+        {
+          method: "POST",
+          headers: await generationRequestHeaders(),
+          signal: run?.controller.signal,
+        },
+      );
+      if (!response.ok) throw new Error(await readApiErrorMessage(response));
+    } catch (error) {
+      if (run?.cancelled || run?.controller.signal.aborted) return;
+      console.warn("The build execution request ended before the plan reached a terminal state.", error);
+      setGenerationInputNotice(
+        error instanceof Error ? error.message : "The build execution request ended unexpectedly.",
+      );
+    }
+  };
+
   const stopContextBuildMessage = (message: ChatMessage) => {
     const projectId = message.contextProjectId;
     const planId = message.buildPlanId;
@@ -3019,6 +3043,7 @@ export function FormaWorkspace({
     const watcherKey = `${projectId}:${planId}`;
     if (contextBuildWatchersRef.current.has(watcherKey)) return;
     contextBuildWatchersRef.current.add(watcherKey);
+    void executeContextBuild(projectId, planId, run);
     let attempts = 0;
     const poll = async () => {
       if (run?.cancelled || run?.controller.signal.aborted) {

--- a/blueprint_core/llm_providers.py
+++ b/blueprint_core/llm_providers.py
@@ -982,6 +982,10 @@ class GeminiProvider(StructuredLLMProvider):
             or DEFAULT_GEMINI_FALLBACK_MODEL
         )
         self.strict_mode = _first_env_bool(["STRICT_LLM", "STRICT_GEMINI"], default=True)
+        self.timeout_seconds = _first_env_float(
+            ["GEMINI_TIMEOUT_SECONDS", "LLM_TIMEOUT_SECONDS"],
+            DEFAULT_TIMEOUT_SECONDS,
+        )
         self.model_name = self.requested_model
         self.client = None
         self.init_error: Optional[str] = None
@@ -989,7 +993,10 @@ class GeminiProvider(StructuredLLMProvider):
 
         if self.api_key and genai:
             try:
-                self.client = genai.Client(api_key=self.api_key)
+                self.client = genai.Client(
+                    api_key=self.api_key,
+                    http_options=genai_types.HttpOptions(timeout=int(self.timeout_seconds * 1000)),
+                )
                 logger.info("%s LLM provider initialized successfully.", self.provider_label)
             except Exception as exc:
                 self.init_error = f"Error initializing {self.provider_label} provider: {exc}"
@@ -1191,6 +1198,10 @@ class VertexAIProvider(GeminiProvider):
             or DEFAULT_VERTEX_FALLBACK_MODEL
         )
         self.strict_mode = _first_env_bool(["STRICT_LLM", "STRICT_VERTEX_AI", "STRICT_VERTEX"], default=True)
+        self.timeout_seconds = _first_env_float(
+            ["VERTEX_AI_TIMEOUT_SECONDS", "VERTEX_TIMEOUT_SECONDS", "LLM_TIMEOUT_SECONDS"],
+            DEFAULT_TIMEOUT_SECONDS,
+        )
         self.model_name = self.requested_model
         self.client = None
         self.init_error: Optional[str] = None
@@ -1202,6 +1213,7 @@ class VertexAIProvider(GeminiProvider):
                     "vertexai": True,
                     "project": self.project,
                     "location": self.location,
+                    "http_options": genai_types.HttpOptions(timeout=int(self.timeout_seconds * 1000)),
                 }
                 credentials = build_vertex_credentials()
                 if credentials is not None:

--- a/tests/projects/test_context_gathering.py
+++ b/tests/projects/test_context_gathering.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import tempfile
 import unittest
 import uuid
@@ -196,6 +197,26 @@ class ContextGatheringIntegrationTests(unittest.TestCase):
         self.assertEqual([execution["job_id"]], list(plan.jobs))
         launch_plan.assert_called_once_with(execution["plan_id"], OWNER)
 
+    def test_vercel_dispatcher_leaves_plan_for_request_bound_execution(self) -> None:
+        project_id = str(uuid.uuid4())
+        conversation_id = "conversation-vercel-dispatch"
+        self.app.dependency_overrides.pop(context_build_dispatcher)
+        with sqlite_repository(), patch.dict(os.environ, {"VERCEL": "1"}), patch(
+            "apps.api.context_builds.ContextBuildDispatcher._launch",
+        ) as launch_plan:
+            self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={"conversation_id": conversation_id, "text": "Build a relay controller."},
+            )
+            started = self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={"conversation_id": conversation_id, "text": "start"},
+            )
+
+        self.assertEqual(201, started.status_code, started.text)
+        self.assertEqual("planned", started.json()["build_execution"]["status"])
+        launch_plan.assert_not_called()
+
     def test_detached_build_worker_inherits_request_vertex_oidc_token(self) -> None:
         observed: list[str | None] = []
         completed = Event()
@@ -239,6 +260,36 @@ class ContextGatheringIntegrationTests(unittest.TestCase):
         self.assertEqual("cancelled", stopped.json()["status"])
         self.assertEqual("cancelled", stopped.json()["jobs"][execution["job_id"]]["status"])
         self.assertEqual("cancelled", persisted.status.value)
+
+    def test_worker_plan_execute_endpoint_keeps_generation_in_request_lifecycle(self) -> None:
+        project_id = str(uuid.uuid4())
+        conversation_id = "conversation-request-bound-build"
+        self.app.dependency_overrides.pop(context_build_dispatcher)
+        with sqlite_repository(), patch(
+            "apps.api.context_builds.ContextBuildDispatcher._launch",
+        ):
+            self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={"conversation_id": conversation_id, "text": "Build a relay controller."},
+            )
+            started = self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={"conversation_id": conversation_id, "text": "start"},
+            )
+            execution = started.json()["build_execution"]
+            plan = database.get_project_generation_plan(execution["plan_id"], OWNER)
+            with patch.object(
+                ContextBuildDispatcher,
+                "execute",
+                new=AsyncMock(return_value=plan),
+            ) as execute_plan:
+                response = self.client.post(
+                    f"/projects/{project_id}/build/plans/{execution['plan_id']}/execute",
+                )
+
+        self.assertEqual(200, response.status_code, response.text)
+        self.assertEqual(execution["plan_id"], response.json()["plan_id"])
+        execute_plan.assert_awaited_once_with(execution["plan_id"], OWNER)
 
     def test_text_image_and_document_append_brief_versions_without_enqueuing_jobs(self) -> None:
         project_id = str(uuid.uuid4())

--- a/tests/providers/test_llm_runtime.py
+++ b/tests/providers/test_llm_runtime.py
@@ -349,10 +349,13 @@ class LLMRuntimeTests(unittest.TestCase):
 
         self.assertEqual("vertex", runtime.provider)
         self.assertEqual("gemini-3.5-flash", runtime.model)
-        self.assertEqual(
-            [{"vertexai": True, "project": "forma-vertex-test", "location": "us-central1"}],
-            client_calls,
-        )
+        self.assertEqual(1, len(client_calls))
+        vertex_client_config = client_calls[0]
+        self.assertTrue(vertex_client_config.pop("vertexai"))
+        self.assertEqual("forma-vertex-test", vertex_client_config.pop("project"))
+        self.assertEqual("us-central1", vertex_client_config.pop("location"))
+        self.assertEqual(90_000, vertex_client_config.pop("http_options").timeout)
+        self.assertEqual({}, vertex_client_config)
         self.assertTrue(provider.is_configured)
         self.assertTrue(validation.requested_model_available)
         self.assertEqual("vertex", validation.provider)

--- a/vercel.json
+++ b/vercel.json
@@ -11,15 +11,18 @@
             "functions": {
                 "apps.api.main:app": {
                     "includeFiles": "blueprint_core/**",
-                    "excludeFiles": "{apps/web/**,.venv/**,node_modules/**,.vercel/**,build/**,dist/**,data/**,tmp/**,.logs/**,*.db,*.log,**/__pycache__/**,**/*.pyc}"
+                    "excludeFiles": "{apps/web/**,.venv/**,node_modules/**,.vercel/**,build/**,dist/**,data/**,tmp/**,.logs/**,*.db,*.log,**/__pycache__/**,**/*.pyc}",
+                    "maxDuration": 300
                 },
                 "apps/api/main.py": {
                     "includeFiles": "blueprint_core/**",
-                    "excludeFiles": "{apps/web/**,.venv/**,node_modules/**,.vercel/**,build/**,dist/**,data/**,tmp/**,.logs/**,*.db,*.log,**/__pycache__/**,**/*.pyc}"
+                    "excludeFiles": "{apps/web/**,.venv/**,node_modules/**,.vercel/**,build/**,dist/**,data/**,tmp/**,.logs/**,*.db,*.log,**/__pycache__/**,**/*.pyc}",
+                    "maxDuration": 300
                 },
                 "main.py": {
                     "includeFiles": "blueprint_core/**",
-                    "excludeFiles": "{apps/web/**,.venv/**,node_modules/**,.vercel/**,build/**,dist/**,data/**,tmp/**,.logs/**,*.db,*.log,**/__pycache__/**,**/*.pyc}"
+                    "excludeFiles": "{apps/web/**,.venv/**,node_modules/**,.vercel/**,build/**,dist/**,data/**,tmp/**,.logs/**,*.db,*.log,**/__pycache__/**,**/*.pyc}",
+                    "maxDuration": 300
                 }
             }
         }


### PR DESCRIPTION
## What changed
- run project generation through a request-bound execution endpoint on Vercel instead of a detached Python thread
- have the in-chat pipeline keep that execution request open while polling durable progress
- add 90-second Gemini/Vertex request deadlines so provider stalls become persisted failures
- set the Vercel backend duration to the Hobby-safe five-minute maximum
- preserve the existing local detached-worker behavior

## Why
Vercel can discard detached work after the initiating HTTP response. The staging generation `fb2439bb-301d-4d38-9bfe-8c6a69ab2ffd` reached the Assembly agent, then its worker disappeared while the stored plan remained `running`, causing the UI to poll forever.

## Verification
- `python -m unittest discover -s tests -t .` — 470 passed, 1 skipped
- `npx eslint app/blueprint-workspace.tsx` — no errors (one existing `<img>` warning)
- Next.js production compile/typecheck/static generation passed inside `vercel build`
- local Vercel backend packaging still hits the pre-existing Python bundle-size limit (346 MB vs 225 MB)