### PR TITLE
Add basic Community project search

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1727,6 +1727,7 @@ def list_projects_endpoint(
     user: UserContext = Depends(optional_user_context),
     limit: Optional[int] = None,
     offset: int = 0,
+    q: Optional[str] = None,
 ):
     """Lists public compiled hardware projects."""
     try:
@@ -1735,6 +1736,7 @@ def list_projects_endpoint(
                 visibility="public",
                 limit=limit,
                 offset=offset,
+                search=q,
             )
             items = [_public_project_cache_record(project) for project in projects]
             return {

--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -1618,6 +1618,8 @@ export function FormaWorkspace({
   const [myProjectHistoryTotal, setMyProjectHistoryTotal] = useState(0);
   const [projectHistoryLoaded, setProjectHistoryLoaded] = useState(false);
   const [myProjectHistoryLoaded, setMyProjectHistoryLoaded] = useState(false);
+  const [projectSearchInput, setProjectSearchInput] = useState("");
+  const [projectSearchQuery, setProjectSearchQuery] = useState("");
   const [localChatItems, setLocalChatItems] = useState<ChatListItem[]>([]);
   const [privateChatItems, setPrivateChatItems] = useState<ChatListItem[]>([]);
   const [privateChatsLoaded, setPrivateChatsLoaded] = useState(false);
@@ -2342,17 +2344,29 @@ export function FormaWorkspace({
 
   useEffect(() => {
     if (homeView !== "projects") return;
-    void fetchProjectHistory(projectHistoryPage);
+    void fetchProjectHistory(projectHistoryPage, projectSearchQuery);
     // Public gallery data becomes critical only when its route is active.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [homeView, projectHistoryPage]);
+  }, [homeView, projectHistoryPage, projectSearchQuery]);
+
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      const nextQuery = projectSearchInput.trim();
+      if (nextQuery === projectSearchQuery) return;
+      setProjectHistoryLoaded(false);
+      setVisibleProjectGalleryIds([]);
+      setProjectHistoryPage(0);
+      setProjectSearchQuery(nextQuery);
+    }, 300);
+    return () => window.clearTimeout(timeout);
+  }, [projectSearchInput, projectSearchQuery]);
 
   useDeferredTask(() => {
-    if (!projectHistoryLoaded) void fetchProjectHistory(projectHistoryPage);
+    if (!projectHistoryLoaded) void fetchProjectHistory(projectHistoryPage, projectSearchQuery);
   }, {
     delayMs: 1200,
     enabled: homeView !== "projects" && !projectHistoryLoaded,
-    taskKey: `${homeView}:${projectHistoryPage}`,
+    taskKey: `${homeView}:${projectHistoryPage}:${projectSearchQuery}`,
     timeoutMs: 1800,
   });
 
@@ -2544,7 +2558,10 @@ export function FormaWorkspace({
   };
 
 
-  const fetchProjectHistory = async (page: number = projectHistoryPage) => {
+  const fetchProjectHistory = async (
+    page: number = projectHistoryPage,
+    search: string = projectSearchQuery,
+  ) => {
     const requestId = projectHistoryRequestIdRef.current + 1;
     projectHistoryRequestIdRef.current = requestId;
     setProjectHistoryLoaded(false);
@@ -2553,6 +2570,8 @@ export function FormaWorkspace({
         limit: String(PROJECT_GALLERY_PAGE_SIZE),
         offset: String(Math.max(0, page) * PROJECT_GALLERY_PAGE_SIZE),
       });
+      const normalizedSearch = search.trim();
+      if (normalizedSearch) params.set("q", normalizedSearch);
       const res = await fetch(`${API_URL}/projects?${params.toString()}`, {
         headers: await optionalAuthHeaders(),
       });
@@ -4767,6 +4786,8 @@ export function FormaWorkspace({
                 totalItems={projectHistoryTotal}
                 currentPage={projectHistoryPage}
                 onPageChange={handleProjectHistoryPageChange}
+                searchValue={projectSearchInput}
+                onSearchValueChange={setProjectSearchInput}
                 standalone
               />
             </>

--- a/apps/web/app/blueprint-workspace/project-gallery.tsx
+++ b/apps/web/app/blueprint-workspace/project-gallery.tsx
@@ -7,8 +7,10 @@ import {
   Clock3,
   Cpu,
   MessageSquare,
+  Search,
   Star,
   Trash2,
+  X,
 } from "lucide-react";
 
 export type ProjectGalleryItem = {
@@ -225,6 +227,8 @@ export function ProjectGallery({
   totalItems,
   currentPage: controlledPage,
   onPageChange,
+  searchValue,
+  onSearchValueChange,
   standalone = false,
 }: {
   sectionRef: React.RefObject<HTMLElement | null>;
@@ -237,6 +241,8 @@ export function ProjectGallery({
   totalItems?: number;
   currentPage?: number;
   onPageChange?: (page: number) => void;
+  searchValue?: string;
+  onSearchValueChange?: (value: string) => void;
   standalone?: boolean;
 }) {
   const pageSize = PROJECT_GALLERY_PAGE_SIZE;
@@ -258,6 +264,8 @@ export function ProjectGallery({
   const showingStart = total ? firstVisibleItem + 1 : 0;
   const showingEnd = Math.min(total, firstVisibleItem + visibleItems.length);
   const pageMarkers = buildProjectGalleryPageMarkers(safePage, pageCount);
+  const searchable = typeof searchValue === "string" && Boolean(onSearchValueChange);
+  const hasSearch = Boolean(searchValue?.trim());
 
   useEffect(() => {
     if (!serverPaginated) setLocalPage(0);
@@ -282,7 +290,7 @@ export function ProjectGallery({
 
   return (
     <section ref={sectionRef} id="all-projects" className={standalone ? "" : "mt-16 border-t border-[#292b31] pt-12"}>
-      <div className="mb-6 flex flex-col gap-3">
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <div className="flex items-center gap-3">
             <span className="flex h-9 w-9 items-center justify-center border border-[#2c2f37] bg-black text-white">
@@ -291,9 +299,34 @@ export function ProjectGallery({
             <h2 className="text-2xl font-black uppercase tracking-[0.22em] text-white">{title}</h2>
           </div>
           <p className="mt-4 text-sm leading-6 text-slate-500">
-            {loading ? "Loading projects..." : `${total} saved projects.`}
+            {loading
+              ? hasSearch ? "Searching projects..." : "Loading projects..."
+              : hasSearch ? `${total} matching projects.` : `${total} saved projects.`}
           </p>
         </div>
+        {searchable && (
+          <label className="relative block w-full sm:max-w-sm">
+            <span className="sr-only">Search community projects</span>
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-500" />
+            <input
+              type="search"
+              value={searchValue}
+              onChange={(event) => onSearchValueChange?.(event.target.value)}
+              placeholder="Search projects"
+              className="h-11 w-full border border-[#2c2f37] bg-[#17181d] pl-10 pr-10 text-sm text-white outline-none transition placeholder:text-slate-600 focus:border-cyan-300"
+            />
+            {hasSearch && (
+              <button
+                type="button"
+                onClick={() => onSearchValueChange?.("")}
+                className="absolute right-1 top-1/2 inline-flex h-9 w-9 -translate-y-1/2 items-center justify-center text-slate-500 transition hover:text-white"
+                aria-label="Clear project search"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            )}
+          </label>
+        )}
       </div>
 
       {loading ? (
@@ -374,7 +407,7 @@ export function ProjectGallery({
         </>
       ) : (
         <div className="border border-[#2c2f37] bg-[#17181d] p-8 text-sm leading-6 text-slate-500">
-          No saved projects yet.
+          {hasSearch ? `No projects match “${searchValue?.trim()}”.` : "No saved projects yet."}
         </div>
       )}
     </section>

--- a/blueprint_core/database.py
+++ b/blueprint_core/database.py
@@ -468,6 +468,7 @@ def list_generated_projects_page(
     visibility: Optional[str] = None,
     limit: int = 6,
     offset: int = 0,
+    search: Optional[str] = None,
 ) -> tuple[List[Any], int]:
     normalized_owner_user_id = _normalize_user_id(owner_user_id)
     normalized_visibility = str(visibility or "").strip().lower() or None
@@ -475,11 +476,13 @@ def list_generated_projects_page(
         raise ValueError("visibility must be public or private.")
     normalized_limit = max(1, min(int(limit), 50))
     normalized_offset = max(0, int(offset))
+    normalized_search = " ".join(str(search or "").split())[:100] or None
     return _DATABASE_REPOSITORY.list_generated_projects_page(
         normalized_owner_user_id,
         visibility=normalized_visibility,
         limit=normalized_limit,
         offset=normalized_offset,
+        search=normalized_search,
     )
 
 

--- a/blueprint_core/persistence/repositories/base.py
+++ b/blueprint_core/persistence/repositories/base.py
@@ -29,6 +29,7 @@ class ApplicationRepository(Protocol):
         visibility: Optional[str],
         limit: int,
         offset: int,
+        search: Optional[str] = None,
     ) -> tuple[List[Any], int]: ...
 
     def get_generated_project(self, project_id: str, include_deleted: bool = False) -> Optional[Any]: ...

--- a/blueprint_core/persistence/repositories/sqlite.py
+++ b/blueprint_core/persistence/repositories/sqlite.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Optional
 
+from sqlalchemy import or_
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
@@ -84,6 +85,7 @@ class SqlAlchemyRepository:
         visibility: Optional[str],
         limit: int,
         offset: int,
+        search: Optional[str] = None,
     ) -> tuple[List[Any], int]:
         with self._session() as session:
             query = session.query(DBGeneratedProject).filter(DBGeneratedProject.status == "active")
@@ -91,6 +93,12 @@ class SqlAlchemyRepository:
                 query = query.filter(DBGeneratedProject.owner_user_id == owner_user_id)
             if visibility:
                 query = query.filter(DBGeneratedProject.visibility == visibility)
+            if search:
+                pattern = f"%{search}%"
+                query = query.filter(or_(
+                    DBGeneratedProject.title.ilike(pattern),
+                    DBGeneratedProject.prompt.ilike(pattern),
+                ))
             total = query.count()
             rows = (
                 query.order_by(DBGeneratedProject.created_at.desc(), DBGeneratedProject.id.desc())

--- a/blueprint_core/persistence/repositories/supabase.py
+++ b/blueprint_core/persistence/repositories/supabase.py
@@ -8,6 +8,17 @@ def _record(row: Dict[str, Any]) -> SimpleNamespace:
     return SimpleNamespace(**row)
 
 
+def _postgrest_ilike_pattern(value: str) -> str:
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("%", "\\%")
+        .replace("_", "\\_")
+        .replace("*", "\\*")
+    )
+    return f'"*{escaped}*"'
+
+
 class SupabaseRepository:
     """Application repository implemented through Supabase PostgREST."""
 
@@ -63,6 +74,7 @@ class SupabaseRepository:
         visibility: Optional[str],
         limit: int,
         offset: int,
+        search: Optional[str] = None,
     ) -> tuple[List[Any], int]:
         query = self._client.table("generated_projects").select(
             "id,project_id,chat_id,title,prompt,created_at,owner_user_id,visibility,hardware_ir,status,"
@@ -73,6 +85,9 @@ class SupabaseRepository:
             query = query.eq("owner_user_id", owner_user_id)
         if visibility:
             query = query.eq("visibility", visibility)
+        if search:
+            pattern = _postgrest_ilike_pattern(search)
+            query = query.or_(f"title.ilike.{pattern},prompt.ilike.{pattern}")
         response = (
             query.order("created_at", desc=True)
             .order("id", desc=True)

--- a/tests/api/test_project_access.py
+++ b/tests/api/test_project_access.py
@@ -142,7 +142,7 @@ class ProjectReadAccessTests(unittest.TestCase):
         ) as list_page, patch.object(main, "list_generated_projects") as list_all:
             response = main.list_projects_endpoint(_user_context("user-a"), limit=2, offset=6)
 
-        list_page.assert_called_once_with(visibility="public", limit=2, offset=6)
+        list_page.assert_called_once_with(visibility="public", limit=2, offset=6, search=None)
         list_all.assert_not_called()
         self.assertEqual(14, response["total"])
         self.assertEqual(2, response["limit"])
@@ -154,6 +154,28 @@ class ProjectReadAccessTests(unittest.TestCase):
         )
         self.assertFalse(response["items"][0]["can_chat"])
         self.assertTrue(response["items"][1]["can_chat"])
+
+    def test_public_list_passes_search_to_the_paginated_query(self) -> None:
+        with self._summary_dependencies(), patch.object(
+            main,
+            "list_generated_projects_page",
+            return_value=([], 0),
+        ) as list_page:
+            response = main.list_projects_endpoint(
+                _user_context("user-a"),
+                limit=6,
+                offset=0,
+                q="motor controller",
+            )
+
+        list_page.assert_called_once_with(
+            visibility="public",
+            limit=6,
+            offset=0,
+            search="motor controller",
+        )
+        self.assertEqual([], response["items"])
+        self.assertEqual(0, response["total"])
 
     def test_public_list_cache_is_shared_but_restores_owner_capabilities(self) -> None:
         owner_digest = main._project_owner_digest("user-a")

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -267,6 +267,61 @@ class PersistenceArchitectureTests(unittest.TestCase):
         self.assertEqual(4, total)
         self.assertEqual(["project-4", "project-2"], [project.project_id for project in projects])
 
+    def test_sqlite_repository_searches_project_titles_and_prompts(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            provider = create_sqlite_provider(
+                source="test primary",
+                url=f"sqlite:///{Path(directory) / 'blueprint.db'}",
+                import_legacy_jobs=False,
+            )
+            assert provider.session_factory is not None
+            provider.initialize()
+            repository = SqlAlchemyRepository(provider.session_factory)
+            with provider.session_factory() as session, session.begin():
+                session.add_all([
+                    DBGeneratedProject(
+                        project_id="title-match",
+                        visibility="public",
+                        title="Compact Motor Controller",
+                        prompt="Build a portable drive.",
+                        hardware_ir={},
+                        created_at="2026-08-03T00:00:00Z",
+                        status="active",
+                    ),
+                    DBGeneratedProject(
+                        project_id="prompt-match",
+                        visibility="public",
+                        title="Factory Fixture",
+                        prompt="Build a MOTOR test stand.",
+                        hardware_ir={},
+                        created_at="2026-08-02T00:00:00Z",
+                        status="active",
+                    ),
+                    DBGeneratedProject(
+                        project_id="no-match",
+                        visibility="public",
+                        title="Weather Station",
+                        prompt="Measure temperature.",
+                        hardware_ir={},
+                        created_at="2026-08-01T00:00:00Z",
+                        status="active",
+                    ),
+                ])
+
+            projects, total = repository.list_generated_projects_page(
+                None,
+                visibility="public",
+                limit=6,
+                offset=0,
+                search="motor",
+            )
+
+        self.assertEqual(2, total)
+        self.assertEqual(
+            ["title-match", "prompt-match"],
+            [project.project_id for project in projects],
+        )
+
     def test_supabase_repository_requests_an_exact_count_and_bounded_range(self) -> None:
         client = _ProjectPageClient()
         repository = SupabaseRepository(client)
@@ -285,6 +340,23 @@ class PersistenceArchitectureTests(unittest.TestCase):
         self.assertIn(("status", "active"), client.query.filters)
         self.assertIn(("owner_user_id", "user-a"), client.query.filters)
         self.assertIn(("visibility", "public"), client.query.filters)
+
+    def test_supabase_repository_searches_titles_and_prompts(self) -> None:
+        client = _ProjectPageClient()
+        repository = SupabaseRepository(client)
+
+        repository.list_generated_projects_page(
+            None,
+            visibility="public",
+            limit=6,
+            offset=0,
+            search="motor, controller",
+        )
+
+        self.assertEqual(
+            'title.ilike."*motor, controller*",prompt.ilike."*motor, controller*"',
+            client.query.or_filter,
+        )
 
     def test_legacy_job_import_is_idempotent_and_does_not_overwrite_primary_rows(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
@@ -439,6 +511,7 @@ class _ProjectPageQuery:
         self.count_mode: str | None = None
         self.requested_range: tuple[int, int] | None = None
         self.filters: list[tuple[str, str]] = []
+        self.or_filter: str | None = None
 
     def select(self, _projection: str, *, count: str | None = None) -> "_ProjectPageQuery":
         self.count_mode = count
@@ -446,6 +519,10 @@ class _ProjectPageQuery:
 
     def eq(self, field: str, value: str) -> "_ProjectPageQuery":
         self.filters.append((field, value))
+        return self
+
+    def or_(self, expression: str) -> "_ProjectPageQuery":
+        self.or_filter = expression
         return self
 
     def order(self, _field: str, *, desc: bool = False) -> "_ProjectPageQuery":


### PR DESCRIPTION
Closes #28.

Adds a simple Community search field that:
- matches public projects by title or prompt
- debounces requests while typing
- preserves server-side pagination and filtered totals
- supports both SQLite and Supabase persistence

Validation:
- `python -m unittest tests.api.test_project_access tests.persistence.test_persistence`
- `npm run lint` (existing image warnings only)
- `npm run build`