### PR TITLE
Fix default-theme selected-state contrast

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -70,6 +70,7 @@
   --forma-scrim-rgb: 238 232 213;
   --forma-scroll-thumb: #93a1a1;
   --forma-card-shadow: 0 18px 38px rgb(88 110 117 / 0.16);
+  --forma-selected-wash-alpha: 0.07;
 }
 
 /*
@@ -107,6 +108,7 @@
   --forma-scrim-rgb: 238 242 247;
   --forma-scroll-thumb: #94a3b8;
   --forma-card-shadow: 0 18px 38px rgb(15 23 42 / 0.12);
+  --forma-selected-wash-alpha: 0.1;
 }
 
 * {
@@ -429,6 +431,19 @@ html:is([data-theme="light"], [data-theme="arctic"]) [class~='bg-[#0f1014]'] {
 }
 
 /*
+ * Sidebar links use this dark-theme utility for hover feedback. Translate the
+ * state as well as the static fill so it cannot flash a near-black rectangle
+ * in either light theme. Keep the text on the theme's strong foreground.
+ */
+html:is([data-theme="light"], [data-theme="arctic"]) [class~='hover:bg-[#17181d]']:hover {
+  background-color: var(--forma-surface-muted);
+}
+
+html:is([data-theme="light"], [data-theme="arctic"]) [class~="hover:text-white"]:hover {
+  color: var(--forma-text-strong);
+}
+
+/*
  * Status washes. The interface tints panels with dark 950 shades, which land as
  * muddy blocks once the surface below them is light. Matching on the class
  * prefix covers every alpha step in one rule.
@@ -477,7 +492,7 @@ html:is([data-theme="light"], [data-theme="arctic"]) [class~="bg-black/30"] {
  */
 html:is([data-theme="light"], [data-theme="arctic"]) [class~="bg-cyan-300/5"],
 html:is([data-theme="light"], [data-theme="arctic"]) [class~="bg-cyan-300/10"] {
-  background-color: rgb(var(--forma-cyan-rgb) / 0.1);
+  background-color: rgb(var(--forma-cyan-rgb) / var(--forma-selected-wash-alpha));
 }
 
 html:is([data-theme="light"], [data-theme="arctic"]) [class~="bg-emerald-400/10"] {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -108,7 +108,7 @@
   --forma-scrim-rgb: 238 242 247;
   --forma-scroll-thumb: #94a3b8;
   --forma-card-shadow: 0 18px 38px rgb(15 23 42 / 0.12);
-  --forma-selected-wash-alpha: 0.1;
+  --forma-selected-wash-alpha: 0.18;
 }
 
 * {

--- a/apps/web/test/theme.test.ts
+++ b/apps/web/test/theme.test.ts
@@ -137,6 +137,7 @@ test("the Solarized block declares the exported palette", () => {
   assert.match(block, new RegExp(`--forma-text: ${solarizedLight.base01};`));
   assert.match(block, new RegExp(`--forma-text-strong: ${solarizedLight.base02};`));
   assert.match(block, new RegExp(`--forma-text-muted: ${solarizedLight.base00};`));
+  assert.match(block, /--forma-selected-wash-alpha: 0\.07;/);
   // Rules and wells are base1 at low alpha so they track whatever sits behind them.
   const [red, green, blue] = channels(solarizedLight.base1);
   assert.match(block, new RegExp(`--forma-surface-muted: rgb\\(${red} ${green} ${blue} / 0\\.18\\);`));
@@ -162,6 +163,7 @@ test("the Arctic block preserves the slate theme Forma shipped before Solarized"
   assert.match(block, new RegExp(`--forma-text-body: ${arcticLight.textBody};`));
   assert.match(block, new RegExp(`--forma-text-secondary: ${arcticLight.textSecondary};`));
   assert.match(block, new RegExp(`--forma-text-muted: ${arcticLight.textMuted};`));
+  assert.match(block, /--forma-selected-wash-alpha: 0\.1;/);
   for (const [name, hex] of Object.entries({
     cyan: arcticLight.cyan,
     green: arcticLight.green,
@@ -203,4 +205,15 @@ test("shared rules resolve their colours through variables, not literals", () =>
       `a literal colour leaked into a shared rule:\n${selector.trim()}\n{${declarations}}`,
     );
   }
+});
+
+test("light-theme interaction states use theme tokens instead of dark utilities", () => {
+  const rules = scopedRules();
+  const sidebarHover = rules.find(({ selector }) => selector.includes("hover:bg-[#17181d]"));
+  assert.ok(sidebarHover, "the sidebar hover utility is not translated for light themes");
+  assert.match(sidebarHover.declarations, /background-color: var\(--forma-surface-muted\)/);
+
+  const selectedWash = rules.find(({ selector }) => selector.includes("bg-cyan-300/10"));
+  assert.ok(selectedWash, "the selected-state wash rule is missing");
+  assert.match(selectedWash.declarations, /var\(--forma-selected-wash-alpha\)/);
 });

--- a/apps/web/test/theme.test.ts
+++ b/apps/web/test/theme.test.ts
@@ -163,7 +163,7 @@ test("the Arctic block preserves the slate theme Forma shipped before Solarized"
   assert.match(block, new RegExp(`--forma-text-body: ${arcticLight.textBody};`));
   assert.match(block, new RegExp(`--forma-text-secondary: ${arcticLight.textSecondary};`));
   assert.match(block, new RegExp(`--forma-text-muted: ${arcticLight.textMuted};`));
-  assert.match(block, /--forma-selected-wash-alpha: 0\.1;/);
+  assert.match(block, /--forma-selected-wash-alpha: 0\.18;/);
   for (const [name, hex] of Object.entries({
     cyan: arcticLight.cyan,
     green: arcticLight.green,


### PR DESCRIPTION
Closes the default-theme half of #262.

## Summary
- translate the sidebar dark hover utility onto light-theme surface tokens
- keep hover text readable instead of allowing a white-on-light state
- introduce a shared selected-wash strength token and soften Solarized/default selection from 10% to 7%
- preserve Arctic at its existing strength for the separate Arctic PR

## Verification
- theme tests: 14 passed
- `npm run lint` (passes with existing `<img>` warnings)
- `npm run build`