### PR TITLE
Fix text-free product renders and unresolved system refs

### DIFF
--- a/blueprint_core/agents/prompt_compaction.py
+++ b/blueprint_core/agents/prompt_compaction.py
@@ -419,7 +419,7 @@ class PromptCompactionAgent:
         return "\n".join(shortened)
 
     def _emergency_fit(self, prompt: str, max_chars: int) -> str:
-        notice = "\n[Prompt compacted to provider limit: middle detail removed, preserve visible dimensions, components, mounting planes, and stage rules.]\n"
+        notice = "\n[Prompt compacted to provider limit: middle detail removed; preserve text-free rendering, physical proportions, components, mounting planes, and stage rules.]\n"
         budget = max_chars - len(notice) - 1
         if budget <= 0:
             return prompt[:max_chars]

--- a/blueprint_core/image_providers.py
+++ b/blueprint_core/image_providers.py
@@ -1449,7 +1449,8 @@ def build_project_image_prompt(user_prompt: str, ir: Any) -> str:
     prompt_parts = [
         "Create a clean realistic product concept render for a safe low-voltage maker electronics build.",
         "Show the assembled physical device, enclosure, visible controls, display openings, ports, and any exposed low-voltage modules that belong in the design.",
-        "Do not include text, labels, watermarks, logos, hands, people, wiring diagrams, schematic symbols, high-voltage equipment, medical devices, or weapons.",
+        "The rendered pixels must contain no text: no dimension lines or values, labels, annotations, captions, legends, watermarks, or logos.",
+        "Do not include hands, people, wiring diagrams, schematic symbols, high-voltage equipment, medical devices, or weapons.",
         "Use a neutral studio background, believable materials, and a three-quarter product view.",
         f"Project title: {_truncate(title, 120)}",
         f"Project description: {_truncate(description, 300)}",
@@ -1463,7 +1464,9 @@ def build_project_image_prompt(user_prompt: str, ir: Any) -> str:
     if fabrication_notes:
         prompt_parts.append("Fabrication notes: " + "; ".join(_limit_list(fabrication_notes, 5)))
     if dimensions:
-        prompt_parts.append(f"Approximate device envelope: {dimensions}.")
+        prompt_parts.append(
+            f"Private proportion reference only (never print or annotate this in the image): {dimensions}."
+        )
 
     return "\n".join(prompt_parts)
 
@@ -1809,7 +1812,7 @@ def _control_loop_visual_requirements(user_prompt: str, ir: Any, nets: List[Dict
         "Closed-loop visuals must separate the measured feedback path from the control output path.",
         "Show the measured variable sensor or feedback signal returning to the controller when present in the IR.",
         "Show the controller output path to the actuator or driver stage, such as PWM to a fan or motor driver, when present in the IR.",
-        "Do not imply closed-loop speed control unless a feedback sensor, tach signal, or measured output path is visible or explicitly labeled from the spec.",
+        "Do not imply closed-loop speed control unless a feedback sensor, tach signal, or measured output path from the spec is physically visible.",
     ]
 
 
@@ -2114,7 +2117,10 @@ def _assembly_state_records() -> List[Dict[str, Any]]:
             "purpose": "Product-like exterior validation.",
             "visible": ["opaque exterior enclosure", "external controls", "ports", "vents", "fasteners"],
             "hidden": ["internal boards and wiring"],
-            "verification_checks": ["dimensions shown from spec", "no internals visible through opaque shell"],
+            "verification_checks": [
+                "proportions match dimensions from spec without visible dimension annotations",
+                "no internals visible through opaque shell",
+            ],
         },
         {
             "id": "transparent_top_down_inspection",
@@ -2274,13 +2280,13 @@ def build_project_visual_spec(user_prompt: str, ir: Any) -> Dict[str, Any]:
         "constraints": _limit_list(getattr(ir, "constraints", []) or [], 10),
         "allowed_visual_labels": allowed_labels,
         "truth_rules": [
-            "Use only these dimensions for all numeric dimension callouts.",
+            "Use dimensions only to establish physical proportions; never render dimension lines, arrows, or values.",
             "Use only listed component refs, names, part numbers, CAD sources, and placements.",
             "Use the design_assembly_model as the source of truth for orientation, part visibility, and component mounting zones.",
             "Preserve every component's subsystem, mounted_on plane, and facing_normal metadata in generated physical layouts.",
             "Preserve subsystem contracts: purpose, inputs, outputs, physical interfaces, placement constraints, dependencies, and verification checks.",
             "Do not invent vendor part numbers, enclosure models, tolerances, wall thickness, mounting hardware, or dimensions.",
-            "If a detail is not present in this spec, show it generically or omit the label.",
+            "Render no text, labels, annotations, captions, legends, watermarks, or logos in the image.",
         ],
     }
 
@@ -2317,7 +2323,6 @@ def _spec_prompt_text(spec: Dict[str, Any]) -> str:
         "cad_sources": spec["cad_sources"],
         "fabrication_notes": spec["fabrication_notes"],
         "constraints": spec["constraints"],
-        "allowed_visual_labels": spec["allowed_visual_labels"],
         "truth_rules": spec["truth_rules"],
     }
     return json.dumps(compact_spec, separators=(",", ":"))
