### PR TITLE
Fix the stretched empty home chat layout

### DIFF
--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -1616,6 +1616,7 @@ export function FormaWorkspace({
   const contextBuildWatchersRef = useRef<Set<string>>(new Set());
   const [contextWorkflowStates, setContextWorkflowStates] = useState<Record<string, string>>({});
   const [contextSkipping, setContextSkipping] = useState(false);
+  const [contextSubmitting, setContextSubmitting] = useState(false);
   const [chatThreads, setChatThreads] = useState<Record<string, ChatMessage[]>>({});
   const [projectChatInput, setProjectChatInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -3214,7 +3215,7 @@ export function FormaWorkspace({
 
   const handleGatherContext = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (isLoading || activeGenerationRef.current) return;
+    if (contextSubmitting || activeGenerationRef.current) return;
     if (!(await requireSignedInForGeneration())) return;
 
     const validation = validateGenerationInput(prompt, Boolean(selectedImage));
@@ -3253,8 +3254,7 @@ export function FormaWorkspace({
     setSelectedImage(null);
     setSelectedImageSource("upload");
     setGenerationInputNotice(null);
-    setIsLoading(true);
-    let contextBuildStarted = false;
+    setContextSubmitting(true);
 
     try {
       const res = await fetch(`${API_URL}/projects/${encodeURIComponent(requestProjectId)}/context/messages`, {
@@ -3332,7 +3332,6 @@ export function FormaWorkspace({
             : null,
       );
       if (buildPlanId && buildJobId && persistedProjectId) {
-        contextBuildStarted = true;
         const run = beginContextBuildRun(
           persistedProjectId,
           buildPlanId,
@@ -3355,12 +3354,12 @@ export function FormaWorkspace({
       updateThreadMessage(requestChatId, assistantMessageId, { content: message, status: "error" });
       setGenerationInputNotice(message);
     } finally {
-      if (!contextBuildStarted) setIsLoading(false);
+      setContextSubmitting(false);
     }
   };
 
   const handleSkipContextGathering = async () => {
-    if (contextSkipping || isLoading) return;
+    if (contextSkipping || contextSubmitting || activeGenerationRef.current) return;
     const requestChatId = activeChatId;
     const availableMessages = requestChatId
       ? chatThreads[requestChatId] || chatMessages
@@ -3378,7 +3377,6 @@ export function FormaWorkspace({
 
     setContextSkipping(true);
     setGenerationInputNotice(null);
-    let contextBuildStarted = false;
     try {
       const response = await fetch(`${API_URL}/projects/${encodeURIComponent(projectId)}/context/messages`, {
         method: "POST",
@@ -3430,7 +3428,6 @@ export function FormaWorkspace({
         buildIsActive ? "Build started. Live agent progress is shown above." : "Design ready for review.",
       );
       if (buildPlanId && buildJobId) {
-        contextBuildStarted = true;
         const run = beginContextBuildRun(projectId, buildPlanId, buildJobId, requestChatId, message.id);
         watchContextBuild(projectId, buildPlanId, buildJobId, requestChatId, message.id, run);
       }
@@ -3438,7 +3435,6 @@ export function FormaWorkspace({
       setGenerationInputNotice(error instanceof Error ? error.message : "Could not skip context gathering.");
     } finally {
       setContextSkipping(false);
-      if (!contextBuildStarted) setIsLoading(false);
     }
   };
 
@@ -4877,7 +4873,7 @@ export function FormaWorkspace({
               })()}
               contextSkipping={contextSkipping}
               onSkipContext={handleSkipContextGathering}
-              isLoading={isLoading}
+              isLoading={contextSubmitting || Boolean(activeGeneration || pendingContextBuildMessage)}
               generationReady
               needsGenerationProvider={false}
               needsImageProvider={false}

--- a/apps/web/app/blueprint-workspace/home-chat-view.tsx
+++ b/apps/web/app/blueprint-workspace/home-chat-view.tsx
@@ -106,7 +106,7 @@ export default function HomeChatView({
     <section
       className={`${
         !started
-          ? "fixed bottom-[224px] left-0 right-0 top-[3.75rem] z-10 max-w-none md:static md:inset-auto md:z-auto md:w-full md:max-w-none"
+          ? "fixed bottom-[224px] left-0 right-0 top-[3.75rem] z-10 max-w-none md:static md:inset-auto md:z-auto md:w-full md:max-w-none md:justify-center md:px-6 md:py-8"
           : "w-full max-w-none"
       } flex min-h-0 flex-1 flex-col text-center`}
     >
@@ -121,7 +121,13 @@ export default function HomeChatView({
         </div>
       )}
 
-      <div className={`${started ? "mt-0" : "mt-4 sm:mt-5"} flex min-h-0 flex-1 flex-col overflow-hidden border-y border-[#2c2f37] bg-[#111216] text-left shadow-2xl shadow-black/30`}>
+      <div
+        className={`${
+          started
+            ? "mt-0 flex-1 overflow-hidden"
+            : "mt-4 flex-1 overflow-hidden sm:mt-5 md:mx-auto md:w-full md:max-w-5xl md:flex-none md:overflow-visible md:border"
+        } flex min-h-0 flex-col border-y border-[#2c2f37] bg-[#111216] text-left shadow-2xl shadow-black/30`}
+      >
         {started && (
           <div className="min-h-0 flex-1 space-y-4 overflow-x-hidden overflow-y-auto px-3 py-4 sm:px-4 sm:py-5">
             {messages.map((message) => {
@@ -192,7 +198,7 @@ export default function HomeChatView({
         )}
 
         {!started && (
-          <div className="mt-auto shrink-0 bg-[#111216] px-3 py-3 sm:border-t sm:border-[#2c2f37] sm:px-4">
+          <div className="mt-auto shrink-0 bg-[#111216] px-3 py-3 sm:border-t sm:border-[#2c2f37] sm:px-4 md:mt-0">
             <div className="flex snap-x gap-2 overflow-x-auto pb-1 sm:flex-wrap sm:overflow-visible sm:pb-0">
               {examples.map((example) => (
                 <button
@@ -208,7 +214,10 @@ export default function HomeChatView({
           </div>
         )}
 
-        <form onSubmit={onSubmit} className="fixed bottom-0 left-0 right-0 z-30 max-h-[calc(100dvh-3rem)] shrink-0 overflow-y-auto overscroll-contain border-y border-[#2c2f37] bg-[#141519]/95 p-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] backdrop-blur sm:p-4 md:sticky md:bottom-0 md:left-auto md:right-auto md:z-20 md:max-h-none md:overflow-visible md:border-b-0 md:pb-4">
+        <form
+          onSubmit={onSubmit}
+          className={`${started ? "md:sticky md:bottom-0" : "md:static"} fixed bottom-0 left-0 right-0 z-30 max-h-[calc(100dvh-3rem)] shrink-0 overflow-y-auto overscroll-contain border-y border-[#2c2f37] bg-[#141519]/95 p-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] backdrop-blur sm:p-4 md:left-auto md:right-auto md:z-20 md:max-h-none md:overflow-visible md:border-b-0 md:pb-4`}
+        >
           {(needsGenerationProvider || needsImageProvider) && (
             <section className="mb-3 border border-cyan-300/30 bg-cyan-300/5 p-3 text-left sm:p-4" aria-label="Bring your own key setup">
               <div className="flex flex-wrap items-start justify-between gap-3">


### PR DESCRIPTION
## Summary

- keep the desktop empty chat state compact, centered, and width-constrained instead of stretching an empty panel across the viewport
- keep the existing fixed mobile composer and the sticky composer after a chat starts
- separate context-submission busy state from general project loading so unrelated loading cannot show a spinner or disable the home-chat composer
- avoid clearing an active build loading state when context gathering or skipping finishes

## Validation

- `./scripts/quality/test.sh` (493 passed, 1 skipped)
- `npm run lint` (passes with 7 existing `no-img-element` warnings)
- `npm run build`

This is intentionally separate from #252.