### PR TITLE
Add user visibility to the admin jobs panel

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import hashlib
 import json
 import logging
@@ -144,6 +145,7 @@ from apps.api.user_integrations_api import router as user_integrations_router
 from apps.api.user_settings_api import router as user_settings_router
 from apps.api.auth import (
     UserContext,
+    clerk_user_profile,
     deployed_auth_required,
     optional_user_context,
     require_admin_user_context,
@@ -334,6 +336,36 @@ def _job_owner_user_id(job: Optional[Dict[str, Any]]) -> Optional[str]:
     if isinstance(value, str) and value.strip():
         return value.strip()
     return None
+
+
+def _admin_job_records(jobs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Add admin-only owner labels without changing the persisted job shape."""
+    records = [dict(job) for job in jobs]
+    owner_user_ids: List[str] = []
+
+    for record in records:
+        owner_user_id = _job_owner_user_id(record)
+        record["owner_user_id"] = owner_user_id
+        if owner_user_id and owner_user_id not in owner_user_ids:
+            owner_user_ids.append(owner_user_id)
+
+    # Clerk lookups are optional display enrichment. Cap and parallelize cold
+    # lookups so a large job list cannot hold the admin request open.
+    profile_user_ids = owner_user_ids[:16]
+    if profile_user_ids:
+        with ThreadPoolExecutor(max_workers=min(8, len(profile_user_ids))) as executor:
+            resolved_profiles = executor.map(clerk_user_profile, profile_user_ids)
+            profiles = dict(zip(profile_user_ids, resolved_profiles))
+    else:
+        profiles = {}
+
+    for record in records:
+        owner_user_id = record.get("owner_user_id")
+        profile = profiles.get(owner_user_id) if isinstance(owner_user_id, str) else None
+        record["owner_display_name"] = profile.get("display_name") if profile else None
+        record["owner_email"] = profile.get("email") if profile else None
+
+    return records
 
 
 def _require_job_reader(job: Dict[str, Any], user: UserContext) -> None:
@@ -1268,7 +1300,7 @@ def list_a2a_jobs(
     _user: UserContext = Depends(require_admin_user_context),
 ):
     """Lists persisted A2A job metadata."""
-    return JOB_STORE.list_jobs(sender=sender, status=job_status, limit=limit)
+    return _admin_job_records(JOB_STORE.list_jobs(sender=sender, status=job_status, limit=limit))
 
 
 @app.get("/a2a/jobs/{job_id}")

--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -4798,7 +4798,7 @@ export function FormaWorkspace({
                 />
               ) : (
                 <div className="border border-[#2a2c33] bg-[#17181d] p-6 text-sm leading-6 text-slate-400">
-                  {adminSessionLoaded ? "Admin access is required to view deployment jobs." : "Checking admin access..."}
+                  {adminSessionLoaded ? "Admin access is required to view jobs." : "Checking admin access..."}
                 </div>
               )}
             </>

--- a/apps/web/app/blueprint-workspace/admin-panels.tsx
+++ b/apps/web/app/blueprint-workspace/admin-panels.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useMemo, useState } from "react";
+
 import {
   AlertTriangle,
   CheckCircle,
@@ -204,7 +206,37 @@ export function JobsPanel({
   compactActionLabel?: string;
   formatLlmLabel: (provider: string, model: string) => string;
 }) {
-  const visibleJobs = compact ? jobs.slice(0, 2) : jobs;
+  const [userFilter, setUserFilter] = useState("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const userOptions = useMemo(() => {
+    const users = new Map<string, { id: string; label: string }>();
+    jobs.forEach((job) => {
+      const id = job.owner_user_id || job.payload?.owner_user_id;
+      if (typeof id !== "string" || !id.trim()) return;
+      const normalizedId = id.trim();
+      const label = job.owner_email || job.owner_display_name || normalizedId;
+      users.set(normalizedId, { id: normalizedId, label });
+    });
+    return Array.from(users.values()).sort((left, right) => left.label.localeCompare(right.label));
+  }, [jobs]);
+  const filteredJobs = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    return jobs.filter((job) => {
+      const ownerUserId = String(job.owner_user_id || job.payload?.owner_user_id || "");
+      if (userFilter !== "all" && ownerUserId !== userFilter) return false;
+      if (!query) return true;
+      const searchable = [
+        job.payload?.prompt,
+        job.result_summary?.title,
+        job.job_id,
+        job.owner_display_name,
+        job.owner_email,
+        ownerUserId,
+      ];
+      return searchable.some((value) => String(value || "").toLowerCase().includes(query));
+    });
+  }, [jobs, searchQuery, userFilter]);
+  const visibleJobs = compact ? filteredJobs.slice(0, 2) : filteredJobs;
   const filters = ["all", "queued", "running", "succeeded", "failed"];
   const panelDescription = description || `Generation and example job metadata. Polling every ${Math.round(pollIntervalMs / 1000)}s.`;
 
@@ -237,21 +269,48 @@ export function JobsPanel({
       </div>
 
       {!compact && (
-        <div className="mb-4 flex flex-wrap gap-2">
-          {filters.map((filter) => (
-            <button
-              key={filter}
-              type="button"
-              onClick={() => onStatusFilterChange(filter)}
-              className={`border px-3 py-2 text-xs font-bold uppercase ${
-                statusFilter === filter
-                  ? "border-white bg-white text-black"
-                  : "border-[#2a2c33] bg-[#141519] text-slate-500 hover:border-slate-500 hover:text-white"
-              }`}
-            >
-              {filter}
-            </button>
-          ))}
+        <div className="mb-4 space-y-3">
+          <div className="flex flex-wrap gap-2">
+            {filters.map((filter) => (
+              <button
+                key={filter}
+                type="button"
+                onClick={() => onStatusFilterChange(filter)}
+                className={`border px-3 py-2 text-xs font-bold uppercase ${
+                  statusFilter === filter
+                    ? "border-white bg-white text-black"
+                    : "border-[#2a2c33] bg-[#141519] text-slate-500 hover:border-slate-500 hover:text-white"
+                }`}
+              >
+                {filter}
+              </button>
+            ))}
+          </div>
+          <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(220px,0.45fr)]">
+            <label className="min-w-0">
+              <span className="sr-only">Search jobs and prompts</span>
+              <input
+                type="search"
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder="Search prompts, users, or job IDs"
+                className="h-10 w-full border border-[#2a2c33] bg-[#141519] px-3 text-xs text-white outline-none placeholder:text-slate-600 focus:border-cyan-400"
+              />
+            </label>
+            <label className="min-w-0">
+              <span className="sr-only">Filter jobs by user</span>
+              <select
+                value={userFilter}
+                onChange={(event) => setUserFilter(event.target.value)}
+                className="h-10 w-full border border-[#2a2c33] bg-[#141519] px-3 text-xs font-bold text-slate-300 outline-none focus:border-cyan-400"
+              >
+                <option value="all">All users ({userOptions.length})</option>
+                {userOptions.map((user) => (
+                  <option key={user.id} value={user.id}>{user.label}</option>
+                ))}
+              </select>
+            </label>
+          </div>
         </div>
       )}
 
@@ -279,7 +338,7 @@ export function JobsPanel({
         </div>
       ) : (
         <div className="border border-[#2a2c33] bg-[#141519] p-5 text-sm leading-6 text-slate-500">
-          {emptyMessage}
+          {jobs.length && (searchQuery || userFilter !== "all") ? "No jobs match these user or prompt filters." : emptyMessage}
         </div>
       )}
 
@@ -324,6 +383,8 @@ export function JobRow({
   const isOpenable = hasChatTarget || hasProjectTarget;
   const imageStatusLabel = formatJobImageStatus(summary);
   const operations = getJobOperations(summary);
+  const ownerUserId = job.owner_user_id || job.payload?.owner_user_id || "";
+  const ownerLabel = job.owner_email || job.owner_display_name || ownerUserId || "Unknown user";
 
   return (
     <article className={`border border-[#2a2c33] bg-[#141519] ${compact ? "p-3" : "p-4"}`}>
@@ -347,6 +408,11 @@ export function JobRow({
               </span>
             )}
             <span className="min-w-0 max-w-full truncate text-[11px] font-bold text-slate-500">{job.sender} {"->"} {job.recipient}</span>
+            {ownerUserId && (
+              <span className="inline-flex max-w-full items-center truncate border border-sky-300/25 bg-sky-300/10 px-2 py-1 text-[11px] font-black text-sky-200" title={ownerUserId}>
+                {ownerLabel}
+              </span>
+            )}
           </div>
           <h3 className="truncate text-sm font-black text-white">{title}</h3>
           <p className="mt-2 line-clamp-2 break-words text-xs leading-5 text-slate-500">{prompt}</p>
@@ -364,7 +430,8 @@ export function JobRow({
       </div>
 
       {!compact && (
-        <div className="mt-4 grid gap-2 text-[11px] sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-8">
+        <div className="mt-4 grid gap-2 text-[11px] sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-9">
+          <JobMetric label="User" value={ownerLabel} />
           <JobMetric label="Job" value={job.job_id} />
           <JobMetric label="Created" value={formatJobTime(job.created_at)} />
           <JobMetric label="Duration" value={formatJobDuration(job)} />
@@ -374,6 +441,20 @@ export function JobRow({
           <JobMetric label="Valid" value={summary.is_valid === undefined ? "-" : summary.is_valid ? "yes" : "no"} />
           <JobMetric label="Image" value={imageStatusLabel} />
         </div>
+      )}
+
+      {!compact && prompt && (
+        <details className="mt-3 border border-[#25272e] bg-black/20 p-3">
+          <summary className="cursor-pointer text-[10px] font-black uppercase tracking-[0.14em] text-cyan-300">
+            View full user prompt
+          </summary>
+          <div className="mt-3 whitespace-pre-wrap break-words text-xs leading-5 text-slate-300">{prompt}</div>
+          {ownerUserId && (
+            <div className="mt-3 border-t border-white/10 pt-2 font-mono text-[10px] text-slate-600">
+              User ID: {ownerUserId}
+            </div>
+          )}
+        </details>
       )}
 
       <JobPipelineEventList events={job.progress_events || []} jobStatus={job.status} compact={compact} />
@@ -690,4 +771,3 @@ function formatJobDuration(job: A2AJob) {
   if (!job.started_at || !job.completed_at) return job.status === "running" ? "running" : "-";
   return formatDurationSeconds(durationSecondsBetween(job.started_at, job.completed_at));
 }
-

--- a/apps/web/app/blueprint-workspace/use-admin-data.ts
+++ b/apps/web/app/blueprint-workspace/use-admin-data.ts
@@ -32,6 +32,9 @@ export type A2AJob = {
   progress_events?: AgentPipelineEvent[];
   error?: string | null;
   error_debug?: Record<string, any> | null;
+  owner_user_id?: string | null;
+  owner_display_name?: string | null;
+  owner_email?: string | null;
 };
 
 export type BackendLogs = {
@@ -234,7 +237,7 @@ export function useJobs({
     setError(null);
 
     try {
-      const params = new URLSearchParams({ limit: "100" });
+      const params = new URLSearchParams({ limit: "200" });
       if (status !== "all") params.set("status", status);
       const nextJobs: A2AJob[] = [];
       const errors: string[] = [];

--- a/tests/api/test_admin_jobs.py
+++ b/tests/api/test_admin_jobs.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from apps.api.main import _admin_job_records, list_a2a_jobs
+from apps.api.auth import UserContext
+
+
+ADMIN = UserContext(
+    provider="clerk",
+    subject="admin_1",
+    owner_user_id="admin_1",
+    is_authenticated=True,
+    is_admin=True,
+    claims={"sub": "admin_1"},
+)
+
+
+class AdminJobsTests(unittest.TestCase):
+    def test_admin_job_records_expose_owner_and_profile_without_mutating_job(self) -> None:
+        job = {
+            "job_id": "job_1",
+            "payload": {"owner_user_id": "user_1", "prompt": "Build a weather station"},
+        }
+
+        with patch(
+            "apps.api.main.clerk_user_profile",
+            return_value={"display_name": "Ada", "email": "ada@example.com", "image_url": None},
+        ):
+            records = _admin_job_records([job])
+
+        self.assertNotIn("owner_user_id", job)
+        self.assertEqual("user_1", records[0]["owner_user_id"])
+        self.assertEqual("Ada", records[0]["owner_display_name"])
+        self.assertEqual("ada@example.com", records[0]["owner_email"])
+        self.assertEqual("Build a weather station", records[0]["payload"]["prompt"])
+
+    def test_admin_job_records_keep_unowned_jobs_visible(self) -> None:
+        records = _admin_job_records([{"job_id": "job_script", "payload": {"prompt": "Example"}}])
+
+        self.assertIsNone(records[0]["owner_user_id"])
+        self.assertIsNone(records[0]["owner_display_name"])
+        self.assertIsNone(records[0]["owner_email"])
+
+    def test_admin_jobs_endpoint_returns_enriched_records(self) -> None:
+        jobs = [{"job_id": "job_2", "payload": {"owner_user_id": "user_2", "prompt": "Make an alarm"}}]
+
+        with patch("apps.api.main.JOB_STORE.list_jobs", return_value=jobs) as list_jobs, patch(
+            "apps.api.main.clerk_user_profile", return_value=None
+        ):
+            response = list_a2a_jobs(sender=None, job_status="running", limit=25, _user=ADMIN)
+
+        list_jobs.assert_called_once_with(sender=None, status="running", limit=25)
+        self.assertEqual("user_2", response[0]["owner_user_id"])
+        self.assertEqual("Make an alarm", response[0]["payload"]["prompt"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- enrich admin-only job records with user IDs and optional profile labels
- add user filtering and search across prompts, users, and job IDs
- expose full user prompts within each admin job row
- increase the admin history window to 200 jobs
- keep the panel platform-neutral with no hosting or deployment configuration

## Security

Job owner details and prompts remain behind the existing server-side admin guard.

## Verification

- 36 targeted backend tests
- frontend ESLint (one pre-existing image warning, no errors)
- TypeScript type check
- production Next.js build