### PR TITLE
Fix stale job metrics across interval changes

### DIFF
--- a/apps/web/app/blueprint-workspace/admin-panels.tsx
+++ b/apps/web/app/blueprint-workspace/admin-panels.tsx
@@ -557,6 +557,7 @@ const JOB_METRICS_WINDOW_OPTIONS: Array<{ value: JobMetricsWindow; label: string
   { value: "24h", label: "24 hours" },
   { value: "7d", label: "7 days" },
 ];
+const JOB_METRICS_WINDOW_HOURS: Record<JobMetricsWindow, number> = { "1h": 1, "24h": 24, "7d": 168 };
 
 function JobMetricsPanel({
   metrics,
@@ -569,14 +570,16 @@ function JobMetricsPanel({
   metricsWindow: JobMetricsWindow;
   onMetricsWindowChange?: (window: JobMetricsWindow) => void;
 }) {
-  if (error && !metrics) {
+  const selectedMetrics = metrics?.interval_hours === JOB_METRICS_WINDOW_HOURS[metricsWindow] ? metrics : null;
+
+  if (error && !selectedMetrics) {
     return (
       <div className="mb-4 border border-amber-500/30 bg-amber-950/20 p-3 text-xs text-amber-200">
         {error}
       </div>
     );
   }
-  if (!metrics) {
+  if (!selectedMetrics) {
     return <div className="mb-4 border border-[#2a2c33] bg-[#17181d] p-4 text-xs text-slate-500">Loading job metrics...</div>;
   }
 
@@ -606,23 +609,23 @@ function JobMetricsPanel({
         </div>
       </div>
       <div className="grid gap-2 sm:grid-cols-3">
-        <JobMetricSummary label={`Jobs · ${intervalLabel}`} value={metrics.total_jobs} detail="Created in selected interval" />
+        <JobMetricSummary label={`Jobs · ${intervalLabel}`} value={selectedMetrics.total_jobs} detail="Created in selected interval" />
         <JobMetricSummary
           label="Completed"
-          value={metrics.completed_jobs}
-          detail={`${metrics.failed_jobs} failed`}
-          danger={metrics.failed_jobs > 0}
+          value={selectedMetrics.completed_jobs}
+          detail={`${selectedMetrics.failed_jobs} failed`}
+          danger={selectedMetrics.failed_jobs > 0}
         />
         <JobMetricSummary
           label={`${intervalLabel} failure rate`}
-          value={`${Number(metrics.failure_rate || 0).toFixed(1)}%`}
-          detail={`${metrics.failed_jobs} failed / ${metrics.completed_jobs} completed`}
-          danger={metrics.failure_rate > 0}
+          value={`${Number(selectedMetrics.failure_rate || 0).toFixed(1)}%`}
+          detail={`${selectedMetrics.failed_jobs} failed / ${selectedMetrics.completed_jobs} completed`}
+          danger={selectedMetrics.failure_rate > 0}
         />
       </div>
       <JobVolumeChart
         title={chartUsesDays ? "Jobs per day" : "Jobs per hour"}
-        buckets={chartUsesDays ? metrics.daily : metrics.hourly}
+        buckets={chartUsesDays ? selectedMetrics.daily : selectedMetrics.hourly}
         unit={chartUsesDays ? "day" : "hour"}
       />
       {error && <p className="text-[11px] text-amber-300">Showing the last available metrics. {error}</p>}

--- a/apps/web/app/blueprint-workspace/use-admin-data.ts
+++ b/apps/web/app/blueprint-workspace/use-admin-data.ts
@@ -253,6 +253,8 @@ export function useJobs({
   const [lastUpdatedAt, setLastUpdatedAt] = useState<string | null>(null);
   const requestIdRef = useRef(0);
   const refreshTokensRef = useRef<Record<string, object>>({});
+  const metricsRequestIdRef = useRef(0);
+  const metricsRefreshTokensRef = useRef<Record<string, object>>({});
   const jobRequestsRef = useRef<Record<string, Promise<A2AJob | null>>>({});
   const requestScopeRef = useRef(requestScopeKey);
   requestScopeRef.current = requestScopeKey;
@@ -265,7 +267,7 @@ export function useJobs({
   ) => {
     if (!enabled) return;
 
-    const refreshKey = `${status || "all"}:${metricsWindow}`;
+    const refreshKey = status || "all";
     if (refreshTokensRef.current[refreshKey]) return;
     const refreshToken = {};
     refreshTokensRef.current[refreshKey] = refreshToken;
@@ -273,7 +275,6 @@ export function useJobs({
     const requestId = ++requestIdRef.current;
     if (!options.silent) setLoading(true);
     setError(null);
-    setMetricsError(null);
 
     try {
       const params = new URLSearchParams({ limit: "200" });
@@ -305,26 +306,6 @@ export function useJobs({
         errors.push("example jobs");
       }
 
-      try {
-        const metricWindow = JOB_METRICS_WINDOW_QUERY[metricsWindow];
-        const metricParams = new URLSearchParams({
-          days: metricWindow.days,
-          hours: metricWindow.hours,
-          interval_hours: metricWindow.intervalHours,
-        });
-        const response = await fetchWithTimeout(`${apiUrl}/a2a/jobs/metrics?${metricParams.toString()}`, {
-          headers: await getHeaders(),
-        });
-        if (!response.ok) throw new Error(`Job metrics endpoint returned ${response.status}`);
-        const payload = await response.json() as JobMetrics;
-        if (requestIdRef.current === requestId && enabledRef.current) setMetrics(payload);
-      } catch (requestError) {
-        console.error("Error fetching job metrics", requestError);
-        if (requestIdRef.current === requestId && enabledRef.current) {
-          setMetricsError("Job metrics are unavailable");
-        }
-      }
-
       nextJobs.sort((left, right) => {
         const leftTime = new Date(left.created_at || left.updated_at || 0).getTime();
         const rightTime = new Date(right.created_at || right.updated_at || 0).getTime();
@@ -350,7 +331,43 @@ export function useJobs({
         delete refreshTokensRef.current[refreshKey];
       }
     }
-  }, [apiUrl, enabled, getHeaders, metricsWindow, statusFilter]);
+  }, [apiUrl, enabled, getHeaders, statusFilter]);
+
+  const refreshMetrics = useCallback(async () => {
+    if (!enabled) return;
+
+    const refreshKey = metricsWindow;
+    if (metricsRefreshTokensRef.current[refreshKey]) return;
+    const refreshToken = {};
+    metricsRefreshTokensRef.current[refreshKey] = refreshToken;
+    const requestId = ++metricsRequestIdRef.current;
+    setMetricsError(null);
+
+    try {
+      const metricWindow = JOB_METRICS_WINDOW_QUERY[metricsWindow];
+      const metricParams = new URLSearchParams({
+        days: metricWindow.days,
+        hours: metricWindow.hours,
+        interval_hours: metricWindow.intervalHours,
+      });
+      const response = await fetchWithTimeout(`${apiUrl}/a2a/jobs/metrics?${metricParams.toString()}`, {
+        headers: await getHeaders(),
+        cache: "no-store",
+      });
+      if (!response.ok) throw new Error(`Job metrics endpoint returned ${response.status}`);
+      const payload = await response.json() as JobMetrics;
+      if (metricsRequestIdRef.current === requestId && enabledRef.current) setMetrics(payload);
+    } catch (requestError) {
+      console.error("Error fetching job metrics", requestError);
+      if (metricsRequestIdRef.current === requestId && enabledRef.current) {
+        setMetricsError("Job metrics are unavailable");
+      }
+    } finally {
+      if (metricsRefreshTokensRef.current[refreshKey] === refreshToken) {
+        delete metricsRefreshTokensRef.current[refreshKey];
+      }
+    }
+  }, [apiUrl, enabled, getHeaders, metricsWindow]);
 
   const fetchJob = useCallback(async (jobId: string): Promise<A2AJob | null> => {
     if (!jobId) return null;
@@ -409,6 +426,37 @@ export function useJobs({
     };
   }, [enabled, pollIntervalMs, refresh, statusFilter]);
 
+  useEffect(() => {
+    if (!enabled) {
+      metricsRequestIdRef.current += 1;
+      metricsRefreshTokensRef.current = {};
+      return;
+    }
+
+    void refreshMetrics();
+    const poll = () => {
+      if (typeof document === "undefined" || document.visibilityState === "visible") {
+        void refreshMetrics();
+      }
+    };
+    const intervalId = window.setInterval(poll, pollIntervalMs);
+    document.addEventListener("visibilitychange", poll);
+
+    return () => {
+      metricsRequestIdRef.current += 1;
+      metricsRefreshTokensRef.current = {};
+      window.clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", poll);
+    };
+  }, [enabled, pollIntervalMs, refreshMetrics]);
+
+  const refreshAll = useCallback(async (status?: string, options?: RefreshOptions) => {
+    await Promise.all([
+      refresh(status, options),
+      refreshMetrics(),
+    ]);
+  }, [refresh, refreshMetrics]);
+
   return {
     jobs,
     metrics,
@@ -420,7 +468,7 @@ export function useJobs({
     statusFilter,
     setStatusFilter,
     lastUpdatedAt,
-    refresh,
+    refresh: refreshAll,
     fetchJob,
   };
 }

--- a/tests/jobs/test_job_metrics.py
+++ b/tests/jobs/test_job_metrics.py
@@ -122,6 +122,22 @@ class JobMetricsTests(unittest.TestCase):
         self.assertEqual(1, metrics["failed_jobs"])
         self.assertEqual(100.0, metrics["failure_rate"])
 
+    def test_each_selected_window_has_independent_totals_and_buckets(self) -> None:
+        rows = [
+            {"created_at": "2026-08-09T12:15:00Z", "status": "succeeded"},
+            {"created_at": "2026-08-09T06:00:00Z", "status": "failed"},
+            {"created_at": "2026-08-06T12:00:00Z", "status": "succeeded"},
+        ]
+        now = datetime(2026, 8, 9, 12, 30, tzinfo=timezone.utc)
+
+        one_hour = summarize_job_metrics(rows, now=now, days=1, hours=1, interval_hours=1)
+        twenty_four_hours = summarize_job_metrics(rows, now=now, days=1, hours=24, interval_hours=24)
+        seven_days = summarize_job_metrics(rows, now=now, days=7, hours=24, interval_hours=168)
+
+        self.assertEqual((1, 1), (one_hour["total_jobs"], len(one_hour["hourly"])))
+        self.assertEqual((2, 24), (twenty_four_hours["total_jobs"], len(twenty_four_hours["hourly"])))
+        self.assertEqual((3, 7), (seven_days["total_jobs"], len(seven_days["daily"])))
+
     def test_metric_windows_are_bounded(self) -> None:
         metrics = summarize_job_metrics([], days=100, hours=1000)
 


### PR DESCRIPTION
## What changed
- fetches job metrics independently from the two job-list requests
- refreshes only metrics when the selected interval changes
- bypasses browser caching for metrics requests
- verifies that the response interval matches the selected interval before rendering
- shows a loading state instead of relabeling stale metrics
- keeps manual and polling refreshes concurrent
- adds coverage proving 1-hour, 24-hour, and 7-day totals and bucket counts differ correctly

## Validation
- 522 Python tests pass (1 skipped)
- frontend lint passes
- production frontend build passes