### PR TITLE
Bootstrap context for first-turn build requests

### DIFF
--- a/apps/api/context_gathering_api.py
+++ b/apps/api/context_gathering_api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 import logging
+import re
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, status
@@ -33,6 +34,44 @@ from blueprint_core.workspaces.workflow import ProjectWorkflowState, WorkflowAct
 
 router = APIRouter(prefix="/projects/{project_id}/context", tags=["context-gathering"])
 logger = logging.getLogger(__name__)
+
+
+_CONTEXT_FREE_USER_TURN = re.compile(
+    r"^(?:(?:please\s+)?(?:go|go ahead|continue|start|start now|build|build it|build it now|"
+    r"make it|make it now|do it|do it now|proceed|ready|skip|skip it|skip context gathering)|"
+    r"idk|i do not know|i don t know|don t know|not sure|unsure|no idea|you choose|up to you|"
+    r"hi|hello|hey)$",
+)
+
+
+def _contains_project_context(text: str) -> bool:
+    normalized = re.sub(r"[^a-z0-9]+", " ", str(text or "").casefold()).strip()
+    return bool(normalized and not _CONTEXT_FREE_USER_TURN.fullmatch(normalized))
+
+
+def _bootstrap_context_request(
+    request: ContextGatheringRequest,
+    existing_messages: list[dict],
+) -> ContextGatheringRequest | None:
+    """Recover project context when build intent arrives before a DesignBrief exists."""
+
+    context_parts: list[str] = []
+    seen: set[str] = set()
+    for message in existing_messages[-12:]:
+        if not isinstance(message, dict) or message.get("role") != "user":
+            continue
+        content = str(message.get("content") or "").strip()
+        key = content.casefold()
+        if _contains_project_context(content) and key not in seen:
+            seen.add(key)
+            context_parts.append(content)
+    current_text = request.text.strip()
+    current_key = current_text.casefold()
+    if _contains_project_context(current_text) and current_key not in seen:
+        context_parts.append(current_text)
+    if not context_parts and not request.attachments:
+        return None
+    return request.model_copy(update={"text": "\n".join(context_parts)})
 
 
 def _owner(user: UserContext) -> str:
@@ -113,6 +152,45 @@ def gather_project_context_endpoint(
     brief = previous
     questions: list[str] = []
     build_execution: ContextBuildExecution | None = None
+    if decision.tool_name == "build_project" and brief is None:
+        bootstrap_request = _bootstrap_context_request(request, existing_messages)
+        if bootstrap_request is not None:
+            if workflow is None:
+                try:
+                    workflow = initialize_project_workflow(
+                        str(project_id),
+                        owner,
+                        actor_type=WorkflowActorType.USER,
+                        actor_id=owner,
+                        reason="Build request supplied initial project context.",
+                    ).workflow
+                except WorkflowStateError as exc:
+                    raise _workflow_error(exc) from exc
+            brief_create, _, questions = agent.update(bootstrap_request, None)
+            try:
+                brief = create_design_brief_version(str(project_id), owner, brief_create)
+            except DesignBriefAccessError as exc:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail={"code": "project_not_found", "message": "Project not found."},
+                ) from exc
+            logger.info(
+                "Bootstrapped DesignBrief from first-turn build request: project_id=%s conversation_id=%s",
+                project_id,
+                request.conversation_id,
+            )
+    elif decision.tool_name == "build_project" and workflow is None:
+        try:
+            workflow = initialize_project_workflow(
+                str(project_id),
+                owner,
+                actor_type=WorkflowActorType.USER,
+                actor_id=owner,
+                reason="Build request resumed existing project context.",
+            ).workflow
+        except WorkflowStateError as exc:
+            raise _workflow_error(exc) from exc
+
     if decision.tool_name == "ask_question" and decision.save_context:
         if workflow is None:
             try:
@@ -224,6 +302,9 @@ def gather_project_context_endpoint(
                 })
     if decision.tool_name == "build_project" and (workflow is None or brief is None):
         decision = decision.model_copy(update={
+            "turn_kind": "clarification",
+            "tool_name": "ask_question",
+            "save_context": False,
             "assistant_message": "Tell me what you want to build first, and I’ll help shape it and start the design.",
         })
 

--- a/tests/projects/test_context_gathering.py
+++ b/tests/projects/test_context_gathering.py
@@ -25,7 +25,7 @@ from blueprint_core import database
 from blueprint_core.persistence.providers import create_sqlite_provider
 from blueprint_core.persistence.repositories import SqlAlchemyRepository
 from blueprint_core.workspaces.projects.models import GenerateProjectRequest
