### PR TITLE
Fix canonical projects missing from galleries

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -86,6 +86,7 @@ from blueprint_core.database import (
     list_project_chats,
     list_component_templates,
     list_generated_projects,
+    list_latest_project_revisions,
     list_project_deletion_audits,
     save_alpha_signup,
     update_generated_project_metadata,
@@ -1563,6 +1564,30 @@ def _project_summary_response(project: Any, current_user_id: Optional[str] = Non
     }
 
 
+def _canonical_project_summary_response(
+    revision: Any,
+    brief: Any,
+    *,
+    owner_user_id: str,
+) -> Dict[str, Any]:
+    """Adapt canonical project state to the established gallery response."""
+
+    state = revision.state
+    overview = getattr(state, "overview", None)
+    title = str(getattr(overview, "title", "") or getattr(brief, "summary", "") or "Untitled project")
+    project = types.SimpleNamespace(
+        project_id=str(revision.project_id),
+        chat_id=brief.conversation_id,
+        owner_user_id=owner_user_id,
+        visibility="private",
+        title=title,
+        prompt=brief.summary,
+        created_at=revision.created_at,
+        hardware_ir=state.model_dump(mode="json"),
+    )
+    return _project_summary_response(project, current_user_id=owner_user_id)
+
+
 def _project_owner_digest(owner_user_id: Optional[str]) -> Optional[str]:
     if not isinstance(owner_user_id, str) or not owner_user_id.strip():
         return None
@@ -1664,9 +1689,37 @@ def list_my_projects_endpoint(user: UserContext = Depends(require_user_context))
         if cached is not None:
             return cached
         projects = list_generated_projects(owner_user_id=owner_user_id)
-        response = jsonable_encoder(
-            [_project_summary_response(p, current_user_id=owner_user_id) for p in projects]
-        )
+        response = [
+            _project_summary_response(project, current_user_id=owner_user_id)
+            for project in projects
+        ]
+        legacy_project_ids = {str(project.project_id) for project in projects}
+        for revision in list_latest_project_revisions(owner_user_id):
+            project_id = str(revision.project_id)
+            if project_id in legacy_project_ids:
+                continue
+            legacy_record = get_generated_project(project_id, include_deleted=True)
+            if legacy_record is not None:
+                # A soft-deleted legacy projection must not be resurrected by
+                # its retained canonical revisions during the recovery window.
+                continue
+            try:
+                brief = get_latest_design_brief(project_id, owner_user_id)
+            except DesignBriefNotFoundError:
+                logger.warning(
+                    "Skipping canonical project without a design brief in owner listing: project_id=%s",
+                    project_id,
+                )
+                continue
+            response.append(
+                _canonical_project_summary_response(
+                    revision,
+                    brief,
+                    owner_user_id=owner_user_id,
+                )
+            )
+        response.sort(key=lambda item: str(item.get("created_at") or ""), reverse=True)
+        response = jsonable_encoder(response)
         cache_project_list("mine", owner_user_id, response, generation)
         return response
     except Exception as e:

--- a/blueprint_core/database.py
+++ b/blueprint_core/database.py
@@ -364,6 +364,7 @@ def save_generated_project(
     chat_id: Optional[str] = None,
     owner_user_id: Optional[str] = None,
     visibility: Optional[str] = "public",
+    create_chat_record: bool = True,
 ) -> None:
     project_id = _canonical_project_id(project_id)
     source_project_id = (hardware_ir.get("assembly_metadata") or {}).get("source_project_id") if isinstance(hardware_ir, dict) else None
@@ -394,7 +395,7 @@ def save_generated_project(
         "status": "active",
     }
     chat_record = None
-    if normalized_chat_id and normalized_owner_user_id:
+    if create_chat_record and normalized_chat_id and normalized_owner_user_id:
         chat_record = {
             "chat_id": normalized_chat_id,
             "owner_user_id": normalized_owner_user_id,
@@ -405,6 +406,55 @@ def save_generated_project(
         }
     _DATABASE_REPOSITORY.save_generated_project(record, chat_record)
     invalidate_project_lists()
+
+
+def publish_project_revision(revision: ProjectRevision, brief: DesignBrief, owner_user_id: str) -> str:
+    """Project canonical state into the public gallery's generated-project store."""
+
+    project_id = _canonical_project_id(str(revision.project_id))
+    normalized_owner_user_id = _normalize_user_id(owner_user_id)
+    if not normalized_owner_user_id or normalized_owner_user_id != revision.owner_user_id:
+        raise ValueError("Project revision owner must match owner_user_id.")
+    if revision.project_id != brief.project_id or revision.design_brief_id != brief.design_brief_id:
+        raise ValueError("Project revision and DesignBrief identities must match.")
+
+    ir = revision.state.model_copy(deep=True)
+    ir.assembly_metadata = {
+        **(ir.assembly_metadata or {}),
+        "project_id": project_id,
+        "chat_id": brief.conversation_id,
+        "project_revision": revision.revision,
+        "design_brief_version": revision.design_brief_version,
+    }
+    hardware_ir = ir.model_dump(mode="json")
+    existing = get_generated_project(project_id, include_deleted=True)
+    if existing is not None:
+        if getattr(existing, "owner_user_id", None) != normalized_owner_user_id:
+            raise DesignBriefAccessError("Project is not owned by the revision owner.")
+        if getattr(existing, "status", "active") != "active":
+            raise RuntimeError("Cannot publish a deleted project revision.")
+        if not update_generated_project_hardware_ir(
+            project_id,
+            hardware_ir,
+            owner_user_id=normalized_owner_user_id,
+        ):
+            raise RuntimeError("Could not refresh the generated-project gallery projection.")
+        return project_id
+
+    save_generated_project(
+        project_id=project_id,
+        title=(ir.overview.title if ir.overview else brief.summary) or "Untitled Forma Project",
+        prompt=brief.summary,
+        hardware_ir=hardware_ir,
+        created_at=revision.created_at.isoformat().replace("+00:00", "Z"),
+        chat_id=brief.conversation_id,
+        owner_user_id=normalized_owner_user_id,
+        visibility="public",
+        # Context gathering already owns the chat and its messages. Publishing
+        # the gallery projection must not replace that thread with an empty one.
+        create_chat_record=False,
+    )
+    return project_id
 
 
 def list_generated_projects(owner_user_id: Optional[str] = None) -> List[Any]:
@@ -840,6 +890,7 @@ async def execute_project_generation_plan(
     worker = GenerationWorker(
         ProjectStateService(_DATABASE_REPOSITORY),
         HardwareIRGenerationEngine(provider_name=provider_name, model_name=model_name),
+        project_publisher=publish_project_revision,
     )
     orchestrator = WorkerOrchestrator(
         _DATABASE_REPOSITORY,

--- a/blueprint_core/database.py
+++ b/blueprint_core/database.py
@@ -701,6 +701,31 @@ def get_latest_project_revision(project_id: str, owner_user_id: str) -> ProjectR
     return ProjectStateService(_DATABASE_REPOSITORY).get_latest(project_id, owner_user_id)
 
 
+def list_latest_project_revisions(owner_user_id: str) -> List[ProjectRevision]:
+    """List each owned project's latest immutable canonical revision."""
+
+    owner = _normalize_user_id(owner_user_id)
+    if not owner:
+        return []
+    revisions: List[ProjectRevision] = []
+    for record in _DATABASE_REPOSITORY.list_latest_project_revisions(owner):
+        payload = getattr(record, "payload_json", None)
+        if not isinstance(payload, dict):
+            logger.warning(
+                "Skipping project revision with invalid payload while listing owner projects: project_id=%s",
+                getattr(record, "project_id", "unknown"),
+            )
+            continue
+        try:
+            revisions.append(ProjectRevision.model_validate(payload))
+        except Exception:
+            logger.exception(
+                "Skipping invalid canonical project revision while listing owner projects: project_id=%s",
+                getattr(record, "project_id", "unknown"),
+            )
+    return revisions
+
+
 def append_project_revision(
     project_id: str,
     owner_user_id: str,
@@ -722,12 +747,14 @@ def append_project_revision(
         parent.design_brief_version,
     )
     draft = build_generation_draft(brief, HardwareIR.model_validate(state))
-    return service.create_revision(
+    revision = service.create_revision(
         draft,
         project_id=project_id,
         owner_user_id=owner_user_id,
         source_job_id=source_job_id,
     ).revision
+    invalidate_project_lists()
+    return revision
 
 
 def create_project_generation_plan(
@@ -820,7 +847,9 @@ async def execute_project_generation_plan(
         workflow_service=ProjectWorkflowService(_DATABASE_REPOSITORY),
         cancellation_check=cancellation_check,
     )
-    return await orchestrator.execute(plan_id, owner)
+    plan = await orchestrator.execute(plan_id, owner)
+    invalidate_project_lists()
+    return plan
 
 
 async def cancel_project_generation_plan(plan_id: str, owner_user_id: str):

--- a/blueprint_core/persistence/repositories/base.py
+++ b/blueprint_core/persistence/repositories/base.py
@@ -87,6 +87,8 @@ class ApplicationRepository(Protocol):
 
     def get_latest_project_revision(self, project_id: str, owner_user_id: str) -> Optional[Any]: ...
 
+    def list_latest_project_revisions(self, owner_user_id: str) -> List[Any]: ...
+
     def get_project_revision(
         self,
         project_id: str,

--- a/blueprint_core/persistence/repositories/sqlite.py
+++ b/blueprint_core/persistence/repositories/sqlite.py
@@ -317,6 +317,25 @@ class SqlAlchemyRepository:
                 .first()
             )
 
+    def list_latest_project_revisions(self, owner_user_id: str) -> List[Any]:
+        with self._session() as session:
+            rows = (
+                session.query(DBProjectRevision)
+                .filter(DBProjectRevision.owner_user_id == owner_user_id)
+                .order_by(DBProjectRevision.created_at.desc())
+                .all()
+            )
+            latest_by_project: Dict[str, Any] = {}
+            for row in rows:
+                current = latest_by_project.get(row.project_id)
+                if current is None or row.revision > current.revision:
+                    latest_by_project[row.project_id] = row
+            return sorted(
+                latest_by_project.values(),
+                key=lambda row: str(row.created_at or ""),
+                reverse=True,
+            )
+
     def get_project_revision(
         self,
         project_id: str,

--- a/blueprint_core/persistence/repositories/supabase.py
+++ b/blueprint_core/persistence/repositories/supabase.py
@@ -274,6 +274,31 @@ class SupabaseRepository:
         )
         return _record(rows[0]) if rows else None
 
+    def list_latest_project_revisions(self, owner_user_id: str) -> List[Any]:
+        rows = (
+            self._client.table("project_revisions")
+            .select("*")
+            .eq("owner_user_id", owner_user_id)
+            .order("created_at", desc=True)
+            .execute()
+            .data
+            or []
+        )
+        latest_by_project: Dict[str, Dict[str, Any]] = {}
+        for row in rows:
+            project_id = str(row.get("project_id") or "").strip()
+            if not project_id:
+                continue
+            current = latest_by_project.get(project_id)
+            if current is None or int(row.get("revision") or 0) > int(current.get("revision") or 0):
+                latest_by_project[project_id] = row
+        latest = sorted(
+            latest_by_project.values(),
+            key=lambda row: str(row.get("created_at") or ""),
+            reverse=True,
+        )
+        return [_record(row) for row in latest]
+
     def get_project_revision(
         self,
         project_id: str,

--- a/blueprint_core/workers/generation.py
+++ b/blueprint_core/workers/generation.py
@@ -26,6 +26,7 @@ from blueprint_core.workers.registry import WorkerCapability, WorkerDefinition
 from blueprint_core.workspaces.design_briefs import DesignBrief
 from blueprint_core.workspaces.projects import (
     ProjectArtifact,
+    ProjectRevision,
     ProjectRevisionOutcome,
     ProjectRevisionDraft,
     ProjectStateError,
@@ -204,6 +205,7 @@ def build_generation_draft(design_brief: DesignBrief, state: HardwareIR) -> Proj
 
 
 ProgressReporter = Callable[[WorkerProgress], Awaitable[None]]
+ProjectPublisher = Callable[[ProjectRevision, DesignBrief, str], str]
 
 
 class GenerationWorker:
@@ -213,9 +215,11 @@ class GenerationWorker:
         self,
         state_service: ProjectStateService,
         engine: GenerationEngine | None = None,
+        project_publisher: ProjectPublisher | None = None,
     ) -> None:
         self._state = state_service
         self._engine = engine or HardwareIRGenerationEngine()
+        self._project_publisher = project_publisher
 
     def worker_definition(self) -> WorkerDefinition:
         return WorkerDefinition(
@@ -270,6 +274,10 @@ class GenerationWorker:
                     ),
                     retryable=False,
                 )
+            try:
+                self._publish(replay, payload.design_brief, owner_user_id)
+            except Exception as exc:
+                return _failure_result(request, exc, retryable=True)
             return _success_result(request, ProjectRevisionOutcome(revision=replay, idempotent_replay=True))
 
         cancellation_check = request.metadata.get("pipeline_cancellation_check")
@@ -336,6 +344,7 @@ class GenerationWorker:
                 design_brief_version=request.design_brief_version,
                 source_job_id=request.job_id,
             )
+            self._publish(outcome.revision, payload.design_brief, owner_user_id)
         except PipelineCancelledError:
             return _cancelled_result(request)
         except ProjectStateError as exc:
@@ -344,6 +353,10 @@ class GenerationWorker:
             return _failure_result(request, exc, retryable=True)
 
         return _success_result(request, outcome)
+
+    def _publish(self, revision: ProjectRevision, brief: DesignBrief, owner_user_id: str) -> None:
+        if self._project_publisher is not None:
+            self._project_publisher(revision, brief, owner_user_id)
 
 
 def _pipeline_event_percent(event: AgentPipelineEvent) -> float:

--- a/supabase/migrations/20260808000100_publish_canonical_projects.sql
+++ b/supabase/migrations/20260808000100_publish_canonical_projects.sql
@@ -1,0 +1,72 @@
+-- Backfill the public generated-project gallery from canonical worker revisions.
+-- New conversational builds maintain this projection in application code.
+
+with latest_revisions as (
+  select distinct on (project_id)
+    project_id,
+    owner_user_id,
+    revision,
+    design_brief_id,
+    design_brief_version,
+    payload_json,
+    created_at
+  from public.project_revisions
+  order by project_id, revision desc
+), canonical_projects as (
+  select
+    revision.project_id,
+    brief.conversation_id as chat_id,
+    revision.owner_user_id,
+    coalesce(
+      nullif(revision.payload_json #>> '{state,overview,title}', ''),
+      nullif(brief.payload_json->>'summary', ''),
+      'Untitled Forma Project'
+    ) as title,
+    coalesce(brief.payload_json->>'summary', '') as prompt,
+    jsonb_set(
+      jsonb_set(
+        jsonb_set(
+          revision.payload_json->'state',
+          '{assembly_metadata,project_id}',
+          to_jsonb(revision.project_id),
+          true
+        ),
+        '{assembly_metadata,chat_id}',
+        to_jsonb(brief.conversation_id),
+        true
+      ),
+      '{assembly_metadata,project_revision}',
+      to_jsonb(revision.revision),
+      true
+    ) as hardware_ir,
+    revision.created_at
+  from latest_revisions revision
+  join public.design_briefs brief
+    on brief.project_id = revision.project_id
+   and brief.owner_user_id = revision.owner_user_id
+   and brief.design_brief_id = revision.design_brief_id
+   and brief.brief_version = revision.design_brief_version
+)
+insert into public.generated_projects (
+  project_id,
+  chat_id,
+  owner_user_id,
+  visibility,
+  title,
+  prompt,
+  hardware_ir,
+  created_at,
+  status
+)
+select
+  project_id,
+  chat_id,
+  owner_user_id,
+  'public',
+  title,
+  prompt,
+  hardware_ir,
+  created_at,
+  'active'
+from canonical_projects
+on conflict (project_id) do nothing;

--- a/tests/agents/test_generation_worker.py
+++ b/tests/agents/test_generation_worker.py
@@ -6,7 +6,7 @@ import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from blueprint_core.agents.orchestrator import HardwarePipelineOrchestrator
 from blueprint_core.agents.pipeline import emit_agent_pipeline_event
@@ -237,7 +237,8 @@ class GenerationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
 
     async def test_registered_worker_persists_initial_revision_through_orchestrator(self) -> None:
         engine = FakeGenerationEngine()
-        worker = GenerationWorker(self.state, engine)
+        publisher = Mock(return_value=str(self.project_id))
+        worker = GenerationWorker(self.state, engine, project_publisher=publisher)
         registry = WorkerRegistry([worker])
         orchestrator = WorkerOrchestrator(
             self.repository,
@@ -270,6 +271,27 @@ class GenerationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(ProjectWorkflowState.AWAITING_FEEDBACK, self.workflow.get(str(self.project_id), OWNER).state)
         self.assertEqual(self.brief, engine.received[0])
         self.assertEqual(["ref-datasheet"], [item.reference_id for item in engine.received[0].references])
+        publisher.assert_called_once_with(revision, self.brief, OWNER)
+
+    async def test_idempotent_replay_retries_the_gallery_projection(self) -> None:
+        engine = FakeGenerationEngine()
+        publisher = Mock(side_effect=[RuntimeError("gallery unavailable"), str(self.project_id)])
+        worker = GenerationWorker(self.state, engine, project_publisher=publisher)
+        request = self.request().model_copy(update={"metadata": {"execution_owner_user_id": OWNER}})
+
+        async def progress(_: Any) -> None:
+            return None
+
+        first = await worker.execute(request, progress)
+        second = await worker.execute(request, progress)
+
+        self.assertEqual("failed", first.status.value)
+        self.assertTrue(first.error.retryable)
+        self.assertIn("gallery unavailable", first.error.message)
+        self.assertEqual("succeeded", second.status.value)
+        self.assertTrue(second.output["idempotent_replay"])
+        self.assertEqual(2, publisher.call_count)
+        self.assertEqual(1, len(engine.received))
 
     async def test_project_chat_iteration_appends_an_immutable_revision(self) -> None:
         engine = FakeGenerationEngine()

--- a/tests/api/test_project_access.py
+++ b/tests/api/test_project_access.py
@@ -156,6 +156,104 @@ class ProjectReadAccessTests(unittest.TestCase):
         self.assertNotIn(main._CACHE_OWNER_DIGEST_FIELD, owner_response[0])
         self.assertNotIn(main._CACHE_OWNER_CHAT_FIELD, owner_response[0])
 
+    def test_owner_list_includes_canonical_project_without_legacy_row(self) -> None:
+        project_id = "11111111-1111-4111-8111-111111111111"
+        state = HardwareIR(
+            overview=ProjectOverview(
+                title="Canonical controller",
+                description="A canonical-only generated project.",
+                difficulty="Intermediate",
+                category="Automation",
+            ),
+            assembly_metadata={
+                "project_id": project_id,
+                "product_image_url": "https://images.example.test/controller.png",
+                "image_output_status": "succeeded",
+            },
+        )
+        revision = SimpleNamespace(
+            project_id=project_id,
+            owner_user_id="user-a",
+            revision=1,
+            created_at="2026-08-07T17:03:57Z",
+            state=state,
+        )
+        brief = SimpleNamespace(
+            conversation_id="chat-canonical-controller",
+            summary="Build a canonical controller.",
+        )
+
+        with self._summary_dependencies(), patch.object(
+            main,
+            "list_generated_projects",
+            return_value=[],
+        ), patch.object(
+            main,
+            "list_latest_project_revisions",
+            return_value=[revision],
+        ), patch.object(
+            main,
+            "get_latest_design_brief",
+            return_value=brief,
+        ), patch.object(
+            main,
+            "get_generated_project",
+            return_value=None,
+        ):
+            response = main.list_my_projects_endpoint(_user_context("user-a"))
+
+        self.assertEqual([project_id], [item["project_id"] for item in response])
+        self.assertEqual("Canonical controller", response[0]["title"])
+        self.assertEqual("chat-canonical-controller", response[0]["chat_id"])
+        self.assertTrue(response[0]["can_chat"])
+        self.assertTrue(response[0]["has_product_image"])
+
+    def test_owner_list_deduplicates_legacy_and_canonical_project_records(self) -> None:
+        project_id = "legacy-and-canonical"
+        legacy_project = _project(
+            project_id,
+            owner_user_id="user-a",
+            visibility="private",
+        )
+        revision = SimpleNamespace(project_id=project_id)
+
+        with self._summary_dependencies(), patch.object(
+            main,
+            "list_generated_projects",
+            return_value=[legacy_project],
+        ), patch.object(
+            main,
+            "list_latest_project_revisions",
+            return_value=[revision],
+        ), patch.object(main, "get_latest_design_brief") as get_brief:
+            response = main.list_my_projects_endpoint(_user_context("user-a"))
+
+        self.assertEqual([project_id], [item["project_id"] for item in response])
+        get_brief.assert_not_called()
+
+    def test_owner_list_does_not_resurrect_soft_deleted_legacy_project(self) -> None:
+        project_id = "deleted-legacy-project"
+        revision = SimpleNamespace(project_id=project_id)
+        deleted_project = SimpleNamespace(project_id=project_id, status="pending_purge")
+
+        with self._summary_dependencies(), patch.object(
+            main,
+            "list_generated_projects",
+            return_value=[],
+        ), patch.object(
+            main,
+            "list_latest_project_revisions",
+            return_value=[revision],
+        ), patch.object(
+            main,
+            "get_generated_project",
+            return_value=deleted_project,
+        ), patch.object(main, "get_latest_design_brief") as get_brief:
+            response = main.list_my_projects_endpoint(_user_context("user-a"))
+
+        self.assertEqual([], response)
+        get_brief.assert_not_called()
+
     def test_owner_can_read_own_private_project(self) -> None:
         private_project = _project(
             "private-project",

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -4,7 +4,9 @@ import sqlite3
 import tempfile
 import unittest
 import uuid
+from datetime import datetime, timezone
 from pathlib import Path
+from unittest.mock import patch
 
 from blueprint_core.jobs.store import JobMetadataStore
 from blueprint_core import database
@@ -13,9 +15,63 @@ from blueprint_core.persistence.models import DBProjectRevision
 from blueprint_core.jobs.migrations import import_legacy_job_database
 from blueprint_core.persistence.providers import SupabaseProvider, create_sqlite_provider
 from blueprint_core.persistence.repositories import SqlAlchemyRepository
+from blueprint_core.workspaces.design_briefs import DESIGN_BRIEF_SCHEMA_VERSION, DesignBrief
+from blueprint_core.workspaces.projects import ProjectRevision
+from blueprint_core.workspaces.projects.models import HardwareIR, ProjectOverview
 
 
 class PersistenceArchitectureTests(unittest.TestCase):
+    def test_canonical_revision_publication_creates_public_gallery_projection_without_replacing_chat(self) -> None:
+        project_id = uuid.uuid4()
+        design_brief_id = uuid.uuid4()
+        brief = DesignBrief(
+            schema_version=DESIGN_BRIEF_SCHEMA_VERSION,
+            conversation_id="conversation-publication",
+            intent="Build a sensor",
+            summary="Build a compact sensor controller.",
+            requirements=["Read a sensor"],
+            constraints=["Use low voltage"],
+            readiness="ready",
+            design_brief_id=design_brief_id,
+            project_id=project_id,
+            brief_version=1,
+            created_at=datetime.now(timezone.utc),
+        )
+        state = HardwareIR(
+            overview=ProjectOverview(
+                title="Published Sensor",
+                description="A compact sensor controller.",
+                difficulty="Beginner",
+                category="Sensors",
+            ),
+            assembly_metadata={"project_id": str(project_id)},
+        )
+        revision = ProjectRevision(
+            revision_id=uuid.uuid4(),
+            project_id=project_id,
+            owner_user_id="publication-owner",
+            revision=1,
+            design_brief_id=design_brief_id,
+            design_brief_version=1,
+            source_job_id="publication-job",
+            state=state,
+            created_at=datetime.now(timezone.utc),
+        )
+
+        with patch.object(database, "get_generated_project", return_value=None), patch.object(
+            database,
+            "save_generated_project",
+        ) as save_project:
+            published_id = database.publish_project_revision(revision, brief, "publication-owner")
+
+        self.assertEqual(str(project_id), published_id)
+        save_project.assert_called_once()
+        saved = save_project.call_args.kwargs
+        self.assertEqual("public", saved["visibility"])
+        self.assertFalse(saved["create_chat_record"])
+        self.assertEqual("conversation-publication", saved["chat_id"])
+        self.assertEqual("conversation-publication", saved["hardware_ir"]["assembly_metadata"]["chat_id"])
+
     def test_supabase_provider_checks_complete_schema_contract(self) -> None:
         client = _SchemaClient()
         provider = SupabaseProvider(source="test", url="https://example.supabase.co", client=client)

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from blueprint_core.jobs.store import JobMetadataStore
 from blueprint_core import database
 from blueprint_core.persistence import APPLICATION_SCHEMA
+from blueprint_core.persistence.models import DBProjectRevision
 from blueprint_core.jobs.migrations import import_legacy_job_database
 from blueprint_core.persistence.providers import SupabaseProvider, create_sqlite_provider
 from blueprint_core.persistence.repositories import SqlAlchemyRepository
@@ -117,6 +118,63 @@ class PersistenceArchitectureTests(unittest.TestCase):
         self.assertIsNotNone(chat)
         self.assertTrue(deleted)
         self.assertIsNone(project_after_chat_delete.chat_id)
+
+    def test_sqlite_repository_lists_only_each_projects_latest_revision(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            provider = create_sqlite_provider(
+                source="test primary",
+                url=f"sqlite:///{Path(directory) / 'blueprint.db'}",
+                import_legacy_jobs=False,
+            )
+            assert provider.session_factory is not None
+            provider.initialize()
+            repository = SqlAlchemyRepository(provider.session_factory)
+            with provider.session_factory() as session, session.begin():
+                session.add_all([
+                    DBProjectRevision(
+                        id="revision-a1",
+                        project_id="project-a",
+                        owner_user_id="user-a",
+                        revision=1,
+                        parent_revision=None,
+                        design_brief_id="brief-a",
+                        design_brief_version=1,
+                        source_job_id="job-a1",
+                        payload_json={},
+                        created_at="2026-08-07T12:00:00Z",
+                    ),
+                    DBProjectRevision(
+                        id="revision-a2",
+                        project_id="project-a",
+                        owner_user_id="user-a",
+                        revision=2,
+                        parent_revision=1,
+                        design_brief_id="brief-a",
+                        design_brief_version=1,
+                        source_job_id="job-a2",
+                        payload_json={},
+                        created_at="2026-08-07T12:02:00Z",
+                    ),
+                    DBProjectRevision(
+                        id="revision-b1",
+                        project_id="project-b",
+                        owner_user_id="user-a",
+                        revision=1,
+                        parent_revision=None,
+                        design_brief_id="brief-b",
+                        design_brief_version=1,
+                        source_job_id="job-b1",
+                        payload_json={},
+                        created_at="2026-08-07T12:01:00Z",
+                    ),
+                ])
+
+            revisions = repository.list_latest_project_revisions("user-a")
+
+        self.assertEqual(
+            [("project-a", 2), ("project-b", 1)],
+            [(revision.project_id, revision.revision) for revision in revisions],
+        )
 
     def test_legacy_job_import_is_idempotent_and_does_not_overwrite_primary_rows(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary
- include canonical-only revisions in My Projects
- publish successful conversational builds into the public generated-project gallery projection
- retry gallery publication on idempotent worker replay
- backfill existing canonical production projects without replacing chats or resurrecting deleted rows

## Validation
- `python -m unittest discover -s tests` (480 passed, 1 skipped)
- Supabase migration executed successfully against local PostgreSQL in a rolled-back transaction
- `git diff --check`

## Migration
- `20260808000100_publish_canonical_projects.sql`