### PR TITLE
Backport Blueprint Core examples and Firecrawl hardening to dev

### DIFF
--- a/blueprint_core/agents/firecrawl_mcp.py
+++ b/blueprint_core/agents/firecrawl_mcp.py
@@ -81,23 +81,55 @@ class FirecrawlResearchResult:
     tool_name: Optional[str] = None
     error: Optional[str] = None
 
-    def as_prompt_context(self, max_chars: int = 14000) -> str:
-        if not self.hits:
-            return "No Firecrawl MCP search results were available."
+    def as_prompt_context(self, max_chars: int = 14_000) -> str:
+        """Render Firecrawl search hits as bounded LLM context.
 
-        blocks = []
-        remaining = max_chars
+        Args:
+            max_chars: Maximum total context length.
+
+        Returns:
+            Prompt-ready external research context.
+        """
+        if self.error:
+            raise RuntimeError(f"Firecrawl external research failed: {self.error}")
+
+        if not self.hits:
+            return (
+                f"Firecrawl completed {self.searches_attempted} searches "
+                "but returned no usable external sources."
+            )
+
+        blocks: list[str] = []
+        remaining = max(0, max_chars)
+        hits_remaining = len(self.hits)
+
         for index, hit in enumerate(self.hits, start=1):
-            text = (hit.content or "").strip()
-            if not text:
-                text = hit.title or hit.url
-            block = f"[{index}] {hit.title or 'Untitled source'}\nURL: {hit.url or 'unknown'}\n{text}"
-            if len(block) > remaining:
-                block = block[: max(0, remaining - 3)] + "..."
-            blocks.append(block)
-            remaining -= len(block)
-            if remaining <= 0:
+            if remaining <= 0 or hits_remaining <= 0:
                 break
