### PR TITLE
Fix missing generation jobs and improve job diagnostics

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -89,6 +89,7 @@ from blueprint_core.database import (
     list_generated_projects,
     list_latest_project_revisions,
     list_project_deletion_audits,
+    list_project_generation_jobs,
     save_alpha_signup,
     update_generated_project_metadata,
     update_generated_project_hardware_ir,
@@ -1305,7 +1306,11 @@ def list_a2a_jobs(
     _user: UserContext = Depends(require_admin_user_context),
 ):
     """Lists persisted A2A job metadata."""
-    return _admin_job_records(JOB_STORE.list_jobs(sender=sender, status=job_status, limit=limit))
+    jobs = JOB_STORE.list_jobs(sender=sender, status=job_status, limit=limit)
+    if sender in {None, "conversation"}:
+        jobs.extend(list_project_generation_jobs(status=job_status, limit=limit))
+    jobs.sort(key=lambda item: str(item.get("created_at") or item.get("updated_at") or ""), reverse=True)
+    return _admin_job_records(jobs[:limit])
 
 
 @app.get("/a2a/jobs/metrics")
@@ -1315,7 +1320,11 @@ def get_a2a_job_metrics(
     _user: UserContext = Depends(require_admin_user_context),
 ):
     """Returns aggregate job volume and failure metrics for administrators."""
-    return JOB_STORE.get_metrics(days=days, hours=hours)
+    return JOB_STORE.get_metrics(
+        days=days,
+        hours=hours,
+        additional_rows=list_project_generation_jobs(limit=1000),
+    )
 
 
 @app.get("/a2a/jobs/{job_id}")

--- a/blueprint_core/database.py
+++ b/blueprint_core/database.py
@@ -874,6 +874,83 @@ def get_project_generation_plan(plan_id: str, owner_user_id: str):
     return orchestrator.get_plan(plan_id, owner)
 
 
+def list_project_generation_jobs(
+    *,
+    status: Optional[str] = None,
+    limit: int = 200,
+) -> List[Dict[str, Any]]:
+    """Project durable generation-plan tasks in the admin job record shape."""
+
+    from blueprint_core.workers import OrchestrationTaskStatus, WorkerExecutionPlan
+
+    normalized_status = str(status or "").strip().lower()
+    records = _DATABASE_REPOSITORY.list_worker_execution_plans(limit=limit)
+    jobs: List[Dict[str, Any]] = []
+    for record in records:
+        state = getattr(record, "state_json", None)
+        if not isinstance(state, dict):
+            logger.warning("Skipping worker execution plan with invalid state_json.")
+            continue
+        try:
+            plan = WorkerExecutionPlan.model_validate(state)
+        except Exception:
+            logger.exception("Skipping invalid worker execution plan while listing admin jobs.")
+            continue
+
+        for job_id, task in plan.jobs.items():
+            job_status = task.status.value
+            if task.status == OrchestrationTaskStatus.BLOCKED:
+                job_status = "failed"
+            if normalized_status and normalized_status != "all" and normalized_status != job_status:
+                continue
+
+            brief = task.request.payload.get("design_brief")
+            brief = brief if isinstance(brief, dict) else {}
+            progress_events = [
+                event
+                for progress in task.progress
+                for event in [progress.metadata.get("pipeline_event")]
+                if isinstance(event, dict)
+            ]
+            error = task.error.message if task.error is not None else None
+            completed_at = task.completed_at or (task.result.completed_at if task.result else None)
+            jobs.append(
+                {
+                    "job_id": job_id,
+                    "message_id": plan.plan_id,
+                    "correlation_id": plan.correlation_id,
+                    "action": "blueprint.generate_project",
+                    "sender": "conversation",
+                    "recipient": task.request.worker_id,
+                    "status": job_status,
+                    "server_owned": True,
+                    "created_at": plan.created_at.isoformat(),
+                    "updated_at": plan.updated_at.isoformat(),
+                    "started_at": task.started_at.isoformat() if task.started_at else None,
+                    "completed_at": completed_at.isoformat() if completed_at else None,
+                    "payload": {
+                        "owner_user_id": plan.owner_user_id,
+                        "project_id": plan.project_id,
+                        "prompt": brief.get("intent") or brief.get("summary"),
+                        "design_brief_id": str(task.request.design_brief_id),
+                        "design_brief_version": task.request.design_brief_version,
+                    },
+                    "result_summary": {
+                        "project_id": plan.project_id,
+                        "title": brief.get("summary") or brief.get("intent"),
+                        "workflow": "default",
+                    },
+                    "source_usage": {"workflow": "default", "source_labels": ["Conversation"]},
+                    "progress_events": progress_events,
+                    "error": error,
+                    "error_debug": task.error.model_dump(mode="json") if task.error is not None else None,
+                }
+            )
+            if len(jobs) >= limit:
+                return jobs
+    return jobs
+
+
 async def execute_project_generation_plan(
     plan_id: str,
     owner_user_id: str,

--- a/blueprint_core/jobs/repositories.py
+++ b/blueprint_core/jobs/repositories.py
@@ -196,7 +196,7 @@ class SupabaseJobRepository:
         while True:
             rows = (
                 self._client.table("a2a_jobs")
-                .select("status,created_at")
+                .select("job_id,status,created_at")
                 .gte("created_at", created_since)
                 .order("created_at")
                 .range(offset, offset + batch_size - 1)
@@ -365,7 +365,7 @@ class SQLiteJobRepository:
     def list_metric_rows(self, *, created_since: str) -> List[Dict[str, Any]]:
         with closing(self._provider.connect_dbapi()) as connection:
             rows = connection.execute(
-                "SELECT status, created_at FROM a2a_jobs WHERE created_at >= ? ORDER BY created_at",
+                "SELECT job_id, status, created_at FROM a2a_jobs WHERE created_at >= ? ORDER BY created_at",
                 (created_since,),
             ).fetchall()
         return [dict(row) for row in rows]

--- a/blueprint_core/jobs/store.py
+++ b/blueprint_core/jobs/store.py
@@ -337,7 +337,13 @@ class JobMetadataStore:
         assert self._repository is not None
         return self._repository.list(sender=sender, status=status, limit=limit)
 
-    def get_metrics(self, *, days: int = 7, hours: int = 24) -> Dict[str, Any]:
+    def get_metrics(
+        self,
+        *,
+        days: int = 7,
+        hours: int = 24,
+        additional_rows: Optional[List[Dict[str, Any]]] = None,
+    ) -> Dict[str, Any]:
         """Return UTC job-volume and failure metrics for the admin dashboard."""
         self.init_db()
         now = datetime.now(timezone.utc)
@@ -345,6 +351,13 @@ class JobMetadataStore:
         created_since = (now - timedelta(days=lookback_days + 1)).isoformat().replace("+00:00", "Z")
         assert self._repository is not None
         rows = self._repository.list_metric_rows(created_since=created_since)
+        if additional_rows:
+            existing_job_ids = {str(row.get("job_id") or "") for row in rows}
+            rows.extend(
+                row
+                for row in additional_rows
+                if str(row.get("job_id") or "") not in existing_job_ids
+            )
         return summarize_job_metrics(rows, now=now, days=days, hours=hours)
 
     def list_project_jobs(self, project_id: str) -> List[Dict[str, Any]]:

--- a/blueprint_core/persistence/repositories/base.py
+++ b/blueprint_core/persistence/repositories/base.py
@@ -78,6 +78,8 @@ class ApplicationRepository(Protocol):
 
     def get_worker_execution_plan(self, plan_id: str, owner_user_id: str) -> Optional[Any]: ...
 
+    def list_worker_execution_plans(self, limit: int = 200) -> List[Any]: ...
+
     def update_worker_execution_plan(
         self,
         plan_id: str,

--- a/blueprint_core/persistence/repositories/sqlite.py
+++ b/blueprint_core/persistence/repositories/sqlite.py
@@ -285,6 +285,15 @@ class SqlAlchemyRepository:
                 DBWorkerExecutionPlan.owner_user_id == owner_user_id,
             ).first()
 
+    def list_worker_execution_plans(self, limit: int = 200) -> List[Any]:
+        with self._session() as session:
+            return (
+                session.query(DBWorkerExecutionPlan)
+                .order_by(DBWorkerExecutionPlan.created_at.desc())
+                .limit(max(1, min(int(limit), 1000)))
+                .all()
+            )
+
     def update_worker_execution_plan(
         self,
         plan_id: str,

--- a/blueprint_core/persistence/repositories/supabase.py
+++ b/blueprint_core/persistence/repositories/supabase.py
@@ -243,6 +243,18 @@ class SupabaseRepository:
         )
         return _record(rows[0]) if rows else None
 
+    def list_worker_execution_plans(self, limit: int = 200) -> List[Any]:
+        rows = (
+            self._client.table("worker_execution_plans")
+            .select("*")
+            .order("created_at", desc=True)
+            .limit(max(1, min(int(limit), 1000)))
+            .execute()
+            .data
+            or []
+        )
+        return [_record(row) for row in rows]
+
     def update_worker_execution_plan(
         self,
         plan_id: str,

--- a/tests/api/test_admin_jobs.py
+++ b/tests/api/test_admin_jobs.py
@@ -72,21 +72,40 @@ class AdminJobsTests(unittest.TestCase):
         jobs = [{"job_id": "job_2", "payload": {"owner_user_id": "user_2", "prompt": "Make an alarm"}}]
 
         with patch("apps.api.main.JOB_STORE.list_jobs", return_value=jobs) as list_jobs, patch(
-            "apps.api.main.clerk_user_profile", return_value=None
-        ):
+            "apps.api.main.list_project_generation_jobs", return_value=[]
+        ), patch("apps.api.main.clerk_user_profile", return_value=None):
             response = list_a2a_jobs(sender=None, job_status="running", limit=25, _user=ADMIN)
 
         list_jobs.assert_called_once_with(sender=None, status="running", limit=25)
         self.assertEqual("user_2", response[0]["owner_user_id"])
         self.assertEqual("Make an alarm", response[0]["payload"]["prompt"])
 
+    def test_admin_jobs_endpoint_includes_durable_generation_plan_jobs(self) -> None:
+        plan_job = {
+            "job_id": "generation-build-1",
+            "created_at": "2026-08-10T12:00:00Z",
+            "payload": {"owner_user_id": "user_3", "prompt": "Build a monitor"},
+        }
+
+        with patch("apps.api.main.JOB_STORE.list_jobs", return_value=[]), patch(
+            "apps.api.main.list_project_generation_jobs", return_value=[plan_job]
+        ) as list_plan_jobs, patch("apps.api.main.clerk_user_profile", return_value=None):
+            response = list_a2a_jobs(sender=None, job_status=None, limit=25, _user=ADMIN)
+
+        list_plan_jobs.assert_called_once_with(status=None, limit=25)
+        self.assertEqual("generation-build-1", response[0]["job_id"])
+        self.assertEqual("user_3", response[0]["owner_user_id"])
+
     def test_admin_job_metrics_endpoint_delegates_bounded_windows(self) -> None:
         metrics = {"jobs_today": 3, "jobs_last_hour": 1, "failure_rate": 25.0}
 
-        with patch("apps.api.main.JOB_STORE.get_metrics", return_value=metrics) as get_metrics:
+        plan_jobs = [{"job_id": "generation-build-2", "status": "failed"}]
+        with patch("apps.api.main.list_project_generation_jobs", return_value=plan_jobs), patch(
+            "apps.api.main.JOB_STORE.get_metrics", return_value=metrics
+        ) as get_metrics:
             response = get_a2a_job_metrics(days=7, hours=24, _user=ADMIN)
 
-        get_metrics.assert_called_once_with(days=7, hours=24)
+        get_metrics.assert_called_once_with(days=7, hours=24, additional_rows=plan_jobs)
         self.assertEqual(metrics, response)
 
 

--- a/tests/jobs/test_job_metrics.py
+++ b/tests/jobs/test_job_metrics.py
@@ -34,6 +34,36 @@ class JobMetricsTests(unittest.TestCase):
         self.assertEqual(1, metrics["failed_jobs"])
         self.assertEqual(50.0, metrics["failure_rate"])
 
+    def test_sqlite_job_store_merges_durable_worker_plan_rows(self) -> None:
+        with tempfile.NamedTemporaryFile(suffix=".db") as file:
+            store = JobMetadataStore(file.name, backend="sqlite")
+            store.create_job(
+                job_id="a2a_success",
+                message_id="message_success",
+                correlation_id=None,
+                action="blueprint.generate_project",
+                sender="frontend",
+                recipient="blueprint",
+                payload={"prompt": "success"},
+                server_owned=True,
+            )
+            store.mark_succeeded("a2a_success", {"project_ir": {}})
+            now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+            metrics = store.get_metrics(
+                days=7,
+                hours=24,
+                additional_rows=[
+                    {"job_id": "generation-failure", "created_at": now, "status": "failed"},
+                    {"job_id": "a2a_success", "created_at": now, "status": "failed"},
+                ],
+            )
+
+        self.assertEqual(2, metrics["jobs_today"])
+        self.assertEqual(2, metrics["completed_jobs"])
+        self.assertEqual(1, metrics["failed_jobs"])
+        self.assertEqual(50.0, metrics["failure_rate"])
+
     def test_summarizes_daily_hourly_and_failure_metrics(self) -> None:
         now = datetime(2026, 8, 9, 12, 30, tzinfo=timezone.utc)
         rows = [


### PR DESCRIPTION
Adds durable conversational generation-plan jobs to the admin Jobs listing and includes them in aggregate metrics. Displays persisted image-generation failure output and debug context in job entries. Adds rolling 1-hour, 24-hour, and 7-day metric controls backed by server-side interval calculations. Includes SQLite and Supabase support plus regression coverage. Tests: 500 passed, 1 skipped. Frontend: type-check passed; lint passed with 7 existing warnings.