### PR TITLE
Add failed-build retry action to the dev chat composer

### DIFF
--- a/apps/api/worker_plans_api.py
+++ b/apps/api/worker_plans_api.py
@@ -6,7 +6,11 @@ from fastapi import APIRouter, Depends, HTTPException, status
 
 from apps.api.auth import UserContext, require_user_context
 from apps.api.context_builds import ContextBuildDispatcher
-from blueprint_core.database import cancel_project_generation_plan, get_project_generation_plan
+from blueprint_core.database import (
+    cancel_project_generation_plan,
+    get_project_generation_plan,
+    reset_project_generation_plan,
+)
 from blueprint_core.workers import WorkerExecutionPlan, WorkerPlanningError
 
 
@@ -68,6 +72,27 @@ async def cancel_build_plan_endpoint(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Build execution not found.")
     ContextBuildDispatcher.signal_cancel(plan_id)
     return await cancel_project_generation_plan(plan_id, owner)
+
+
+@router.post("/plans/{plan_id}/reset", response_model=WorkerExecutionPlan)
+async def reset_build_plan_endpoint(
+    project_id: UUID,
+    plan_id: str,
+    user: UserContext = Depends(require_user_context),
+) -> WorkerExecutionPlan:
+    """Reset a failed generation plan so the current user can try it again."""
+
+    owner = _owner(user)
+    try:
+        plan = get_project_generation_plan(plan_id, owner)
+    except WorkerPlanningError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.as_dict()) from exc
+    if str(plan.project_id) != str(project_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Build execution not found.")
+    try:
+        return await reset_project_generation_plan(plan_id, owner)
+    except WorkerPlanningError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=exc.as_dict()) from exc
 
 
 __all__ = ["router"]

