### PR TITLE
Navigate New Chat to the newly created thread

### DIFF
--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -2242,6 +2242,7 @@ export function FormaWorkspace({
     setChatRouteTransition(null);
     setProjectIR(null);
     setActiveTab("overview");
+    return nextChatId;
   };
 
   const goHome = () => {
@@ -2257,8 +2258,8 @@ export function FormaWorkspace({
 
   const startNewProjectChat = () => {
     if (!currentProjectChatHasStarted()) return;
-    resetToNewProjectChat();
-    router.push("/");
+    const nextChatId = resetToNewProjectChat();
+    router.push(chatRoute(nextChatId));
   };
 
   const openChatItem = (item: ChatListItem) => {


### PR DESCRIPTION
## Summary
- retain the freshly generated chat ID when resetting the workspace
- navigate New Chat directly to `/chat/<new-id>` instead of the home route
- keep the active thread, sidebar selection, and browser URL aligned

## Verification
- `npm run lint` (passes with existing image optimization warnings)
- `npm run build`