### PR TITLE
Separate physical component instances from BOM aggregation

### DIFF
--- a/apps/web/app/blueprint-workspace.tsx
+++ b/apps/web/app/blueprint-workspace.tsx
@@ -11,7 +11,7 @@ import {
 import { buildProjectDocsMarkdown, docsExportFilename } from "../lib/docs-export";
 import { normalizeContextSuggestions } from "../lib/context-suggestions";
 import { usableRuntimeLlmOptions, webConfig, type RuntimeConfigContract } from "../lib/config";
-import { calculateProjectCostMetrics } from "../lib/project-cost-metrics";
+import { calculateProjectCostMetrics, resolveProjectComponentInstances } from "../lib/project-cost-metrics";
 import { useFormaAuth } from "../lib/forma-auth";
 import {
   humanContextSkipChatSummary,
@@ -4451,7 +4451,12 @@ export function FormaWorkspace({
   };
 
   const metrics = calculateProjectCostMetrics(projectIR);
-  const components = projectIR?.components || [];
+  const components = useMemo(() => resolveProjectComponentInstances(projectIR), [projectIR]);
+  const bomLineItems = projectIR?.bom?.length ? projectIR.bom : components;
+  const schematicProject = useMemo(
+    () => projectIR ? { ...projectIR, components } : projectIR,
+    [components, projectIR]
+  );
   const assembly = projectIR?.assembly || [];
   const constraints = projectIR?.constraints || [];
   const imageFeatures = projectIR?.assembly_metadata?.image_features?.length
@@ -4570,7 +4575,7 @@ export function FormaWorkspace({
       case "bom":
         return (
           <BomPanel
-            components={components}
+            components={bomLineItems}
             metrics={metrics}
             cadSources={(projectIR?.mechanical && Array.isArray(projectIR.mechanical.cad_sources)) ? projectIR.mechanical.cad_sources : []}
             fabricationCost={Number(projectIR?.mechanical?.fabrication_cost_estimate_usd || 0)}
@@ -4591,7 +4596,7 @@ export function FormaWorkspace({
           />
         );
       case "schematic":
-        return <SchematicCanvas project={projectIR} />;
+        return <SchematicCanvas project={schematicProject} />;
       case "assembly":
         return (
           <AssemblyPanel

--- a/apps/web/app/blueprint-workspace/project-detail-panels.tsx
+++ b/apps/web/app/blueprint-workspace/project-detail-panels.tsx
@@ -252,10 +252,11 @@ export function BomPanel({
         {components.map((component) => {
           const tone = categoryTone[component.category?.toLowerCase()] || categoryTone.default;
           const Icon = iconForCategory(component.category);
-          const subtotal = (component.unit_price || 0) * (component.quantity || 1);
+          const subtotal = component.extended_price ?? (component.unit_price || 0) * (component.quantity || 1);
+          const itemKey = component.line_id || component.ref_des || component.part_definition_id;
 
           return (
-            <article key={component.ref_des} className="border border-[#2a2c33] bg-[#17181d] p-4">
+            <article key={itemKey} className="border border-[#2a2c33] bg-[#17181d] p-4">
               <div className="flex min-w-0 items-start gap-3">
                 <span className={`flex h-11 w-11 shrink-0 items-center justify-center border ${tone.border} ${tone.bg}`}>
                   <Icon className={`h-5 w-5 ${tone.text}`} />
@@ -263,6 +264,11 @@ export function BomPanel({
                 <div className="min-w-0 flex-1">
                   <h3 className="break-words text-sm font-black text-white">{component.name}</h3>
                   <p className="mt-2 break-words text-xs leading-5 text-slate-500">{component.rationale}</p>
+                  {Array.isArray(component.instance_refs) && component.instance_refs.length > 0 && (
+                    <p className="mt-2 break-words text-[10px] font-bold text-slate-600">
+                      {component.instance_refs.join(", ")}
+                    </p>
+                  )}
                   <CategoryBadge category={component.category} />
                 </div>
               </div>
@@ -311,13 +317,16 @@ export function BomPanel({
           </div>
           <div className="divide-y divide-[#282a30]">
             {components.map((component) => (
-              <div key={component.ref_des} className="grid grid-cols-[minmax(420px,1fr)_110px_110px_150px_140px] items-center px-5 py-6">
+              <div key={component.line_id || component.ref_des || component.part_definition_id} className="grid grid-cols-[minmax(420px,1fr)_110px_110px_150px_140px] items-center px-5 py-6">
                 <div className="flex items-start gap-4">
                   <PartThumb component={component} />
                   <div className="min-w-0">
                     <h3 className="text-lg font-black text-white">{component.name}</h3>
                     <div className="mt-2 text-sm text-slate-500">{component.category}</div>
                     <p className="mt-3 max-w-xl text-sm leading-6 text-slate-500">{component.rationale}</p>
+                    {Array.isArray(component.instance_refs) && component.instance_refs.length > 0 && (
+                      <p className="mt-2 text-xs font-bold text-slate-600">{component.instance_refs.join(", ")}</p>
+                    )}
                     <CategoryBadge category={component.category} />
                   </div>
                 </div>
@@ -334,7 +343,7 @@ export function BomPanel({
                     />
                   ))}
                 </div>
-                <div className="text-right text-lg font-black text-white">~${((component.unit_price || 0) * (component.quantity || 1)).toFixed(2)}</div>
+                <div className="text-right text-lg font-black text-white">~${Number(component.extended_price ?? ((component.unit_price || 0) * (component.quantity || 1))).toFixed(2)}</div>
               </div>
             ))}
           </div>

--- a/apps/web/lib/project-cost-metrics.ts
+++ b/apps/web/lib/project-cost-metrics.ts
@@ -12,17 +12,40 @@ function nonNegativeNumber(value: unknown): number {
   return Number.isFinite(number) && number > 0 ? number : 0;
 }
 
+export function resolveProjectComponentInstances(project: any): any[] {
+  const components = Array.isArray(project?.components) ? project.components : [];
+  const definitions = new Map(
+    (Array.isArray(project?.part_definitions) ? project.part_definitions : [])
+      .filter((definition: any) => definition?.part_definition_id)
+      .map((definition: any) => [definition.part_definition_id, definition])
+  );
+
+  return components.map((component: any) => {
+    const definition = definitions.get(component?.part_definition_id) as any;
+    if (!definition) return component;
+    return {
+      ...definition,
+      ...component,
+      pins: Array.isArray(definition.pins) ? definition.pins : (component.pins || []),
+      quantity: component.quantity || 1,
+    };
+  });
+}
+
 export function calculateProjectCostMetrics(project: any): ProjectCostMetrics {
   let electricalParts = 0;
   let mechanicalParts = 0;
   let electricalCost = 0;
   let mechanicalCost = 0;
 
-  const components = Array.isArray(project?.components) ? project.components : [];
+  const components = Array.isArray(project?.bom) && project.bom.length
+    ? project.bom
+    : (Array.isArray(project?.components) ? project.components : []);
   components.forEach((component: any) => {
     const category = String(component?.category || "").trim().toLowerCase();
     const quantity = nonNegativeNumber(component?.quantity) || 1;
-    const componentCost = nonNegativeNumber(component?.unit_price) * quantity;
+    const componentCost = nonNegativeNumber(component?.extended_price)
+      || nonNegativeNumber(component?.unit_price) * quantity;
     if (["mechanical", "3d print"].includes(category)) {
       mechanicalParts += quantity;
       mechanicalCost += componentCost;

--- a/apps/web/test/project-cost-metrics.test.ts
+++ b/apps/web/test/project-cost-metrics.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  calculateProjectCostMetrics,
+  resolveProjectComponentInstances,
+} from "../lib/project-cost-metrics.ts";
+
+const project = {
+  part_definitions: [{
+    part_definition_id: "PART_N20",
+    part_number: "N20-6V",
+    name: "N20 gear motor",
+    category: "Actuator",
+    pins: [{ pin_id: "+", name: "Positive", pin_type: "Power" }],
+    unit_price: 3.25,
+  }],
+  components: ["M1", "M2", "M3", "M4"].map((ref_des) => ({
+    ref_des,
+    part_definition_id: "PART_N20",
+    rationale: "Wheel drive",
+  })),
+  bom: [{
+    line_id: "BOM_PART_N20",
+    part_definition_id: "PART_N20",
+    instance_refs: ["M1", "M2", "M3", "M4"],
+    quantity: 4,
+    name: "N20 gear motor",
+    category: "Actuator",
+    unit_price: 3.25,
+    extended_price: 13,
+  }],
+};
+
+test("normalized component instances resolve shared display and pin data", () => {
+  const components = resolveProjectComponentInstances(project);
+
+  assert.equal(components.length, 4);
+  assert.equal(components[0].name, "N20 gear motor");
+  assert.equal(components[0].pins[0].pin_id, "+");
+  assert.equal(components[0].quantity, 1);
+});
+
+test("cost metrics use aggregated BOM rows without double counting instances", () => {
+  const metrics = calculateProjectCostMetrics(project);
+
+  assert.equal(metrics.electricalParts, 4);
+  assert.equal(metrics.electricalCost, 13);
+});

--- a/blueprint_core/agents/component_reconciliation.py
+++ b/blueprint_core/agents/component_reconciliation.py
@@ -84,7 +84,6 @@ def reconcile_explicit_catalog_components(
             part_number=part_number,
             name=str(template.get("name") or part_number),
             category=str(template.get("category") or "Component"),
-            quantity=1,
             unit_price=float(template.get("price") or template.get("unit_price") or 0.0),
             sourcing_url=template.get("sourcing_url"),
             rationale="Explicitly requested catalog part; restored by deterministic component reconciliation.",

--- a/blueprint_core/agents/orchestrator.py
+++ b/blueprint_core/agents/orchestrator.py
@@ -50,7 +50,8 @@ from blueprint_core.workspaces.projects.models import (
     MechanicalNotes, MechanicalSource, MechanicalVector3, MechanicalRotation3,
     MechanicalPlacement, MechanicalSpatialRelationship, PinMappingEntry,
     ValidationIssue, PinDefinition, ValidationSummary, BusConnection, PowerRail,
-    SystemArchitecture,
+    SystemArchitecture, component_detail_payload, component_instance_count,
+    expand_component_instances,
 )
 from blueprint_core.validation import validate_circuit, check_safety_violations, build_validation_summary
 
@@ -838,9 +839,12 @@ class HardwarePipelineOrchestrator:
                 For each selected component, instantiate it as a ComponentInstance with:
                 - ref_des: Unique ID like 'U1' (for MCUs), 'SEN1', 'ACT1', 'DISP1', 'R1', 'LED1', 'BAT1'
                 - part_number: MUST match exactly one of the available part_numbers in the database list above.
-                - name, category, quantity, unit_price, sourcing_url: Match the selected DB template.
+                - name, category, unit_price, sourcing_url: Match the selected DB template.
                 - rationale: Explain why this component is selected and how it fits.
                 - pins: Return an empty list. Exact catalog pins are hydrated deterministically after selection.
+                Every ComponentInstance is one physical occurrence. Repeated parts must be emitted as separate
+                records with unique reference designators (for example M1, M2, M3, and M4), never as one record
+                with an aggregate quantity.
                 
                 Output a JSON representation conforming to a List[ComponentInstance].
                 """
@@ -860,9 +864,10 @@ class HardwarePipelineOrchestrator:
                         "Restored explicitly requested catalog parts omitted by component selection: %s",
                         ", ".join(reconciled_component_parts),
                     )
+                components = expand_component_instances(components)
 
             # Compile intermediate IR for wiring
-            components_json = json.dumps([c.model_dump() for c in components], indent=2)
+            components_json = json.dumps([component_detail_payload(c) for c in components], indent=2)
 
             # 5. Wiring/Netlist Agent (With Auto-Correction Loop)
             logger.info("Invoking Wiring/Netlist Agent...")
@@ -944,7 +949,7 @@ class HardwarePipelineOrchestrator:
             # 5. BOM Agent
             logger.info("Invoking BOM Agent...")
             with agent_pipeline_step("default", "bom"):
-                total_cost = sum(c.unit_price * c.quantity for c in components)
+                total_cost = sum(c.unit_price * component_instance_count(c) for c in components)
                 overview.estimated_cost = round(total_cost, 2)
 
             # 6. Mechanical/Fabrication Agent
@@ -1263,7 +1268,10 @@ class HardwarePipelineOrchestrator:
                 rationale="Pull-up resistor for the DHT22 single-wire data line.",
             ),
         ]
-        overview.estimated_cost = round(sum(component.unit_price * component.quantity for component in components), 2)
+        overview.estimated_cost = round(
+            sum(component.unit_price * component_instance_count(component) for component in components),
+            2,
+        )
         emit_agent_pipeline_event("default", "component_selection", "completed", details={"component_count": len(components)})
 
         emit_agent_pipeline_event("default", "wiring_netlist", "started", details={"adapter": "parti-base-v1"})
@@ -1961,7 +1969,7 @@ class HardwarePipelineOrchestrator:
             )
         ]
 
-        overview.estimated_cost = sum(c.unit_price * c.quantity for c in components)
+        overview.estimated_cost = sum(c.unit_price * component_instance_count(c) for c in components)
 
         nets = [
             ConnectionNet(
@@ -2503,7 +2511,7 @@ class HardwarePipelineOrchestrator:
             )
         ]
 
-        overview.estimated_cost = sum(c.unit_price * c.quantity for c in components)
+        overview.estimated_cost = sum(c.unit_price * component_instance_count(c) for c in components)
 
         nets = [
             ConnectionNet(

--- a/blueprint_core/agents/system_architecture.py
+++ b/blueprint_core/agents/system_architecture.py
@@ -94,10 +94,10 @@ def hydrate_catalog_components(
                 part_number=component.part_number,
                 name=str(template.get("name") or component.name),
                 category=str(template.get("category") or component.category),
-                quantity=component.quantity,
                 unit_price=float(template.get("price") or 0.0),
                 sourcing_url=template.get("sourcing_url"),
                 rationale=component.rationale,
+                configuration=component.configuration,
                 pins=template.get("pins") or [],
             )
         )
@@ -112,7 +112,6 @@ def compact_component_context(components: Iterable[ComponentInstance]) -> list[d
             "part_number": component.part_number,
             "name": component.name,
             "category": component.category,
-            "quantity": component.quantity,
             "rationale": component.rationale,
         }
         for component in components

--- a/blueprint_core/agents/web_research_workflow.py
+++ b/blueprint_core/agents/web_research_workflow.py
@@ -42,6 +42,9 @@ from blueprint_core.workspaces.projects.models import (
     ProjectOverview,
     SystemArchitecture,
     ValidationIssue,
+    component_detail_payload,
+    component_instance_count,
+    expand_component_instances,
 )
 from blueprint_core.observability import serialize_for_langfuse, start_observation, update_observation
 from blueprint_core.agents.pipeline import PipelineCancelledError, agent_pipeline_step, emit_agent_pipeline_event, ensure_agent_pipeline_active
@@ -301,8 +304,8 @@ class WebResearchHardwarePipeline:
         logger.info("Invoking Web Component Sourcing Agent...")
         with agent_pipeline_step(self.workflow_id, "web_component_sourcing"):
             selection = self._select_components(user_prompt, plan, research_context)
-            components = selection.components
-            components_json = json.dumps([component.model_dump() for component in components], indent=2)
+            components = expand_component_instances(selection.components)
+            components_json = json.dumps([component_detail_payload(component) for component in components], indent=2)
 
         logger.info("Invoking Wiring/Netlist Agent...")
         with agent_pipeline_step(self.workflow_id, "wiring_netlist"):
@@ -322,7 +325,10 @@ class WebResearchHardwarePipeline:
                 validation_issues = validate_circuit(components, nets, plan.requirements, prompt=user_prompt)
                 is_valid = not any(issue.severity.upper() == "CRITICAL" for issue in validation_issues)
 
-        total_cost = sum(component.unit_price * component.quantity for component in components)
+        total_cost = sum(
+            component.unit_price * component_instance_count(component)
+            for component in components
+        )
         plan.overview.estimated_cost = round(total_cost, 2)
 
         logger.info("Invoking Mechanical/Fabrication Agent...")
@@ -488,6 +494,8 @@ class WebResearchHardwarePipeline:
         - Include a realistic low-voltage power source/regulator path.
         - Include complete relevant pins for each selected component: power, ground, interfaces, control, analog, and outputs.
         - Give each project instance a unique ref_des such as U1, SEN1, DIS1, PWR1, REG1, ACT1, SW1, R1.
+        - Every ComponentInstance is one physical occurrence. Emit repeated parts as separate records with unique
+          reference designators (for example M1, M2, M3, and M4); never use aggregate quantity semantics.
         - For complex boards, include the pins needed for this build rather than every package pin.
 
         Return WebComponentSelection.
@@ -635,7 +643,7 @@ class WebResearchHardwarePipeline:
         {plan.requirements.model_dump_json()}
 
         Components:
-        {json.dumps([component.model_dump() for component in components], indent=2)}
+        {json.dumps([component_detail_payload(component) for component in components], indent=2)}
 
         Nets:
         {json.dumps([net.model_dump() for net in nets], indent=2)}

--- a/blueprint_core/video_prompts.py
+++ b/blueprint_core/video_prompts.py
@@ -38,7 +38,8 @@ def _component_label(component: Dict[str, Any]) -> str:
 
 
 def _top_components(payload: Dict[str, Any], limit: int = 6) -> List[str]:
-    components = payload.get("components") if isinstance(payload.get("components"), list) else []
+    bom = payload.get("bom") if isinstance(payload.get("bom"), list) else []
+    components = bom or (payload.get("components") if isinstance(payload.get("components"), list) else [])
     labels = []
     for component in components:
         if not isinstance(component, dict):

--- a/blueprint_core/workspaces/projects/models.py
+++ b/blueprint_core/workspaces/projects/models.py
@@ -1,5 +1,5 @@
-from pydantic import BaseModel, Field, field_validator
-from typing import List, Optional, Dict, Any
+from pydantic import BaseModel, Field, field_validator, model_validator
+from typing import List, Optional, Dict, Any, Iterable, Mapping
 import re
 
 # ==========================================
@@ -23,6 +23,24 @@ class ComponentTemplate(BaseModel):
     pins: List[PinDefinition] = Field(default_factory=list, description="List of physical pins on the component")
     use_cases: List[str] = Field(default_factory=list, description="Common use cases or keywords")
 
+
+class PartDefinition(BaseModel):
+    """Source-agnostic identity and shared physical data for one selected part."""
+
+    part_definition_id: str = Field(..., description="Stable project-local ID referenced by component instances and BOM rows")
+    manufacturer: Optional[str] = Field(None, description="Part manufacturer when known")
+    part_number: str = Field(..., description="Manufacturer or generic part number")
+    name: str = Field(..., description="Human-readable part name")
+    category: str = Field(..., description="Electrical or mechanical part category")
+    description: str = Field("", description="Source-agnostic description of the selected part")
+    electrical_specs: Dict[str, Any] = Field(default_factory=dict, description="Shared electrical limits and ratings")
+    pins: List[PinDefinition] = Field(default_factory=list, description="Shared physical pin definitions")
+    dimensions_mm: Dict[str, float] = Field(default_factory=dict, description="Known physical dimensions in millimeters")
+    datasheet_url: Optional[str] = Field(None, description="Datasheet URL when known")
+    sourcing_url: Optional[str] = Field(None, description="Selected sourcing URL when known")
+    sourcing_offers: List[Dict[str, Any]] = Field(default_factory=list, description="Optional alternate sourcing offers")
+    unit_price: float = Field(0.0, ge=0.0, description="Selected estimated unit price in USD")
+
 # ==========================================
 # 2. Project-Level Hardware IR (Shared State)
 # ==========================================
@@ -43,15 +61,80 @@ class FunctionalRequirements(BaseModel):
     missing_info: List[str] = Field(default_factory=list, description="Clarifying questions or unknown requirements")
 
 class ComponentInstance(BaseModel):
+    """One independently addressable physical occurrence in a project.
+
+    The excluded identity fields keep Python callers and legacy records readable
+    during the 0.1 -> 0.2 transition. New serialized IR stores those values once
+    in ``part_definitions`` and emits only the definition reference here.
+    """
+
     ref_des: str = Field(..., description="Reference designator, e.g., 'U1', 'R1', 'SEN1'")
-    part_number: str = Field(..., description="Matching part number from the template database")
-    name: str = Field(..., description="Display name of this instance")
-    category: str = Field(..., description="Category of the component")
-    quantity: int = Field(1, description="Quantity required")
-    unit_price: float = Field(0.0, description="Estimated unit price in USD")
-    sourcing_url: Optional[str] = Field(None, description="Sourcing URL")
+    part_definition_id: Optional[str] = Field(None, description="ID of the shared PartDefinition")
     rationale: str = Field(..., description="Why this component was selected for this project")
-    pins: List[PinDefinition] = Field(default_factory=list, description="Full pinout of the instantiated component")
+    configuration: Dict[str, Any] = Field(default_factory=dict, description="Instance-specific configuration only")
+
+    # Transitional runtime fields. They are deliberately excluded from serialized
+    # Hardware IR; HardwareIR hydrates them from the referenced PartDefinition.
+    part_number: str = Field("", exclude=True, repr=False)
+    name: str = Field("", exclude=True, repr=False)
+    category: str = Field("", exclude=True, repr=False)
+    unit_price: float = Field(0.0, exclude=True, repr=False)
+    sourcing_url: Optional[str] = Field(None, exclude=True, repr=False)
+    pins: List[PinDefinition] = Field(default_factory=list, exclude=True, repr=False)
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_legacy_quantity(cls, value: Any) -> Any:
+        if not isinstance(value, Mapping) or "quantity" not in value:
+            return value
+        payload = dict(value)
+        try:
+            quantity = max(1, int(payload.pop("quantity") or 1))
+        except (TypeError, ValueError):
+            quantity = 1
+        configuration = dict(payload.get("configuration") or {})
+        if quantity > 1:
+            configuration["_legacy_aggregate_quantity"] = quantity
+        payload["configuration"] = configuration
+        return payload
+
+    @model_validator(mode="after")
+    def assign_part_definition_id(self) -> "ComponentInstance":
+        if not self.part_definition_id:
+            self.part_definition_id = _part_definition_id(self.part_number or self.name or self.ref_des)
+        return self
+
+    @property
+    def quantity(self) -> int:
+        """Every instance represents exactly one physical occurrence."""
+
+        return 1
+
+
+class BOMLineItem(BaseModel):
+    """Deterministic procurement aggregation over physical component instances."""
+
+    line_id: str = Field(..., description="Stable project-local BOM row ID")
+    part_definition_id: str = Field(..., description="Referenced shared part definition")
+    instance_refs: List[str] = Field(default_factory=list, description="Physical instances aggregated into this row")
+    quantity: int = Field(..., ge=1, description="Number of referenced physical instances")
+    manufacturer: Optional[str] = None
+    part_number: str
+    name: str
+    category: str
+    unit_price: float = Field(0.0, ge=0.0)
+    sourcing_url: Optional[str] = None
+    extended_price: float = Field(0.0, ge=0.0)
+    rationale: str = Field("", description="Combined project roles represented by this BOM row")
+
+    @model_validator(mode="after")
+    def quantity_matches_instances(self) -> "BOMLineItem":
+        if self.quantity != len(self.instance_refs):
+            raise ValueError(
+                f"BOM line '{self.line_id}' quantity {self.quantity} does not match "
+                f"its {len(self.instance_refs)} referenced component instances."
+            )
+        return self
 
 class PinReference(BaseModel):
     ref_des: str = Field(..., description="Component reference designator, e.g., 'U1'")
@@ -227,13 +310,176 @@ class SystemArchitecture(BaseModel):
     summary: str = Field(..., description="Concise explanation of the complete system decomposition")
     root: SystemNode = Field(..., description="Root of the hierarchical system tree")
 
+
+def _part_definition_id(value: str) -> str:
+    stem = re.sub(r"[^A-Z0-9]+", "_", str(value or "PART").upper()).strip("_") or "PART"
+    return f"PART_{stem}"
+
+
+def _instance_payload(value: ComponentInstance | Mapping[str, Any]) -> Dict[str, Any]:
+    if isinstance(value, ComponentInstance):
+        return {
+            "ref_des": value.ref_des,
+            "part_definition_id": value.part_definition_id,
+            "rationale": value.rationale,
+            "configuration": dict(value.configuration),
+            "part_number": value.part_number,
+            "name": value.name,
+            "category": value.category,
+            "unit_price": value.unit_price,
+            "sourcing_url": value.sourcing_url,
+            "pins": [pin.model_dump(mode="json") for pin in value.pins],
+        }
+    return dict(value)
+
+
+def _expanded_ref_des(base_ref: str, offset: int, used_refs: set[str]) -> str:
+    match = re.fullmatch(r"(.*?)(\d+)", base_ref.strip())
+    prefix = (match.group(1) if match else base_ref.strip()) or "X"
+    start = int(match.group(2)) if match else 1
+    candidate_index = start + offset
+    candidate = f"{prefix}{candidate_index}"
+    while candidate in used_refs:
+        candidate_index += 1
+        candidate = f"{prefix}{candidate_index}"
+    return candidate
+
+
+def expand_component_instances(
+    components: Iterable[ComponentInstance | Mapping[str, Any]],
+) -> List[ComponentInstance]:
+    """Expand legacy aggregate quantities into unique physical instances."""
+
+    expanded: List[ComponentInstance] = []
+    used_refs: set[str] = set()
+    for value in components:
+        payload = _instance_payload(value)
+        configuration = dict(payload.get("configuration") or {})
+        legacy_quantity = configuration.pop("_legacy_aggregate_quantity", None)
+        if legacy_quantity is None:
+            legacy_quantity = payload.pop("quantity", 1)
+        try:
+            quantity = max(1, int(legacy_quantity or 1))
+        except (TypeError, ValueError):
+            quantity = 1
+        payload["configuration"] = configuration
+        base_ref = str(payload.get("ref_des") or "X1").strip() or "X1"
+        for offset in range(quantity):
+            if offset == 0:
+                ref_des = base_ref
+            else:
+                ref_des = _expanded_ref_des(base_ref, offset, used_refs)
+            if ref_des in used_refs:
+                raise ValueError(f"Duplicate component reference designator '{ref_des}'.")
+            used_refs.add(ref_des)
+            expanded.append(ComponentInstance.model_validate({**payload, "ref_des": ref_des}))
+    return expanded
+
+
+def part_definition_from_instance(component: ComponentInstance) -> PartDefinition:
+    return PartDefinition(
+        part_definition_id=str(component.part_definition_id),
+        part_number=component.part_number or str(component.part_definition_id),
+        name=component.name or component.part_number or str(component.part_definition_id),
+        category=component.category or "Component",
+        pins=component.pins,
+        sourcing_url=component.sourcing_url,
+        unit_price=max(0.0, component.unit_price),
+    )
+
+
+def derive_part_definitions(
+    components: Iterable[ComponentInstance],
+    existing: Iterable[PartDefinition] = (),
+) -> List[PartDefinition]:
+    definitions = {item.part_definition_id: item for item in existing}
+    for component in components:
+        part_id = str(component.part_definition_id)
+        candidate = part_definition_from_instance(component)
+        current = definitions.get(part_id)
+        if current is None:
+            definitions[part_id] = candidate
+            continue
+        has_legacy_identity = bool(
+            component.part_number or component.name or component.category or component.pins
+        )
+        if not has_legacy_identity:
+            continue
+        if current.part_number != candidate.part_number:
+            raise ValueError(f"Part definition '{part_id}' is used for conflicting part numbers.")
+        if current.pins and candidate.pins and current.pins != candidate.pins:
+            raise ValueError(f"Part definition '{part_id}' has conflicting shared pin data.")
+    return list(definitions.values())
+
+
+def derive_bom_line_items(
+    part_definitions: Iterable[PartDefinition],
+    components: Iterable[ComponentInstance],
+) -> List[BOMLineItem]:
+    definitions = {item.part_definition_id: item for item in part_definitions}
+    grouped: Dict[str, List[ComponentInstance]] = {}
+    for component in components:
+        grouped.setdefault(str(component.part_definition_id), []).append(component)
+
+    rows: List[BOMLineItem] = []
+    for part_id, instances in grouped.items():
+        definition = definitions.get(part_id)
+        if definition is None:
+            raise ValueError(f"Component instance '{instances[0].ref_des}' references unknown part definition '{part_id}'.")
+        refs = [instance.ref_des for instance in instances]
+        rationales = list(dict.fromkeys(instance.rationale for instance in instances if instance.rationale.strip()))
+        quantity = len(refs)
+        rows.append(BOMLineItem(
+            line_id=f"BOM_{part_id}",
+            part_definition_id=part_id,
+            instance_refs=refs,
+            quantity=quantity,
+            manufacturer=definition.manufacturer,
+            part_number=definition.part_number,
+            name=definition.name,
+            category=definition.category,
+            unit_price=definition.unit_price,
+            sourcing_url=definition.sourcing_url,
+            extended_price=round(definition.unit_price * quantity, 2),
+            rationale="; ".join(rationales),
+        ))
+    return rows
+
+
+def component_instance_count(component: ComponentInstance) -> int:
+    """Return one for normalized instances or a pending legacy expansion count."""
+
+    try:
+        return max(1, int(component.configuration.get("_legacy_aggregate_quantity") or 1))
+    except (TypeError, ValueError):
+        return 1
+
+
+def component_detail_payload(component: ComponentInstance) -> Dict[str, Any]:
+    """Resolve the shared part fields needed by specialist-agent prompts."""
+
+    return {
+        "ref_des": component.ref_des,
+        "part_definition_id": component.part_definition_id,
+        "part_number": component.part_number,
+        "name": component.name,
+        "category": component.category,
+        "unit_price": component.unit_price,
+        "sourcing_url": component.sourcing_url,
+        "rationale": component.rationale,
+        "configuration": component.configuration,
+        "pins": [pin.model_dump(mode="json") for pin in component.pins],
+    }
+
 class HardwareIR(BaseModel):
     """The master typed document capturing the entire generated hardware design."""
-    hardware_ir_version: str = Field("0.1", description="Structured schema version")
+    hardware_ir_version: str = Field("0.2", description="Structured schema version")
     overview: Optional[ProjectOverview] = Field(None, description="Project overview metadata")
     requirements: Optional[FunctionalRequirements] = Field(None, description="Extracted constraints & requirements")
     system_architecture: Optional[SystemArchitecture] = Field(None, description="Hierarchical, purpose-driven decomposition of the complete product")
-    components: List[ComponentInstance] = Field(default_factory=list, description="Instantiated Bill of Materials")
+    part_definitions: List[PartDefinition] = Field(default_factory=list, description="Shared source-agnostic part definitions")
+    components: List[ComponentInstance] = Field(default_factory=list, description="Independently addressable physical component instances")
+    bom: List[BOMLineItem] = Field(default_factory=list, description="Deterministically aggregated procurement rows")
     nets: List[ConnectionNet] = Field(default_factory=list, description="Electrical netlist connections")
     buses: List[BusConnection] = Field(default_factory=list, description="Digital communication buses")
     pin_mappings: List[PinMappingEntry] = Field(default_factory=list, description="MCU functional pin map")
@@ -250,6 +496,112 @@ class HardwareIR(BaseModel):
     
     validation: ValidationSummary = Field(default_factory=ValidationSummary, description="Categorized safety and electrical checks")
     is_valid: bool = Field(True, description="True if project passes critical validation checks")
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_component_model(cls, value: Any) -> Any:
+        if not isinstance(value, Mapping):
+            return value
+        payload = dict(value)
+        components = expand_component_instances(payload.get("components") or [])
+        existing_definitions = [
+            item if isinstance(item, PartDefinition) else PartDefinition.model_validate(item)
+            for item in (payload.get("part_definitions") or [])
+        ]
+        definitions = derive_part_definitions(components, existing_definitions)
+        payload["hardware_ir_version"] = "0.2"
+        payload["components"] = components
+        payload["part_definitions"] = definitions
+        if not payload.get("bom"):
+            payload["bom"] = derive_bom_line_items(definitions, components)
+        return payload
+
+    @model_validator(mode="after")
+    def validate_component_model(self) -> "HardwareIR":
+        definitions = {item.part_definition_id: item for item in self.part_definitions}
+        component_refs: Dict[str, ComponentInstance] = {}
+        expected_bom_refs: Dict[str, List[str]] = {}
+        for component in self.components:
+            if component.ref_des in component_refs:
+                raise ValueError(f"Duplicate component reference designator '{component.ref_des}'.")
+            definition = definitions.get(str(component.part_definition_id))
+            if definition is None:
+                raise ValueError(
+                    f"Component instance '{component.ref_des}' references unknown part definition "
+                    f"'{component.part_definition_id}'."
+                )
+            component.part_number = definition.part_number
+            component.name = definition.name
+            component.category = definition.category
+            component.unit_price = definition.unit_price
+            component.sourcing_url = definition.sourcing_url
+            component.pins = list(definition.pins)
+            component_refs[component.ref_des] = component
+            expected_bom_refs.setdefault(str(component.part_definition_id), []).append(component.ref_des)
+
+        bom_refs: List[str] = []
+        bom_part_ids: set[str] = set()
+        bom_line_ids: set[str] = set()
+        for row in self.bom:
+            if row.line_id in bom_line_ids:
+                raise ValueError(f"Duplicate BOM line ID '{row.line_id}'.")
+            if row.part_definition_id in bom_part_ids:
+                raise ValueError(
+                    f"Part definition '{row.part_definition_id}' must aggregate into exactly one BOM line."
+                )
+            bom_line_ids.add(row.line_id)
+            bom_part_ids.add(row.part_definition_id)
+            definition = definitions.get(row.part_definition_id)
+            if definition is None:
+                raise ValueError(f"BOM line '{row.line_id}' references unknown part definition '{row.part_definition_id}'.")
+            if sorted(row.instance_refs) != sorted(expected_bom_refs.get(row.part_definition_id, [])):
+                raise ValueError(
+                    f"BOM line '{row.line_id}' must contain every physical instance of its part definition."
+                )
+            if (
+                row.part_number != definition.part_number
+                or row.name != definition.name
+                or row.category != definition.category
+                or row.manufacturer != definition.manufacturer
+                or round(row.unit_price, 2) != round(definition.unit_price, 2)
+                or row.sourcing_url != definition.sourcing_url
+            ):
+                raise ValueError(f"BOM line '{row.line_id}' does not match its shared part definition.")
+            for ref_des in row.instance_refs:
+                component = component_refs.get(ref_des)
+                if component is None:
+                    raise ValueError(f"BOM line '{row.line_id}' references unknown component instance '{ref_des}'.")
+                if component.part_definition_id != row.part_definition_id:
+                    raise ValueError(
+                        f"BOM line '{row.line_id}' includes instance '{ref_des}' from a different part definition."
+                    )
+                bom_refs.append(ref_des)
+            expected_extended = round(row.unit_price * row.quantity, 2)
+            if round(row.extended_price, 2) != expected_extended:
+                raise ValueError(f"BOM line '{row.line_id}' extended price is not deterministic.")
+        if sorted(bom_refs) != sorted(component_refs):
+            raise ValueError("Every component instance must appear exactly once in the BOM.")
+
+        for net in self.nets:
+            for pin_ref in net.pins:
+                component = component_refs.get(pin_ref.ref_des)
+                if component is None:
+                    raise ValueError(
+                        f"Net '{net.net_id}' references unknown component instance '{pin_ref.ref_des}'."
+                    )
+                valid_pins = {pin.pin_id for pin in component.pins}
+                if valid_pins and pin_ref.pin_id not in valid_pins:
+                    raise ValueError(
+                        f"Net '{net.net_id}' references unknown pin '{pin_ref.pin_id}' on instance '{pin_ref.ref_des}'."
+                    )
+
+        if self.mechanical:
+            for placement in self.mechanical.component_placements:
+                if placement.ref_des not in component_refs:
+                    raise ValueError(
+                        f"Mechanical placement references unknown component instance '{placement.ref_des}'."
+                    )
+        return self
 
 
 class Project(BaseModel):

--- a/blueprint_core/workspaces/projects/objects.py
+++ b/blueprint_core/workspaces/projects/objects.py
@@ -7,7 +7,7 @@ from typing import Any, Iterable, Mapping, Optional
 
 from pydantic import BaseModel, Field
 
-from blueprint_core.workspaces.projects.models import HardwareIR
+from blueprint_core.workspaces.projects.models import HardwareIR, component_detail_payload
 
 
 PROJECT_OBJECT_TYPE = "blueprint.project"
@@ -465,6 +465,18 @@ def build_project_attribute_objects(
 
 
 def _component_bom_payload(ir_payload: dict[str, Any]) -> dict[str, Any]:
+    bom = ir_payload.get("bom") or []
+    if bom:
+        line_items = [dict(item) for item in bom if isinstance(item, dict)]
+        electrical_total = round(sum(float(item.get("extended_price") or 0.0) for item in line_items), 2)
+        return {
+            "line_items": line_items,
+            "component_count": sum(int(item.get("quantity") or 0) for item in line_items),
+            "line_item_count": len(line_items),
+            "estimated_electrical_cost": electrical_total,
+            "estimated_total_cost": (ir_payload.get("overview") or {}).get("estimated_cost", electrical_total),
+        }
+
     components = ir_payload.get("components") or []
     total = 0.0
     line_items = []
@@ -565,7 +577,9 @@ def namespace_payload(ir: HardwareIR | dict[str, Any], namespace: str) -> dict[s
         }
     elif normalized == "product.electrical":
         selected_payload = {
-            "components": payload.get("components") or [],
+            "part_definitions": payload.get("part_definitions") or [],
+            "components": [component_detail_payload(component) for component in hardware_ir.components],
+            "bom": payload.get("bom") or [],
             "nets": payload.get("nets") or [],
             "buses": payload.get("buses") or [],
             "pin_mappings": payload.get("pin_mappings") or [],

--- a/blueprint_core/workspaces/projects/state.py
+++ b/blueprint_core/workspaces/projects/state.py
@@ -58,8 +58,13 @@ class ProjectRevisionDraft(BaseModel):
 
     @model_validator(mode="after")
     def require_consistent_unique_output(self) -> "ProjectRevisionDraft":
-        if self.components != self.state.components:
+        component_payloads = [item.model_dump(mode="json") for item in self.components]
+        state_component_payloads = [item.model_dump(mode="json") for item in self.state.components]
+        if component_payloads != state_component_payloads:
             raise ValueError("Project revision components must match the canonical HardwareIR state.")
+        # Keep runtime-only shared part details available to worker consumers while
+        # persisting only the normalized physical-instance records.
+        self.components = list(self.state.components)
         for values, label in (
             ([item.system_id for item in self.systems], "system_id"),
             ([item.artifact_id for item in self.artifacts], "artifact_id"),

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -41,7 +41,7 @@ Forma uses an **ADK-style** sequential multi-agent workflow (implemented in `app
 **Input:** Requirements + system tree + compact seed component catalog
 
 **Output:** `ComponentInstance[]`  
-**Goal:** Choose compatible parts by system role. Exact catalog pinouts are hydrated deterministically after selection.
+**Goal:** Choose compatible parts by system role. Repeated parts are emitted as one physical instance per reference designator; exact catalog pinouts are hydrated deterministically after selection.
 
 ### Wiring/Netlist Agent
 **Input:** Components + requirements  
@@ -52,8 +52,8 @@ If validation produces CRITICAL issues, the orchestrator runs a one-step **auto-
 
 ### BOM Agent
 **Input:** Component list  
-**Output:** Updated `ProjectOverview.estimated_cost`  
-**Goal:** Calculate total cost from unit prices and quantities (deterministic step).
+**Output:** `PartDefinition[]`, `BOMLineItem[]`, and updated `ProjectOverview.estimated_cost`
+**Goal:** Store shared part data once, aggregate physical instance references into procurement rows, and calculate deterministic extended and total costs.
 
 ### Mechanical/Fabrication Agent
 **Input:** Mechanical system branch + pin-free component summaries

--- a/docs/hardware-ir.md
+++ b/docs/hardware-ir.md
@@ -9,13 +9,15 @@ Forma’s **Hardware IR** is a typed, versioned JSON schema built with Pydantic.
 - **Diffable:** Changes across versions are explicit and comparable.
 
 ## Top-level structure
-The core schema lives in `apps/api/models.py` and includes:
+The core schema lives in `blueprint_core/workspaces/projects/models.py` and includes:
 
 - **hardware_ir_version** – schema version string.
 - **overview** – `ProjectOverview` with title, description, difficulty, category.
 - **requirements** – `FunctionalRequirements` with power, constraints, safety notes.
 - **system_architecture** – purpose-driven `SystemArchitecture` tree of discipline and nested subsystem nodes.
-- **components** – list of `ComponentInstance` objects (instantiated BOM).
+- **part_definitions** – shared, source-agnostic `PartDefinition` identity, specifications, pinout, dimensions, datasheet, sourcing, and unit-price records.
+- **components** – physical `ComponentInstance` occurrences; every record has one unique reference designator and points to a part definition.
+- **bom** – deterministic `BOMLineItem` aggregation over physical instance references.
 - **nets** – list of `ConnectionNet` objects (netlist connections).
 - **buses** – `BusConnection` definitions (I2C/SPI/UART groups).
 - **pin_mappings** – `PinMappingEntry` for MCU signal mapping.
@@ -36,7 +38,8 @@ Additional fields commonly populated at runtime:
 
 ## Key relationships
 - **SystemArchitecture → SystemNode:** The complete product nests electrical, mechanical, firmware, and more specific systems. Each node records why it exists, its responsibilities, interfaces, abstract component roles, and detail owner.
-- **ComponentInstance → PinDefinition:** Each instance carries a full pinout.
+- **ComponentInstance → PartDefinition:** Each physical occurrence references shared part identity and pin data by `part_definition_id`.
+- **BOMLineItem → ComponentInstance:** Each procurement row aggregates `instance_refs`; its quantity must equal the number of those references.
 - **ConnectionNet → PinReference:** Nets reference component pins by `ref_des` + `pin_id`.
 - **BusConnection → ConnectionNet:** Buses group nets for higher-level comms.
 - **ValidationSummary → ValidationIssue:** Structured diagnostics live inside the IR.
@@ -49,6 +52,12 @@ The IR is produced in a loop:
 4. Validation results are embedded back into the IR.
 
 This makes the IR more than a snapshot—it’s a record of what was checked and why the design is considered safe within MVP scope.
+
+## Hardware IR 0.2 migration
+
+Hardware IR 0.2 separates physical design state from procurement aggregation. Repeated parts are represented as independently addressable instances (`M1`, `M2`, `M3`, `M4`), while the BOM can still contain one row with quantity four. Nets and mechanical placements always target a physical instance, and validation rejects duplicate or unknown references, unknown pins when a pinout is defined, mismatched BOM quantities, and non-deterministic extended prices.
+
+The validator reads 0.1 quantity-bearing component records and expands them deterministically. Shared legacy identity and pin fields are moved into `part_definitions`, BOM rows are derived, and the serialized result is emitted as 0.2. Runtime compatibility properties remain available to existing Python consumers during the transition, but new JSON must not use aggregate component quantities.
 
 ## Image inputs
 When `image_data` is provided to `POST /api/generate`, the backend uploads the reference image to Supabase Storage when the Supabase service-role/secret key is configured and `BLUEPRINT_DEV_MODE` is not enabled, then records `assembly_metadata.reference_image_url`, `reference_image_s3_bucket`, and `reference_image_s3_key`. If storage is not configured or `BLUEPRINT_DEV_MODE=true`, it falls back to `assembly_metadata.reference_image_data`.

--- a/tests/agents/test_generation_worker.py
+++ b/tests/agents/test_generation_worker.py
@@ -195,7 +195,7 @@ class GenerationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(attach_image.call_args.kwargs["generate_image"])
         self.assertEqual("Vertex Image Project", draft.state.overview.title)
 
-    def test_generation_draft_preserves_dangling_ir_refs_without_invalid_system_refs(self) -> None:
+    def test_hardware_ir_rejects_dangling_component_references(self) -> None:
         component = ComponentInstance(
             ref_des="U1",
             part_number="ESP32-DEVKIT",
@@ -203,38 +203,30 @@ class GenerationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
             category="Microcontroller",
             rationale="Provides processing and connectivity.",
         )
-        state = HardwareIR(
-            components=[component],
-            nets=[
-                ConnectionNet(
-                    net_id="NET_I2C_SDA",
-                    name="I2C data",
-                    net_type="I2C",
-                    pins=[
-                        PinReference(ref_des="U1", pin_id="SDA"),
-                        PinReference(ref_des="R2", pin_id="1"),
-                    ],
-                )
-            ],
-            buses=[BusConnection(bus_id="I2C_1", bus_type="I2C", nets=["NET_I2C_SDA"])],
-            power_rails=[
-                PowerRail(
-                    rail_id="3V3",
-                    voltage=3.3,
-                    max_current_capacity_ma=500,
-                    source_component="R2",
-                )
-            ],
-        )
-
-        draft = build_generation_draft(self.brief, state)
-
-        power_system = next(system for system in draft.systems if system.kind == "power")
-        bus_system = next(system for system in draft.systems if system.kind == "bus")
-        self.assertEqual([], power_system.component_refs)
-        self.assertEqual(["R2"], power_system.metadata["unresolved_component_refs"])
-        self.assertEqual(["U1"], bus_system.component_refs)
-        self.assertEqual(["R2"], bus_system.metadata["unresolved_component_refs"])
+        with self.assertRaisesRegex(ValueError, "unknown component instance 'R2'"):
+            HardwareIR(
+                components=[component],
+                nets=[
+                    ConnectionNet(
+                        net_id="NET_I2C_SDA",
+                        name="I2C data",
+                        net_type="I2C",
+                        pins=[
+                            PinReference(ref_des="U1", pin_id="SDA"),
+                            PinReference(ref_des="R2", pin_id="1"),
+                        ],
+                    )
+                ],
+                buses=[BusConnection(bus_id="I2C_1", bus_type="I2C", nets=["NET_I2C_SDA"])],
+                power_rails=[
+                    PowerRail(
+                        rail_id="3V3",
+                        voltage=3.3,
+                        max_current_capacity_ma=500,
+                        source_component="R2",
+                    )
+                ],
+            )
 
     def tearDown(self) -> None:
         self.directory.cleanup()

--- a/tests/agents/test_system_architecture.py
+++ b/tests/agents/test_system_architecture.py
@@ -19,6 +19,7 @@ from blueprint_core.workspaces.projects.models import (
     PinReference,
     ProjectOverview,
     SystemArchitecture,
+    expand_component_instances,
 )
 from blueprint_core.workspaces.projects.objects import namespace_payload
 
@@ -76,6 +77,7 @@ class SystemArchitectureTests(unittest.TestCase):
             part_number="MCU-1",
             name="placeholder",
             category="placeholder",
+            quantity=4,
             rationale="Runs the product.",
             pins=[],
         )
@@ -88,6 +90,9 @@ class SystemArchitectureTests(unittest.TestCase):
         self.assertEqual(["Power"], compact_catalog[0]["available_interfaces"])
         self.assertEqual("3V3", hydrated[0].pins[0].pin_id)
         self.assertNotIn("pins", compact_components[0])
+        self.assertEqual(["U1", "U2", "U3", "U4"], [
+            component.ref_des for component in expand_component_instances(hydrated)
+        ])
 
     def test_compact_net_context_keeps_components_not_pin_ids(self) -> None:
         net = ConnectionNet(

--- a/tests/projects/test_component_instances.py
+++ b/tests/projects/test_component_instances.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import unittest
+
+from pydantic import ValidationError
+
+from blueprint_core.workspaces.projects.models import (
+    BOMLineItem,
+    ComponentInstance,
+    ConnectionNet,
+    HardwareIR,
+    MechanicalNotes,
+    MechanicalPlacement,
+    MechanicalVector3,
+    PartDefinition,
+    PinDefinition,
+    PinReference,
+)
+
+
+def motor_payload(*, quantity: int = 4) -> dict:
+    return {
+        "ref_des": "M1",
+        "part_number": "N20-6V",
+        "name": "N20 gear motor",
+        "category": "Actuator",
+        "quantity": quantity,
+        "unit_price": 3.25,
+        "sourcing_url": "https://example.com/n20",
+        "rationale": "Independent wheel drive",
+        "pins": [
+            {"pin_id": "+", "name": "Motor positive", "pin_type": "Power"},
+            {"pin_id": "-", "name": "Motor negative", "pin_type": "Ground"},
+        ],
+    }
+
+
+class PhysicalComponentInstanceTests(unittest.TestCase):
+    def test_legacy_aggregate_expands_to_instances_and_one_bom_row(self) -> None:
+        ir = HardwareIR(hardware_ir_version="0.1", components=[motor_payload()])
+
+        self.assertEqual("0.2", ir.hardware_ir_version)
+        self.assertEqual(["M1", "M2", "M3", "M4"], [item.ref_des for item in ir.components])
+        self.assertTrue(all(item.quantity == 1 for item in ir.components))
+        self.assertEqual(1, len(ir.part_definitions))
+        self.assertEqual(1, len(ir.bom))
+        self.assertEqual(4, ir.bom[0].quantity)
+        self.assertEqual(["M1", "M2", "M3", "M4"], ir.bom[0].instance_refs)
+        self.assertEqual(13.0, ir.bom[0].extended_price)
+
+        serialized = ir.model_dump(mode="json")
+        self.assertNotIn("quantity", serialized["components"][0])
+        self.assertNotIn("part_number", serialized["components"][0])
+        self.assertNotIn("pins", serialized["components"][0])
+
+    def test_each_expanded_motor_can_be_wired_and_placed_independently(self) -> None:
+        placements = [
+            MechanicalPlacement(
+                ref_des=f"M{index}",
+                position=MechanicalVector3(x_mm=float(index), y_mm=0, z_mm=0),
+                size=MechanicalVector3(x_mm=12, y_mm=10, z_mm=25),
+            )
+            for index in range(1, 5)
+        ]
+        nets = [
+            ConnectionNet(
+                net_id=f"MOTOR_{index}_POS",
+                name=f"Motor {index} positive",
+                net_type="Power",
+                pins=[PinReference(ref_des=f"M{index}", pin_id="+")],
+            )
+            for index in range(1, 5)
+        ]
+
+        ir = HardwareIR(
+            components=[motor_payload()],
+            nets=nets,
+            mechanical=MechanicalNotes(
+                enclosure_type="Open frame",
+                mounting_guidance="Mount each motor independently",
+                manufacturability_rating="Easy",
+                component_placements=placements,
+            ),
+        )
+
+        self.assertEqual(4, len(ir.nets))
+        self.assertEqual(4, len(ir.mechanical.component_placements))
+
+    def test_unknown_instance_and_pin_references_are_rejected(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "unknown component instance 'M5'"):
+            HardwareIR(
+                components=[motor_payload(quantity=1)],
+                nets=[
+                    ConnectionNet(
+                        net_id="BAD_REF",
+                        name="Bad reference",
+                        net_type="Power",
+                        pins=[PinReference(ref_des="M5", pin_id="+")],
+                    )
+                ],
+            )
+
+        with self.assertRaisesRegex(ValidationError, "unknown pin 'PWM'"):
+            HardwareIR(
+                components=[motor_payload(quantity=1)],
+                nets=[
+                    ConnectionNet(
+                        net_id="BAD_PIN",
+                        name="Bad pin",
+                        net_type="PWM",
+                        pins=[PinReference(ref_des="M1", pin_id="PWM")],
+                    )
+                ],
+            )
+
+    def test_invalid_bom_aggregation_is_rejected(self) -> None:
+        definition = PartDefinition(
+            part_definition_id="PART_N20_6V",
+            part_number="N20-6V",
+            name="N20 gear motor",
+            category="Actuator",
+            unit_price=3.25,
+        )
+        components = [
+            ComponentInstance(
+                ref_des=f"M{index}",
+                part_definition_id=definition.part_definition_id,
+                rationale="Wheel drive",
+            )
+            for index in range(1, 5)
+        ]
+        bad_bom = BOMLineItem(
+            line_id="BOM_PART_N20_6V",
+            part_definition_id=definition.part_definition_id,
+            instance_refs=["M1", "M2", "M3"],
+            quantity=3,
+            part_number=definition.part_number,
+            name=definition.name,
+            category=definition.category,
+            unit_price=definition.unit_price,
+            extended_price=9.75,
+        )
+
+        with self.assertRaisesRegex(ValidationError, "must contain every physical instance"):
+            HardwareIR(part_definitions=[definition], components=components, bom=[bad_bom])
+
+    def test_source_agnostic_part_definition_round_trips(self) -> None:
+        definition = PartDefinition(
+            part_definition_id="PART_LED_RED",
+            manufacturer="Example Semiconductor",
+            part_number="LED-5MM-RED",
+            name="Red LED",
+            category="Display",
+            description="Diffused indicator LED",
+            electrical_specs={"forward_voltage_v": 2.0},
+            pins=[
+                PinDefinition(pin_id="A", name="Anode", pin_type="Power"),
+                PinDefinition(pin_id="K", name="Cathode", pin_type="Ground"),
+            ],
+            dimensions_mm={"diameter": 5.0},
+            datasheet_url="https://example.com/led.pdf",
+            unit_price=0.12,
+        )
+        ir = HardwareIR(
+            part_definitions=[definition],
+            components=[
+                ComponentInstance(
+                    ref_des="D1",
+                    part_definition_id=definition.part_definition_id,
+                    rationale="Status indicator",
+                    configuration={"color": "red"},
+                )
+            ],
+        )
+
+        restored = HardwareIR.model_validate(ir.model_dump(mode="json"))
+
+        self.assertEqual(definition, restored.part_definitions[0])
+        self.assertEqual("LED-5MM-RED", restored.components[0].part_number)
+        self.assertEqual(["D1"], restored.bom[0].instance_refs)
+
+    def test_duplicate_reference_designators_are_rejected(self) -> None:
+        with self.assertRaisesRegex(ValidationError, "Duplicate component reference designator 'M1'"):
+            HardwareIR(components=[motor_payload(quantity=1), motor_payload(quantity=1)])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Hardware IR 0.2 PartDefinition, physical ComponentInstance, and deterministic BOMLineItem records
- migrate legacy aggregate quantities into unique references and validate BOM, net, pin, and placement integrity
- resolve shared part data in generation, project objects, schematic/mechanical views, BOM UI, and cost metrics
- document the compatibility transition and add backend/frontend regression coverage

## Tests
- PYTHON_BIN=/home/isayah/caid-technologies/Blueprint-OSS/.venv/bin/python ./scripts/quality/test.sh (526 passed, 1 skipped)
- node --test --experimental-strip-types test/project-cost-metrics.test.ts (2 passed)
- npm run build (passed; existing img-element warnings only)

Closes #297