@@ -2329,7 +2334,7 @@ def build_project_image_sequence_prompts(user_prompt: str, ir: Any) -> List[Dict
     shared = [
         "Canonical Visual Design Spec, generated from the Hardware IR:",
         spec_text,
-        f"Fixed dimensions for every view: {spec['external_dimensions_text']}; {spec['internal_dimensions_text']}.",
+        f"Private geometry guidance for proportions only: {spec['external_dimensions_text']}; {spec['internal_dimensions_text']}. Never depict these measurements.",
         "Traditional design rule: this is one assembly model with derived view states, not three independent product concepts.",
         "Keep the same object identity, proportions, port positions, display/control layout, material, and scale across all images.",
         "Only the camera angle and part visibility state may change between stages.",
@@ -2342,7 +2347,7 @@ def build_project_image_sequence_prompts(user_prompt: str, ir: Any) -> List[Dict
         "Preserve each component's mounted_on plane and facing_normal; do not rotate electronics to face the camera for aesthetics.",
         "Prefer top-down transparent or ghosted enclosure views for internal inspection rather than dramatic perspective views.",
         "Do not fuse an exterior lid/top surface with internal electronics, and do not place internals under an opaque closed lid.",
-        "Do not add labels, dimensions, enclosure models, hardware kit contents, tolerances, or component names unless they appear in the spec.",
+        "The rendered pixels must contain no text: no dimension lines or values, measurement arrows, labels, annotations, captions, legends, component names, part numbers, watermarks, or logos.",
         "Safe low-voltage maker electronics only. No hands, people, watermarks, brand logos, weapons, medical equipment, or mains-voltage hazards.",
     ]
 
@@ -2359,7 +2364,7 @@ def build_project_image_sequence_prompts(user_prompt: str, ir: Any) -> List[Dict
                     "Render a realistic closed enclosure/case only: visible screen/window openings, buttons, knobs, ports, seams, fillets, screw bosses if visible, and panel cutouts.",
                     "The lid/operator panel is installed and opaque except for display windows, cutouts, ports, vents, or controls that are explicitly visible externally.",
                     "Use consistent orientation landmarks: front wall remains front, right wall remains right, and top/lid controls stay on the top/lid.",
-                    "Dimension callouts must exactly match the external_dimensions_mm values in the spec. If external_dimensions_mm is null, do not draw numeric dimension callouts.",
+                    "Use external_dimensions_mm only to guide proportions. Do not draw dimension lines, measurement arrows, numeric values, or any other text.",
                     "Use a clean neutral studio background and a three-quarter view. Do not show internal electronics in this stage.",
                 ]
             ),
@@ -2379,14 +2384,14 @@ def build_project_image_sequence_prompts(user_prompt: str, ir: Any) -> List[Dict
                     "Do not show the case exterior underside facing upward while the electronics face upward. The visible cavity, side walls, standoffs, and electronics must all agree on one coordinate frame.",
                     "Use each component's mounted_on, facing_normal, visible_side, view_preference, and render_rule metadata. Floor boards face +Z, lid controls remain on the lid plane, wall components remain on side-wall planes.",
                     "Do not rotate wall-mounted fans, ports, or lid-mounted displays to face the camera; use transparent shell visibility, ghosting, or small true-plane insets instead.",
-                    "Show subtle subsystem grouping cues for UI, control, power/driver, sensing, airflow, and mechanical subsystems without adding unsupported labels.",
+                    "Show subtle subsystem grouping through placement and color cues only, with no written labels.",
                     "Respect subsystem placement constraints: sensors stay exposed to the intended medium, hot drivers stay away from sensors, ports align with wall cutouts, airflow paths remain unblocked, and service loops remain plausible.",
                     "For behavior/control systems, preserve the measured variable source, controller, driver/output path, actuator, and feedback path from behavior_control_model.",
                     "The opaque lid/top surface must not cover or blend into internal electronics.",
                     "Keep lid-mounted display, knob, button, and switch parts attached to the separate lid/operator panel or show their underside/cables clearly; do not relocate them onto the bottom shell unless their mounting_zone says so.",
                     "Keep floor-mounted boards, drivers, power modules, terminals, standoffs, and wiring on the bottom shell floor.",
                     "Show only the electronics and placements listed in the spec: mounted boards, display module, buttons, encoder/knob, power board, connectors, wiring harnesses, standoffs, screws, cable routing, and clearance.",
-                    "Dimension callouts must exactly match external_dimensions_mm and internal_usable_dimensions_mm. Preserve exterior port, vent, fan, and control positions from the case render.",
+                    "Use external_dimensions_mm and internal_usable_dimensions_mm only to guide proportions. Do not draw dimension lines, measurement arrows, numeric values, or any other text. Preserve exterior port, vent, fan, and control positions from the case render.",
                     "Use a realistic three-quarter product view with the internal electronics clearly visible.",
                 ]
             ),