+
+            separator_length = 2 if blocks else 0
+            available = remaining - separator_length
+            if available <= 0:
+                break
+
+            fair_share = max(500, available // hits_remaining)
+            hit_budget = min(4_000, fair_share, available)
+            text = (hit.content or "").strip() or hit.title or hit.url
+            block = (
+                f"[{index}] {hit.title or 'Untitled source'}\n"
+                f"URL: {hit.url or 'unknown'}\n{text}"
+            )
+            if len(block) > hit_budget:
+                block = (
+                    block[: hit_budget - 3] + "..."
+                    if hit_budget >= 3
+                    else block[:hit_budget]
+                )
+            blocks.append(block)
+
+            remaining -= len(block) + separator_length
+            hits_remaining -= 1
+
         return "\n\n".join(blocks)
 
     def metadata(self) -> Dict[str, Any]:
@@ -149,31 +181,36 @@ class _MCPStdioSession:
         self.process = None
 
     def _read_stdout(self) -> None:
-        assert self.process is not None and self.process.stdout is not None
+        """Read newline-delimited JSON-RPC messages from MCP stdout."""
+        assert self.process is not None
+        assert self.process.stdout is not None
+
         while True:
-            headers: Dict[str, str] = {}
-            line = self.process.stdout.readline()
+            raw_line = self.process.stdout.readline()
+
+            if not raw_line:
+                break
+
+            line = raw_line.decode("utf-8", errors="replace").strip()
+
             if not line:
-                return
-            while line and line.strip():
-                try:
-                    key, value = line.decode("utf-8", errors="replace").split(":", 1)
-                    headers[key.strip().lower()] = value.strip()
-                except ValueError:
-                    pass
-                line = self.process.stdout.readline()
-
-            length = int(headers.get("content-length", "0") or "0")
-            if length <= 0:
                 continue
 
-            body = self.process.stdout.read(length)
-            if not body:
-                return
             try:
-                self._responses.put(json.loads(body.decode("utf-8")))
-            except json.JSONDecodeError:
+                message = json.loads(line)
+            except json.JSONDecodeError as error:
+                self._stderr_lines.put(
+                    f"Invalid JSON received from MCP stdout: {error}: {line[:500]}"
+                )
                 continue
+
+            if not isinstance(message, dict):
+                self._stderr_lines.put(
+                    f"Unexpected MCP message type: {type(message).__name__}"
+                )
+                continue
+
+            self._responses.put(message)
 
     def _read_stderr(self) -> None:
         assert self.process is not None and self.process.stderr is not None
@@ -183,10 +220,26 @@ class _MCPStdioSession:
                 self._stderr_lines.put(text)
 
     def _send(self, payload: Dict[str, Any]) -> None:
-        assert self.process is not None and self.process.stdin is not None
-        raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
-        header = f"Content-Length: {len(raw)}\r\n\r\n".encode("ascii")
-        self.process.stdin.write(header + raw)
+        """Send one newline-delimited JSON-RPC message to the MCP server.
+
+        Args:
+            payload: JSON-RPC request, response, or notification payload.
+
+        Raises:
+            RuntimeError: If the MCP subprocess is not running.
+        """
+        if self.process is None or self.process.stdin is None:
+            raise RuntimeError(
+                "Cannot send MCP message because the process is not running."
+            )
+
+        raw = json.dumps(
+            payload,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+
+        self.process.stdin.write(raw + b"\n")
         self.process.stdin.flush()
 
     def notify(self, method: str, params: Optional[Dict[str, Any]] = None) -> None:
@@ -257,35 +310,89 @@ def _stringify_tool_content(result: Dict[str, Any]) -> str:
 
 
 def _flatten_firecrawl_hits(value: Any) -> List[FirecrawlSearchHit]:
+    """Normalize Firecrawl MCP output into individual web search hits.
+
+    Args:
+        value: Parsed or serialized Firecrawl MCP tool output.
+
+    Returns:
+        Individual normalized web search results. Response envelopes and empty
+        result collections do not produce hits.
+    """
     if isinstance(value, str):
         try:
             return _flatten_firecrawl_hits(json.loads(value))
         except json.JSONDecodeError:
-            return [FirecrawlSearchHit(content=value)]
-
-    if isinstance(value, dict):
-        if isinstance(value.get("data"), list):
-            return _flatten_firecrawl_hits(value["data"])
-        if isinstance(value.get("results"), list):
-            return _flatten_firecrawl_hits(value["results"])
-        if any(key in value for key in ("url", "title", "markdown", "content", "description")):
-            content = value.get("markdown") or value.get("content") or value.get("description") or value.get("text") or ""
-            return [
-                FirecrawlSearchHit(
-                    title=str(value.get("title") or value.get("name") or ""),
-                    url=str(value.get("url") or value.get("source") or ""),
-                    content=str(content),
-                )
-            ]
-        return [FirecrawlSearchHit(content=json.dumps(value, sort_keys=True))]
+            return []
 
     if isinstance(value, list):
         hits: List[FirecrawlSearchHit] = []
+
         for item in value:
             hits.extend(_flatten_firecrawl_hits(item))
+
         return hits
 
-    return []
+    if not isinstance(value, dict):
+        return []
+
+    # Firecrawl search response:
+    # {"success": true, "data": {"web": [...]}}
+    data = value.get("data")
+
+    if isinstance(data, (dict, list)):
+        return _flatten_firecrawl_hits(data)
+
+    # Firecrawl web-result collection:
+    # {"web": [{...}, {...}]}
+    web_results = value.get("web")
+
+    if isinstance(web_results, list):
+        return _flatten_firecrawl_hits(web_results)
+
+    results = value.get("results")
+
+    if isinstance(results, (dict, list)):
+        return _flatten_firecrawl_hits(results)
+
+    url = value.get("url") or value.get("source")
+    title = value.get("title") or value.get("name")
+
+    if not url and not title:
+        # Do not convert metadata envelopes into fake sources.
+        return []
+
+    description = value.get("description")
+    markdown = value.get("markdown")
+    content = value.get("content")
+    text = value.get("text")
+
+    # Search descriptions are cleaner than entire scraped pages. Preserve a
+    # bounded markdown excerpt when it contains additional useful evidence.
+    content_parts: List[str] = []
+
+    if isinstance(description, str) and description.strip():
+        content_parts.append(description.strip())
+
+    if isinstance(markdown, str) and markdown.strip():
+        markdown_excerpt = markdown.strip()[:4_000]
+
+        if markdown_excerpt not in content_parts:
+            content_parts.append(markdown_excerpt)
+
+    if not content_parts:
+        for candidate in (content, text):
+            if isinstance(candidate, str) and candidate.strip():
+                content_parts.append(candidate.strip()[:4_000])
+                break
+
+    return [
+        FirecrawlSearchHit(
+            title=str(title or "").strip(),
+            url=str(url or "").strip(),
+            content="\n\n".join(content_parts),
+        )
+    ]
 
 
 class FirecrawlMCPResearchClient:

--- a/blueprint_core/external_sources.py
+++ b/blueprint_core/external_sources.py
@@ -63,7 +63,7 @@ class ExternalSourceRecord(BaseModel):
         text = (self.content or "").strip() or self.title or self.url
         block = f"[{index}] {self.title or 'Untitled source'}\nProvider: {self.provider or 'unknown'}\nURL: {self.url or 'unknown'}\n{text}"
         if len(block) > max_chars:
-            return block[: max(0, max_chars - 3)] + "..."
+            return block[: max_chars - 3] + "..." if max_chars >= 3 else block[:max_chars]
         return block
 
     def metadata_preview(self, *, max_chars: int = 360) -> dict[str, Any]:
@@ -91,23 +91,61 @@ class ExternalSourceLibrary(BaseModel):
     def hits(self) -> list[ExternalSourceRecord]:
         return self.sources
 
-    def as_prompt_context(self, max_chars: int = 14000) -> str:
+    def as_prompt_context(self, max_chars: int = 14_000) -> str:
+        """Render normalized external sources as bounded LLM context.
+
+        Args:
+            max_chars: Maximum total context length.
+
+        Returns:
+            Prompt-ready external research context.
+        """
+        if self.error:
+            raise RuntimeError(
+                f"{self.provider} external research failed: {self.error}"
+            )
+
         if not self.sources:
-            return f"No {self.provider} external source results were available."
+            return (
+                f"{self.provider} completed {self.searches_attempted} searches "
+                "but returned no usable external sources."
+            )
 
         blocks: list[str] = []
-        remaining = max_chars
-        if self.answer:
-            answer_block = f"{self.provider} answer summary:\n{self.answer.strip()}"
-            blocks.append(answer_block[:remaining])
-            remaining -= len(blocks[-1])
+        remaining = max(0, max_chars)
+
+        if self.answer and remaining > 0:
+            answer_block = (
+                f"{self.provider} answer summary:\n"
+                f"{self.answer.strip()}"
+            )
+            answer_block = answer_block[: min(3_000, remaining)]
+            blocks.append(answer_block)
+            remaining -= len(answer_block)
+
+        sources_remaining = len(self.sources)
 
         for index, source in enumerate(self.sources, start=1):
-            if remaining <= 0:
+            if remaining <= 0 or sources_remaining <= 0:
                 break
-            block = source.as_prompt_block(index, max_chars=remaining)
+
+            separator_length = 2 if blocks else 0
+            available = remaining - separator_length
+            if available <= 0:
+                break
+
+            fair_share = max(500, available // sources_remaining)
+            source_budget = min(4_000, fair_share, available)
+
+            block = source.as_prompt_block(
+                index,
+                max_chars=source_budget,
+            )
             blocks.append(block)
-            remaining -= len(block)
+
+            remaining -= len(block) + separator_length
+            sources_remaining -= 1
+
         return "\n\n".join(blocks)
 
     def source_metadata(self) -> dict[str, Any]:

--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,3 +1,4 @@
 results/
 __pycache__/
 */__pycache__/
+blueprint_core/*.db

--- a/examples/README.md
+++ b/examples/README.md
@@ -44,6 +44,20 @@ Outputs are written to `examples/results/`:
 The examples run in strict test mode. Provider failures raise and are recorded as
 failed jobs; they do not fall back to simulation.
 
+## Blueprint Core samples
+
+Focused Blueprint Core examples live in `examples/blueprint_core/`:
+
+```bash
+python examples/blueprint_core/sample.py
+python examples/blueprint_core/sample1.py
+python examples/blueprint_core/sample2.py
+```
+
+- `sample.py` generates a simulated project from a frozen design brief.
+- `sample1.py` generates a project with a local Ollama model.
+- `sample2.py` combines Ollama generation with Firecrawl web research.
+
 Useful overrides:
 
 ```bash

--- a/examples/blueprint_core/sample.py
+++ b/examples/blueprint_core/sample.py
@@ -1,0 +1,104 @@
+"""Generate a Forma project object from a frozen design brief."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from blueprint_core.workers.generation import HardwareIRGenerationEngine
+from blueprint_core.workspaces.design_briefs import (
+    DESIGN_BRIEF_SCHEMA_VERSION,
+    DesignBrief,
+    DesignBriefReadiness,
+)
+from blueprint_core.workspaces.projects.objects import (
+    FormaProjectObject,
+    attach_project_object_metadata,
+    build_project_object,
+)
+
+
+def generate_project() -> FormaProjectObject:
+    """Generate and return a complete Forma project object."""
+    project_id = uuid4()
+
+    design_brief = DesignBrief(
+        schema_version=DESIGN_BRIEF_SCHEMA_VERSION,
+        design_brief_id=uuid4(),
+        project_id=project_id,
+        conversation_id="manual-generation-example",
+        brief_version=1,
+        previous_version=None,
+        created_at=datetime.now(timezone.utc),
+        intent="Create a compact desktop environmental monitor.",
+        summary=(
+            "A compact environmental monitor with an OLED display, "
+            "temperature and humidity sensing, and USB-C power."
+        ),
+        requirements=[
+            "Measure temperature and relative humidity.",
+            "Display live measurements on an OLED screen.",
+            "Use USB-C for power.",
+        ],
+        constraints=[
+            "The enclosure should fit on a desktop.",
+            "Use commonly available components.",
+        ],
+        references=[],
+        requested_outputs=[
+            "hardware design",
+            "bill of materials",
+            "wiring plan",
+            "mechanical plan",
+            "assembly guide",
+        ],
+        validation_criteria=[
+            "All electrical components must have valid connections.",
+            "The selected power supply must support the complete system.",
+        ],
+        unresolved_questions=[],
+        assumptions=[
+            "The device will be used indoors.",
+            "Wi-Fi connectivity is not required.",
+        ],
+        readiness=DesignBriefReadiness.READY,
+    )
+
+    engine = HardwareIRGenerationEngine(
+        use_simulation=True,
+        generate_image=False,
+    )
+
+    revision_draft = engine.generate(design_brief)
+
+    hardware_ir = attach_project_object_metadata(
+        revision_draft.state,
+    )
+
+    project = build_project_object(hardware_ir)
+
+    return project
+
+
+def main() -> None:
+    """Generate a project and print its serialized representation."""
+    project_1 = generate_project()
+
+    print(project_1.model_dump_json(indent=2))
+
+    mechanical = project_1.get_namespace("product.mech")
+    electrical = project_1.get_namespace("product.electrical")
+    assembly = project_1.get_namespace("product.assembly")
+
+    print("\nMechanical:")
+    print(mechanical.model_dump_json(indent=2) if mechanical else "Not generated")
+
+    print("\nElectrical:")
+    print(electrical.model_dump_json(indent=2) if electrical else "Not generated")
+
+    print("\nAssembly:")
+    print(assembly.model_dump_json(indent=2) if assembly else "Not generated")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/blueprint_core/sample1.py
+++ b/examples/blueprint_core/sample1.py
@@ -1,0 +1,106 @@
+"""Generate a Forma project object using a local Ollama model."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from uuid import uuid4
+
+from blueprint_core.config import config
+
+
+OLLAMA_MODEL = config.get("OLLAMA_MODEL", "qwen3:8b") or "qwen3:8b"
+OLLAMA_BASE_URL = (
+    config.get("OLLAMA_BASE_URL", "http://127.0.0.1:11434/v1")
+    or "http://127.0.0.1:11434/v1"
+)
+
+# Configure the runtime before importing generation modules.
+for name, value in {
+    "BLUEPRINT_DEV_MODE": "true",
+    "BLUEPRINT_DISABLE_GENERATION_FALLBACK": "true",
+    "BLUEPRINT_STRICT_GENERATION": "true",
+    "LLM_DISABLE_FALLBACK": "true",
+    "LLM_PROVIDER": "openai-compatible",
+    "LLM_ALLOWED_PROVIDERS": "openai-compatible",
+    "LLM_BASE_URL": OLLAMA_BASE_URL,
+    "LLM_MODEL": OLLAMA_MODEL,
+    "OPENAI_COMPATIBLE_ALLOWED_MODELS": OLLAMA_MODEL,
+    "LLM_ALLOW_NO_API_KEY": "true",
+    "LLM_RESPONSE_FORMAT": "json_object",
+    "OPENAI_FALLBACK_MODEL": "",
+    "LLM_FALLBACK_MODEL": "",
+    "LLM_TIMEOUT_SECONDS": "1200",
+    "IMAGE_OUTPUT_ENABLED": "false",
+}.items():
+    config.set_default(name, value)
+
+database_path = Path(__file__).resolve().with_name("forma-local-test.db")
+config.update(
+    {
+        "DATABASE_BACKEND": "sqlite",
+        "SQLITE_DATABASE_URL": f"sqlite:///{database_path}",
+    }
+)
+
+from blueprint_core.workers.generation import HardwareIRGenerationEngine  # noqa: E402
+from blueprint_core.workspaces.design_briefs import (  # noqa: E402
+    DESIGN_BRIEF_SCHEMA_VERSION,
+    DesignBrief,
+    DesignBriefReadiness,
+)
+from blueprint_core.workspaces.projects.objects import (  # noqa: E402
+    FormaProjectObject,
+    attach_project_object_metadata,
+    build_project_object,
+)
+
+
+def generate_project() -> FormaProjectObject:
+    """Generate a Forma project object from a manually constructed design brief."""
+    project_id = uuid4()
+    design_brief = DesignBrief(
+        schema_version=DESIGN_BRIEF_SCHEMA_VERSION,
+        conversation_id="manual-generation-example",
+        intent="Create a compact desktop environmental monitor.",
+        summary="A compact environmental monitor with an OLED display and USB-C power.",
+        requirements=[
+            "Measure temperature and relative humidity.",
+            "Display live measurements on an OLED screen.",
+            "Use USB-C for power.",
+        ],
+        constraints=["Use commonly available components."],
+        references=[],
+        requested_outputs=["bill of materials", "wiring plan", "assembly guide"],
+        validation_criteria=["All electrical components must have valid connections."],
+        unresolved_questions=[],
+        assumptions=["The device will be used indoors."],
+        readiness=DesignBriefReadiness.READY,
+        design_brief_id=uuid4(),
+        project_id=project_id,
+        brief_version=1,
+        previous_version=None,
+        created_at=datetime.now(timezone.utc),
+    )
+
+    engine = HardwareIRGenerationEngine(
+        provider_name="openai-compatible",
+        model_name=OLLAMA_MODEL,
+        use_simulation=False,
+        generate_image=False,
+    )
+    revision_draft = engine.generate(design_brief)
+    hardware_ir = attach_project_object_metadata(revision_draft.state)
+    return build_project_object(hardware_ir)
+
+
+def main() -> None:
+    """Generate a project and print its JSON representation."""
+    print(f"Using Ollama model: {OLLAMA_MODEL}")
+    print(f"Ollama endpoint: {OLLAMA_BASE_URL}")
+    project = generate_project()
+    print(project.model_dump_json(indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/blueprint_core/sample2.py
+++ b/examples/blueprint_core/sample2.py
@@ -1,0 +1,127 @@
+"""Generate a Forma project with Ollama and Firecrawl web research."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from uuid import uuid4
+
+from dotenv import load_dotenv
+
+from blueprint_core.config import config
+
+
+load_dotenv()
+
+OLLAMA_MODEL = config.get("OLLAMA_MODEL", "qwen3:8b") or "qwen3:8b"
+OLLAMA_BASE_URL = (
+    config.get("OLLAMA_BASE_URL", "http://127.0.0.1:11434/v1")
+    or "http://127.0.0.1:11434/v1"
+)
+DATABASE_PATH = Path(__file__).resolve().with_name("forma-web-research.db")
+
+# Configure the runtime before importing generation modules. The web-research
+# workflow uses Firecrawl instead of component_templates and saves the completed
+# project to a standalone SQLite database without seeding component templates.
+config.update(
+    {
+        "BLUEPRINT_DEV_MODE": "true",
+        "BLUEPRINT_DISABLE_GENERATION_FALLBACK": "true",
+        "BLUEPRINT_STRICT_GENERATION": "true",
+        "LLM_DISABLE_FALLBACK": "true",
+        "LLM_PROVIDER": "openai-compatible",
+        "LLM_ALLOWED_PROVIDERS": "openai-compatible",
+        "LLM_BASE_URL": OLLAMA_BASE_URL,
+        "LLM_MODEL": OLLAMA_MODEL,
+        "OPENAI_COMPATIBLE_ALLOWED_MODELS": OLLAMA_MODEL,
+        "LLM_ALLOW_NO_API_KEY": "true",
+        "LLM_RESPONSE_FORMAT": "json_object",
+        "OPENAI_FALLBACK_MODEL": "",
+        "LLM_FALLBACK_MODEL": "",
+        "LLM_TIMEOUT_SECONDS": "1200",
+        "IMAGE_OUTPUT_ENABLED": "false",
+        "EXTERNAL_SOURCE_PROVIDER": "firecrawl",
+        "DATABASE_BACKEND": "sqlite",
+        "SQLITE_DATABASE_URL": f"sqlite:///{DATABASE_PATH}",
+    }
+)
+config.set_default("FIRECRAWL_SEARCH_LIMIT", "3")
+config.set_default("FIRECRAWL_MCP_TIMEOUT_SECONDS", "90")
+
+from blueprint_core.agents.workflows import (  # noqa: E402
+    generate_project_with_workflow,
+    get_workflow_debug_config,
+)
+from blueprint_core.database import init_db  # noqa: E402
+from blueprint_core.workspaces.projects.objects import (  # noqa: E402
+    FormaProjectObject,
+    attach_project_object_metadata,
+    build_project_object,
+)
+
+
+PROMPT = (
+    "Design a compact desktop environmental monitor using an ESP32, a real "
+    "temperature and humidity sensor, an OLED display, and USB-C power. Research "
+    "real components, datasheets, sourcing references, wiring requirements, and "
+    "a practical 3D-printable enclosure."
+)
+
+
+def validate_local_runtime() -> None:
+    """Fail early when Ollama or Firecrawl prerequisites are missing."""
+    firecrawl_api_key = config.optional("FIRECRAWL_API_KEY")
+    firecrawl_command = config.optional("FIRECRAWL_MCP_COMMAND")
+
+    if not firecrawl_api_key and not firecrawl_command:
+        raise RuntimeError(
+            "Set FIRECRAWL_API_KEY or FIRECRAWL_MCP_COMMAND before running this example."
+        )
+
+    if firecrawl_api_key and not firecrawl_command and shutil.which("npx") is None:
+        raise RuntimeError(
+            "Firecrawl defaults to 'npx -y firecrawl-mcp', but npx is not installed."
+        )
+
+
+def generate_project(prompt: str = PROMPT) -> FormaProjectObject:
+    """Generate a Forma project using Ollama and Firecrawl research."""
+    validate_local_runtime()
+    init_db()
+
+    project_id = uuid4()
+    hardware_ir = generate_project_with_workflow(
+        "web_research",
+        prompt,
+        provider_name="openai-compatible",
+        model_name=OLLAMA_MODEL,
+        external_source_provider="firecrawl",
+        generation_metadata={
+            "project_id": str(project_id),
+            "project_prompt": prompt,
+        },
+    )
+
+    hardware_ir = attach_project_object_metadata(hardware_ir)
+    return build_project_object(hardware_ir)
+
+
+def main() -> None:
+    """Validate configuration, generate the project, and print its JSON."""
+    debug = get_workflow_debug_config(
+        "web_research",
+        provider_name="openai-compatible",
+        model_name=OLLAMA_MODEL,
+        external_source_provider="firecrawl",
+    )
+    print(f"Ollama model: {OLLAMA_MODEL}")
+    print(f"Ollama endpoint: {OLLAMA_BASE_URL}")
+    print(f"Firecrawl configured: {debug['external_sources']['enabled']}")
+    print(f"SQLite metadata database: {DATABASE_PATH}")
+
+    project = generate_project()
+    print(project.model_dump_json(indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integrations/test_external_sources.py
+++ b/tests/integrations/test_external_sources.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
+import json
 import os
 import unittest
 from contextlib import contextmanager
+from io import BytesIO
+from types import SimpleNamespace
 from typing import Iterator
 
-from blueprint_core.agents.firecrawl_mcp import FirecrawlResearchResult, FirecrawlSearchHit
+from blueprint_core.agents.firecrawl_mcp import (
+    FirecrawlResearchResult,
+    FirecrawlSearchHit,
+    _MCPStdioSession,
+    _flatten_firecrawl_hits,
+)
 from blueprint_core.external_sources import (
     ExternalSourceLibrary,
     ExternalSourceProviderConfig,
@@ -69,6 +77,68 @@ class FakeFirecrawlClient:
 
 
 class ExternalSourceTests(unittest.TestCase):
+    def test_mcp_stdio_sends_newline_delimited_json(self) -> None:
+        stdin = BytesIO()
+        session = _MCPStdioSession(["firecrawl-mcp"], timeout_seconds=1)
+        session.process = SimpleNamespace(stdin=stdin)  # type: ignore[assignment]
+
+        session._send({"jsonrpc": "2.0", "id": 1, "method": "tools/list"})
+
+        payload = stdin.getvalue()
+        self.assertTrue(payload.endswith(b"\n"))
+        self.assertNotIn(b"Content-Length", payload)
+        self.assertEqual("tools/list", json.loads(payload)["method"])
+
+    def test_mcp_stdio_reads_newline_delimited_json(self) -> None:
+        stdout = BytesIO(b'{"jsonrpc":"2.0","id":1,"result":{}}\n')
+        session = _MCPStdioSession(["firecrawl-mcp"], timeout_seconds=1)
+        session.process = SimpleNamespace(stdout=stdout)  # type: ignore[assignment]
+
+        session._read_stdout()
+
+        self.assertEqual(1, session._responses.get_nowait()["id"])
+
+    def test_firecrawl_flattens_nested_web_results(self) -> None:
+        hits = _flatten_firecrawl_hits(
+            {
+                "success": True,
+                "data": {
+                    "web": [
+                        {
+                            "title": "Sensor datasheet",
+                            "url": "https://example.com/datasheet",
+                            "description": "Electrical specifications.",
+                            "markdown": "# Sensor\nAdditional details.",
+                        }
+                    ]
+                },
+            }
+        )
+
+        self.assertEqual(1, len(hits))
+        self.assertEqual("Sensor datasheet", hits[0].title)
+        self.assertIn("Electrical specifications.", hits[0].content)
+        self.assertIn("Additional details.", hits[0].content)
+
+    def test_firecrawl_prompt_context_is_bounded(self) -> None:
+        result = FirecrawlResearchResult(
+            configured=True,
+            searches_attempted=2,
+            hits=[
+                FirecrawlSearchHit(
+                    title=f"Source {index}",
+                    url=f"https://example.com/{index}",
+                    content="Evidence " * 100,
+                )
+                for index in range(2)
+            ],
+        )
+
+        context = result.as_prompt_context(max_chars=240)
+
+        self.assertLessEqual(len(context), 240)
+        self.assertIn("Source 0", context)
+
     def test_auto_provider_selects_firecrawl_even_when_tavily_key_is_present(self) -> None:
         with isolated_external_source_env(FIRECRAWL_API_KEY="fc_test", TAVILY_API_KEY="tvly_test"):
             provider = build_external_source_provider()
@@ -119,6 +189,23 @@ class ExternalSourceTests(unittest.TestCase):
         self.assertIn("Short answer.", context)
         self.assertIn("Provider: firecrawl", context)
         self.assertIn("Useful sourced text.", context)
+
+    def test_external_source_library_prompt_context_is_bounded(self) -> None:
+        library = ExternalSourceLibrary(
+            provider="firecrawl",
+            configured=True,
+            answer="Summary " * 100,
+            sources=[
+                ExternalSourceRecord(
+                    title="Example",
+                    url="https://example.com",
+                    content="Evidence " * 100,
+                    provider="firecrawl",
+                )
+            ],
+        )
+
+        self.assertLessEqual(len(library.as_prompt_context(max_chars=240)), 240)
 
     def test_source_usage_records_tavily_provider(self) -> None:
         usage = infer_source_usage(


### PR DESCRIPTION
## Summary

Backports the changes from #291 onto `dev` as a single clean commit, without bringing along the unrelated commits on the original feature branch.

- add simulated, Ollama, and Ollama + Firecrawl samples under `examples/blueprint_core`
- document the samples and keep their local SQLite databases out of git
- update Firecrawl MCP stdio framing and normalize nested web results
- bound external-source prompt context and surface research failures
- add integration coverage for transport, parsing, and prompt limits

## Why

This makes the #291 functionality available for the feature work currently being tested on `dev`.

## Tests

- `python -m unittest tests.tooling.test_config tests.integrations.test_external_sources tests.agents.test_prompt_continuity` (22 passed)
- `python -m compileall -q examples/blueprint_core blueprint_core/agents/firecrawl_mcp.py blueprint_core/external_sources.py tests/integrations/test_external_sources.py`