### PR TITLE
Fix Arctic-theme selected-state contrast

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -108,7 +108,7 @@
   --forma-scrim-rgb: 238 242 247;
   --forma-scroll-thumb: #94a3b8;
   --forma-card-shadow: 0 18px 38px rgb(15 23 42 / 0.12);
-  --forma-selected-wash-alpha: 0.1;
+  --forma-selected-wash-alpha: 0.18;
 }
 
 * {

--- a/apps/web/test/theme.test.ts
+++ b/apps/web/test/theme.test.ts
@@ -163,7 +163,7 @@ test("the Arctic block preserves the slate theme Forma shipped before Solarized"
   assert.match(block, new RegExp(`--forma-text-body: ${arcticLight.textBody};`));
   assert.match(block, new RegExp(`--forma-text-secondary: ${arcticLight.textSecondary};`));
   assert.match(block, new RegExp(`--forma-text-muted: ${arcticLight.textMuted};`));
-  assert.match(block, /--forma-selected-wash-alpha: 0\.1;/);
+  assert.match(block, /--forma-selected-wash-alpha: 0\.18;/);
   for (const [name, hex] of Object.entries({
     cyan: arcticLight.cyan,
     green: arcticLight.green,


### PR DESCRIPTION
Closes the Arctic-theme half of #262.

Stacked on #264 so this review contains only the Arctic-specific contrast change. After #264 merges, this PR should be retargeted to `main`.

## Summary
- increase Arctic selected-state wash strength from 10% to 18%
- preserve the default/Solarized value from #264
- keep hover and selected states distinct through the shared tokenized rule

## Verification
- theme tests: 14 passed
- `npm run lint` (passes with existing `<img>` warnings)
- production build verified on the base PR