-from blueprint_core.workspaces.context import ContextBuildExecution
+from blueprint_core.workspaces.context import ContextBuildExecution, ContextTurnDecision
 from blueprint_core.workspaces.workflow import ProjectWorkflowState, WorkflowActorType, WorkflowStateError
 from blueprint_core.vertex_auth import (
     bind_vertex_oidc_token,
@@ -119,6 +119,117 @@ class ContextGatheringIntegrationTests(unittest.TestCase):
         self.assertEqual(201, replay.status_code, replay.text)
         self.assertEqual("proceed", replay.json()["turn_kind"])
         self.assertEqual("ready_to_build", replay.json()["workflow"]["state"])
+
+    def test_first_turn_build_intent_bootstraps_the_brief_and_starts_the_build(self) -> None:
+        project_id = str(uuid.uuid4())
+        conversation_id = "conversation-first-turn-build"
+        prompt = (
+            "Build me a chip that supports a Mamba-like latent-space model as an orchestrator "
+            "for an LLM and reinforcement-learning model. Start with a scalable compute tile "
+            "for a 7B to 30B parameter reference workload with HBM-attached tensor compute."
+        )
+
+        class FirstTurnBuildAgent(ContextGatheringAgent):
+            def route_turn(self, *_args, **_kwargs):
+                return ContextTurnDecision(
+                    turn_kind="proceed",
+                    tool_name="build_project",
+                    assistant_message="I’ll start the design.",
+                )
+
+        self.app.dependency_overrides[context_gathering_agent] = lambda: FirstTurnBuildAgent()
+        self.app.dependency_overrides.pop(context_build_dispatcher)
+        with sqlite_repository(), patch(
+            "apps.api.context_builds.ContextBuildDispatcher._launch",
+        ):
+            response = self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={"conversation_id": conversation_id, "text": prompt},
+            )
+            brief = database.get_latest_design_brief(project_id, OWNER)
+
+        self.assertEqual(201, response.status_code, response.text)
+        body = response.json()
+        self.assertEqual("building", body["workflow"]["state"])
+        self.assertIsNotNone(body["build_execution"])
+        self.assertIn("started the design", body["assistant_message"])
+        persisted_requirements = " ".join(brief.requirements)
+        self.assertIn("Mamba-like latent-space model", persisted_requirements)
+        self.assertIn("7B to 30B parameter reference workload", persisted_requirements)
+        self.assertNotIn("Tell me what you want to build first", body["assistant_message"])
+
+    def test_first_turn_build_control_without_project_context_does_not_start(self) -> None:
+        project_id = str(uuid.uuid4())
+
+        class FirstTurnBuildAgent(ContextGatheringAgent):
+            def route_turn(self, *_args, **_kwargs):
+                return ContextTurnDecision(
+                    turn_kind="proceed",
+                    tool_name="build_project",
+                    assistant_message="I’ll start the design.",
+                )
+
+        self.app.dependency_overrides[context_gathering_agent] = lambda: FirstTurnBuildAgent()
+        with sqlite_repository():
+            response = self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={"conversation_id": "conversation-no-context", "text": "start"},
+            )
+
+        self.assertEqual(201, response.status_code, response.text)
+        body = response.json()
+        self.assertIsNone(body["workflow"])
+        self.assertIsNone(body["design_brief"])
+        self.assertIsNone(body["build_execution"])
+        self.assertEqual("clarification", body["turn_kind"])
+        self.assertEqual("ask_question", body["tool_name"])
+        self.assertIn("Tell me what you want to build first", body["assistant_message"])
+
+    def test_stuck_chat_recovers_prior_project_context_on_the_next_build_command(self) -> None:
+        project_id = str(uuid.uuid4())
+        conversation_id = "conversation-recover-build"
+        original_prompt = (
+            "Build a scalable compute tile with HBM-attached tensor and sequence compute, "
+            "FP8 and INT8 inference, and a tile-to-tile interconnect."
+        )
+
+        class BuildAgent(ContextGatheringAgent):
+            def route_turn(self, *_args, **_kwargs):
+                return ContextTurnDecision(
+                    turn_kind="proceed",
+                    tool_name="build_project",
+                    assistant_message="I’ll start the design.",
+                )
+
+        self.app.dependency_overrides[context_gathering_agent] = lambda: BuildAgent()
+        self.app.dependency_overrides.pop(context_build_dispatcher)
+        with sqlite_repository(), patch(
+            "apps.api.context_builds.ContextBuildDispatcher._launch",
+        ):
+            database.upsert_project_chat(
+                chat_id=conversation_id,
+                owner_user_id=OWNER,
+                title="Scalable compute tile",
+                messages=[
+                    {"role": "user", "content": original_prompt},
+                    {
+                        "role": "assistant",
+                        "content": "Tell me what you want to build first, and I’ll help shape it and start the design.",
+                    },
+                ],
+                created_at="2026-08-10T09:09:00Z",
+                updated_at="2026-08-10T09:09:00Z",
+            )
+            response = self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={"conversation_id": conversation_id, "text": "start"},
+            )
+            brief = database.get_latest_design_brief(project_id, OWNER)
+
+        self.assertEqual(201, response.status_code, response.text)
+        self.assertEqual("building", response.json()["workflow"]["state"])
+        self.assertIsNotNone(response.json()["build_execution"])
+        self.assertIn("HBM-attached tensor and sequence compute", " ".join(brief.requirements))
 
     def test_proceed_dispatches_a_real_build_stage_when_a_dispatcher_is_available(self) -> None:
         project_id = str(uuid.uuid4())


### PR DESCRIPTION
## Summary
- create the DesignBrief and workflow when a substantive first message also requests a build
- start the build in that same turn instead of returning the intake prompt again
- recover requirements from recent user messages for chats already caught in the loop
- keep bare commands such as `start` from creating an empty project
- return clarification metadata when there is genuinely no project context

## Verification
- `.venv/bin/python -m unittest tests.projects.test_context_gathering` (18 passed)
- `.venv/bin/python -m unittest discover -s tests/projects` (74 passed)
- `.venv/bin/python -m unittest discover -s tests` (502 passed, 1 skipped; one unrelated existing Vertex timeout assertion fails: expected 90s, configured 600s)