### PR TITLE
Add clickable context choices and Build Now

### DIFF
--- a/apps/api/context_gathering_api.py
+++ b/apps/api/context_gathering_api.py
@@ -151,6 +151,7 @@ def gather_project_context_endpoint(
 
     brief = previous
     questions: list[str] = []
+    suggestions = list(decision.suggestions) if decision.tool_name == "ask_question" else []
     build_execution: ContextBuildExecution | None = None
     if decision.tool_name == "build_project" and brief is None:
         bootstrap_request = _bootstrap_context_request(request, existing_messages)
@@ -166,7 +167,7 @@ def gather_project_context_endpoint(
                     ).workflow
                 except WorkflowStateError as exc:
                     raise _workflow_error(exc) from exc
-            brief_create, _, questions = agent.update(bootstrap_request, None)
+            brief_create, _, questions, _ = agent.update(bootstrap_request, None)
             try:
                 brief = create_design_brief_version(str(project_id), owner, brief_create)
             except DesignBriefAccessError as exc:
@@ -224,7 +225,9 @@ def gather_project_context_endpoint(
                 },
             )
 
-        brief_create, _, questions = agent.update(request, previous)
+        brief_create, _, questions, generated_suggestions = agent.update(request, previous)
+        if not suggestions:
+            suggestions = generated_suggestions
         try:
             brief = create_design_brief_version(str(project_id), owner, brief_create)
         except DesignBriefAccessError as exc:
@@ -337,6 +340,7 @@ def gather_project_context_endpoint(
             "status": "complete",
             "timestamp": now,
             "questions": questions,
+            "suggestions": suggestions,
             "turnKind": decision.turn_kind,
             "toolName": decision.tool_name,
         }
@@ -371,5 +375,6 @@ def gather_project_context_endpoint(
         design_brief=brief,
         assistant_message=decision.assistant_message,
         questions=questions,
+        suggestions=suggestions,
         build_execution=build_execution,
     )

--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -9,6 +9,7 @@ import {
   type GenerationLlmOption,
 } from "../lib/active-llms";
 import { buildProjectDocsMarkdown, docsExportFilename } from "../lib/docs-export";
+import { normalizeContextSuggestions } from "../lib/context-suggestions";
 import { usableRuntimeLlmOptions, webConfig, type RuntimeConfigContract } from "../lib/config";
 import { calculateProjectCostMetrics } from "../lib/project-cost-metrics";
 import { useFormaAuth } from "../lib/forma-auth";
@@ -181,6 +182,7 @@ type ChatMessage = {
   contextProjectId?: string | null;
   workflowState?: string | null;
   contextQuestions?: string[];
+  contextSuggestions?: string[];
   buildPlanId?: string | null;
   buildJobId?: string | null;
 };
