### PR TITLE
feat: support Upstash Redis in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,9 +34,12 @@ BLUEPRINT_USER_SECRETS_KEY=replace-with-a-high-entropy-server-only-secret
 # its backend can reach your Supabase URL:
 # COMPOSE_DATABASE_BACKEND=supabase
 # COMPOSE_SQLITE_DATABASE_URL=sqlite:////data/blueprint.db
-# Redis cache for the projects and my-projects API responses. Both REDIS_URL
-# and REDIS_CACHE_PREFIX are required when BLUEPRINT_DEV_MODE is false.
+# Redis cache for the projects and my-projects API responses. Set REDIS_URL or
+# both Upstash REST variables. REDIS_CACHE_PREFIX is also required when
+# BLUEPRINT_DEV_MODE is false.
 # REDIS_URL=redis://localhost:6379/0
+# UPSTASH_REDIS_REST_URL=https://your-database.upstash.io
+# UPSTASH_REDIS_REST_TOKEN=your_rest_token
 # PROJECTS_CACHE_TTL_SECONDS=60
 # REDIS_CACHE_PREFIX=blueprint
 # REDIS_SOCKET_TIMEOUT_SECONDS=0.25

--- a/blueprint_core/project_list_cache.py
+++ b/blueprint_core/project_list_cache.py
@@ -1,7 +1,8 @@
 """Redis-backed cache for project gallery response payloads.
 
-The cache is deliberately optional. Deployments without ``REDIS_URL`` use the
-database exactly as before, and Redis errors never fail project reads or writes.
+The cache is deliberately optional in development. It supports either a Redis
+connection URL or Upstash's HTTP API, and Redis errors never fail project reads
+or writes.
 """
 
 from __future__ import annotations
@@ -9,11 +10,12 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from blueprint_core.config import config
 import threading
 import time
 from typing import Any, Optional
+from urllib import request
 
+from blueprint_core.config import config
 from blueprint_core.config.runtime import blueprint_dev_mode_enabled
 
 
@@ -25,9 +27,46 @@ _FAILURE_COOLDOWN_SECONDS = 30.0
 _VERSION_KEY_SUFFIX = "version"
 
 _client: Any = None
-_client_url: Optional[str] = None
+_client_identity: Optional[tuple[str, ...]] = None
 _client_lock = threading.Lock()
 _disabled_until = 0.0