--- a/blueprint_core/workers/generation.py
+++ b/blueprint_core/workers/generation.py
@@ -122,6 +122,7 @@ class HardwareIRGenerationEngine:
 
 def build_generation_draft(design_brief: DesignBrief, state: HardwareIR) -> ProjectRevisionDraft:
     component_refs = [component.ref_des for component in state.components]
+    known_component_refs = set(component_refs)
     systems = [
         ProjectSystem(
             system_id="system-primary",
@@ -131,26 +132,39 @@ def build_generation_draft(design_brief: DesignBrief, state: HardwareIR) -> Proj
         )
     ]
     for rail in state.power_rails:
+        rail_refs = [rail.source_component] if rail.source_component in known_component_refs else []
+        rail_metadata: dict[str, Any] = {
+            "voltage": rail.voltage,
+            "max_current_capacity_ma": rail.max_current_capacity_ma,
+            "source_component": rail.source_component,
+        }
+        if not rail_refs:
+            rail_metadata["unresolved_component_refs"] = [rail.source_component]
         systems.append(ProjectSystem(
             system_id=f"power-{rail.rail_id}",
             kind="power",
             name=rail.rail_id,
-            component_refs=[rail.source_component],
-            metadata={"voltage": rail.voltage, "max_current_capacity_ma": rail.max_current_capacity_ma},
+            component_refs=rail_refs,
+            metadata=rail_metadata,
         ))
     for bus in state.buses:
-        bus_components = sorted({
+        declared_bus_components = {
             pin.ref_des
             for net in state.nets
             if net.net_id in bus.nets
             for pin in net.pins
-        })
+        }
+        bus_components = sorted(declared_bus_components.intersection(known_component_refs))
+        unresolved_bus_components = sorted(declared_bus_components.difference(known_component_refs))
+        bus_metadata: dict[str, Any] = {"bus_type": bus.bus_type, "net_ids": list(bus.nets)}
+        if unresolved_bus_components:
+            bus_metadata["unresolved_component_refs"] = unresolved_bus_components
         systems.append(ProjectSystem(
             system_id=f"bus-{bus.bus_id}",
             kind="bus",
             name=bus.bus_id,
             component_refs=bus_components,
-            metadata={"bus_type": bus.bus_type, "net_ids": list(bus.nets)},
+            metadata=bus_metadata,
         ))
 
     revision_base = f"forma://projects/{design_brief.project_id}/revisions/1"

