### PR TITLE
Show image failures and selectable job metric intervals

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1317,12 +1317,14 @@ def list_a2a_jobs(
 def get_a2a_job_metrics(
     days: int = Query(7, ge=1, le=31),
     hours: int = Query(24, ge=1, le=168),
+    interval_hours: int | None = Query(None, ge=1, le=744),
     _user: UserContext = Depends(require_admin_user_context),
 ):
     """Returns aggregate job volume and failure metrics for administrators."""
     return JOB_STORE.get_metrics(
         days=days,
         hours=hours,
+        interval_hours=interval_hours,
         additional_rows=list_project_generation_jobs(limit=1000),
     )
 

--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -2115,6 +2115,8 @@ export function FormaWorkspace({
     jobs: a2aJobs,
     metrics: jobMetrics,
     metricsError: jobMetricsError,
+    metricsWindow: jobMetricsWindow,
+    setMetricsWindow: setJobMetricsWindow,
     loading: jobsLoading,
     error: jobsError,
     statusFilter: jobStatusFilter,
@@ -4767,6 +4769,8 @@ export function FormaWorkspace({
                   jobs={a2aJobs}
                   metrics={jobMetrics}
                   metricsError={jobMetricsError}
+                  metricsWindow={jobMetricsWindow}
+                  onMetricsWindowChange={setJobMetricsWindow}
                   loading={jobsLoading}
                   error={jobsError}
                   statusFilter={jobStatusFilter}

--- a/apps/web/app/blueprint-workspace/admin-panels.tsx
+++ b/apps/web/app/blueprint-workspace/admin-panels.tsx
@@ -21,6 +21,7 @@ import {
   type BackendLogs,
   type JobMetricBucket,
   type JobMetrics,
+  type JobMetricsWindow,
 } from "./use-admin-data";
 import {
   ADMIN_JOB_SORT_OPTIONS,
@@ -181,6 +182,8 @@ export function JobsPanel({
   jobs,
   metrics,
   metricsError,
+  metricsWindow = "7d",
+  onMetricsWindowChange,
   loading,
   error,
   statusFilter,
@@ -201,6 +204,8 @@ export function JobsPanel({
   jobs: A2AJob[];
   metrics?: JobMetrics | null;
   metricsError?: string | null;
+  metricsWindow?: JobMetricsWindow;
+  onMetricsWindowChange?: (window: JobMetricsWindow) => void;
   loading: boolean;
   error: string | null;
   statusFilter: string;
@@ -283,7 +288,14 @@ export function JobsPanel({
         </button>
       </div>
 
-      {!compact && <JobMetricsPanel metrics={metrics || null} error={metricsError || null} />}
+      {!compact && metrics !== undefined && (
+        <JobMetricsPanel
+          metrics={metrics || null}
+          error={metricsError || null}
+          metricsWindow={metricsWindow}
+          onMetricsWindowChange={onMetricsWindowChange}
+        />
+      )}
 
       {!compact && (
         <div className="mb-4 space-y-3">
@@ -386,7 +398,23 @@ export function JobsPanel({
   );
 }
 
-function JobMetricsPanel({ metrics, error }: { metrics: JobMetrics | null; error: string | null }) {
+const JOB_METRICS_WINDOW_OPTIONS: Array<{ value: JobMetricsWindow; label: string }> = [
+  { value: "1h", label: "1 hour" },
+  { value: "24h", label: "24 hours" },
+  { value: "7d", label: "7 days" },
+];
+
+function JobMetricsPanel({
+  metrics,
+  error,
+  metricsWindow,
+  onMetricsWindowChange,
+}: {
+  metrics: JobMetrics | null;
+  error: string | null;
+  metricsWindow: JobMetricsWindow;
+  onMetricsWindowChange?: (window: JobMetricsWindow) => void;
+}) {
   if (error && !metrics) {
     return (
       <div className="mb-4 border border-amber-500/30 bg-amber-950/20 p-3 text-xs text-amber-200">
@@ -398,22 +426,51 @@ function JobMetricsPanel({ metrics, error }: { metrics: JobMetrics | null; error
     return <div className="mb-4 border border-[#2a2c33] bg-[#17181d] p-4 text-xs text-slate-500">Loading job metrics...</div>;
   }
 
+  const intervalLabel = JOB_METRICS_WINDOW_OPTIONS.find((option) => option.value === metricsWindow)?.label || metricsWindow;
+  const chartUsesDays = metricsWindow === "7d";
+
   return (
     <section className="mb-5 space-y-3" aria-label="Job metrics">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <span className="text-[10px] font-black uppercase tracking-[0.14em] text-slate-500">Metrics interval</span>
+        <div className="flex flex-wrap gap-2" role="group" aria-label="Job metrics interval">
+          {JOB_METRICS_WINDOW_OPTIONS.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onMetricsWindowChange?.(option.value)}
+              aria-pressed={metricsWindow === option.value}
+              className={`border px-3 py-1.5 text-[10px] font-black uppercase ${
+                metricsWindow === option.value
+                  ? "border-white bg-white text-black"
+                  : "border-[#2a2c33] text-slate-500 hover:border-slate-500 hover:text-white"
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
       <div className="grid gap-2 sm:grid-cols-3">
-        <JobMetricSummary label="Jobs today" value={metrics.jobs_today} detail="UTC calendar day" />
-        <JobMetricSummary label="Jobs last hour" value={metrics.jobs_last_hour} detail="Rolling 60 minutes" />
+        <JobMetricSummary label={`Jobs · ${intervalLabel}`} value={metrics.total_jobs} detail="Created in selected interval" />
         <JobMetricSummary
-          label={`${metrics.window_days}-day failure rate`}
+          label="Completed"
+          value={metrics.completed_jobs}
+          detail={`${metrics.failed_jobs} failed`}
+          danger={metrics.failed_jobs > 0}
+        />
+        <JobMetricSummary
+          label={`${intervalLabel} failure rate`}
           value={`${Number(metrics.failure_rate || 0).toFixed(1)}%`}
           detail={`${metrics.failed_jobs} failed / ${metrics.completed_jobs} completed`}
           danger={metrics.failure_rate > 0}
         />
       </div>
-      <div className="grid gap-3 xl:grid-cols-2">
-        <JobVolumeChart title="Jobs per day" buckets={metrics.daily} unit="day" />
-        <JobVolumeChart title="Jobs per hour" buckets={metrics.hourly} unit="hour" />
-      </div>
+      <JobVolumeChart
+        title={chartUsesDays ? "Jobs per day" : "Jobs per hour"}
+        buckets={chartUsesDays ? metrics.daily : metrics.hourly}
+        unit={chartUsesDays ? "day" : "hour"}
+      />
       {error && <p className="text-[11px] text-amber-300">Showing the last available metrics. {error}</p>}
     </section>
   );
@@ -520,6 +577,19 @@ export function JobRow({
   const isOpenable = hasChatTarget || hasProjectTarget;
   const imageStatusLabel = formatJobImageStatus(summary);
   const operations = getJobOperations(summary);
+  const imageOperation = operations.find((operation) => operation.id === "image_generation") || {};
+  const imageFailed = Boolean(
+    summary.image_output_failed
+    || summary.image_output_status === "failed"
+    || imageOperation.status === "failed"
+  );
+  const imageFailureOutput = firstString(
+    summary.image_output_error,
+    summary.product_image_error,
+    imageOperation.error,
+    summary.image_output_reason,
+    imageOperation.reason,
+  ) || "Image generation failed without an error message.";
   const ownerUserId = job.owner_user_id || job.payload?.owner_user_id || "";
   const ownerLabel = formatJobOwnerUsername(job) || ownerUserId || "Unknown user";
   const lastOccurredAt = adminJobLastOccurredAt(job);
@@ -600,9 +670,9 @@ export function JobRow({
 
       <OperationStatusList operations={operations} compact={compact} />
 
-      {summary.image_output_failed && summary.image_output_error && (
+      {imageFailed && (
         <div className="break-anywhere mt-3 border border-amber-500/30 bg-amber-950/20 p-3 text-xs leading-5 text-amber-200">
-          Image generation failed: {summary.image_output_error}
+          Image generation failed: {imageFailureOutput}
           {summary.image_output_debug && (
             <pre className="break-anywhere mt-2 max-h-40 overflow-auto whitespace-pre-wrap border border-amber-500/20 bg-black/25 p-2 font-mono text-[10px] leading-4 text-amber-100">
               {JSON.stringify(summary.image_output_debug, null, 2)}

--- a/apps/web/app/blueprint-workspace/use-admin-data.ts
+++ b/apps/web/app/blueprint-workspace/use-admin-data.ts
@@ -61,6 +61,7 @@ export type JobMetrics = {
   timezone: string;
   window_days: number;
   window_hours: number;
+  interval_hours?: number | null;
   total_jobs: number;
   jobs_today: number;
   jobs_last_hour: number;
@@ -69,6 +70,14 @@ export type JobMetrics = {
   failure_rate: number;
   daily: JobMetricBucket[];
   hourly: JobMetricBucket[];
+};
+
+export type JobMetricsWindow = "1h" | "24h" | "7d";
+
+const JOB_METRICS_WINDOW_QUERY: Record<JobMetricsWindow, { days: string; hours: string; intervalHours: string }> = {
+  "1h": { days: "1", hours: "1", intervalHours: "1" },
+  "24h": { days: "1", hours: "24", intervalHours: "24" },
+  "7d": { days: "7", hours: "24", intervalHours: "168" },
 };
 
 export type HeaderFactory = () => HeadersInit | Promise<HeadersInit>;
@@ -214,6 +223,8 @@ export type UseJobsResult = {
   jobs: A2AJob[];
   metrics: JobMetrics | null;
   metricsError: string | null;
+  metricsWindow: JobMetricsWindow;
+  setMetricsWindow: (window: JobMetricsWindow) => void;
   loading: boolean;
   error: string | null;
   statusFilter: string;
@@ -235,6 +246,7 @@ export function useJobs({
   const [jobs, setJobs] = useState<A2AJob[]>([]);
   const [metrics, setMetrics] = useState<JobMetrics | null>(null);
   const [metricsError, setMetricsError] = useState<string | null>(null);
+  const [metricsWindow, setMetricsWindow] = useState<JobMetricsWindow>("7d");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [statusFilter, setStatusFilter] = useState(initialStatusFilter);
@@ -253,7 +265,7 @@ export function useJobs({
   ) => {
     if (!enabled) return;
 
-    const refreshKey = status || "all";
+    const refreshKey = `${status || "all"}:${metricsWindow}`;
     if (refreshTokensRef.current[refreshKey]) return;
     const refreshToken = {};
     refreshTokensRef.current[refreshKey] = refreshToken;
@@ -294,7 +306,13 @@ export function useJobs({
       }
 
       try {
-        const response = await fetchWithTimeout(`${apiUrl}/a2a/jobs/metrics?days=7&hours=24`, {
+        const metricWindow = JOB_METRICS_WINDOW_QUERY[metricsWindow];
+        const metricParams = new URLSearchParams({
+          days: metricWindow.days,
+          hours: metricWindow.hours,
+          interval_hours: metricWindow.intervalHours,
+        });
+        const response = await fetchWithTimeout(`${apiUrl}/a2a/jobs/metrics?${metricParams.toString()}`, {
           headers: await getHeaders(),
         });
         if (!response.ok) throw new Error(`Job metrics endpoint returned ${response.status}`);
@@ -332,7 +350,7 @@ export function useJobs({
         delete refreshTokensRef.current[refreshKey];
       }
     }
-  }, [apiUrl, enabled, getHeaders, statusFilter]);
+  }, [apiUrl, enabled, getHeaders, metricsWindow, statusFilter]);
 
   const fetchJob = useCallback(async (jobId: string): Promise<A2AJob | null> => {
     if (!jobId) return null;
@@ -395,6 +413,8 @@ export function useJobs({
     jobs,
     metrics,
     metricsError,
+    metricsWindow,
+    setMetricsWindow,
     loading,
     error,
     statusFilter,

--- a/blueprint_core/database.py
+++ b/blueprint_core/database.py
@@ -914,6 +914,15 @@ def list_project_generation_jobs(
             ]
             error = task.error.message if task.error is not None else None
             completed_at = task.completed_at or (task.result.completed_at if task.result else None)
+            result_output = task.result.output if task.result is not None else {}
+            project_revision = result_output.get("project_revision")
+            project_revision = project_revision if isinstance(project_revision, dict) else {}
+            project_state = project_revision.get("state")
+            project_state = project_state if isinstance(project_state, dict) else {}
+            assembly_metadata = project_state.get("assembly_metadata")
+            assembly_metadata = assembly_metadata if isinstance(assembly_metadata, dict) else {}
+            image_status = assembly_metadata.get("image_output_status")
+            image_error = assembly_metadata.get("image_output_error") or assembly_metadata.get("product_image_error")
             jobs.append(
                 {
                     "job_id": job_id,
@@ -939,6 +948,18 @@ def list_project_generation_jobs(
                         "project_id": plan.project_id,
                         "title": brief.get("summary") or brief.get("intent"),
                         "workflow": "default",
+                        "image_output_status": image_status,
+                        "image_output_failed": bool(
+                            assembly_metadata.get("image_output_failed") or image_status == "failed"
+                        ),
+                        "image_output_error": image_error,
+                        "image_output_error_type": assembly_metadata.get("image_output_error_type"),
+                        "image_output_reason": assembly_metadata.get("image_output_reason"),
+                        "image_output_debug": assembly_metadata.get("image_output_debug"),
+                        "image_output_provider": assembly_metadata.get("image_output_provider"),
+                        "image_output_model": assembly_metadata.get("image_output_model"),
+                        "operation_statuses": assembly_metadata.get("operation_statuses") or [],
+                        "operation_summary": assembly_metadata.get("operation_summary"),
                     },
                     "source_usage": {"workflow": "default", "source_labels": ["Conversation"]},
                     "progress_events": progress_events,

--- a/blueprint_core/jobs/metrics.py
+++ b/blueprint_core/jobs/metrics.py
@@ -30,6 +30,7 @@ def summarize_job_metrics(
     now: Optional[datetime] = None,
     days: int = 7,
     hours: int = 24,
+    interval_hours: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Aggregate persisted job timestamps into UTC admin dashboard metrics."""
     current = now or datetime.now(timezone.utc)
@@ -38,12 +39,22 @@ def summarize_job_metrics(
     current = current.astimezone(timezone.utc)
     days = max(1, min(int(days), 31))
     hours = max(1, min(int(hours), 168))
+    normalized_interval_hours = (
+        max(1, min(int(interval_hours), 31 * 24))
+        if interval_hours is not None
+        else None
+    )
 
     today = current.replace(hour=0, minute=0, second=0, microsecond=0)
     daily_start = today - timedelta(days=days - 1)
     current_hour = current.replace(minute=0, second=0, microsecond=0)
     hourly_start = current_hour - timedelta(hours=hours - 1)
     last_hour_start = current - timedelta(hours=1)
+    interval_start = (
+        current - timedelta(hours=normalized_interval_hours)
+        if normalized_interval_hours is not None
+        else daily_start
+    )
 
     daily_counts = {
         (daily_start + timedelta(days=index)).date().isoformat(): 0
@@ -56,6 +67,7 @@ def summarize_job_metrics(
     failed_jobs = 0
     completed_jobs = 0
     jobs_last_hour = 0
+    total_jobs = 0
 
     for row in rows:
         created_at = _utc_datetime(row.get("created_at"))
@@ -66,6 +78,9 @@ def summarize_job_metrics(
             day_key = created_at.date().isoformat()
             if day_key in daily_counts:
                 daily_counts[day_key] += 1
+
+        if created_at >= interval_start:
+            total_jobs += 1
             status = str(row.get("status") or "").strip().lower()
             if status in SUCCESS_STATUSES:
                 completed_jobs += 1
@@ -88,7 +103,8 @@ def summarize_job_metrics(
         "timezone": "UTC",
         "window_days": days,
         "window_hours": hours,
-        "total_jobs": sum(daily_counts.values()),
+        "interval_hours": normalized_interval_hours,
+        "total_jobs": total_jobs,
         "jobs_today": daily_counts.get(today.date().isoformat(), 0),
         "jobs_last_hour": jobs_last_hour,
         "completed_jobs": completed_jobs,

--- a/blueprint_core/jobs/store.py
+++ b/blueprint_core/jobs/store.py
@@ -342,12 +342,17 @@ class JobMetadataStore:
         *,
         days: int = 7,
         hours: int = 24,
+        interval_hours: Optional[int] = None,
         additional_rows: Optional[List[Dict[str, Any]]] = None,
     ) -> Dict[str, Any]:
         """Return UTC job-volume and failure metrics for the admin dashboard."""
         self.init_db()
         now = datetime.now(timezone.utc)
-        lookback_days = max(max(1, min(days, 31)), (max(1, min(hours, 168)) + 23) // 24)
+        lookback_days = max(
+            max(1, min(days, 31)),
+            (max(1, min(hours, 168)) + 23) // 24,
+            (max(1, min(interval_hours or 1, 31 * 24)) + 23) // 24,
+        )
         created_since = (now - timedelta(days=lookback_days + 1)).isoformat().replace("+00:00", "Z")
         assert self._repository is not None
         rows = self._repository.list_metric_rows(created_since=created_since)
@@ -358,7 +363,13 @@ class JobMetadataStore:
                 for row in additional_rows
                 if str(row.get("job_id") or "") not in existing_job_ids
             )
-        return summarize_job_metrics(rows, now=now, days=days, hours=hours)
+        return summarize_job_metrics(
+            rows,
+            now=now,
+            days=days,
+            hours=hours,
+            interval_hours=interval_hours,
+        )
 
     def list_project_jobs(self, project_id: str) -> List[Dict[str, Any]]:
         """Return every persisted job whose payload or result references a project."""

--- a/tests/agents/test_generation_worker.py
+++ b/tests/agents/test_generation_worker.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock, patch
 
 from blueprint_core.agents.orchestrator import HardwarePipelineOrchestrator
 from blueprint_core.agents.pipeline import emit_agent_pipeline_event
+from blueprint_core.database import list_project_generation_jobs
 from blueprint_core.persistence.providers import create_sqlite_provider
 from blueprint_core.persistence.repositories import SqlAlchemyRepository
 from blueprint_core.workers import (
@@ -59,9 +60,16 @@ OWNER = "generation-worker-user"
 
 
 class FakeGenerationEngine:
-    def __init__(self, *, fail: bool = False, target_project_id: str | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        fail: bool = False,
+        target_project_id: str | None = None,
+        assembly_metadata: dict[str, Any] | None = None,
+    ) -> None:
         self.fail = fail
         self.target_project_id = target_project_id
+        self.assembly_metadata = assembly_metadata or {}
         self.received: list[DesignBrief] = []
 
     def generate(self, design_brief: DesignBrief) -> ProjectRevisionDraft:
@@ -86,6 +94,7 @@ class FakeGenerationEngine:
             assembly_metadata={
                 "project_id": self.target_project_id or str(design_brief.project_id),
                 "revision": 1,
+                **self.assembly_metadata,
             },
         )
         return ProjectRevisionDraft(
@@ -434,6 +443,31 @@ class GenerationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
         with self.assertRaises(ProjectStateError) as missing:
             self.state.get_latest(self.project_id, OWNER)
         self.assertEqual("project_revision_not_found", missing.exception.code)
+
+    async def test_admin_job_projection_includes_image_failure_output(self) -> None:
+        engine = FakeGenerationEngine(assembly_metadata={
+            "image_output_status": "failed",
+            "image_output_failed": True,
+            "image_output_error": "Image provider returned no images.",
+            "image_output_error_type": "empty_response",
+            "operation_statuses": [
+                {"id": "image_generation", "label": "Image generation", "status": "failed"},
+            ],
+        })
+        worker = GenerationWorker(self.state, engine)
+        orchestrator = WorkerOrchestrator(self.repository, [worker], workflow_service=self.workflow)
+        plan = orchestrator.create_plan([self.request()], OWNER)
+        await orchestrator.execute(plan.plan_id, OWNER)
+
+        with patch("blueprint_core.database._DATABASE_REPOSITORY", self.repository):
+            jobs = list_project_generation_jobs(limit=10)
+
+        projected = next(job for job in jobs if job["job_id"] == "job-generation-initial")
+        summary = projected["result_summary"]
+        self.assertTrue(summary["image_output_failed"])
+        self.assertEqual("failed", summary["image_output_status"])
+        self.assertEqual("Image provider returned no images.", summary["image_output_error"])
+        self.assertEqual("failed", summary["operation_statuses"][0]["status"])
 
     async def test_numeric_provider_status_is_preserved_as_a_retryable_worker_error(self) -> None:
         worker = GenerationWorker(self.state, ProviderDeadlineGenerationEngine())

--- a/tests/api/test_admin_jobs.py
+++ b/tests/api/test_admin_jobs.py
@@ -103,9 +103,14 @@ class AdminJobsTests(unittest.TestCase):
         with patch("apps.api.main.list_project_generation_jobs", return_value=plan_jobs), patch(
             "apps.api.main.JOB_STORE.get_metrics", return_value=metrics
         ) as get_metrics:
-            response = get_a2a_job_metrics(days=7, hours=24, _user=ADMIN)
+            response = get_a2a_job_metrics(days=7, hours=24, interval_hours=24, _user=ADMIN)
 
-        get_metrics.assert_called_once_with(days=7, hours=24, additional_rows=plan_jobs)
+        get_metrics.assert_called_once_with(
+            days=7,
+            hours=24,
+            interval_hours=24,
+            additional_rows=plan_jobs,
+        )
         self.assertEqual(metrics, response)
 
 

--- a/tests/jobs/test_job_metrics.py
+++ b/tests/jobs/test_job_metrics.py
@@ -104,6 +104,24 @@ class JobMetricsTests(unittest.TestCase):
         self.assertEqual(4, len(metrics["hourly"]))
         self.assertTrue(all(bucket["count"] == 0 for bucket in metrics["daily"] + metrics["hourly"]))
 
+    def test_failure_metrics_use_the_selected_rolling_interval(self) -> None:
+        metrics = summarize_job_metrics(
+            [
+                {"created_at": "2026-08-09T12:15:00Z", "status": "failed"},
+                {"created_at": "2026-08-09T10:00:00Z", "status": "succeeded"},
+            ],
+            now=datetime(2026, 8, 9, 12, 30, tzinfo=timezone.utc),
+            days=1,
+            hours=1,
+            interval_hours=1,
+        )
+
+        self.assertEqual(1, metrics["interval_hours"])
+        self.assertEqual(1, metrics["total_jobs"])
+        self.assertEqual(1, metrics["completed_jobs"])
+        self.assertEqual(1, metrics["failed_jobs"])
+        self.assertEqual(100.0, metrics["failure_rate"])
+
     def test_metric_windows_are_bounded(self) -> None:
         metrics = summarize_job_metrics([], days=100, hours=1000)
 


### PR DESCRIPTION
Displays persisted image-generation failure output and debug context in job entries. Adds rolling 1-hour, 24-hour, and 7-day metric controls backed by server-side interval calculations. Tests: 500 passed, 1 skipped. Frontend: type-check passed; lint passed with 7 existing warnings.