+
+
+class _UpstashRedisRestClient:
+    """Minimal Redis command client for Upstash's REST endpoint."""
+
+    def __init__(self, url: str, token: str, timeout: float) -> None:
+        self._url = url.rstrip("/")
+        self._token = token
+        self._timeout = timeout
+
+    def _command(self, *parts: str) -> Any:
+        body = json.dumps(list(parts), separators=(",", ":")).encode("utf-8")
+        redis_request = request.Request(
+            self._url,
+            data=body,
+            headers={
+                "Authorization": f"Bearer {self._token}",
+                "Content-Type": "application/json",
+            },
+            method="POST",
+        )
+        with request.urlopen(redis_request, timeout=self._timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        if not isinstance(payload, dict):
+            raise RuntimeError("Upstash Redis returned an invalid response")
+        if payload.get("error"):
+            raise RuntimeError(f"Upstash Redis command failed: {payload['error']}")
+        return payload.get("result")
+
+    def get(self, key: str) -> Any:
+        return self._command("GET", key)
+
+    def set(self, key: str, value: str, *, ex: int) -> Any:
+        return self._command("SET", key, value, "EX", str(ex))
+
+    def incr(self, key: str) -> Any:
+        return self._command("INCR", key)
 
 
 def require_project_list_cache_config() -> None:
@@ -35,18 +74,18 @@ def require_project_list_cache_config() -> None:
     if blueprint_dev_mode_enabled():
         return
 
-    missing = [
-        name
-        for name in ("REDIS_URL", "REDIS_CACHE_PREFIX")
-        if not config.get(name, "").strip()
-    ]
-    if not missing:
+    redis_url = config.get("REDIS_URL", "").strip()
+    upstash_url = config.get("UPSTASH_REDIS_REST_URL", "").strip()
+    upstash_token = config.get("UPSTASH_REDIS_REST_TOKEN", "").strip()
+    cache_prefix = config.get("REDIS_CACHE_PREFIX", "").strip()
+    if cache_prefix and (redis_url or (upstash_url and upstash_token)):
         return
 
-    names = ", ".join(missing)
     message = (
         "BLUEPRINT_DEV_MODE=false requires Redis project caching. "
-        f"Set the following server-only environment variables: {names}."
+        "Set REDIS_CACHE_PREFIX and either REDIS_URL or both "
+        "UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN as server-only "
+        "environment variables."
     )
     logger.critical(message)
     raise RuntimeError(message)
@@ -75,29 +114,42 @@ def _version_key() -> str:
 
 def _get_redis_client() -> Any:
     """Return a lazy Redis client without importing redis for uncached installs."""
-    global _client, _client_url
+    global _client, _client_identity
 
     redis_url = config.get("REDIS_URL", "").strip()
-    if not redis_url:
+    upstash_url = config.get("UPSTASH_REDIS_REST_URL", "").strip()
+    upstash_token = config.get("UPSTASH_REDIS_REST_TOKEN", "").strip()
+    if redis_url:
+        identity = ("redis", redis_url)
+    elif upstash_url and upstash_token:
+        identity = ("upstash", upstash_url, upstash_token)
+    else:
         return None
-    if _client is not None and _client_url == redis_url:
+    if _client is not None and _client_identity == identity:
         return _client
 
     with _client_lock:
-        if _client is not None and _client_url == redis_url:
+        if _client is not None and _client_identity == identity:
             return _client
-        try:
-            import redis
-        except ImportError:
-            logger.warning("REDIS_URL is configured but the redis package is not installed; project caching is disabled.")
-            return None
-
         timeout = _bounded_float(
             "REDIS_SOCKET_TIMEOUT_SECONDS",
             _DEFAULT_SOCKET_TIMEOUT_SECONDS,
             0.05,
             5.0,
         )
+        if identity[0] == "upstash":
+            _client = _UpstashRedisRestClient(upstash_url, upstash_token, timeout)
+            _client_identity = identity
+            return _client
+        try:
+            import redis
+        except ImportError:
+            logger.warning(
+                "REDIS_URL is configured but the redis package is not installed; "
+                "project caching is disabled."
+            )
+            return None
+
         _client = redis.Redis.from_url(
             redis_url,
             decode_responses=True,
@@ -105,7 +157,7 @@ def _get_redis_client() -> Any:
             socket_timeout=timeout,
             health_check_interval=30,
         )
-        _client_url = redis_url
+        _client_identity = identity
         return _client
 
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -56,7 +56,8 @@ LLM configuration behavior:
 - `BLUEPRINT_DEBUG=true`: include redacted traceback/context debug payloads in API errors and failed job metadata; this also defaults backend logging to `DEBUG` when `LOG_LEVEL` is unset
 - `BLUEPRINT_DEV_MODE=true`: selects SQLite for the complete application database even when remote Supabase env vars are present; Supabase Storage writes are disabled and image data stays inline in the SQLite project record
 - `BLUEPRINT_DEPLOYMENT=true`: requires a configured deployment provider or signed-in user's BYOK provider for `/api/generate`; the frontend keeps the composer visible and directs users without an active provider to Settings
-- `REDIS_URL`: Redis connection URL for cached `/projects` and `/my/projects` responses. It and `REDIS_CACHE_PREFIX` are required at startup when `BLUEPRINT_DEV_MODE=false`; runtime cache failures still fall back to the database.
+- `REDIS_URL`: Redis connection URL for cached `/projects` and `/my/projects` responses. In production, set it or the complete Upstash REST pair below, plus `REDIS_CACHE_PREFIX`; runtime cache failures still fall back to the database.
+- `UPSTASH_REDIS_REST_URL` / `UPSTASH_REDIS_REST_TOKEN`: server-only Upstash REST credentials that can replace `REDIS_URL`, which avoids persistent Redis socket requirements on serverless deployments.
 - `PROJECTS_CACHE_TTL_SECONDS`: project-list cache lifetime in seconds, default `60`; successful project writes invalidate all list variants immediately.
 - `REDIS_CACHE_PREFIX`: Redis key namespace, required when `BLUEPRINT_DEV_MODE=false` and defaulting to `blueprint` only for development-mode cache usage.
 - `REDIS_SOCKET_TIMEOUT_SECONDS`: Redis connect/read timeout, default `0.25`; failures open a 30-second local circuit breaker.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -86,9 +86,12 @@ SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
 # DATABASE_BACKEND=sqlite
 SQLITE_DATABASE_URL=sqlite:///./blueprint.db
 
-# Project gallery cache. Required when BLUEPRINT_DEV_MODE is false; development
-# mode may leave these unset to read directly from the database.
+# Project gallery cache. REDIS_CACHE_PREFIX plus either REDIS_URL or both
+# Upstash REST variables are required when BLUEPRINT_DEV_MODE is false;
+# development mode may leave these unset to read directly from the database.
 REDIS_URL=redis://localhost:6379/0
+# UPSTASH_REDIS_REST_URL=https://your-database.upstash.io
+# UPSTASH_REDIS_REST_TOKEN=your_rest_token
 # PROJECTS_CACHE_TTL_SECONDS=60
 # REDIS_CACHE_PREFIX=blueprint
 # REDIS_SOCKET_TIMEOUT_SECONDS=0.25

--- a/tests/api/test_auth_mode.py
+++ b/tests/api/test_auth_mode.py
@@ -74,7 +74,7 @@ class AuthModeTests(unittest.IsolatedAsyncioTestCase):
             clear=True,
         ), patch.object(main, "init_db") as init_db:
             with self.assertLogs("blueprint_core.project_list_cache", level="CRITICAL"):