@@ -448,6 +450,7 @@ function normalizeChatMessage(value: any): ChatMessage | null {
     contextQuestions: (Array.isArray(value.contextQuestions) ? value.contextQuestions : value.questions)
       ?.filter((question: unknown): question is string => typeof question === "string" && Boolean(question.trim()))
       .map((question: string) => question.trim()) || [],
+    contextSuggestions: normalizeContextSuggestions(value.contextSuggestions ?? value.suggestions),
     buildPlanId: typeof value.buildPlanId === "string"
       ? value.buildPlanId
       : typeof value.build_plan_id === "string"
@@ -1602,7 +1605,7 @@ export function FormaWorkspace({
   const contextProjectIdsRef = useRef<Record<string, string>>({});
   const contextBuildWatchersRef = useRef<Set<string>>(new Set());
   const [contextWorkflowStates, setContextWorkflowStates] = useState<Record<string, string>>({});
-  const [contextSkipping, setContextSkipping] = useState(false);
+  const [contextBuildStarting, setContextBuildStarting] = useState(false);
   const [contextSubmitting, setContextSubmitting] = useState(false);
   const [chatThreads, setChatThreads] = useState<Record<string, ChatMessage[]>>({});
   const [projectChatInput, setProjectChatInput] = useState("");
@@ -3246,12 +3249,12 @@ export function FormaWorkspace({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeChatId, chatMessageIdentityKey(chatMessages)]);
 
-  const handleGatherContext = async (event: React.FormEvent) => {
-    event.preventDefault();
+  const submitGatherContext = async (answer?: string) => {
     if (contextSubmitting || activeGenerationRef.current) return;
     if (!(await requireSignedInForGeneration())) return;
 
-    const validation = validateGenerationInput(prompt, Boolean(selectedImage));
+    const submittedPrompt = answer ?? prompt;
+    const validation = validateGenerationInput(submittedPrompt, Boolean(selectedImage));
     if (!validation.isValid) {
       setGenerationInputNotice(validation.message);
       return;
@@ -3264,7 +3267,7 @@ export function FormaWorkspace({
         : newBuildChatId()
     );
     contextProjectIdsRef.current[requestChatId] = requestProjectId;
-    const text = prompt.trim();
+    const text = submittedPrompt.trim();
     const imageData = selectedImage;
     const userMessageId = newChatMessageId();
     const assistantMessageId = newChatMessageId();
@@ -3342,6 +3345,7 @@ export function FormaWorkspace({
         contextProjectId: persistedProjectId || null,
         workflowState: workflowState || null,
         contextQuestions: Array.isArray(data?.questions) ? data.questions : [],
+        contextSuggestions: normalizeContextSuggestions(data?.suggestions),
         buildPlanId: buildPlanId || null,
         buildJobId: buildJobId || null,
       });
@@ -3352,6 +3356,7 @@ export function FormaWorkspace({
         contextProjectId: persistedProjectId || null,
         workflowState: workflowState || null,
         contextQuestions: Array.isArray(data?.questions) ? data.questions : [],
+        contextSuggestions: normalizeContextSuggestions(data?.suggestions),
         buildPlanId: buildPlanId || null,
         buildJobId: buildJobId || null,
       });
@@ -3391,8 +3396,13 @@ export function FormaWorkspace({
     }
   };
 
-  const handleSkipContextGathering = async () => {
-    if (contextSkipping || contextSubmitting || activeGenerationRef.current) return;
+  const handleGatherContext = (event: React.FormEvent) => {
+    event.preventDefault();
+    void submitGatherContext();
+  };
+
+  const handleBuildNow = async () => {
+    if (contextBuildStarting || contextSubmitting || activeGenerationRef.current) return;
     const requestChatId = activeChatId;
     const availableMessages = requestChatId
       ? chatThreads[requestChatId] || chatMessages
@@ -3404,11 +3414,11 @@ export function FormaWorkspace({
       ? contextProjectIdsRef.current[requestChatId] || persistedContextMessage?.contextProjectId || ""
       : "";
     if (!requestChatId || !projectId) {
-      setGenerationInputNotice("Save the initial project context before skipping this stage.");
+      setGenerationInputNotice("Share the initial project context before starting the build.");
       return;
     }
 
-    setContextSkipping(true);
+    setContextBuildStarting(true);
     setGenerationInputNotice(null);
     try {
       const response = await fetch(`${API_URL}/projects/${encodeURIComponent(projectId)}/context/messages`, {
@@ -3465,9 +3475,9 @@ export function FormaWorkspace({
         watchContextBuild(projectId, buildPlanId, buildJobId, requestChatId, message.id, run);
       }
     } catch (error) {
-      setGenerationInputNotice(error instanceof Error ? error.message : "Could not skip context gathering.");
+      setGenerationInputNotice(error instanceof Error ? error.message : "Could not start the build.");
     } finally {
-      setContextSkipping(false);
+      setContextBuildStarting(false);
     }
   };
 
@@ -4907,7 +4917,7 @@ export function FormaWorkspace({
                 setPrompt(example);
               }}
               onSubmit={handleGatherContext}
-              canSkipContext={(() => {
+              canBuildNow={(() => {
                 const messages = activeChatId ? chatThreads[activeChatId] || chatMessages : chatMessages;
                 const contextMessage = [...messages].reverse().find((message) => Boolean(message.contextProjectId));
                 const state = contextWorkflowStates[activeChatId]
@@ -4915,8 +4925,11 @@ export function FormaWorkspace({
                   || (contextMessage?.contextProjectId ? "gathering_context" : "");
                 return state === "gathering_context";
               })()}
-              contextSkipping={contextSkipping}
-              onSkipContext={handleSkipContextGathering}
+              buildNowLoading={contextBuildStarting}
+              onBuildNow={handleBuildNow}
+              onSelectContextSuggestion={(suggestion) => {
+                void submitGatherContext(suggestion);
+              }}
               isLoading={contextSubmitting || Boolean(activeGeneration || pendingContextBuildMessage)}
               generationReady
               needsGenerationProvider={false}

--- a/apps/web/app/blueprint-workspace/home-chat-view.tsx
+++ b/apps/web/app/blueprint-workspace/home-chat-view.tsx
@@ -30,6 +30,7 @@ type HomeChatMessage = {
   contextProjectId?: string | null;
   workflowState?: string | null;
   contextQuestions?: string[];
+  contextSuggestions?: string[];
   buildPlanId?: string | null;
   buildJobId?: string | null;
 };
@@ -43,9 +44,10 @@ type HomeChatViewProps = {
   examples: string[];
   onSelectExample: (example: string) => void;
   onSubmit: FormEventHandler<HTMLFormElement>;
-  canSkipContext: boolean;
-  contextSkipping: boolean;
-  onSkipContext: () => void;
+  canBuildNow: boolean;
+  buildNowLoading: boolean;
+  onBuildNow: () => void;
+  onSelectContextSuggestion: (suggestion: string) => void;
   isLoading: boolean;
   generationReady: boolean;
   needsGenerationProvider: boolean;
@@ -79,9 +81,10 @@ export default function HomeChatView({
   examples,
   onSelectExample,
   onSubmit,
-  canSkipContext,
-  contextSkipping,
-  onSkipContext,
+  canBuildNow,
+  buildNowLoading,
+  onBuildNow,
+  onSelectContextSuggestion,
   isLoading,
   generationReady,
   needsGenerationProvider,
@@ -100,9 +103,12 @@ export default function HomeChatView({
   onImagePaste,
 }: HomeChatViewProps) {
   const { containerRef, endRef, handleScroll } = useChatAutoScroll(conversationKey, messages);
-  const latestContextMessageId = [...messages]
+  const latestBuildNowMessageId = [...messages]
     .reverse()
     .find((message) => message.role === "assistant" && message.workflowState === "gathering_context")?.id;
+  const latestChoiceMessageId = [...messages]
+    .reverse()
+    .find((message) => message.role === "assistant" && Boolean(message.contextSuggestions?.length))?.id;
 
   return (
     <section
@@ -175,15 +181,31 @@ export default function HomeChatView({
                       />
                     </div>
                     <p className="break-anywhere whitespace-pre-wrap text-sm leading-6">{message.content}</p>
-                    {!isUser && canSkipContext && message.id === latestContextMessageId && (
+                    {!isUser && message.id === latestChoiceMessageId && Boolean(message.contextSuggestions?.length) && (
+                      <div className="mt-3 grid gap-2 sm:grid-cols-2" aria-label="Suggested answers">
+                        {message.contextSuggestions?.map((suggestion) => (
+                          <button
+                            key={suggestion}
+                            type="button"
+                            onClick={() => onSelectContextSuggestion(suggestion)}
+                            disabled={isLoading}
+                            className="flex min-h-12 items-center gap-2 border border-[#3a3e48] bg-[#111216] px-3 py-2 text-left text-xs font-black uppercase tracking-[0.08em] text-slate-200 transition hover:border-cyan-300 hover:bg-cyan-300 hover:text-black disabled:cursor-not-allowed disabled:opacity-50"
+                          >
+                            <ArrowRight className="h-3.5 w-3.5 shrink-0" />
+                            <span className="break-words">{suggestion}</span>
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                    {!isUser && canBuildNow && message.id === latestBuildNowMessageId && (
                       <button
                         type="button"
-                        onClick={onSkipContext}
-                        disabled={contextSkipping || isLoading}
+                        onClick={onBuildNow}
+                        disabled={buildNowLoading || isLoading}
                         className="mt-3 inline-flex h-9 items-center justify-center gap-2 border border-cyan-300/40 px-3 text-[10px] font-black uppercase tracking-[0.12em] text-cyan-100 hover:bg-cyan-300 hover:text-black disabled:cursor-not-allowed disabled:opacity-50"
                       >
-                        {contextSkipping ? <RefreshCw className="h-3.5 w-3.5 animate-spin" /> : <ArrowRight className="h-3.5 w-3.5" />}
-                        Skip context gathering
+                        {buildNowLoading ? <RefreshCw className="h-3.5 w-3.5 animate-spin" /> : <ArrowRight className="h-3.5 w-3.5" />}
+                        Build now
                       </button>
                     )}
                     {message.imagePreview && (

--- a/apps/web/lib/context-suggestions.ts
+++ b/apps/web/lib/context-suggestions.ts
@@ -1,0 +1,22 @@
+const ARTIFICIAL_CHOICES = new Set([
+  "custom",
+  "other",
+  "something else",
+  "none of these",
+]);
+
+export function normalizeContextSuggestions(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set<string>();
+  const suggestions: string[] = [];
+  for (const item of value) {
+    if (typeof item !== "string") continue;
+    const suggestion = item.trim().replace(/\s+/g, " ").slice(0, 120);
+    const key = suggestion.toLowerCase();
+    if (!suggestion || ARTIFICIAL_CHOICES.has(key) || seen.has(key)) continue;
+    seen.add(key);
+    suggestions.push(suggestion);
+    if (suggestions.length === 4) break;
+  }
+  return suggestions;
+}

--- a/apps/web/test/context-suggestions.test.ts
+++ b/apps/web/test/context-suggestions.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { normalizeContextSuggestions } from "../lib/context-suggestions.ts";
+
+test("context suggestions are trimmed, deduplicated, and bounded", () => {
+  assert.deepEqual(
+    normalizeContextSuggestions([" 3-season ", "3-SEASON", "4-season", "Rain", "Wind", "Snow"]),
+    ["3-season", "4-season", "Rain", "Wind"],
+  );
+});
+
+test("artificial free-text choices are not displayed", () => {
+  assert.deepEqual(
+    normalizeContextSuggestions(["Custom", "Other", "Something else", "None of these", "Battery powered"]),
+    ["Battery powered"],
+  );
+});

--- a/blueprint_core/agents/context_gathering.py
+++ b/blueprint_core/agents/context_gathering.py
@@ -69,6 +69,7 @@ class ContextGatheringAgent(ContextBriefUpdater):
             "- iterate_project: a completed project exists and the user requests a change to it.",
             "Set turn_kind only as compatibility metadata: ask_question uses chat, clarification, or context; all other tools use proceed.",
             "Never mention internal fields, unresolved-context bookkeeping, routing, or context collection. Never repeat a question the user just answered or asked you to explain.",
+            "When ask_question offers a finite choice, populate suggestions with 2 to 4 concise, self-contained answers that the user can submit verbatim. Never add Custom, Other, Something else, or an equivalent catch-all; free text is always available.",
             "If the user asks what they can build, offer a few relevant ideas and invite them to choose or describe a direction.",
             "If the user says they do not know, guide them using outcomes and tradeoffs rather than repeating a technical question.",
             f"Workflow state: {workflow_state or 'not_started'}",

--- a/blueprint_core/workspaces/context/agent.py
+++ b/blueprint_core/workspaces/context/agent.py
@@ -140,7 +140,7 @@ def _assistant_reply(text: str, questions: list[str], previous: DesignBrief | No
         return (
             "That’s okay—you don’t need to choose technical parts yet. "
             "Tell me any outcome, operating condition, or constraint you do know, and the build agents can propose the open technical choices. "
-            "You can also skip context gathering whenever you’re ready."
+            "Choose Build Now whenever you’re ready, and the build agents will resolve the remaining technical choices."
         )
     if previous:
         if questions:
@@ -160,7 +160,11 @@ def _assistant_reply(text: str, questions: list[str], previous: DesignBrief | No
 class ContextBriefUpdater:
     """Updates a DesignBrief without invoking a model, tool, or worker job."""
 
-    def update(self, request: ContextGatheringRequest, previous: DesignBrief | None = None) -> tuple[DesignBriefCreate, str, list[str]]:
+    def update(
+        self,
+        request: ContextGatheringRequest,
+        previous: DesignBrief | None = None,
+    ) -> tuple[DesignBriefCreate, str, list[str], list[str]]:
         text = request.text.strip()
         attachment_text = [item.extracted_text for item in request.attachments if item.extracted_text]
         combined_update = "\n".join([text, *attachment_text]).strip()
@@ -221,6 +225,11 @@ class ContextBriefUpdater:
             if not _question_answered(question.question, full_context)
         ]
         questions = _unique([*prior_questions, *new_questions])
+        suggestions = next((
+            list(question.suggestions)
+            for question in clarification.questions
+            if question.question in questions and question.suggestions
+        ), [])
 
         if previous and previous.summary:
             summary = previous.summary
@@ -247,4 +256,4 @@ class ContextBriefUpdater:
             readiness=DesignBriefReadiness.NEEDS_CLARIFICATION if questions else DesignBriefReadiness.DRAFT,
         )
         assistant_message = _assistant_reply(text, questions, previous)
-        return brief, assistant_message, questions
+        return brief, assistant_message, questions, suggestions

--- a/blueprint_core/workspaces/context/models.py
+++ b/blueprint_core/workspaces/context/models.py
@@ -3,13 +3,33 @@ from __future__ import annotations
 from typing import Annotated, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, field_validator, model_validator
 
 from blueprint_core.workspaces.design_briefs import DesignBrief
 from blueprint_core.workspaces.workflow import ProjectWorkflow
 
 
 NonEmptyString = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+
+
+def _suggested_answers(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    excluded = {"custom", "other", "something else", "none of these"}
+    seen: set[str] = set()
+    suggestions: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        suggestion = " ".join(item.split())
+        key = suggestion.casefold()
+        if not suggestion or key in excluded or key in seen:
+            continue
+        seen.add(key)
+        suggestions.append(suggestion[:120])
+        if len(suggestions) == 4:
+            break
+    return suggestions
 
 
 class ContextAttachment(BaseModel):
@@ -69,7 +89,13 @@ class ContextGatheringResponse(BaseModel):
     design_brief: DesignBrief | None = None
     assistant_message: NonEmptyString
     questions: list[NonEmptyString] = Field(default_factory=list)
+    suggestions: list[NonEmptyString] = Field(default_factory=list)
     build_execution: ContextBuildExecution | None = None
+
+    @field_validator("suggestions", mode="before")
+    @classmethod
+    def normalize_suggestions(cls, value: object) -> list[str]:
+        return _suggested_answers(value)
 
 
 class ContextTurnDecision(BaseModel):
@@ -81,3 +107,9 @@ class ContextTurnDecision(BaseModel):
     tool_name: Literal["ask_question", "build_project", "render_project", "iterate_project"] = "ask_question"
     save_context: bool = False
     assistant_message: NonEmptyString
+    suggestions: list[NonEmptyString] = Field(default_factory=list)
+
+    @field_validator("suggestions", mode="before")
+    @classmethod
+    def normalize_suggestions(cls, value: object) -> list[str]:
+        return _suggested_answers(value)

--- a/tests/projects/test_context_gathering.py
+++ b/tests/projects/test_context_gathering.py
@@ -153,6 +153,7 @@ class ContextGatheringIntegrationTests(unittest.TestCase):
         self.assertEqual("building", body["workflow"]["state"])
         self.assertIsNotNone(body["build_execution"])
         self.assertIn("started the design", body["assistant_message"])
+        self.assertEqual([], body["suggestions"])
         persisted_requirements = " ".join(brief.requirements)
         self.assertIn("Mamba-like latent-space model", persisted_requirements)
         self.assertIn("7B to 30B parameter reference workload", persisted_requirements)
@@ -444,6 +445,8 @@ class ContextGatheringIntegrationTests(unittest.TestCase):
         self.assertEqual(201, first.status_code, first.text)
         self.assertEqual("gathering_context", first.json()["workflow"]["state"])
         self.assertTrue(first.json()["questions"])
+        self.assertTrue(first.json()["suggestions"])
+        self.assertNotIn("Other", first.json()["suggestions"])
         self.assertEqual(201, second.status_code, second.text)
         self.assertEqual(2, second.json()["design_brief"]["brief_version"])
         self.assertEqual([1, 2], [brief.brief_version for brief in versions])
@@ -452,6 +455,32 @@ class ContextGatheringIntegrationTests(unittest.TestCase):
         self.assertIn("The display must remain readable outdoors.", versions[-1].requirements)
         self.assertEqual(4, len(chat.messages))
         create_job.assert_not_called()
+
+    def test_agent_suggestions_are_returned_and_persisted_with_the_assistant_turn(self) -> None:
+        project_id = str(uuid.uuid4())
+        conversation_id = "context-chat-suggestions"
+
+        class SuggestedAnswerAgent(ContextGatheringAgent):
+            def route_turn(self, *_args, **_kwargs):
+                return ContextTurnDecision(
+                    turn_kind="context",
+                    tool_name="ask_question",
+                    save_context=True,
+                    assistant_message="Which deployment environment should I design for?",
+                    suggestions=["3-season", "4-season", "Other"],
+                )
+
+        self.app.dependency_overrides[context_gathering_agent] = lambda: SuggestedAnswerAgent()
+        with sqlite_repository():
+            response = self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={"conversation_id": conversation_id, "text": "Build a one-person tent."},
+            )
+            chat = database.get_project_chat(conversation_id, OWNER)
+
+        self.assertEqual(201, response.status_code, response.text)
+        self.assertEqual(["3-season", "4-season"], response.json()["suggestions"])
+        self.assertEqual(["3-season", "4-season"], chat.messages[-1]["suggestions"])
 
     def test_generation_and_mutating_tools_are_blocked_during_gathering(self) -> None:
         project_id = str(uuid.uuid4())


### PR DESCRIPTION
Closes #271.

- carries agent-suggested answers through the context API and persisted chat messages
- renders the latest discrete choices as responsive, immediately-submitting buttons
- keeps free-text context input available
- filters synthetic `Other`/`Custom` catch-all choices
- replaces `Skip context gathering` with `Build now` while preserving the existing direct build handoff

Validation:
- `python -m unittest tests.projects.test_context_gathering tests.agents.test_clarifying_questions`
- `node --experimental-strip-types --test test/context-suggestions.test.ts`
- `npm run lint` (existing `<img>` warnings only)
- `npm run build`