### PR TITLE
Prefer GitHub usernames in admin job identities

### DIFF
--- a/apps/api/auth.py
+++ b/apps/api/auth.py
@@ -166,6 +166,20 @@ def _display_name_from_clerk_user(user: Dict[str, Any]) -> Optional[str]:
     return _primary_email_local_part(user)
 
 
+def _github_username_from_clerk_user(user: Dict[str, Any]) -> Optional[str]:
+    external_accounts = user.get("external_accounts")
+    if not isinstance(external_accounts, list):
+        return None
+    for account in external_accounts:
+        if not isinstance(account, dict):
+            continue
+        provider = str(account.get("provider") or "").strip().lower()
+        username = account.get("username")
+        if provider in {"github", "oauth_github"} and isinstance(username, str) and username.strip():
+            return username.strip().lstrip("@") or None
+    return None
+
+
 @lru_cache(maxsize=512)
 def clerk_user_profile(user_id: str) -> Optional[Dict[str, Optional[str]]]:
     normalized_user_id = str(user_id or "").strip()
@@ -196,6 +210,7 @@ def clerk_user_profile(user_id: str) -> Optional[Dict[str, Optional[str]]]:
     return {
         "display_name": _display_name_from_clerk_user(payload),
         "email": _primary_email_address(payload),
+        "github_username": _github_username_from_clerk_user(payload),
         "image_url": image_url.strip() if isinstance(image_url, str) and image_url.strip().startswith(("http://", "https://")) else None,
     }
 

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -362,8 +362,13 @@ def _admin_job_records(jobs: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     for record in records:
         owner_user_id = record.get("owner_user_id")
         profile = profiles.get(owner_user_id) if isinstance(owner_user_id, str) else None
-        record["owner_display_name"] = profile.get("display_name") if profile else None
-        record["owner_email"] = profile.get("email") if profile else None
+        display_name = profile.get("display_name") if profile else None
+        email = profile.get("email") if profile else None
+        github_username = profile.get("github_username") if profile else None
+        record["owner_display_name"] = display_name
+        record["owner_email"] = email
+        record["owner_github_username"] = github_username
+        record["owner_username"] = github_username or email or display_name or owner_user_id
 
     return records
 

--- a/apps/web/app/blueprint-workspace/admin-panels.tsx
+++ b/apps/web/app/blueprint-workspace/admin-panels.tsx
@@ -214,7 +214,7 @@ export function JobsPanel({
       const id = job.owner_user_id || job.payload?.owner_user_id;
       if (typeof id !== "string" || !id.trim()) return;
       const normalizedId = id.trim();
-      const label = job.owner_email || job.owner_display_name || normalizedId;
+      const label = formatJobOwnerUsername(job) || normalizedId;
       users.set(normalizedId, { id: normalizedId, label });
     });
     return Array.from(users.values()).sort((left, right) => left.label.localeCompare(right.label));
@@ -231,6 +231,7 @@ export function JobsPanel({
         job.job_id,
         job.owner_display_name,
         job.owner_email,
+        job.owner_github_username,
         ownerUserId,
       ];
       return searchable.some((value) => String(value || "").toLowerCase().includes(query));
@@ -384,7 +385,7 @@ export function JobRow({
   const imageStatusLabel = formatJobImageStatus(summary);
   const operations = getJobOperations(summary);
   const ownerUserId = job.owner_user_id || job.payload?.owner_user_id || "";
-  const ownerLabel = job.owner_email || job.owner_display_name || ownerUserId || "Unknown user";
+  const ownerLabel = formatJobOwnerUsername(job) || ownerUserId || "Unknown user";
 
   return (
     <article className={`border border-[#2a2c33] bg-[#141519] ${compact ? "p-3" : "p-4"}`}>
@@ -500,6 +501,12 @@ export function JobRow({
       )}
     </article>
   );
+}
+
+function formatJobOwnerUsername(job: A2AJob) {
+  const githubUsername = String(job.owner_github_username || "").trim().replace(/^@+/, "");
+  if (githubUsername) return `@${githubUsername}`;
+  return String(job.owner_username || job.owner_email || job.owner_display_name || "").trim();
 }
 
 function getJobOperations(summary: Record<string, any>) {

--- a/apps/web/app/blueprint-workspace/use-admin-data.ts
+++ b/apps/web/app/blueprint-workspace/use-admin-data.ts
@@ -33,8 +33,10 @@ export type A2AJob = {
   error?: string | null;
   error_debug?: Record<string, any> | null;
   owner_user_id?: string | null;
+  owner_username?: string | null;
   owner_display_name?: string | null;
   owner_email?: string | null;
+  owner_github_username?: string | null;
 };
 
 export type BackendLogs = {

--- a/tests/api/test_admin_jobs.py
+++ b/tests/api/test_admin_jobs.py
@@ -26,15 +26,38 @@ class AdminJobsTests(unittest.TestCase):
 
         with patch(
             "apps.api.main.clerk_user_profile",
-            return_value={"display_name": "Ada", "email": "ada@example.com", "image_url": None},
+            return_value={
+                "display_name": "Ada Lovelace",
+                "email": "ada@example.com",
+                "github_username": "ada-l",
+                "image_url": None,
+            },
         ):
             records = _admin_job_records([job])
 
         self.assertNotIn("owner_user_id", job)
         self.assertEqual("user_1", records[0]["owner_user_id"])
-        self.assertEqual("Ada", records[0]["owner_display_name"])
+        self.assertEqual("Ada Lovelace", records[0]["owner_display_name"])
         self.assertEqual("ada@example.com", records[0]["owner_email"])
+        self.assertEqual("ada-l", records[0]["owner_github_username"])
+        self.assertEqual("ada-l", records[0]["owner_username"])
         self.assertEqual("Build a weather station", records[0]["payload"]["prompt"])
+
+    def test_admin_job_records_use_email_as_username_without_github(self) -> None:
+        job = {"job_id": "job_email", "payload": {"owner_user_id": "user_email"}}
+
+        with patch(
+            "apps.api.main.clerk_user_profile",
+            return_value={
+                "display_name": "Grace Hopper",
+                "email": "grace@example.com",
+                "github_username": None,
+                "image_url": None,
+            },
+        ):
+            records = _admin_job_records([job])
+
+        self.assertEqual("grace@example.com", records[0]["owner_username"])
 
     def test_admin_job_records_keep_unowned_jobs_visible(self) -> None:
         records = _admin_job_records([{"job_id": "job_script", "payload": {"prompt": "Example"}}])
@@ -42,6 +65,8 @@ class AdminJobsTests(unittest.TestCase):
         self.assertIsNone(records[0]["owner_user_id"])
         self.assertIsNone(records[0]["owner_display_name"])
         self.assertIsNone(records[0]["owner_email"])
+        self.assertIsNone(records[0]["owner_github_username"])
+        self.assertIsNone(records[0]["owner_username"])
 
     def test_admin_jobs_endpoint_returns_enriched_records(self) -> None:
         jobs = [{"job_id": "job_2", "payload": {"owner_user_id": "user_2", "prompt": "Make an alarm"}}]

--- a/tests/api/test_user_context.py
+++ b/tests/api/test_user_context.py
@@ -11,6 +11,7 @@ from starlette.requests import Request
 from apps.api.auth import (
     LOCAL_USER_ID,
     UserContext,
+    _github_username_from_clerk_user,
     optional_deployed_clerk_auth,
     optional_user_context,
     require_admin_user_context,
@@ -32,6 +33,21 @@ def request_with_authorization(value: str | None = None) -> Request:
 
 
 class UserContextTests(unittest.IsolatedAsyncioTestCase):
+    def test_extracts_github_username_from_clerk_external_account(self) -> None:
+        user = {
+            "external_accounts": [
+                {"provider": "oauth_google", "username": ""},
+                {"provider": "oauth_github", "username": "@octocat"},
+            ]
+        }
+
+        self.assertEqual("octocat", _github_username_from_clerk_user(user))
+
+    def test_ignores_non_github_external_username(self) -> None:
+        user = {"external_accounts": [{"provider": "oauth_google", "username": "google-user"}]}
+
+        self.assertIsNone(_github_username_from_clerk_user(user))
+
     async def test_local_mode_resolves_a_stable_authenticated_admin(self) -> None:
         request = request_with_authorization("Bearer ignored-in-local-mode")
 


### PR DESCRIPTION
## Summary

- extract GitHub usernames from Clerk external accounts
- use GitHub usernames as the preferred admin job identity
- use email addresses as the username when GitHub is unavailable
- retain display-name and user-ID fallbacks
- include GitHub usernames in admin job search

## Identity order

1. GitHub username
2. Email address
3. Display name
4. User ID

## Verification

- 29 targeted backend tests
- frontend ESLint
- TypeScript type check