--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -1606,6 +1606,7 @@ export function FormaWorkspace({
   const contextBuildWatchersRef = useRef<Set<string>>(new Set());
   const [contextWorkflowStates, setContextWorkflowStates] = useState<Record<string, string>>({});
   const [contextBuildStarting, setContextBuildStarting] = useState(false);
+  const [resettingBuildMessageId, setResettingBuildMessageId] = useState<string | null>(null);
   const [contextSubmitting, setContextSubmitting] = useState(false);
   const [chatThreads, setChatThreads] = useState<Record<string, ChatMessage[]>>({});
   const [projectChatInput, setProjectChatInput] = useState("");
@@ -1806,6 +1807,12 @@ export function FormaWorkspace({
       projectId: message.projectId,
       pipelineProgress: message.pipelineProgress || null,
       imagePreview: message.imagePreview || null,
+      contextProjectId: message.contextProjectId || null,
+      workflowState: message.workflowState || null,
+      contextQuestions: message.contextQuestions || [],
+      contextSuggestions: message.contextSuggestions || [],
+      buildPlanId: message.buildPlanId || null,
+      buildJobId: message.buildJobId || null,
       timestamp: chatTimestamp(),
     };
     setChatMessages((current) => [...current, nextMessage]);
@@ -1854,6 +1861,12 @@ export function FormaWorkspace({
       projectId: message.projectId,
       pipelineProgress: message.pipelineProgress || null,
       imagePreview: message.imagePreview || null,
+      contextProjectId: message.contextProjectId || null,
+      workflowState: message.workflowState || null,
+      contextQuestions: message.contextQuestions || [],
+      contextSuggestions: message.contextSuggestions || [],
+      buildPlanId: message.buildPlanId || null,
+      buildJobId: message.buildJobId || null,
       timestamp: chatTimestamp(),
     };
     setChatThreads((current) => {
@@ -3209,6 +3222,53 @@ export function FormaWorkspace({
       if (attempts < 600) window.setTimeout(poll, 2000);
     };
     window.setTimeout(poll, 750);
+  };
+
+  const resetFailedContextBuild = async (message: ChatMessage) => {
+    const projectId = message.contextProjectId;
+    const planId = message.buildPlanId;
+    const jobId = message.buildJobId;
+    const chatId = activeChatId;
+    if (!projectId || !planId || !jobId || !chatId || activeGenerationRef.current) return;
+
+    setResettingBuildMessageId(message.id);
+    setGenerationInputNotice(null);
+    try {
+      const response = await fetch(
+        `${API_URL}/projects/${encodeURIComponent(projectId)}/build/plans/${encodeURIComponent(planId)}/reset`,
+        { method: "POST", headers: await generationRequestHeaders() },
+      );
+      if (!response.ok) throw new Error(await readApiErrorMessage(response));
+
+      const resetPlan = await response.json();
+      const resetJobId = typeof resetPlan?.jobs?.[jobId]?.request?.job_id === "string"
+        ? resetPlan.jobs[jobId].request.job_id
+        : jobId;
+      const previousProgress = message.pipelineProgress;
+      const progress = createAgentPipelineProgress(
+        previousProgress?.steps || defaultAgentPipelineSteps,
+        progressIncludesImageStep(previousProgress),
+        chatTimestamp(),
+        resetJobId,
+      );
+      const patch: Partial<Omit<ChatMessage, "id">> = {
+        content: "Trying the design build again with the preserved project brief.",
+        status: "loading",
+        pipelineProgress: progress,
+        workflowState: "building",
+      };
+      updateChatMessage(message.id, patch);
+      updateThreadMessage(chatId, message.id, patch);
+      setContextWorkflowStates((current) => ({ ...current, [chatId]: "building" }));
+      setGenerationInputNotice("Job reset. The build agents are trying again.");
+
+      const run = beginContextBuildRun(projectId, planId, resetJobId, chatId, message.id);
+      watchContextBuild(projectId, planId, resetJobId, chatId, message.id, run);
+    } catch (error) {
+      setGenerationInputNotice(error instanceof Error ? error.message : "Could not reset the failed job.");
+    } finally {
+      setResettingBuildMessageId(null);
+    }
   };
 
   useEffect(() => {
@@ -4893,6 +4953,17 @@ export function FormaWorkspace({
                       ? () => stopContextBuildMessage(message as ChatMessage)
                       : undefined
                   }
+                  onReset={
+                    message.status === "error"
+                    && message.buildPlanId
+                    && message.buildJobId
+                    && message.contextProjectId
+                    && !activeGeneration
+                    && !pendingContextBuildMessage
+                      ? () => void resetFailedContextBuild(message as ChatMessage)
+                      : undefined
+                  }
+                  resetting={resettingBuildMessageId === message.id}
                 />
               )}
               projectArtifact={
@@ -6725,11 +6796,15 @@ function AgentPipelineProgressView({
   status,
   compact = false,
   onStop,
+  onReset,
+  resetting = false,
 }: {
   progress?: AgentPipelineProgress | null;
   status?: ChatMessage["status"];
   compact?: boolean;
   onStop?: () => void;
+  onReset?: () => void;
+  resetting?: boolean;
 }) {
   if (!progress) return null;
 
@@ -6806,6 +6881,19 @@ function AgentPipelineProgressView({
             >
               <Square className="h-3 w-3 fill-current" />
               Stop
+            </button>
+          )}
+          {isError && onReset && (
+            <button
+              type="button"
+              onClick={onReset}
+              disabled={resetting}
+              className="inline-flex h-7 items-center gap-1 border border-cyan-300/40 px-2 text-[10px] font-black uppercase text-cyan-100 hover:bg-cyan-300 hover:text-black disabled:cursor-wait disabled:opacity-60"
+              aria-label="Reset failed generation job"
+              title="Reset failed generation job and try again"
+            >
+              <RefreshCw className={`h-3 w-3 ${resetting ? "animate-spin" : ""}`} />
+              {resetting ? "Resetting" : "Reset job"}
             </button>
           )}
           <div className="text-right">

--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -2201,6 +2201,14 @@ export function FormaWorkspace({
     )) || null,
     [chatMessages],
   );
+  const retryableContextBuildMessage = useMemo(() => {
+    const latestBuildMessage = [...chatMessages].reverse().find((message) => (
+      Boolean(message.buildPlanId)
+      && Boolean(message.buildJobId)
+      && Boolean(message.contextProjectId)
+    ));
+    return latestBuildMessage?.status === "error" ? latestBuildMessage : null;
+  }, [chatMessages]);
 
 
   const persistChatThread = (chatId: string | null, messages: ChatMessage[], explicitTitle?: string | null) => {
@@ -5001,7 +5009,7 @@ export function FormaWorkspace({
               onSelectContextSuggestion={(suggestion) => {
                 void submitGatherContext(suggestion);
               }}
-              isLoading={contextSubmitting || Boolean(activeGeneration || pendingContextBuildMessage)}
+              isLoading={contextSubmitting || Boolean(activeGeneration || pendingContextBuildMessage || resettingBuildMessageId)}
               generationReady
               needsGenerationProvider={false}
               needsImageProvider={false}
@@ -5017,6 +5025,11 @@ export function FormaWorkspace({
               onStop={() => {
                 if (activeGenerationRef.current) stopActiveGeneration();
                 else if (pendingContextBuildMessage) stopContextBuildMessage(pendingContextBuildMessage);
+              }}
+              canRetryFailedBuild={Boolean(retryableContextBuildMessage)}
+              retryingFailedBuild={resettingBuildMessageId === retryableContextBuildMessage?.id}
+              onRetryFailedBuild={() => {
+                if (retryableContextBuildMessage) void resetFailedContextBuild(retryableContextBuildMessage);
               }}
               hasGenerationInput={hasGenerationInput}
               inputValid={generationInputValidation.isValid}

--- a/apps/web/app/blueprint-workspace/home-chat-view.tsx
+++ b/apps/web/app/blueprint-workspace/home-chat-view.tsx
@@ -59,6 +59,9 @@ type HomeChatViewProps = {
   onPromptChange: (prompt: string) => void;
   generationActive: boolean;
   onStop: () => void;
+  canRetryFailedBuild: boolean;
+  retryingFailedBuild: boolean;
+  onRetryFailedBuild: () => void;
   hasGenerationInput: boolean;
   inputValid: boolean;
   imageInputRef: RefObject<HTMLInputElement | null>;
@@ -96,6 +99,9 @@ export default function HomeChatView({
   onPromptChange,
   generationActive,
   onStop,
+  canRetryFailedBuild,
+  retryingFailedBuild,
+  onRetryFailedBuild,
   hasGenerationInput,
   inputValid,
   imageInputRef,
@@ -109,6 +115,14 @@ export default function HomeChatView({
   const latestChoiceMessageId = [...messages]
     .reverse()
     .find((message) => message.role === "assistant" && Boolean(message.contextSuggestions?.length))?.id;
+  const retryMode = canRetryFailedBuild && !hasGenerationInput && !generationActive;
+  const primaryActionLabel = generationActive
+    ? "Stop generation"
+    : retryMode
+      ? "Try failed build again"
+      : inputValid
+        ? "Send context"
+        : "Check hardware idea";
 
   return (
     <section
@@ -317,7 +331,12 @@ export default function HomeChatView({
               onKeyDown={(event) => {
                 if (event.key === "Enter" && !event.shiftKey) {
                   event.preventDefault();
-                  if (!isLoading) event.currentTarget.form?.requestSubmit();
+                  if (isLoading) return;
+                  if (retryMode) {
+                    onRetryFailedBuild();
+                    return;
+                  }
+                  event.currentTarget.form?.requestSubmit();
                 }
               }}
               placeholder="Describe the product, constraints, references, and outputs you need…"
@@ -335,14 +354,22 @@ export default function HomeChatView({
               <Paperclip className="h-4 w-4" />
             </button>
             <button
-              type={generationActive ? "button" : "submit"}
-              onClick={generationActive ? onStop : undefined}
-              disabled={!generationActive && (isLoading || !hasGenerationInput || !generationReady)}
+              type={generationActive || retryMode ? "button" : "submit"}
+              onClick={generationActive ? onStop : retryMode ? onRetryFailedBuild : undefined}
+              disabled={retryMode ? retryingFailedBuild : !generationActive && (isLoading || !hasGenerationInput || !generationReady)}
               className="absolute bottom-3 right-3 inline-flex h-9 w-9 items-center justify-center bg-white text-black transition hover:bg-slate-200 disabled:cursor-not-allowed disabled:opacity-40 sm:bottom-4 sm:right-4 sm:h-10 sm:w-10"
-              aria-label={generationActive ? "Stop generation" : inputValid ? "Send context" : "Check hardware idea"}
-              title={generationActive ? "Stop generation" : inputValid ? "Send context" : "Check hardware idea"}
+              aria-label={primaryActionLabel}
+              title={primaryActionLabel}
             >
-              {generationActive ? <Square className="h-4 w-4 fill-current" /> : isLoading ? <RefreshCw className="h-4 w-4 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
+              {generationActive ? (
+                <Square className="h-4 w-4 fill-current" />
+              ) : retryMode ? (
+                <RefreshCw className={`h-4 w-4 ${retryingFailedBuild ? "animate-spin" : ""}`} />
+              ) : isLoading ? (
+                <RefreshCw className="h-4 w-4 animate-spin" />
+              ) : (
+                <ArrowRight className="h-4 w-4" />
+              )}
             </button>
           </div>
 

--- a/blueprint_core/_version.py
+++ b/blueprint_core/_version.py
@@ -1,3 +1,3 @@
 """Package version for blueprint-core."""
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/blueprint_core/database.py
+++ b/blueprint_core/database.py
@@ -1039,6 +1039,20 @@ async def cancel_project_generation_plan(plan_id: str, owner_user_id: str):
     return await orchestrator.cancel(plan_id, owner)
 
 
+async def reset_project_generation_plan(plan_id: str, owner_user_id: str):
+    """Reset failed generation work while preserving the frozen project brief."""
+
+    from blueprint_core.workers import GenerationWorker, WorkerOrchestrator
+
+    owner = _normalize_user_id(owner_user_id)
+    orchestrator = WorkerOrchestrator(
+        _DATABASE_REPOSITORY,
+        [GenerationWorker(ProjectStateService(_DATABASE_REPOSITORY))],
+        workflow_service=ProjectWorkflowService(_DATABASE_REPOSITORY),
+    )
+    return await orchestrator.reset(plan_id, owner)
+
+
 def list_project_workflow_transitions(
     project_id: str,
     owner_user_id: str,

--- a/blueprint_core/workers/orchestration.py
+++ b/blueprint_core/workers/orchestration.py
@@ -82,6 +82,7 @@ class WorkerExecutionPlan(BaseModel):
     owner_user_id: NonEmptyString
     project_id: str
     correlation_id: NonEmptyString
+    attempt: int = Field(default=1, ge=1)
     status: WorkerPlanStatus = WorkerPlanStatus.PLANNED
     max_concurrency: int = Field(default=4, ge=1, le=64)
     jobs: dict[str, OrchestrationTaskState]
@@ -347,6 +348,43 @@ class WorkerOrchestrator:
         await self._advance_workflow(plan)
         return plan
 
+    async def reset(self, plan_id: str, owner_user_id: str) -> WorkerExecutionPlan:
+        """Reset failed work so a user can make another execution attempt."""
+
+        plan = self.get_plan(plan_id, owner_user_id)
+        if plan.status != WorkerPlanStatus.FAILED:
+            raise WorkerPlanningError(
+                "worker_plan_not_failed",
+                "Only a failed worker plan can be reset.",
+                context={"plan_id": plan.plan_id, "status": plan.status.value},
+            )
+
+        for job in plan.jobs.values():
+            if job.status not in {OrchestrationTaskStatus.FAILED, OrchestrationTaskStatus.BLOCKED}:
+                continue
+            job.status = OrchestrationTaskStatus.QUEUED
+            job.progress = []
+            job.result = None
+            job.error = None
+            job.started_at = None
+            job.completed_at = None
+
+        plan.attempt += 1
+        plan.status = WorkerPlanStatus.PLANNED
+        plan.aggregate = {}
+        plan.completed_at = None
+        self._workflow.transition(
+            plan.project_id,
+            plan.owner_user_id,
+            ProjectWorkflowState.BUILDING,
+            actor_type=WorkflowActorType.USER,
+            actor_id=plan.owner_user_id,
+            reason=f"User reset failed worker execution plan {plan.plan_id} for another attempt.",
+            idempotency_key=f"worker-plan:{plan.plan_id}:attempt:{plan.attempt}:reset",
+        )
+        await self._persist(plan)
+        return plan
+
     def _ready_jobs(self, plan: WorkerExecutionPlan) -> list[str]:
         ready: list[str] = []
         for job_id, job in plan.jobs.items():
@@ -523,7 +561,7 @@ class WorkerOrchestrator:
             actor_type=WorkflowActorType.SYSTEM,
             actor_id="worker-orchestrator",
             reason=f"Worker execution plan {plan.plan_id} reached a terminal result.",
-            idempotency_key=f"worker-plan:{plan.plan_id}:terminal",
+            idempotency_key=f"worker-plan:{plan.plan_id}:attempt:{plan.attempt}:terminal",
         )
 
     async def _persist(self, plan: WorkerExecutionPlan) -> None:

--- a/tests/agents/test_worker_orchestrator.py
+++ b/tests/agents/test_worker_orchestrator.py
@@ -227,6 +227,54 @@ class WorkerOrchestratorIntegrationTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual("required_dependency_failed", completed.jobs["job-dependent"].error.code)
         self.assertEqual(0, dependent.execution_count)
 
+    async def test_failed_plan_can_be_reset_and_run_again(self) -> None:
+        self.enter_building()
+        source = FakeWorker("source")
+        flaky = FakeWorker("flaky", fail=True)
+        orchestrator = WorkerOrchestrator(self.repository, [source, flaky], workflow_service=self.workflow)
+        plan = orchestrator.create_plan(
+            [
+                make_request("source", "job-source"),
+                make_request(
+                    "flaky",
+                    "job-flaky",
+                    dependencies=[WorkerDependency(job_id="job-source", required=True)],
+                ),
+            ],
+            OWNER,
+        )
+
+        failed = await orchestrator.execute(plan.plan_id, OWNER)
+        reset = await orchestrator.reset(plan.plan_id, OWNER)
+
+        self.assertEqual(WorkerPlanStatus.FAILED, failed.status)
+        self.assertEqual(2, reset.attempt)
+        self.assertEqual(WorkerPlanStatus.PLANNED, reset.status)
+        self.assertEqual(OrchestrationTaskStatus.SUCCEEDED, reset.jobs["job-source"].status)
+        self.assertEqual(OrchestrationTaskStatus.QUEUED, reset.jobs["job-flaky"].status)
+        self.assertEqual([], reset.jobs["job-flaky"].progress)
+        self.assertIsNone(reset.jobs["job-flaky"].error)
+        self.assertEqual(ProjectWorkflowState.BUILDING, self.workflow.get(str(PROJECT_ID), OWNER).state)
+
+        flaky.fail = False
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+
+        self.assertEqual(1, source.execution_count)
+        self.assertEqual(2, flaky.execution_count)
+        self.assertEqual(WorkerPlanStatus.SUCCEEDED, completed.status)
+        self.assertEqual(ProjectWorkflowState.AWAITING_FEEDBACK, self.workflow.get(str(PROJECT_ID), OWNER).state)
+
+    async def test_non_failed_plan_cannot_be_reset(self) -> None:
+        self.enter_building()
+        worker = FakeWorker("generation")
+        orchestrator = WorkerOrchestrator(self.repository, [worker], workflow_service=self.workflow)
+        plan = orchestrator.create_plan([make_request("generation", "job-generation")], OWNER)
+
+        with self.assertRaises(WorkerPlanningError) as raised:
+            await orchestrator.reset(plan.plan_id, OWNER)
+
+        self.assertEqual("worker_plan_not_failed", raised.exception.code)
+
     async def test_planned_build_can_be_cancelled_without_running_workers(self) -> None:
         self.enter_building()
         worker = FakeWorker("generation")

--- a/tests/projects/test_context_gathering.py
+++ b/tests/projects/test_context_gathering.py
@@ -24,6 +24,7 @@ from blueprint_core.agents.context_gathering import ContextGatheringAgent
 from blueprint_core import database
 from blueprint_core.persistence.providers import create_sqlite_provider
 from blueprint_core.persistence.repositories import SqlAlchemyRepository
+from blueprint_core.workers import WorkerPlanStatus
 from blueprint_core.workspaces.projects.models import GenerateProjectRequest
 from blueprint_core.workspaces.context import ContextBuildExecution, ContextTurnDecision
 from blueprint_core.workspaces.workflow import ProjectWorkflowState, WorkflowActorType, WorkflowStateError
@@ -402,6 +403,37 @@ class ContextGatheringIntegrationTests(unittest.TestCase):
         self.assertEqual(200, response.status_code, response.text)
         self.assertEqual(execution["plan_id"], response.json()["plan_id"])
         execute_plan.assert_awaited_once_with(execution["plan_id"], OWNER)
+
+    def test_worker_plan_reset_endpoint_resets_owned_failed_build(self) -> None:
+        project_id = str(uuid.uuid4())
+        conversation_id = "conversation-reset-build"
+        self.app.dependency_overrides.pop(context_build_dispatcher)
+        with sqlite_repository(), patch(
+            "apps.api.context_builds.ContextBuildDispatcher._launch",
+        ):
+            self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={"conversation_id": conversation_id, "text": "Build a relay controller."},
+            )
+            started = self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={"conversation_id": conversation_id, "text": "start"},
+            )
+            execution = started.json()["build_execution"]
+            plan = database.get_project_generation_plan(execution["plan_id"], OWNER)
+            reset_plan = plan.model_copy(update={"status": WorkerPlanStatus.PLANNED, "attempt": 2})
+            with patch(
+                "apps.api.worker_plans_api.reset_project_generation_plan",
+                new=AsyncMock(return_value=reset_plan),
+            ) as reset:
+                response = self.client.post(
+                    f"/projects/{project_id}/build/plans/{execution['plan_id']}/reset",
+                )
+
+        self.assertEqual(200, response.status_code, response.text)
+        self.assertEqual("planned", response.json()["status"])
+        self.assertEqual(2, response.json()["attempt"])
+        reset.assert_awaited_once_with(execution["plan_id"], OWNER)
 
     def test_text_image_and_document_append_brief_versions_without_enqueuing_jobs(self) -> None:
         project_id = str(uuid.uuid4())


### PR DESCRIPTION
## Summary

Backports the failed-plan reset prerequisite from #274 and adds the #294 composer retry control to `dev`.

- add the authenticated, owner-scoped reset transition for failed durable build plans
- preserve the frozen brief and already-successful prerequisite jobs
- show a refresh/retry action in the composer when the latest build failed and the input is empty
- preserve normal message submission when the user enters new context
- prevent duplicate reset requests

Related to #294. The matching `main` PR is #295.

## Verification

- `npm run lint` (passes with 7 existing `no-img-element` warnings)
- `npx tsc --noEmit --allowImportingTsExtensions`
- `npm run build`
- `.venv/bin/python -m unittest tests.agents.test_worker_orchestrator tests.projects.test_context_gathering` (28 passed)

## Scope

The partial-generation behavior described as future work in #294 is intentionally not included.