### PR TITLE
Rename Docs tab to Assembly

### DIFF
--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -1435,7 +1435,7 @@ const workspaceTabs = [
   { id: "bom", label: "BOM", icon: ShoppingBag },
   { id: "mechanical", label: "MECH", icon: Box },
   { id: "schematic", label: "WIRE", icon: Cpu },
-  { id: "assembly", label: "DOCS", icon: Info },
+  { id: "assembly", label: "ASSEMBLY", icon: Info },
   { id: "video", label: "MEDIA", icon: Film },
 ];
 


### PR DESCRIPTION
## Summary
- rename the project workspace Docs tab to Assembly
- preserve the existing tab id, route, and build-instructions content

## Validation
- `npx eslint app/blueprint-workspace.tsx` (passes with one pre-existing `no-img-element` warning)