### PR TITLE
Add job metrics to the admin panel

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1308,6 +1308,16 @@ def list_a2a_jobs(
     return _admin_job_records(JOB_STORE.list_jobs(sender=sender, status=job_status, limit=limit))
 
 
+@app.get("/a2a/jobs/metrics")
+def get_a2a_job_metrics(
+    days: int = Query(7, ge=1, le=31),
+    hours: int = Query(24, ge=1, le=168),
+    _user: UserContext = Depends(require_admin_user_context),
+):
+    """Returns aggregate job volume and failure metrics for administrators."""
+    return JOB_STORE.get_metrics(days=days, hours=hours)
+
+
 @app.get("/a2a/jobs/{job_id}")
 def get_a2a_job(job_id: str, user: UserContext = Depends(require_user_context)):
     """Fetches persisted metadata for one A2A job."""

--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -2127,6 +2127,8 @@ export function FormaWorkspace({
   const logsViewActive = canViewAdminTools && (homeView === "logs" || Boolean(projectIR && activeTab === "logs"));
   const {
     jobs: a2aJobs,
+    metrics: jobMetrics,
+    metricsError: jobMetricsError,
     loading: jobsLoading,
     error: jobsError,
     statusFilter: jobStatusFilter,
@@ -4782,6 +4784,8 @@ export function FormaWorkspace({
               {canViewJobs ? (
                 <JobsPanel
                   jobs={a2aJobs}
+                  metrics={jobMetrics}
+                  metricsError={jobMetricsError}
                   loading={jobsLoading}
                   error={jobsError}
                   statusFilter={jobStatusFilter}

--- a/apps/web/app/blueprint-workspace/admin-panels.tsx
+++ b/apps/web/app/blueprint-workspace/admin-panels.tsx
@@ -19,6 +19,8 @@ import {
   type A2AJob,
   type AgentPipelineEvent,
   type BackendLogs,
+  type JobMetricBucket,
+  type JobMetrics,
 } from "./use-admin-data";
 
 const DEFAULT_LOG_POLL_INTERVAL_MS = 5000;
@@ -171,6 +173,8 @@ export function LogsPanel({
 
 export function JobsPanel({
   jobs,
+  metrics,
+  metricsError,
   loading,
   error,
   statusFilter,
@@ -189,6 +193,8 @@ export function JobsPanel({
   formatLlmLabel,
 }: {
   jobs: A2AJob[];
+  metrics?: JobMetrics | null;
+  metricsError?: string | null;
   loading: boolean;
   error: string | null;
   statusFilter: string;
@@ -268,6 +274,8 @@ export function JobsPanel({
           <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
         </button>
       </div>
+
+      {!compact && <JobMetricsPanel metrics={metrics || null} error={metricsError || null} />}
 
       {!compact && (
         <div className="mb-4 space-y-3">
@@ -356,6 +364,114 @@ export function JobsPanel({
       )}
     </div>
   );
+}
+
+function JobMetricsPanel({ metrics, error }: { metrics: JobMetrics | null; error: string | null }) {
+  if (error && !metrics) {
+    return (
+      <div className="mb-4 border border-amber-500/30 bg-amber-950/20 p-3 text-xs text-amber-200">
+        {error}
+      </div>
+    );
+  }
+  if (!metrics) {
+    return <div className="mb-4 border border-[#2a2c33] bg-[#17181d] p-4 text-xs text-slate-500">Loading job metrics...</div>;
+  }
+
+  return (
+    <section className="mb-5 space-y-3" aria-label="Job metrics">
+      <div className="grid gap-2 sm:grid-cols-3">
+        <JobMetricSummary label="Jobs today" value={metrics.jobs_today} detail="UTC calendar day" />
+        <JobMetricSummary label="Jobs last hour" value={metrics.jobs_last_hour} detail="Rolling 60 minutes" />
+        <JobMetricSummary
+          label={`${metrics.window_days}-day failure rate`}
+          value={`${Number(metrics.failure_rate || 0).toFixed(1)}%`}
+          detail={`${metrics.failed_jobs} failed / ${metrics.completed_jobs} completed`}
+          danger={metrics.failure_rate > 0}
+        />
+      </div>
+      <div className="grid gap-3 xl:grid-cols-2">
+        <JobVolumeChart title="Jobs per day" buckets={metrics.daily} unit="day" />
+        <JobVolumeChart title="Jobs per hour" buckets={metrics.hourly} unit="hour" />
+      </div>
+      {error && <p className="text-[11px] text-amber-300">Showing the last available metrics. {error}</p>}
+    </section>
+  );
+}
+
+function JobMetricSummary({
+  label,
+  value,
+  detail,
+  danger = false,
+}: {
+  label: string;
+  value: string | number;
+  detail: string;
+  danger?: boolean;
+}) {
+  return (
+    <div className={`border bg-[#17181d] p-4 ${danger ? "border-rose-500/30" : "border-[#2a2c33]"}`}>
+      <div className="text-[10px] font-black uppercase tracking-[0.14em] text-slate-500">{label}</div>
+      <div className={`mt-2 text-2xl font-black ${danger ? "text-rose-300" : "text-white"}`}>{value}</div>
+      <div className="mt-1 text-[11px] text-slate-600">{detail}</div>
+    </div>
+  );
+}
+
+function JobVolumeChart({
+  title,
+  buckets,
+  unit,
+}: {
+  title: string;
+  buckets: JobMetricBucket[];
+  unit: "day" | "hour";
+}) {
+  const maximum = Math.max(1, ...buckets.map((bucket) => Number(bucket.count || 0)));
+  return (
+    <div className="min-w-0 border border-[#2a2c33] bg-[#17181d] p-4">
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <h3 className="text-[10px] font-black uppercase tracking-[0.14em] text-slate-400">{title}</h3>
+        <span className="text-[10px] text-slate-600">UTC</span>
+      </div>
+      <div className="flex h-28 items-end gap-1" role="img" aria-label={`${title} in UTC`}>
+        {buckets.map((bucket, index) => {
+          const count = Number(bucket.count || 0);
+          const height = count ? Math.max(6, Math.round((count / maximum) * 100)) : 2;
+          const showLabel = unit === "day" || index % 4 === 0 || index === buckets.length - 1;
+          return (
+            <div key={bucket.period} className="flex h-full min-w-0 flex-1 flex-col justify-end" title={`${formatMetricPeriod(bucket.period, unit)}: ${count} jobs`}>
+              <div className="mb-1 text-center text-[9px] font-bold text-slate-500">{count || ""}</div>
+              <div className="w-full bg-cyan-400/80" style={{ height: `${height}%` }} />
+              <div className="mt-2 truncate text-center text-[8px] text-slate-600">
+                {showLabel ? formatMetricAxisLabel(bucket.period, unit) : ""}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function formatMetricPeriod(value: string, unit: "day" | "hour") {
+  const date = new Date(unit === "day" ? `${value}T00:00:00Z` : value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString([], {
+    timeZone: "UTC",
+    month: "short",
+    day: "numeric",
+    ...(unit === "hour" ? { hour: "numeric", hour12: true } : {}),
+  });
+}
+
+function formatMetricAxisLabel(value: string, unit: "day" | "hour") {
+  const date = new Date(unit === "day" ? `${value}T00:00:00Z` : value);
+  if (Number.isNaN(date.getTime())) return value;
+  return unit === "day"
+    ? date.toLocaleDateString([], { timeZone: "UTC", weekday: "short" })
+    : date.toLocaleTimeString([], { timeZone: "UTC", hour: "numeric", hour12: true }).replace(" ", "");
 }
 
 export function JobRow({

--- a/apps/web/app/blueprint-workspace/use-admin-data.ts
+++ b/apps/web/app/blueprint-workspace/use-admin-data.ts
@@ -51,6 +51,26 @@ export type BackendLogs = {
   updated_at?: string;
 };
 
+export type JobMetricBucket = {
+  period: string;
+  count: number;
+};
+
+export type JobMetrics = {
+  generated_at: string;
+  timezone: string;
+  window_days: number;
+  window_hours: number;
+  total_jobs: number;
+  jobs_today: number;
+  jobs_last_hour: number;
+  completed_jobs: number;
+  failed_jobs: number;
+  failure_rate: number;
+  daily: JobMetricBucket[];
+  hourly: JobMetricBucket[];
+};
+
 export type HeaderFactory = () => HeadersInit | Promise<HeadersInit>;
 export type ApiErrorReader = (response: Response) => Promise<string>;
 
@@ -192,6 +212,8 @@ export type UseJobsOptions = ApiDependencies & {
 
 export type UseJobsResult = {
   jobs: A2AJob[];
+  metrics: JobMetrics | null;
+  metricsError: string | null;
   loading: boolean;
   error: string | null;
   statusFilter: string;
@@ -211,6 +233,8 @@ export function useJobs({
   initialStatusFilter = "all",
 }: UseJobsOptions): UseJobsResult {
   const [jobs, setJobs] = useState<A2AJob[]>([]);
+  const [metrics, setMetrics] = useState<JobMetrics | null>(null);
+  const [metricsError, setMetricsError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState(initialStatusFilter);
@@ -237,6 +261,7 @@ export function useJobs({
     const requestId = ++requestIdRef.current;
     if (!options.silent) setLoading(true);
     setError(null);
+    setMetricsError(null);
 
     try {
       const params = new URLSearchParams({ limit: "200" });
@@ -266,6 +291,20 @@ export function useJobs({
       } catch (requestError) {
         console.error("Error fetching example project object jobs", requestError);
         errors.push("example jobs");
+      }
+
+      try {
+        const response = await fetchWithTimeout(`${apiUrl}/a2a/jobs/metrics?days=7&hours=24`, {
+          headers: await getHeaders(),
+        });
+        if (!response.ok) throw new Error(`Job metrics endpoint returned ${response.status}`);
+        const payload = await response.json() as JobMetrics;
+        if (requestIdRef.current === requestId && enabledRef.current) setMetrics(payload);
+      } catch (requestError) {
+        console.error("Error fetching job metrics", requestError);
+        if (requestIdRef.current === requestId && enabledRef.current) {
+          setMetricsError("Job metrics are unavailable");
+        }
       }
 
       nextJobs.sort((left, right) => {
@@ -354,6 +393,8 @@ export function useJobs({
 
   return {
     jobs,
+    metrics,
+    metricsError,
     loading,
     error,
     statusFilter,

--- a/blueprint_core/jobs/metrics.py
+++ b/blueprint_core/jobs/metrics.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Iterable, Optional
+
+
+SUCCESS_STATUSES = {"succeeded", "success", "completed", "complete", "done"}
+FAILED_STATUSES = {"failed", "failure", "error"}
+
+
+def _utc_datetime(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _iso_hour(value: datetime) -> str:
+    return value.strftime("%Y-%m-%dT%H:00:00Z")
+
+
+def summarize_job_metrics(
+    rows: Iterable[Dict[str, Any]],
+    *,
+    now: Optional[datetime] = None,
+    days: int = 7,
+    hours: int = 24,
+) -> Dict[str, Any]:
+    """Aggregate persisted job timestamps into UTC admin dashboard metrics."""
+    current = now or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    current = current.astimezone(timezone.utc)
+    days = max(1, min(int(days), 31))
+    hours = max(1, min(int(hours), 168))
+
+    today = current.replace(hour=0, minute=0, second=0, microsecond=0)
+    daily_start = today - timedelta(days=days - 1)
+    current_hour = current.replace(minute=0, second=0, microsecond=0)
+    hourly_start = current_hour - timedelta(hours=hours - 1)
+    last_hour_start = current - timedelta(hours=1)
+
+    daily_counts = {
+        (daily_start + timedelta(days=index)).date().isoformat(): 0
+        for index in range(days)
+    }
+    hourly_counts = {
+        _iso_hour(hourly_start + timedelta(hours=index)): 0
+        for index in range(hours)
+    }
+    failed_jobs = 0
+    completed_jobs = 0
+    jobs_last_hour = 0
+
+    for row in rows:
+        created_at = _utc_datetime(row.get("created_at"))
+        if created_at is None or created_at > current:
+            continue
+
+        if created_at >= daily_start:
+            day_key = created_at.date().isoformat()
+            if day_key in daily_counts:
+                daily_counts[day_key] += 1
+            status = str(row.get("status") or "").strip().lower()
+            if status in SUCCESS_STATUSES:
+                completed_jobs += 1
+            elif status in FAILED_STATUSES:
+                completed_jobs += 1
+                failed_jobs += 1
+
+        if created_at >= hourly_start:
+            hour_key = _iso_hour(created_at.replace(minute=0, second=0, microsecond=0))
+            if hour_key in hourly_counts:
+                hourly_counts[hour_key] += 1
+
+        if created_at >= last_hour_start:
+            jobs_last_hour += 1
+
+    daily = [{"period": period, "count": count} for period, count in daily_counts.items()]
+    hourly = [{"period": period, "count": count} for period, count in hourly_counts.items()]
+    return {
+        "generated_at": current.isoformat(timespec="seconds").replace("+00:00", "Z"),
+        "timezone": "UTC",
+        "window_days": days,
+        "window_hours": hours,
+        "total_jobs": sum(daily_counts.values()),
+        "jobs_today": daily_counts.get(today.date().isoformat(), 0),
+        "jobs_last_hour": jobs_last_hour,
+        "completed_jobs": completed_jobs,
+        "failed_jobs": failed_jobs,
+        "failure_rate": round((failed_jobs / completed_jobs) * 100, 1) if completed_jobs else 0.0,
+        "daily": daily,
+        "hourly": hourly,
+    }
+
+
+__all__ = ["FAILED_STATUSES", "SUCCESS_STATUSES", "summarize_job_metrics"]

--- a/blueprint_core/jobs/repositories.py
+++ b/blueprint_core/jobs/repositories.py
@@ -81,6 +81,8 @@ class JobRepository(Protocol):
 
     def list(self, *, sender: Optional[str], status: Optional[str], limit: int) -> List[Dict[str, Any]]: ...
 
+    def list_metric_rows(self, *, created_since: str) -> List[Dict[str, Any]]: ...
+
     def list_for_project(self, project_id: str) -> List[Dict[str, Any]]: ...
 
     def delete_for_project(self, project_id: str) -> int: ...
@@ -186,6 +188,27 @@ class SupabaseJobRepository:
             query = query.eq("status", status)
         rows = query.order("created_at", desc=True).limit(limit).execute().data or []
         return [_row_to_dict(row) for row in rows]
+
+    def list_metric_rows(self, *, created_since: str) -> List[Dict[str, Any]]:
+        records: List[Dict[str, Any]] = []
+        offset = 0
+        batch_size = 1000
+        while True:
+            rows = (
+                self._client.table("a2a_jobs")
+                .select("status,created_at")
+                .gte("created_at", created_since)
+                .order("created_at")
+                .range(offset, offset + batch_size - 1)
+                .execute()
+                .data
+                or []
+            )
+            records.extend(dict(row) for row in rows)
+            if len(rows) < batch_size:
+                break
+            offset += batch_size
+        return records
 
     def update_status(self, job_id: str, status: str, now: str) -> None:
         self._client.table("a2a_jobs").update(
@@ -338,6 +361,14 @@ class SQLiteJobRepository:
                 parameters,
             ).fetchall()
         return [_row_to_dict(row) for row in rows]
+
+    def list_metric_rows(self, *, created_since: str) -> List[Dict[str, Any]]:
+        with closing(self._provider.connect_dbapi()) as connection:
+            rows = connection.execute(
+                "SELECT status, created_at FROM a2a_jobs WHERE created_at >= ? ORDER BY created_at",
+                (created_since,),
+            ).fetchall()
+        return [dict(row) for row in rows]
 
     def update_status(self, job_id: str, status: str, now: str) -> None:
         with self._locked_connection() as connection:

--- a/blueprint_core/jobs/store.py
+++ b/blueprint_core/jobs/store.py
@@ -1,10 +1,11 @@
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from dotenv import load_dotenv
 
+from blueprint_core.jobs.metrics import summarize_job_metrics
 from blueprint_core.jobs.repositories import (
     JobCancelledError,
     JobRepository,
@@ -335,6 +336,16 @@ class JobMetadataStore:
         limit = max(1, min(limit, 200))
         assert self._repository is not None
         return self._repository.list(sender=sender, status=status, limit=limit)
+
+    def get_metrics(self, *, days: int = 7, hours: int = 24) -> Dict[str, Any]:
+        """Return UTC job-volume and failure metrics for the admin dashboard."""
+        self.init_db()
+        now = datetime.now(timezone.utc)
+        lookback_days = max(max(1, min(days, 31)), (max(1, min(hours, 168)) + 23) // 24)
+        created_since = (now - timedelta(days=lookback_days + 1)).isoformat().replace("+00:00", "Z")
+        assert self._repository is not None
+        rows = self._repository.list_metric_rows(created_since=created_since)
+        return summarize_job_metrics(rows, now=now, days=days, hours=hours)
 
     def list_project_jobs(self, project_id: str) -> List[Dict[str, Any]]:
         """Return every persisted job whose payload or result references a project."""

--- a/tests/api/test_admin_jobs.py
+++ b/tests/api/test_admin_jobs.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import unittest
 from unittest.mock import patch
 
-from apps.api.main import _admin_job_records, list_a2a_jobs
+from apps.api.main import _admin_job_records, get_a2a_job_metrics, list_a2a_jobs
 from apps.api.auth import UserContext
 
 
@@ -79,6 +79,15 @@ class AdminJobsTests(unittest.TestCase):
         list_jobs.assert_called_once_with(sender=None, status="running", limit=25)
         self.assertEqual("user_2", response[0]["owner_user_id"])
         self.assertEqual("Make an alarm", response[0]["payload"]["prompt"])
+
+    def test_admin_job_metrics_endpoint_delegates_bounded_windows(self) -> None:
+        metrics = {"jobs_today": 3, "jobs_last_hour": 1, "failure_rate": 25.0}
+
+        with patch("apps.api.main.JOB_STORE.get_metrics", return_value=metrics) as get_metrics:
+            response = get_a2a_job_metrics(days=7, hours=24, _user=ADMIN)
+
+        get_metrics.assert_called_once_with(days=7, hours=24)
+        self.assertEqual(metrics, response)
 
 
 if __name__ == "__main__":

--- a/tests/jobs/test_job_metrics.py
+++ b/tests/jobs/test_job_metrics.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+import tempfile
+
+from blueprint_core.jobs.metrics import summarize_job_metrics
+from blueprint_core.jobs.store import JobMetadataStore
+
+
+class JobMetricsTests(unittest.TestCase):
+    def test_sqlite_job_store_reports_persisted_metrics(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".db") as file:
+            store = JobMetadataStore(file.name, backend="sqlite")
+            for job_id in ("job_success", "job_failure"):
+                store.create_job(
+                    job_id=job_id,
+                    message_id=f"message_{job_id}",
+                    correlation_id=None,
+                    action="blueprint.generate_project",
+                    sender="frontend",
+                    recipient="blueprint",
+                    payload={"prompt": job_id},
+                    server_owned=True,
+                )
+            store.mark_succeeded("job_success", {"project_ir": {}})
+            store.mark_failed("job_failure", "provider failed")
+
+            metrics = store.get_metrics(days=7, hours=24)
+
+        self.assertEqual(2, metrics["jobs_today"])
+        self.assertEqual(2, metrics["jobs_last_hour"])
+        self.assertEqual(2, metrics["completed_jobs"])
+        self.assertEqual(1, metrics["failed_jobs"])
+        self.assertEqual(50.0, metrics["failure_rate"])
+
+    def test_summarizes_daily_hourly_and_failure_metrics(self) -> None:
+        now = datetime(2026, 8, 9, 12, 30, tzinfo=timezone.utc)
+        rows = [
+            {"created_at": "2026-08-09T12:15:00Z", "status": "succeeded"},
+            {"created_at": "2026-08-09T11:45:00Z", "status": "failed"},
+            {"created_at": "2026-08-08T10:00:00Z", "status": "failed"},
+            {"created_at": "2026-08-03T09:00:00Z", "status": "completed"},
+            {"created_at": "2026-08-01T09:00:00Z", "status": "failed"},
+            {"created_at": "2026-08-09T09:00:00Z", "status": "queued"},
+            {"created_at": "2026-08-09T10:00:00Z", "status": "cancelled"},
+            {"created_at": "not-a-time", "status": "failed"},
+            {"created_at": "2026-08-09T13:00:00Z", "status": "failed"},
+        ]
+
+        metrics = summarize_job_metrics(rows, now=now, days=7, hours=24)
+
+        self.assertEqual(6, metrics["total_jobs"])
+        self.assertEqual(4, metrics["jobs_today"])
+        self.assertEqual(2, metrics["jobs_last_hour"])
+        self.assertEqual(4, metrics["completed_jobs"])
+        self.assertEqual(2, metrics["failed_jobs"])
+        self.assertEqual(50.0, metrics["failure_rate"])
+        self.assertEqual(1, metrics["daily"][0]["count"])
+        self.assertEqual(4, metrics["daily"][-1]["count"])
+        self.assertEqual(4, sum(bucket["count"] for bucket in metrics["hourly"]))
+        self.assertEqual("2026-08-09T12:00:00Z", metrics["hourly"][-1]["period"])
+
+    def test_empty_metrics_have_zero_failure_rate_and_complete_buckets(self) -> None:
+        metrics = summarize_job_metrics(
+            [],
+            now=datetime(2026, 8, 9, 12, 30, tzinfo=timezone.utc),
+            days=3,
+            hours=4,
+        )
+
+        self.assertEqual(0.0, metrics["failure_rate"])
+        self.assertEqual(3, len(metrics["daily"]))
+        self.assertEqual(4, len(metrics["hourly"]))
+        self.assertTrue(all(bucket["count"] == 0 for bucket in metrics["daily"] + metrics["hourly"]))
+
+    def test_metric_windows_are_bounded(self) -> None:
+        metrics = summarize_job_metrics([], days=100, hours=1000)
+
+        self.assertEqual(31, metrics["window_days"])
+        self.assertEqual(168, metrics["window_hours"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add an admin-only aggregate job metrics endpoint
- show jobs today and jobs in the rolling last hour
- chart seven days of daily job volume
- chart 24 hours of hourly job volume
- calculate failure rate as failed jobs divided by succeeded-plus-failed jobs
- aggregate the complete metric window independently of visible job filters
- support both SQLite and Supabase job repositories

## Verification

- 34 targeted backend tests
- SQLite-backed metrics integration test
- frontend ESLint and TypeScript checks
- production Next.js build

Closes #248