### PR TITLE
Improve project browsing, chat follow, and Gemini defaults

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -87,6 +87,7 @@ from blueprint_core.database import (
     list_project_chats,
     list_component_templates,
     list_generated_projects,
+    list_generated_projects_page,
     list_latest_project_revisions,
     list_project_deletion_audits,
     list_project_generation_jobs,
@@ -1722,9 +1723,27 @@ def _without_downloadable_project_assets(hardware_ir: Dict[str, Any]) -> Dict[st
 
 
 @app.get("/projects")
-def list_projects_endpoint(user: UserContext = Depends(optional_user_context)):
+def list_projects_endpoint(
+    user: UserContext = Depends(optional_user_context),
+    limit: Optional[int] = None,
+    offset: int = 0,
+):
     """Lists public compiled hardware projects."""
     try:
+        if limit is not None:
+            projects, total = list_generated_projects_page(
+                visibility="public",
+                limit=limit,
+                offset=offset,
+            )
+            items = [_public_project_cache_record(project) for project in projects]
+            return {
+                "items": _personalize_public_project_records(items, user.owner_user_id),
+                "total": total,
+                "limit": max(1, min(int(limit), 50)),
+                "offset": max(0, int(offset)),
+                "has_more": max(0, int(offset)) + len(items) < total,
+            }
         cached, generation = get_cached_project_list("public", None)
         if cached is not None:
             return _personalize_public_project_records(cached, user.owner_user_id)
@@ -1739,10 +1758,31 @@ def list_projects_endpoint(user: UserContext = Depends(optional_user_context)):
 
 
 @app.get("/my/projects")
-def list_my_projects_endpoint(user: UserContext = Depends(require_user_context)):
+def list_my_projects_endpoint(
+    user: UserContext = Depends(require_user_context),
+    limit: Optional[int] = None,
+    offset: int = 0,
+):
     """Lists projects owned by the signed-in user."""
     owner_user_id = _require_authenticated_user(user)
     try:
+        if limit is not None:
+            projects, total = list_generated_projects_page(
+                owner_user_id=owner_user_id,
+                limit=limit,
+                offset=offset,
+            )
+            items = [
+                _project_summary_response(project, current_user_id=owner_user_id)
+                for project in projects
+            ]
+            return {
+                "items": items,
+                "total": total,
+                "limit": max(1, min(int(limit), 50)),
+                "offset": max(0, int(offset)),
+                "has_more": max(0, int(offset)) + len(items) < total,
+            }
         cached, generation = get_cached_project_list("mine", owner_user_id)
         if cached is not None:
             return cached

--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -46,6 +46,7 @@ import {
   statusTone,
 } from "./blueprint-workspace/admin-panels";
 import HomeChatView from "./blueprint-workspace/home-chat-view";
+import useChatAutoScroll from "./blueprint-workspace/use-chat-auto-scroll";
 import {
   ProjectGallery,
   PROJECT_GALLERY_PAGE_SIZE,
@@ -1685,8 +1686,6 @@ export function FormaWorkspace({
   const fileInputRefSidebar = useRef<HTMLInputElement>(null);
   const fileInputRefCenter = useRef<HTMLInputElement>(null);
   const projectsSectionRef = useRef<HTMLElement>(null);
-  const chatEndRef = useRef<HTMLDivElement>(null);
-  const projectChatEndRef = useRef<HTMLDivElement>(null);
   const chatPersistenceTimersRef = useRef<Record<string, number>>({});
   const projectHistoryRequestIdRef = useRef(0);
   const myProjectHistoryRequestIdRef = useRef(0);
@@ -1749,16 +1748,6 @@ export function FormaWorkspace({
     setVisibleProjectGalleryIds([]);
     setMyProjectHistoryPage(page);
   }, []);
-  const chatMessageScrollKey = useMemo(
-    () => `${activeChatId || ""}:${chatMessageIdentityKey(chatMessages)}`,
-    [activeChatId, chatMessages]
-  );
-  const projectChatMessageScrollKey = useMemo(() => {
-    if (currentRouteProjectId) return "project-detail";
-    const chatId = projectIR ? (chatIdFromIR(projectIR) || projectIdFromIR(projectIR) || activeChatId) : activeChatId;
-    const messages = chatId ? chatThreads[chatId] || [] : [];
-    return `${chatId || ""}:${chatMessageIdentityKey(messages)}`;
-  }, [activeChatId, chatThreads, currentRouteProjectId, projectIR]);
   const inlineChatProjectId = useMemo(() => {
     const activeThread = activeChatId ? chatThreads[activeChatId] || [] : [];
     const messages = activeThread.length ? activeThread : chatMessages;
@@ -2451,14 +2440,6 @@ export function FormaWorkspace({
       window.clearInterval(intervalId);
     };
   }, [isLoading]);
-
-  useEffect(() => {
-    chatEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-  }, [chatMessageScrollKey]);
-
-  useEffect(() => {
-    projectChatEndRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
-  }, [projectChatMessageScrollKey]);
 
   const checkServerStatus = async () => {
     try {
@@ -4869,8 +4850,8 @@ export function FormaWorkspace({
           ) : (
             <HomeChatView
               started={activeSidebarChatStarted}
+              conversationKey={activeChatId || "new-chat"}
               messages={chatMessages}
-              endRef={chatEndRef}
               renderPipelineProgress={(message) => (
                 <AgentPipelineProgressView
                   progress={message.pipelineProgress as AgentPipelineProgress | null}
@@ -5041,7 +5022,6 @@ export function FormaWorkspace({
                 canStop={activeGeneration?.kind === "project-chat"}
                 onStop={stopActiveGeneration}
                 canChat={currentUserOwnsProject}
-                endRef={projectChatEndRef}
                 namespaceTabs={visibleWorkspaceTabs}
                 activeNamespace={activeWorkspaceTab.id}
                 activeNamespaceLabel={activeWorkspaceTab.label}
@@ -6354,7 +6334,6 @@ function ChatWorkspace({
   canStop,
   onStop,
   canChat,
-  endRef,
   namespaceTabs,
   activeNamespace,
   activeNamespaceLabel,
@@ -6374,7 +6353,6 @@ function ChatWorkspace({
   canStop: boolean;
   onStop: () => void;
   canChat: boolean;
-  endRef: React.RefObject<HTMLDivElement | null>;
   namespaceTabs: typeof workspaceTabs;
   activeNamespace: string;
   activeNamespaceLabel: string;
@@ -6382,6 +6360,8 @@ function ChatWorkspace({
   onNamespaceChange: (value: string) => void;
   projectContent: React.ReactNode;
 }) {
+  const { containerRef, endRef, handleScroll } = useChatAutoScroll(chatId || projectId || "project-chat", messages);
+
   return (
     <div className="flex h-full min-h-0 min-w-0 flex-col bg-[#141519]">
       <header className="flex min-h-[78px] min-w-0 items-center gap-3 overflow-hidden border-b border-[#282a30] bg-[#17181d] px-3 py-3 sm:px-4">
@@ -6403,7 +6383,11 @@ function ChatWorkspace({
       <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
         {canChat && (
           <div className="flex h-full min-h-0 min-w-0 flex-col">
-            <div className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-3 py-5 sm:px-5 sm:py-6">
+            <div
+              ref={containerRef}
+              onScroll={handleScroll}
+              className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-3 py-5 sm:px-5 sm:py-6"
+            >
               <div className="mx-auto flex w-full min-w-0 max-w-6xl flex-col gap-3">
                 {messages.length ? (
                   messages.map((message) => {
@@ -6449,7 +6433,6 @@ function ChatWorkspace({
                     This chat has no project messages yet.
                   </div>
                 )}
-
                 <div ref={endRef} />
                 <ChatProjectArtifact
                   projectId={projectId}

--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -48,6 +48,7 @@ import {
 import HomeChatView from "./blueprint-workspace/home-chat-view";
 import {
   ProjectGallery,
+  PROJECT_GALLERY_PAGE_SIZE,
   buildProjectGalleryItems,
   previewableImageSrc,
   resolveProjectImageCandidates,
@@ -1610,6 +1611,10 @@ export function FormaWorkspace({
   const [projectIR, setProjectIR] = useState<any>(null);
   const [projectHistory, setProjectHistory] = useState<any[]>([]);
   const [myProjectHistory, setMyProjectHistory] = useState<any[]>([]);
+  const [projectHistoryPage, setProjectHistoryPage] = useState(0);
+  const [myProjectHistoryPage, setMyProjectHistoryPage] = useState(0);
+  const [projectHistoryTotal, setProjectHistoryTotal] = useState(0);
+  const [myProjectHistoryTotal, setMyProjectHistoryTotal] = useState(0);
   const [projectHistoryLoaded, setProjectHistoryLoaded] = useState(false);
   const [myProjectHistoryLoaded, setMyProjectHistoryLoaded] = useState(false);
   const [localChatItems, setLocalChatItems] = useState<ChatListItem[]>([]);
@@ -1683,6 +1688,8 @@ export function FormaWorkspace({
   const chatEndRef = useRef<HTMLDivElement>(null);
   const projectChatEndRef = useRef<HTMLDivElement>(null);
   const chatPersistenceTimersRef = useRef<Record<string, number>>({});
+  const projectHistoryRequestIdRef = useRef(0);
+  const myProjectHistoryRequestIdRef = useRef(0);
   const generationLlmRequestIdRef = useRef(0);
   const pipelineStepsRequestIdRef = useRef(0);
   const pipelineStepsAbortRef = useRef<AbortController | null>(null);
@@ -1714,25 +1721,33 @@ export function FormaWorkspace({
   );
   const myProjectGalleryItems = useMemo(
     () => buildProjectGalleryItems(
-      mergeProjectRecords(myProjectHistory, projectRecordsFromChatItems(chatListItems)),
+      myProjectHistory,
       projectGalleryImages,
       blueprintDevMode,
     ).map((item) => ({
       ...item,
       canChat: item.canChat && (!authRequired || Boolean(isSignedIn)),
     })),
-    [authRequired, blueprintDevMode, chatListItems, isSignedIn, myProjectHistory, projectGalleryImages]
+    [authRequired, blueprintDevMode, isSignedIn, myProjectHistory, projectGalleryImages]
   );
   const chatHistoryLoaded = myProjectHistoryLoaded && privateChatsLoaded;
   const projectsPageLoading = !projectHistoryLoaded;
   const myProjectsPageLoading = (authRequired && !authLoaded)
-    || !myProjectHistoryLoaded
-    || !privateChatsLoaded
-    || !chatIndexLoaded;
+    || !myProjectHistoryLoaded;
   const handleVisibleProjectGalleryIdsChange = useCallback((projectIds: string[]) => {
     setVisibleProjectGalleryIds((current) => (
       sameStringList(current, projectIds) ? current : projectIds
     ));
+  }, []);
+  const handleProjectHistoryPageChange = useCallback((page: number) => {
+    setProjectHistoryLoaded(false);
+    setVisibleProjectGalleryIds([]);
+    setProjectHistoryPage(page);
+  }, []);
+  const handleMyProjectHistoryPageChange = useCallback((page: number) => {
+    setMyProjectHistoryLoaded(false);
+    setVisibleProjectGalleryIds([]);
+    setMyProjectHistoryPage(page);
   }, []);
   const chatMessageScrollKey = useMemo(
     () => `${activeChatId || ""}:${chatMessageIdentityKey(chatMessages)}`,
@@ -2338,17 +2353,17 @@ export function FormaWorkspace({
 
   useEffect(() => {
     if (homeView !== "projects") return;
-    void fetchProjectHistory();
+    void fetchProjectHistory(projectHistoryPage);
     // Public gallery data becomes critical only when its route is active.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [homeView]);
+  }, [homeView, projectHistoryPage]);
 
   useDeferredTask(() => {
-    if (!projectHistoryLoaded) void fetchProjectHistory();
+    if (!projectHistoryLoaded) void fetchProjectHistory(projectHistoryPage);
   }, {
     delayMs: 1200,
     enabled: homeView !== "projects" && !projectHistoryLoaded,
-    taskKey: homeView,
+    taskKey: `${homeView}:${projectHistoryPage}`,
     timeoutMs: 1800,
   });
 
@@ -2384,16 +2399,23 @@ export function FormaWorkspace({
 
   useEffect(() => {
     if (authRequired && !authLoaded) {
-      setMyProjectHistoryLoaded(false);
       setPrivateChatsLoaded(false);
       return;
     }
-    setMyProjectHistoryLoaded(false);
+    setMyProjectHistoryPage(0);
     setPrivateChatsLoaded(false);
-    void fetchMyProjectHistory();
     void fetchPrivateChats();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authIdentityKey, authLoaded, authRequired, isSignedIn]);
+
+  useEffect(() => {
+    if (authRequired && !authLoaded) {
+      setMyProjectHistoryLoaded(false);
+      return;
+    }
+    void fetchMyProjectHistory(myProjectHistoryPage);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [authIdentityKey, authLoaded, authRequired, isSignedIn, myProjectHistoryPage]);
 
   useDeferredTask(() => {
     void fetchAgentPipelineSteps(generationWorkflow);
@@ -2541,17 +2563,27 @@ export function FormaWorkspace({
   };
 
 
-  const fetchProjectHistory = async () => {
+  const fetchProjectHistory = async (page: number = projectHistoryPage) => {
+    const requestId = projectHistoryRequestIdRef.current + 1;
+    projectHistoryRequestIdRef.current = requestId;
+    setProjectHistoryLoaded(false);
     try {
-      const res = await fetch(`${API_URL}/projects`, {
+      const params = new URLSearchParams({
+        limit: String(PROJECT_GALLERY_PAGE_SIZE),
+        offset: String(Math.max(0, page) * PROJECT_GALLERY_PAGE_SIZE),
+      });
+      const res = await fetch(`${API_URL}/projects?${params.toString()}`, {
         headers: await optionalAuthHeaders(),
       });
+      if (projectHistoryRequestIdRef.current !== requestId) return;
       if (res.ok) {
-        const projects = await res.json();
-        setProjectHistory(projects);
+        const result = normalizeProjectListPage(await res.json());
+        if (projectHistoryRequestIdRef.current !== requestId) return;
+        setProjectHistory(result.items);
+        setProjectHistoryTotal(result.total);
         if (!authRequired) {
           setLocalChatItems((current) => {
-            const repairedItems = buildChatListItems(projects, current);
+            const repairedItems = buildChatListItems(result.items, current);
             writeStoredChatIndex(repairedItems, chatStorageScope);
             return repairedItems;
           });
@@ -2560,36 +2592,49 @@ export function FormaWorkspace({
     } catch (e) {
       console.error("Error fetching project history", e);
     } finally {
-      setProjectHistoryLoaded(true);
+      if (projectHistoryRequestIdRef.current === requestId) setProjectHistoryLoaded(true);
     }
   };
 
-  const fetchMyProjectHistory = async () => {
+  const fetchMyProjectHistory = async (page: number = myProjectHistoryPage) => {
+    const requestId = myProjectHistoryRequestIdRef.current + 1;
+    myProjectHistoryRequestIdRef.current = requestId;
     if (authRequired && !authLoaded) {
       setMyProjectHistoryLoaded(false);
       return;
     }
     if (authRequired && !isSignedIn) {
       setMyProjectHistory([]);
+      setMyProjectHistoryTotal(0);
       setMyProjectHistoryLoaded(true);
       return;
     }
 
+    setMyProjectHistoryLoaded(false);
     try {
-      const res = await fetch(`${API_URL}/my/projects`, {
+      const params = new URLSearchParams({
+        limit: String(PROJECT_GALLERY_PAGE_SIZE),
+        offset: String(Math.max(0, page) * PROJECT_GALLERY_PAGE_SIZE),
+      });
+      const res = await fetch(`${API_URL}/my/projects?${params.toString()}`, {
         headers: await generationRequestHeaders(),
       });
+      if (myProjectHistoryRequestIdRef.current !== requestId) return;
       if (res.ok) {
-        setMyProjectHistory(await res.json());
+        const result = normalizeProjectListPage(await res.json());
+        if (myProjectHistoryRequestIdRef.current !== requestId) return;
+        setMyProjectHistory(result.items);
+        setMyProjectHistoryTotal(result.total);
       } else if (res.status === 401) {
         setMyProjectHistory([]);
+        setMyProjectHistoryTotal(0);
       } else {
         throw new Error(await readApiErrorMessage(res));
       }
     } catch (e) {
       console.error("Error fetching my project history", e);
     } finally {
-      setMyProjectHistoryLoaded(true);
+      if (myProjectHistoryRequestIdRef.current === requestId) setMyProjectHistoryLoaded(true);
     }
   };
 
@@ -4738,6 +4783,9 @@ export function FormaWorkspace({
                 onOpenProjectPage={(projectId) => router.push(projectRoute(projectId))}
                 onDeleteProject={(item) => openProjectDeletion({ projectId: item.projectId, title: item.title })}
                 onVisibleProjectIdsChange={handleVisibleProjectGalleryIdsChange}
+                totalItems={projectHistoryTotal}
+                currentPage={projectHistoryPage}
+                onPageChange={handleProjectHistoryPageChange}
                 standalone
               />
             </>
@@ -4756,6 +4804,9 @@ export function FormaWorkspace({
                 onOpenProjectPage={(projectId) => router.push(projectRoute(projectId))}
                 onDeleteProject={(item) => openProjectDeletion({ projectId: item.projectId, title: item.title })}
                 onVisibleProjectIdsChange={handleVisibleProjectGalleryIdsChange}
+                totalItems={myProjectHistoryTotal}
+                currentPage={myProjectHistoryPage}
+                onPageChange={handleMyProjectHistoryPageChange}
                 standalone
               />
             </>
@@ -5184,6 +5235,16 @@ function normalizePrivateChatItems(value: any): ChatListItem[] {
       };
     })
     .filter((item: ChatListItem | null): item is ChatListItem => Boolean(item));
+}
+
+function normalizeProjectListPage(value: any): { items: any[]; total: number } {
+  if (Array.isArray(value)) return { items: value, total: value.length };
+  const items = Array.isArray(value?.items) ? value.items : [];
+  const parsedTotal = Number(value?.total);
+  return {
+    items,
+    total: Number.isFinite(parsedTotal) ? Math.max(items.length, Math.trunc(parsedTotal)) : items.length,
+  };
 }
 
 function mergeChatListItems(primary: ChatListItem[], secondary: ChatListItem[]): ChatListItem[] {

--- a/apps/web/app/blueprint-workspace/home-chat-view.tsx
+++ b/apps/web/app/blueprint-workspace/home-chat-view.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 
 import CopyButton from "../../components/copy-button";
+import useChatAutoScroll from "./use-chat-auto-scroll";
 
 type HomeChatMessage = {
   id: string;
@@ -35,8 +36,8 @@ type HomeChatMessage = {
 
 type HomeChatViewProps = {
   started: boolean;
+  conversationKey: string;
   messages: HomeChatMessage[];
-  endRef: RefObject<HTMLDivElement | null>;
   renderPipelineProgress: (message: HomeChatMessage) => ReactNode;
   projectArtifact?: ReactNode;
   examples: string[];
@@ -71,8 +72,8 @@ function formatTimestamp(value: string) {
 
 export default function HomeChatView({
   started,
+  conversationKey,
   messages,
-  endRef,
   renderPipelineProgress,
   projectArtifact,
   examples,
@@ -98,6 +99,7 @@ export default function HomeChatView({
   onImageChange,
   onImagePaste,
 }: HomeChatViewProps) {
+  const { containerRef, endRef, handleScroll } = useChatAutoScroll(conversationKey, messages);
   const latestContextMessageId = [...messages]
     .reverse()
     .find((message) => message.role === "assistant" && message.workflowState === "gathering_context")?.id;
@@ -129,7 +131,11 @@ export default function HomeChatView({
         } flex min-h-0 flex-col border-y border-[#2c2f37] bg-[#111216] text-left shadow-2xl shadow-black/30`}
       >
         {started && (
-          <div className="min-h-0 flex-1 space-y-4 overflow-x-hidden overflow-y-auto px-3 py-4 sm:px-4 sm:py-5">
+          <div
+            ref={containerRef}
+            onScroll={handleScroll}
+            className="min-h-0 flex-1 space-y-4 overflow-x-hidden overflow-y-auto px-3 py-4 sm:px-4 sm:py-5"
+          >
             {messages.map((message) => {
               const isUser = message.role === "user";
               const statusTone =

--- a/apps/web/app/blueprint-workspace/project-gallery.tsx
+++ b/apps/web/app/blueprint-workspace/project-gallery.tsx
@@ -28,7 +28,7 @@ export type ProjectGalleryItem = {
 
 // Keep pagination stable across server render and hydration. The grid itself is
 // responsive; changing the item count after mount caused the whole page to jump.
-const PROJECT_GALLERY_PAGE_SIZE = 6;
+export const PROJECT_GALLERY_PAGE_SIZE = 6;
 
 export type ProjectImageCandidate = {
   src: string;
@@ -222,6 +222,9 @@ export function ProjectGallery({
   onOpenProjectPage,
   onDeleteProject,
   onVisibleProjectIdsChange,
+  totalItems,
+  currentPage: controlledPage,
+  onPageChange,
   standalone = false,
 }: {
   sectionRef: React.RefObject<HTMLElement | null>;
@@ -231,41 +234,50 @@ export function ProjectGallery({
   onOpenProjectPage: (projectId: string) => void;
   onDeleteProject?: (item: ProjectGalleryItem) => void;
   onVisibleProjectIdsChange?: (projectIds: string[]) => void;
+  totalItems?: number;
+  currentPage?: number;
+  onPageChange?: (page: number) => void;
   standalone?: boolean;
 }) {
   const pageSize = PROJECT_GALLERY_PAGE_SIZE;
-  const [currentPage, setCurrentPage] = useState(0);
-  const pageCount = Math.max(1, Math.ceil(items.length / pageSize));
+  const [localPage, setLocalPage] = useState(0);
+  const serverPaginated = typeof totalItems === "number" && typeof controlledPage === "number" && Boolean(onPageChange);
+  const currentPage = serverPaginated ? controlledPage : localPage;
+  const total = serverPaginated ? Math.max(0, totalItems) : items.length;
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
   const safePage = Math.min(currentPage, pageCount - 1);
   const firstVisibleItem = safePage * pageSize;
   const visibleItems = useMemo(
-    () => items.slice(firstVisibleItem, firstVisibleItem + pageSize),
-    [firstVisibleItem, items, pageSize]
+    () => serverPaginated ? items : items.slice(firstVisibleItem, firstVisibleItem + pageSize),
+    [firstVisibleItem, items, pageSize, serverPaginated]
   );
   const visibleProjectIds = useMemo(
     () => visibleItems.map((item) => item.projectId),
     [visibleItems]
   );
-  const showingStart = items.length ? firstVisibleItem + 1 : 0;
-  const showingEnd = Math.min(items.length, firstVisibleItem + visibleItems.length);
+  const showingStart = total ? firstVisibleItem + 1 : 0;
+  const showingEnd = Math.min(total, firstVisibleItem + visibleItems.length);
   const pageMarkers = buildProjectGalleryPageMarkers(safePage, pageCount);
 
   useEffect(() => {
-    setCurrentPage(0);
-  }, [items.length, pageSize]);
+    if (!serverPaginated) setLocalPage(0);
+  }, [items.length, pageSize, serverPaginated]);
 
   useEffect(() => {
     if (safePage !== currentPage) {
-      setCurrentPage(safePage);
+      if (serverPaginated) onPageChange?.(safePage);
+      else setLocalPage(safePage);
     }
-  }, [currentPage, safePage]);
+  }, [currentPage, onPageChange, safePage, serverPaginated]);
 
   useEffect(() => {
     onVisibleProjectIdsChange?.(visibleProjectIds);
   }, [onVisibleProjectIdsChange, visibleProjectIds]);
 
   const goToPage = (page: number) => {
-    setCurrentPage(Math.min(Math.max(page, 0), pageCount - 1));
+    const nextPage = Math.min(Math.max(page, 0), pageCount - 1);
+    if (serverPaginated) onPageChange?.(nextPage);
+    else setLocalPage(nextPage);
   };
 
   return (
@@ -279,14 +291,14 @@ export function ProjectGallery({
             <h2 className="text-2xl font-black uppercase tracking-[0.22em] text-white">{title}</h2>
           </div>
           <p className="mt-4 text-sm leading-6 text-slate-500">
-            {loading ? "Loading projects..." : `${items.length} saved projects.`}
+            {loading ? "Loading projects..." : `${total} saved projects.`}
           </p>
         </div>
       </div>
 
       {loading ? (
         <ProjectGallerySkeleton count={pageSize} />
-      ) : items.length ? (
+      ) : total && visibleItems.length ? (
         <>
           <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
             {visibleItems.map((item) => (
@@ -302,7 +314,7 @@ export function ProjectGallery({
           {pageCount > 1 && (
             <div className="mt-5 flex flex-col gap-3 border border-[#2c2f37] bg-[#17181d] p-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="text-xs font-black uppercase tracking-[0.14em] text-slate-500">
-                Showing {showingStart}-{showingEnd} of {items.length}
+                Showing {showingStart}-{showingEnd} of {total}
               </div>
 
               <div className="grid grid-cols-[44px_minmax(0,1fr)_44px] gap-2 sm:flex sm:items-center">

--- a/apps/web/app/blueprint-workspace/use-chat-auto-scroll.ts
+++ b/apps/web/app/blueprint-workspace/use-chat-auto-scroll.ts
@@ -1,0 +1,44 @@
+"use client";
+
+import { useCallback, useLayoutEffect, useRef } from "react";
+
+const FOLLOW_THRESHOLD_PX = 120;
+
+export default function useChatAutoScroll(conversationKey: string, updateKey: unknown) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const endRef = useRef<HTMLDivElement>(null);
+  const shouldFollowRef = useRef(true);
+  const previousConversationRef = useRef(conversationKey);
+
+  const handleScroll = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    if (container.scrollHeight <= container.clientHeight + FOLLOW_THRESHOLD_PX) {
+      shouldFollowRef.current = true;
+      return;
+    }
+
+    const end = endRef.current;
+    const distanceFromEnd = end
+      ? end.getBoundingClientRect().bottom - container.getBoundingClientRect().bottom
+      : container.scrollHeight - container.scrollTop - container.clientHeight;
+    shouldFollowRef.current = Math.abs(distanceFromEnd) <= FOLLOW_THRESHOLD_PX;
+  }, []);
+
+  useLayoutEffect(() => {
+    const conversationChanged = previousConversationRef.current !== conversationKey;
+    previousConversationRef.current = conversationKey;
+    if (conversationChanged) shouldFollowRef.current = true;
+
+    const container = containerRef.current;
+    if (!container || !shouldFollowRef.current) return;
+    const end = endRef.current;
+    const nextTop = end
+      ? container.scrollTop + end.getBoundingClientRect().bottom - container.getBoundingClientRect().bottom
+      : container.scrollHeight;
+    container.scrollTo({ top: nextTop, behavior: "auto" });
+  }, [conversationKey, updateKey]);
+
+  return { containerRef, endRef, handleScroll };
+}

--- a/blueprint_core/database.py
+++ b/blueprint_core/database.py
@@ -462,6 +462,27 @@ def list_generated_projects(owner_user_id: Optional[str] = None) -> List[Any]:
     return _DATABASE_REPOSITORY.list_generated_projects(normalized_owner_user_id)
 
 
+def list_generated_projects_page(
+    owner_user_id: Optional[str] = None,
+    *,
+    visibility: Optional[str] = None,
+    limit: int = 6,
+    offset: int = 0,
+) -> tuple[List[Any], int]:
+    normalized_owner_user_id = _normalize_user_id(owner_user_id)
+    normalized_visibility = str(visibility or "").strip().lower() or None
+    if normalized_visibility not in {None, "public", "private"}:
+        raise ValueError("visibility must be public or private.")
+    normalized_limit = max(1, min(int(limit), 50))
+    normalized_offset = max(0, int(offset))
+    return _DATABASE_REPOSITORY.list_generated_projects_page(
+        normalized_owner_user_id,
+        visibility=normalized_visibility,
+        limit=normalized_limit,
+        offset=normalized_offset,
+    )
+
+
 def get_generated_project(project_id: str, *, include_deleted: bool = False) -> Optional[Any]:
     return _DATABASE_REPOSITORY.get_generated_project(project_id, include_deleted=include_deleted)
 

--- a/blueprint_core/persistence/repositories/base.py
+++ b/blueprint_core/persistence/repositories/base.py
@@ -22,6 +22,15 @@ class ApplicationRepository(Protocol):
 
     def list_generated_projects(self, owner_user_id: Optional[str]) -> List[Any]: ...
 
+    def list_generated_projects_page(
+        self,
+        owner_user_id: Optional[str],
+        *,
+        visibility: Optional[str],
+        limit: int,
+        offset: int,
+    ) -> tuple[List[Any], int]: ...
+
     def get_generated_project(self, project_id: str, include_deleted: bool = False) -> Optional[Any]: ...
 
     def insert_design_brief_version(self, record: Dict[str, Any]) -> Any: ...

--- a/blueprint_core/persistence/repositories/sqlite.py
+++ b/blueprint_core/persistence/repositories/sqlite.py
@@ -77,6 +77,29 @@ class SqlAlchemyRepository:
                 query = query.filter(DBGeneratedProject.owner_user_id == owner_user_id)
             return query.order_by(DBGeneratedProject.id.desc()).all()
 
+    def list_generated_projects_page(
+        self,
+        owner_user_id: Optional[str],
+        *,
+        visibility: Optional[str],
+        limit: int,
+        offset: int,
+    ) -> tuple[List[Any], int]:
+        with self._session() as session:
+            query = session.query(DBGeneratedProject).filter(DBGeneratedProject.status == "active")
+            if owner_user_id:
+                query = query.filter(DBGeneratedProject.owner_user_id == owner_user_id)
+            if visibility:
+                query = query.filter(DBGeneratedProject.visibility == visibility)
+            total = query.count()
+            rows = (
+                query.order_by(DBGeneratedProject.created_at.desc(), DBGeneratedProject.id.desc())
+                .offset(offset)
+                .limit(limit)
+                .all()
+            )
+            return rows, total
+
     def get_generated_project(self, project_id: str, include_deleted: bool = False) -> Optional[Any]:
         with self._session() as session:
             query = session.query(DBGeneratedProject).filter(

--- a/blueprint_core/persistence/repositories/supabase.py
+++ b/blueprint_core/persistence/repositories/supabase.py
@@ -56,6 +56,34 @@ class SupabaseRepository:
         rows = query.order("id", desc=True).execute().data or []
         return [_record(row) for row in rows]
 
+    def list_generated_projects_page(
+        self,
+        owner_user_id: Optional[str],
+        *,
+        visibility: Optional[str],
+        limit: int,
+        offset: int,
+    ) -> tuple[List[Any], int]:
+        query = self._client.table("generated_projects").select(
+            "id,project_id,chat_id,title,prompt,created_at,owner_user_id,visibility,hardware_ir,status,"
+            "deleted_at,deletion_requested_by,purge_after,purge_started_at,purge_completed_at,deletion_error",
+            count="exact",
+        ).eq("status", "active")
+        if owner_user_id:
+            query = query.eq("owner_user_id", owner_user_id)
+        if visibility:
+            query = query.eq("visibility", visibility)
+        response = (
+            query.order("created_at", desc=True)
+            .order("id", desc=True)
+            .range(offset, offset + limit - 1)
+            .execute()
+        )
+        rows = response.data or []
+        response_count = getattr(response, "count", None)
+        total = response_count if isinstance(response_count, int) else len(rows)
+        return [_record(row) for row in rows], total
+
     def get_generated_project(self, project_id: str, include_deleted: bool = False) -> Optional[Any]:
         query = self._client.table("generated_projects").select("*").eq("project_id", project_id)
         if not include_deleted:

--- a/tests/api/test_project_access.py
+++ b/tests/api/test_project_access.py
@@ -129,6 +129,32 @@ class ProjectReadAccessTests(unittest.TestCase):
         self.assertIsNone(response[0]["chat_id"])
         self.assertFalse(response[0]["can_chat"])
 
+    def test_public_list_paginates_before_building_gallery_summaries(self) -> None:
+        page_projects = [
+            _project("public-project-7", owner_user_id="user-b", visibility="public"),
+            _project("public-project-8", owner_user_id="user-a", visibility="public"),
+        ]
+
+        with self._summary_dependencies(), patch.object(
+            main,
+            "list_generated_projects_page",
+            return_value=(page_projects, 14),
+        ) as list_page, patch.object(main, "list_generated_projects") as list_all:
+            response = main.list_projects_endpoint(_user_context("user-a"), limit=2, offset=6)
+
+        list_page.assert_called_once_with(visibility="public", limit=2, offset=6)
+        list_all.assert_not_called()
+        self.assertEqual(14, response["total"])
+        self.assertEqual(2, response["limit"])
+        self.assertEqual(6, response["offset"])
+        self.assertTrue(response["has_more"])
+        self.assertEqual(
+            ["public-project-7", "public-project-8"],
+            [item["project_id"] for item in response["items"]],
+        )
+        self.assertFalse(response["items"][0]["can_chat"])
+        self.assertTrue(response["items"][1]["can_chat"])
+
     def test_public_list_cache_is_shared_but_restores_owner_capabilities(self) -> None:
         owner_digest = main._project_owner_digest("user-a")
         cached_record = {
@@ -207,6 +233,30 @@ class ProjectReadAccessTests(unittest.TestCase):
         self.assertEqual("chat-canonical-controller", response[0]["chat_id"])
         self.assertTrue(response[0]["can_chat"])
         self.assertTrue(response[0]["has_product_image"])
+
+    def test_owner_list_uses_bounded_projection_page(self) -> None:
+        page_projects = [
+            _project("private-project-7", owner_user_id="user-a", visibility="private"),
+            _project("private-project-8", owner_user_id="user-a", visibility="private"),
+        ]
+
+        with self._summary_dependencies(), patch.object(
+            main,
+            "list_generated_projects_page",
+            return_value=(page_projects, 9),
+        ) as list_page, patch.object(main, "list_latest_project_revisions") as list_revisions:
+            response = main.list_my_projects_endpoint(_user_context("user-a"), limit=2, offset=6)
+
+        list_page.assert_called_once_with(owner_user_id="user-a", limit=2, offset=6)
+        list_revisions.assert_not_called()
+        self.assertEqual(9, response["total"])
+        self.assertEqual(2, response["limit"])
+        self.assertEqual(6, response["offset"])
+        self.assertTrue(response["has_more"])
+        self.assertEqual(
+            ["private-project-7", "private-project-8"],
+            [item["project_id"] for item in response["items"]],
+        )
 
     def test_owner_list_deduplicates_legacy_and_canonical_project_records(self) -> None:
         project_id = "legacy-and-canonical"

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -11,10 +11,10 @@ from unittest.mock import patch
 from blueprint_core.jobs.store import JobMetadataStore
 from blueprint_core import database
 from blueprint_core.persistence import APPLICATION_SCHEMA
-from blueprint_core.persistence.models import DBProjectRevision
+from blueprint_core.persistence.models import DBGeneratedProject, DBProjectRevision
 from blueprint_core.jobs.migrations import import_legacy_job_database
 from blueprint_core.persistence.providers import SupabaseProvider, create_sqlite_provider
-from blueprint_core.persistence.repositories import SqlAlchemyRepository
+from blueprint_core.persistence.repositories import SqlAlchemyRepository, SupabaseRepository
 from blueprint_core.workspaces.design_briefs import DESIGN_BRIEF_SCHEMA_VERSION, DesignBrief
 from blueprint_core.workspaces.projects import ProjectRevision
 from blueprint_core.workspaces.projects.models import HardwareIR, ProjectOverview
@@ -232,6 +232,60 @@ class PersistenceArchitectureTests(unittest.TestCase):
             [(revision.project_id, revision.revision) for revision in revisions],
         )
 
+    def test_sqlite_repository_pages_filtered_projects_before_loading_records(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            provider = create_sqlite_provider(
+                source="test primary",
+                url=f"sqlite:///{Path(directory) / 'blueprint.db'}",
+                import_legacy_jobs=False,
+            )
+            assert provider.session_factory is not None
+            provider.initialize()
+            repository = SqlAlchemyRepository(provider.session_factory)
+            with provider.session_factory() as session, session.begin():
+                session.add_all([
+                    DBGeneratedProject(
+                        project_id=f"project-{index}",
+                        owner_user_id="user-a" if index < 8 else "user-b",
+                        visibility="public" if index % 2 == 0 else "private",
+                        title=f"Project {index}",
+                        prompt="Build a test fixture.",
+                        hardware_ir={},
+                        created_at=f"2026-08-{index + 1:02d}T00:00:00Z",
+                        status="active",
+                    )
+                    for index in range(10)
+                ])
+
+            projects, total = repository.list_generated_projects_page(
+                "user-a",
+                visibility="public",
+                limit=2,
+                offset=1,
+            )
+
+        self.assertEqual(4, total)
+        self.assertEqual(["project-4", "project-2"], [project.project_id for project in projects])
+
+    def test_supabase_repository_requests_an_exact_count_and_bounded_range(self) -> None:
+        client = _ProjectPageClient()
+        repository = SupabaseRepository(client)
+
+        projects, total = repository.list_generated_projects_page(
+            "user-a",
+            visibility="public",
+            limit=6,
+            offset=12,
+        )
+
+        self.assertEqual(37, total)
+        self.assertEqual(["project-13", "project-14"], [project.project_id for project in projects])
+        self.assertEqual("exact", client.query.count_mode)
+        self.assertEqual((12, 17), client.query.requested_range)
+        self.assertIn(("status", "active"), client.query.filters)
+        self.assertIn(("owner_user_id", "user-a"), client.query.filters)
+        self.assertIn(("visibility", "public"), client.query.filters)
+
     def test_legacy_job_import_is_idempotent_and_does_not_overwrite_primary_rows(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             primary_path = Path(directory) / "blueprint.db"
@@ -370,6 +424,48 @@ class _SchemaClient:
 
     def table(self, table: str) -> _SchemaQuery:
         return _SchemaQuery(self, table)
+
+
+class _ProjectPageResponse:
+    data = [
+        {"project_id": "project-13"},
+        {"project_id": "project-14"},
+    ]
+    count = 37
+
+
+class _ProjectPageQuery:
+    def __init__(self) -> None:
+        self.count_mode: str | None = None
+        self.requested_range: tuple[int, int] | None = None
+        self.filters: list[tuple[str, str]] = []
+
+    def select(self, _projection: str, *, count: str | None = None) -> "_ProjectPageQuery":
+        self.count_mode = count
+        return self
+
+    def eq(self, field: str, value: str) -> "_ProjectPageQuery":
+        self.filters.append((field, value))
+        return self
+
+    def order(self, _field: str, *, desc: bool = False) -> "_ProjectPageQuery":
+        return self
+
+    def range(self, start: int, end: int) -> "_ProjectPageQuery":
+        self.requested_range = (start, end)
+        return self
+
+    def execute(self) -> _ProjectPageResponse:
+        return _ProjectPageResponse()
+
+
+class _ProjectPageClient:
+    def __init__(self) -> None:
+        self.query = _ProjectPageQuery()
+
+    def table(self, table: str) -> _ProjectPageQuery:
+        assert table == "generated_projects"
+        return self.query
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fetch Community and My Projects as six-item server-side pages with exact totals
- hydrate project images only for the visible page
- keep main and project chats pinned to incoming updates until the reader scrolls away
- use Gemini 3.6 Flash as the default Gemini and Vertex text model
- update environment examples and integration placeholders for Gemini 3.6 Flash
- retain the existing unpaginated API response when pagination parameters are omitted

## Deployment configuration
- set `LLM_MODEL` and `VERTEX_AI_MODEL` to `gemini-3.6-flash` for development, preview, staging, and production
- repair preview provider routing to Vertex with the existing keyless workload-identity configuration
- redeploy and verify preview, staging, and production runtime configuration

## Verification
- `npm run lint` (passes with pre-existing `<img>` warnings)
- `npm run build`
- project API/persistence regression tests pass
- Gemini 3.6 default regression passes
- user integration suite: 50 passed
- deployed runtime config reports `vertex/gemini-3.6-flash` in preview, staging, and production
- full Python suite retains one unrelated existing Vertex timeout assertion: the test expects 90s while configuration is 600s