### PR TITLE
fix: rename project video tab to media

### DIFF
--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -1445,7 +1445,7 @@ const workspaceTabs = [
   { id: "mechanical", label: "MECH", icon: Box },
   { id: "schematic", label: "WIRE", icon: Cpu },
   { id: "assembly", label: "DOCS", icon: Info },
-  { id: "video", label: "VIDEO", icon: Film },
+  { id: "video", label: "MEDIA", icon: Film },
 ];
 
 const workspaceTabNamespaces: Record<string, string> = {


### PR DESCRIPTION
Closes #234

## Summary
- rename the Projects workspace tab from `VIDEO` to `MEDIA`
- preserve the internal video tab identifier and namespace so existing behavior and links remain compatible

## Testing
- `npm run lint -- --quiet`
- `npx tsc --noEmit`