### PR TITLE
Ignore null entries in generated system architectures

### DIFF
--- a/blueprint_core/workspaces/projects/models.py
+++ b/blueprint_core/workspaces/projects/models.py
@@ -181,6 +181,8 @@ class SystemNode(BaseModel):
         items = value if isinstance(value, list) else [value]
         normalized: List[Any] = []
         for item in items:
+            if item is None:
+                continue
             if not isinstance(item, str):
                 normalized.append(item)
                 continue
@@ -203,6 +205,8 @@ class SystemNode(BaseModel):
         items = value if isinstance(value, list) else [value]
         normalized: List[Any] = []
         for item in items:
+            if item is None:
+                continue
             if not isinstance(item, str):
                 normalized.append(item)
                 continue

--- a/tests/agents/test_system_architecture.py
+++ b/tests/agents/test_system_architecture.py
@@ -137,6 +137,62 @@ class SystemArchitectureTests(unittest.TestCase):
         ])
         self.assertEqual(["electrical", "firmware"], [child.domain for child in architecture.root.children])
 
+    def test_null_recursive_entries_are_removed_without_replacing_valid_nodes(self) -> None:
+        architecture = SystemArchitecture.model_validate({
+            "summary": "Provider output contains null array placeholders.",
+            "root": {
+                "system_id": "product",
+                "name": "Product",
+                "domain": "product",
+                "purpose": "Coordinates the complete product.",
+                "interfaces": [
+                    None,
+                    {
+                        "name": "Enclosure boundary",
+                        "connects_to": "mechanical.enclosure",
+                        "purpose": "Coordinates packaging constraints.",
+                    },
+                ],
+                "children": [
+                    {
+                        "system_id": "electrical",
+                        "name": "Electrical",
+                        "domain": "electrical",
+                        "purpose": "Owns electronics.",
+                        "children": [
+                            {
+                                "system_id": "electrical.power",
+                                "name": "Power",
+                                "domain": "electrical",
+                                "purpose": "Owns power delivery.",
+                            },
+                            None,
+                            {
+                                "system_id": "electrical.control",
+                                "name": "Control",
+                                "domain": "electrical",
+                                "purpose": "Owns control electronics.",
+                                "interfaces": [None],
+                            },
+                            None,
+                        ],
+                    },
+                    None,
+                ],
+            },
+        })
+
+        self.assertEqual(["electrical"], [child.system_id for child in architecture.root.children])
+        self.assertEqual(
+            ["electrical.power", "electrical.control"],
+            [child.system_id for child in architecture.root.children[0].children],
+        )
+        self.assertEqual(
+            ["mechanical.enclosure"],
+            [interface.connects_to for interface in architecture.root.interfaces],
+        )
+        self.assertEqual([], architecture.root.children[0].children[1].interfaces)
+
     def test_flattened_recursive_fields_are_rejected_as_an_architecture_tree(self) -> None:
         architecture = SystemArchitecture.model_validate({
             "summary": "Provider output flattened a nested object.",


### PR DESCRIPTION
## Summary
- remove `null` placeholders from generated `children` and `interfaces` arrays before typed validation
- preserve valid architecture nodes and their original ordering
- cover nested provider output with a regression test

## Tests
- `.venv/bin/python -m unittest tests.agents.test_system_architecture tests.agents.test_pipeline`
- `.venv/bin/python -m unittest discover -s tests` *(499 passed, 1 skipped; one unrelated existing Vertex timeout assertion fails: expected 90s, configured 600s)*