-                with self.assertRaisesRegex(RuntimeError, "REDIS_URL, REDIS_CACHE_PREFIX"):
+                with self.assertRaisesRegex(RuntimeError, "UPSTASH_REDIS_REST_URL"):
                     await main.startup_event()
         init_db.assert_not_called()
 

--- a/tests/api/test_project_list_cache.py
+++ b/tests/api/test_project_list_cache.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import unittest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from blueprint_core import project_list_cache
 
@@ -28,6 +28,8 @@ class _FakeRedis:
 class ProjectListCacheTests(unittest.TestCase):
     def setUp(self) -> None:
         project_list_cache._disabled_until = 0.0
+        project_list_cache._client = None
+        project_list_cache._client_identity = None
 
     def test_round_trip_uses_hashed_identity_and_configured_ttl(self) -> None:
         redis = _FakeRedis()
@@ -80,7 +82,7 @@ class ProjectListCacheTests(unittest.TestCase):
     def test_non_development_mode_requires_url_and_prefix(self) -> None:
         with patch.dict("os.environ", {"BLUEPRINT_DEV_MODE": "false"}, clear=True):
             with self.assertLogs(project_list_cache.logger, level="CRITICAL"):
-                with self.assertRaisesRegex(RuntimeError, "REDIS_URL, REDIS_CACHE_PREFIX"):
+                with self.assertRaisesRegex(RuntimeError, "UPSTASH_REDIS_REST_URL"):
                     project_list_cache.require_project_list_cache_config()
 
     def test_non_development_mode_accepts_complete_redis_config(self) -> None:
@@ -94,6 +96,38 @@ class ProjectListCacheTests(unittest.TestCase):
             clear=True,
         ):
             project_list_cache.require_project_list_cache_config()
+
+    def test_non_development_mode_accepts_complete_upstash_config(self) -> None:
+        with patch.dict(
+            "os.environ",
+            {
+                "BLUEPRINT_DEV_MODE": "false",
+                "UPSTASH_REDIS_REST_URL": "https://example.upstash.io",
+                "UPSTASH_REDIS_REST_TOKEN": "secret",
+                "REDIS_CACHE_PREFIX": "blueprint-production",
+            },
+            clear=True,
+        ):
+            project_list_cache.require_project_list_cache_config()
+
+    def test_upstash_rest_client_sends_redis_commands(self) -> None:
+        response = Mock()
+        response.read.return_value = b'{"result":"cached-value"}'
+        response.__enter__ = Mock(return_value=response)
+        response.__exit__ = Mock(return_value=False)
+
+        client = project_list_cache._UpstashRedisRestClient(
+            "https://example.upstash.io/", "secret-token", 0.5
+        )
+        with patch.object(project_list_cache.request, "urlopen", return_value=response) as urlopen:
+            result = client.get("cache-key")
+
+        self.assertEqual("cached-value", result)
+        redis_request = urlopen.call_args.args[0]
+        self.assertEqual("https://example.upstash.io", redis_request.full_url)
+        self.assertEqual(["GET", "cache-key"], json.loads(redis_request.data))
+        self.assertEqual("Bearer secret-token", redis_request.get_header("Authorization"))
+        self.assertEqual(0.5, urlopen.call_args.kwargs["timeout"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add native Upstash Redis REST support for project-list caching
- allow production startup with either REDIS_URL or the complete Upstash REST credential pair
- document the production Redis alternatives and cover the Upstash adapter/config guard with tests

## Validation
- 472 Python tests passed (1 skipped)
- production Upstash write/read/delete round-trip passed
- production-targeted Vercel build completed

## Production configuration
- added UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN, and REDIS_CACHE_PREFIX
- copied the verified staging Vertex AI model, image, and workload-identity settings to Production
- set BLUEPRINT_DEV_MODE=false explicitly