### PR TITLE
Add failed-build retry action to the chat composer

### DIFF
--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -2204,6 +2204,14 @@ export function FormaWorkspace({
     )) || null,
     [chatMessages],
   );
+  const retryableContextBuildMessage = useMemo(() => {
+    const latestBuildMessage = [...chatMessages].reverse().find((message) => (
+      Boolean(message.buildPlanId)
+      && Boolean(message.buildJobId)
+      && Boolean(message.contextProjectId)
+    ));
+    return latestBuildMessage?.status === "error" ? latestBuildMessage : null;
+  }, [chatMessages]);
 
 
   const persistChatThread = (chatId: string | null, messages: ChatMessage[], explicitTitle?: string | null) => {
@@ -5031,7 +5039,7 @@ export function FormaWorkspace({
               onSelectContextSuggestion={(suggestion) => {
                 void submitGatherContext(suggestion);
               }}
-              isLoading={contextSubmitting || Boolean(activeGeneration || pendingContextBuildMessage)}
+              isLoading={contextSubmitting || Boolean(activeGeneration || pendingContextBuildMessage || resettingBuildMessageId)}
               generationReady
               needsGenerationProvider={false}
               needsImageProvider={false}
@@ -5047,6 +5055,11 @@ export function FormaWorkspace({
               onStop={() => {
                 if (activeGenerationRef.current) stopActiveGeneration();
                 else if (pendingContextBuildMessage) stopContextBuildMessage(pendingContextBuildMessage);
+              }}
+              canRetryFailedBuild={Boolean(retryableContextBuildMessage)}
+              retryingFailedBuild={resettingBuildMessageId === retryableContextBuildMessage?.id}
+              onRetryFailedBuild={() => {
+                if (retryableContextBuildMessage) void resetFailedContextBuild(retryableContextBuildMessage);
               }}
               hasGenerationInput={hasGenerationInput}
               inputValid={generationInputValidation.isValid}

--- a/apps/web/app/blueprint-workspace/home-chat-view.tsx
+++ b/apps/web/app/blueprint-workspace/home-chat-view.tsx
@@ -59,6 +59,9 @@ type HomeChatViewProps = {
   onPromptChange: (prompt: string) => void;
   generationActive: boolean;
   onStop: () => void;
+  canRetryFailedBuild: boolean;
+  retryingFailedBuild: boolean;
+  onRetryFailedBuild: () => void;
   hasGenerationInput: boolean;
   inputValid: boolean;
   imageInputRef: RefObject<HTMLInputElement | null>;
@@ -96,6 +99,9 @@ export default function HomeChatView({
   onPromptChange,
   generationActive,
   onStop,
+  canRetryFailedBuild,
+  retryingFailedBuild,
+  onRetryFailedBuild,
   hasGenerationInput,
   inputValid,
   imageInputRef,
@@ -109,6 +115,14 @@ export default function HomeChatView({
   const latestChoiceMessageId = [...messages]
     .reverse()
     .find((message) => message.role === "assistant" && Boolean(message.contextSuggestions?.length))?.id;
+  const retryMode = canRetryFailedBuild && !hasGenerationInput && !generationActive;
+  const primaryActionLabel = generationActive
+    ? "Stop generation"
+    : retryMode
+      ? "Try failed build again"
+      : inputValid
+        ? "Send context"
+        : "Check hardware idea";
 
   return (
     <section
@@ -317,7 +331,12 @@ export default function HomeChatView({
               onKeyDown={(event) => {
                 if (event.key === "Enter" && !event.shiftKey) {
                   event.preventDefault();
-                  if (!isLoading) event.currentTarget.form?.requestSubmit();
+                  if (isLoading) return;
+                  if (retryMode) {
+                    onRetryFailedBuild();
+                    return;
+                  }
+                  event.currentTarget.form?.requestSubmit();
                 }
               }}
               placeholder="Describe the product, constraints, references, and outputs you need…"
@@ -335,14 +354,22 @@ export default function HomeChatView({
               <Paperclip className="h-4 w-4" />
             </button>
             <button
-              type={generationActive ? "button" : "submit"}
-              onClick={generationActive ? onStop : undefined}
-              disabled={!generationActive && (isLoading || !hasGenerationInput || !generationReady)}
+              type={generationActive || retryMode ? "button" : "submit"}
+              onClick={generationActive ? onStop : retryMode ? onRetryFailedBuild : undefined}
+              disabled={retryMode ? retryingFailedBuild : !generationActive && (isLoading || !hasGenerationInput || !generationReady)}
               className="absolute bottom-3 right-3 inline-flex h-9 w-9 items-center justify-center bg-white text-black transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-40 sm:bottom-4 sm:right-4 sm:h-10 sm:w-10"
-              aria-label={generationActive ? "Stop generation" : inputValid ? "Send context" : "Check hardware idea"}
-              title={generationActive ? "Stop generation" : inputValid ? "Send context" : "Check hardware idea"}
+              aria-label={primaryActionLabel}
+              title={primaryActionLabel}
             >
-              {generationActive ? <Square className="h-4 w-4 fill-current" /> : isLoading ? <RefreshCw className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
+              {generationActive ? (
+                <Square className="h-4 w-4 fill-current" />
+              ) : retryMode ? (
+                <RefreshCw className={`h-4 w-4 ${retryingFailedBuild ? "animate-spin" : ""}`} />
+              ) : isLoading ? (
+                <RefreshCw className="h-4 w-4 animate-spin" />
+              ) : (
+                <ArrowRight className="h-4 w-4" />
+              )}
             </button>
           </div>
 


### PR DESCRIPTION
## Summary

- turn the chat composer primary action into a refresh/retry control when the latest build failed and the input is empty
- reuse the existing owner-scoped failed-plan reset flow from #274
- preserve normal message submission when the user enters new context
- prevent duplicate retries while the reset request is in flight

Closes #294

## Verification

- `npm run lint` (passes with 7 existing `no-img-element` warnings)
- `npx tsc --noEmit --allowImportingTsExtensions`
- `npm run build`
- `.venv/bin/python -m unittest tests.agents.test_worker_orchestrator tests.projects.test_context_gathering` (28 passed)

## Scope

The partial-generation behavior described as future work in #294 is intentionally not included.