### PR TITLE
Sort jobs by last occurrence

### DIFF
--- a/apps/web/app/blueprint-workspace/admin-panels.tsx
+++ b/apps/web/app/blueprint-workspace/admin-panels.tsx
@@ -22,6 +22,12 @@ import {
   type JobMetricBucket,
   type JobMetrics,
 } from "./use-admin-data";
+import {
+  ADMIN_JOB_SORT_OPTIONS,
+  adminJobLastOccurredAt,
+  sortAdminJobs,
+  type AdminJobSortMode,
+} from "../../lib/admin-job-sort";
 
 const DEFAULT_LOG_POLL_INTERVAL_MS = 5000;
 
@@ -214,6 +220,7 @@ export function JobsPanel({
 }) {
   const [userFilter, setUserFilter] = useState("all");
   const [searchQuery, setSearchQuery] = useState("");
+  const [sortMode, setSortMode] = useState<AdminJobSortMode>("last_occurred_desc");
   const userOptions = useMemo(() => {
     const users = new Map<string, { id: string; label: string }>();
     jobs.forEach((job) => {
@@ -243,7 +250,8 @@ export function JobsPanel({
       return searchable.some((value) => String(value || "").toLowerCase().includes(query));
     });
   }, [jobs, searchQuery, userFilter]);
-  const visibleJobs = compact ? filteredJobs.slice(0, 2) : filteredJobs;
+  const sortedJobs = useMemo(() => sortAdminJobs(filteredJobs, sortMode), [filteredJobs, sortMode]);
+  const visibleJobs = compact ? sortedJobs.slice(0, 2) : sortedJobs;
   const filters = ["all", "queued", "running", "succeeded", "failed"];
   const panelDescription = description || `Generation and example job metadata. Polling every ${Math.round(pollIntervalMs / 1000)}s.`;
 
@@ -295,7 +303,7 @@ export function JobsPanel({
               </button>
             ))}
           </div>
-          <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(220px,0.45fr)]">
+          <div className="grid gap-2 md:grid-cols-[minmax(0,1fr)_minmax(190px,0.35fr)_minmax(190px,0.35fr)]">
             <label className="min-w-0">
               <span className="sr-only">Search jobs and prompts</span>
               <input
@@ -316,6 +324,18 @@ export function JobsPanel({
                 <option value="all">All users ({userOptions.length})</option>
                 {userOptions.map((user) => (
                   <option key={user.id} value={user.id}>{user.label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="min-w-0">
+              <span className="sr-only">Sort jobs</span>
+              <select
+                value={sortMode}
+                onChange={(event) => setSortMode(event.target.value as AdminJobSortMode)}
+                className="h-10 w-full border border-[#2a2c33] bg-[#141519] px-3 text-xs font-bold text-slate-300 outline-none focus:border-cyan-400"
+              >
+                {ADMIN_JOB_SORT_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
                 ))}
               </select>
             </label>
@@ -502,6 +522,7 @@ export function JobRow({
   const operations = getJobOperations(summary);
   const ownerUserId = job.owner_user_id || job.payload?.owner_user_id || "";
   const ownerLabel = formatJobOwnerUsername(job) || ownerUserId || "Unknown user";
+  const lastOccurredAt = adminJobLastOccurredAt(job);
 
   return (
     <article className={`border border-[#2a2c33] bg-[#141519] ${compact ? "p-3" : "p-4"}`}>
@@ -547,10 +568,11 @@ export function JobRow({
       </div>
 
       {!compact && (
-        <div className="mt-4 grid gap-2 text-[11px] sm:grid-cols-2 lg:grid-cols-4 xl:grid-cols-9">
+        <div className="mt-4 grid gap-2 text-[11px] sm:grid-cols-2 lg:grid-cols-5 xl:grid-cols-10">
           <JobMetric label="User" value={ownerLabel} />
           <JobMetric label="Job" value={job.job_id} />
           <JobMetric label="Created" value={formatJobTime(job.created_at)} />
+          <JobMetric label="Last occurred" value={formatJobTime(lastOccurredAt)} />
           <JobMetric label="Duration" value={formatJobDuration(job)} />
           <JobMetric label="Source" value={sourceLabel} />
           <JobMetric label="LLM" value={llmInfo.label} />

--- a/apps/web/lib/admin-job-sort.ts
+++ b/apps/web/lib/admin-job-sort.ts
@@ -1,0 +1,56 @@
+export type AdminJobSortMode =
+  | "last_occurred_desc"
+  | "last_occurred_asc"
+  | "created_desc"
+  | "created_asc";
+
+export type SortableAdminJob = {
+  job_id: string;
+  created_at?: string | null;
+  updated_at?: string | null;
+  started_at?: string | null;
+  completed_at?: string | null;
+};
+
+export const ADMIN_JOB_SORT_OPTIONS: Array<{ value: AdminJobSortMode; label: string }> = [
+  { value: "last_occurred_desc", label: "Last occurred: recent" },
+  { value: "last_occurred_asc", label: "Last occurred: oldest" },
+  { value: "created_desc", label: "Created: newest" },
+  { value: "created_asc", label: "Created: oldest" },
+];
+
+function timestampMs(value?: string | null): number | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  const valueMs = new Date(value).getTime();
+  return Number.isNaN(valueMs) ? null : valueMs;
+}
+
+export function adminJobLastOccurredMs(job: SortableAdminJob): number | null {
+  const timestamps = [job.created_at, job.started_at, job.updated_at, job.completed_at]
+    .map(timestampMs)
+    .filter((value): value is number => value !== null);
+  return timestamps.length ? Math.max(...timestamps) : null;
+}
+
+export function adminJobLastOccurredAt(job: SortableAdminJob): string | null {
+  const occurredMs = adminJobLastOccurredMs(job);
+  return occurredMs === null ? null : new Date(occurredMs).toISOString();
+}
+
+function compareOptionalTimestamps(left: number | null, right: number | null, ascending: boolean) {
+  if (left === null && right === null) return 0;
+  if (left === null) return 1;
+  if (right === null) return -1;
+  return ascending ? left - right : right - left;
+}
+
+export function sortAdminJobs<T extends SortableAdminJob>(jobs: T[], mode: AdminJobSortMode): T[] {
+  const ascending = mode.endsWith("_asc");
+  const byCreated = mode.startsWith("created_");
+  return [...jobs].sort((left, right) => {
+    const leftTimestamp = byCreated ? timestampMs(left.created_at) : adminJobLastOccurredMs(left);
+    const rightTimestamp = byCreated ? timestampMs(right.created_at) : adminJobLastOccurredMs(right);
+    const timestampOrder = compareOptionalTimestamps(leftTimestamp, rightTimestamp, ascending);
+    return timestampOrder || left.job_id.localeCompare(right.job_id);
+  });
+}

--- a/apps/web/test/admin-job-sort.test.mjs
+++ b/apps/web/test/admin-job-sort.test.mjs
@@ -1,0 +1,63 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  adminJobLastOccurredAt,
+  sortAdminJobs,
+} from "../lib/admin-job-sort.ts";
+
+const jobs = [
+  {
+    job_id: "old-created-recent-update",
+    created_at: "2026-08-01T10:00:00Z",
+    updated_at: "2026-08-09T12:00:00Z",
+  },
+  {
+    job_id: "new-created",
+    created_at: "2026-08-08T10:00:00Z",
+    updated_at: "2026-08-08T10:00:00Z",
+  },
+  { job_id: "unknown-time", created_at: "invalid" },
+];
+
+test("last occurred uses the latest lifecycle timestamp", () => {
+  assert.equal(adminJobLastOccurredAt({
+    job_id: "completed",
+    created_at: "2026-08-01T10:00:00Z",
+    started_at: "2026-08-01T10:01:00Z",
+    updated_at: "2026-08-01T10:02:00Z",
+    completed_at: "2026-08-01T10:03:00Z",
+  }), "2026-08-01T10:03:00.000Z");
+});
+
+test("recent last occurrence moves updated jobs ahead of newer created jobs", () => {
+  const sorted = sortAdminJobs(jobs, "last_occurred_desc");
+
+  assert.deepEqual(sorted.map((job) => job.job_id), [
+    "old-created-recent-update",
+    "new-created",
+    "unknown-time",
+  ]);
+});
+
+test("last occurred supports oldest-first ordering and keeps missing dates last", () => {
+  const sorted = sortAdminJobs(jobs, "last_occurred_asc");
+
+  assert.deepEqual(sorted.map((job) => job.job_id), [
+    "new-created",
+    "old-created-recent-update",
+    "unknown-time",
+  ]);
+});
+
+test("created ordering is available and does not mutate the input", () => {
+  const originalOrder = jobs.map((job) => job.job_id);
+  const sorted = sortAdminJobs(jobs, "created_desc");
+
+  assert.deepEqual(sorted.map((job) => job.job_id), [
+    "new-created",
+    "old-created-recent-update",
+    "unknown-time",
+  ]);
+  assert.deepEqual(jobs.map((job) => job.job_id), originalOrder);
+});


### PR DESCRIPTION
## Summary

- add Last occurred as the default Jobs-page ordering
- calculate last occurrence from the latest created, started, updated, or completed timestamp
- add recent-first and oldest-first last-occurrence options
- retain created-newest and created-oldest alternatives
- show the computed last occurrence on each job row
- keep missing or invalid timestamps at the bottom

## Verification

- 4 focused ordering tests
- frontend ESLint and TypeScript checks
- production Next.js build

Closes #249