--- a/tests/agents/test_generation_worker.py
+++ b/tests/agents/test_generation_worker.py
@@ -25,6 +25,7 @@ from blueprint_core.workers import (
     WorkerPlanStatus,
     WorkerRegistry,
     WorkerRequest,
+    build_generation_draft,
 )
 from blueprint_core.workspaces.design_briefs import (
     DESIGN_BRIEF_SCHEMA_VERSION,
@@ -38,7 +39,15 @@ from blueprint_core.workspaces.projects import (
     ProjectStateService,
     ProjectSystem,
 )
-from blueprint_core.workspaces.projects.models import ComponentInstance, HardwareIR, ProjectOverview
+from blueprint_core.workspaces.projects.models import (
+    BusConnection,
+    ComponentInstance,
+    ConnectionNet,
+    HardwareIR,
+    PinReference,
+    PowerRail,
+    ProjectOverview,
+)
 from blueprint_core.workspaces.workflow import (
     ProjectWorkflowService,
     ProjectWorkflowState,
@@ -176,6 +185,47 @@ class GenerationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
         attach_image.assert_called_once()
         self.assertTrue(attach_image.call_args.kwargs["generate_image"])
         self.assertEqual("Vertex Image Project", draft.state.overview.title)
+
+    def test_generation_draft_preserves_dangling_ir_refs_without_invalid_system_refs(self) -> None:
+        component = ComponentInstance(
+            ref_des="U1",
+            part_number="ESP32-DEVKIT",
+            name="ESP32 controller",
+            category="Microcontroller",
+            rationale="Provides processing and connectivity.",
+        )
+        state = HardwareIR(
+            components=[component],
+            nets=[
+                ConnectionNet(
+                    net_id="NET_I2C_SDA",
+                    name="I2C data",
+                    net_type="I2C",
+                    pins=[
+                        PinReference(ref_des="U1", pin_id="SDA"),
+                        PinReference(ref_des="R2", pin_id="1"),
+                    ],
+                )
+            ],
+            buses=[BusConnection(bus_id="I2C_1", bus_type="I2C", nets=["NET_I2C_SDA"])],
+            power_rails=[
+                PowerRail(
+                    rail_id="3V3",
+                    voltage=3.3,
+                    max_current_capacity_ma=500,
+                    source_component="R2",
+                )
+            ],
+        )
+
+        draft = build_generation_draft(self.brief, state)
+
+        power_system = next(system for system in draft.systems if system.kind == "power")
+        bus_system = next(system for system in draft.systems if system.kind == "bus")
+        self.assertEqual([], power_system.component_refs)
+        self.assertEqual(["R2"], power_system.metadata["unresolved_component_refs"])
+        self.assertEqual(["U1"], bus_system.component_refs)
+        self.assertEqual(["R2"], bus_system.metadata["unresolved_component_refs"])
 
     def tearDown(self) -> None:
         self.directory.cleanup()

--- a/tests/providers/test_image_providers.py
+++ b/tests/providers/test_image_providers.py
@@ -6,10 +6,45 @@ from types import SimpleNamespace
 from unittest.mock import Mock
 from unittest.mock import patch
 
-from blueprint_core.image_providers import GeneratedImage, GMIImageProvider, HuggingFaceImageProvider, OpenAIImageProvider, TogetherImageProvider, VertexAIImageProvider, build_image_provider
+from blueprint_core.image_providers import (
+    GeneratedImage,
+    GMIImageProvider,
+    HuggingFaceImageProvider,
+    OpenAIImageProvider,
+    TogetherImageProvider,
+    VertexAIImageProvider,
+    build_image_provider,
+    build_project_image_prompt,
+    build_project_image_sequence_prompts,
+)
 
 
 class ImageProviderRoutingTests(unittest.TestCase):
+    def test_project_image_prompts_keep_measurements_and_text_out_of_rendered_pixels(self) -> None:
+        ir = SimpleNamespace(
+            overview=SimpleNamespace(title="Pocket monitor", description="A compact sensor monitor"),
+            mechanical=SimpleNamespace(
+                render_dimensions=SimpleNamespace(x_mm=120, y_mm=70, z_mm=28),
+                enclosure_type="3D printed enclosure",
+            ),
+            components=[],
+            constraints=[],
+            fabrication_notes=[],
+            assembly_metadata={},
+        )
+
+        product_prompt = build_project_image_prompt("Build a pocket monitor", ir)
+        self.assertIn("rendered pixels must contain no text", product_prompt.lower())
+        self.assertIn("never print or annotate this in the image", product_prompt.lower())
+
+        sequence = build_project_image_sequence_prompts("Build a pocket monitor", ir)
+        self.assertEqual(["case", "inside"], [item["view_id"] for item in sequence])
+        for item in sequence:
+            prompt = item["prompt"].lower()
+            self.assertIn("rendered pixels must contain no text", prompt)
+            self.assertIn("do not draw dimension lines", prompt)
+            self.assertNotIn("dimension callouts must", prompt)
+
     def test_openai_image_provider_does_not_inherit_llm_base_url(self) -> None:
         with patch.dict(
             os.environ,


### PR DESCRIPTION
## Summary

- prevent generated product renders from displaying dimensions, labels, annotations, or other text
- keep dimensions as private proportion guidance and preserve the text-free rule during prompt compaction
- filter derived bus and power system references against the canonical BOM
- retain missing references as unresolved metadata so validation can report them without blocking revision creation

## Testing

- `./scripts/quality/test.sh`
- 482 tests passed, 1 skipped