### PR TITLE
Preserve partial generation artifacts across stage failures

### DIFF
--- a/apps/api/a2a.py
+++ b/apps/api/a2a.py
@@ -760,11 +760,47 @@ def build_generation_response(
     data_sources: Optional[List[str]] = None,
     past_job_context: Optional[PastJobContext] = None,
     project_id: Optional[str] = None,
+    retry_stage: Optional[str] = None,
 ) -> Dict[str, Any]:
     _apply_owner_user_integrations(owner_user_id)
 
     prompt_text = (prompt or "").strip()
     workflow_id = normalize_workflow_id(workflow)
+    normalized_retry_stage = str(retry_stage or "").strip() or None
+    prior_generation_run: Optional[Dict[str, Any]] = None
+    retry_stage_replay = False
+    if normalized_retry_stage:
+        if workflow_id != "web_research":
+            raise ValueError("Named generation-stage retry is currently supported by the web_research workflow.")
+        if not project_id:
+            raise ValueError("project_id is required when retry_stage is provided.")
+        existing_project = get_generated_project(project_id)
+        if existing_project is None:
+            raise ValueError("The project containing the failed generation stage was not found.")
+        if owner_user_id and str(getattr(existing_project, "owner_user_id", "") or "") != str(owner_user_id):
+            raise ValueError("The failed generation stage is not owned by the requesting user.")
+        existing_ir = getattr(existing_project, "hardware_ir", None)
+        if hasattr(existing_ir, "model_dump"):
+            existing_ir = existing_ir.model_dump(mode="json")
+        existing_ir = existing_ir if isinstance(existing_ir, dict) else {}
+        existing_metadata = existing_ir.get("assembly_metadata") or {}
+        candidate_run = existing_metadata.get("generation_run")
+        if not isinstance(candidate_run, dict):
+            raise ValueError("The project does not contain persisted generation-stage artifacts.")
+        candidate_record = (candidate_run.get("records") or {}).get(normalized_retry_stage)
+        if not isinstance(candidate_record, dict):
+            raise ValueError(f"Generation stage '{normalized_retry_stage}' is not failed and cannot be retried.")
+        if candidate_record.get("status") == "succeeded":
+            retry_stage_replay = bool(
+                frontend_job_id
+                and existing_metadata.get("frontend_job_id") == frontend_job_id
+                and candidate_run.get("retry_stage") == normalized_retry_stage
+            )
+            if not retry_stage_replay:
+                raise ValueError(f"Generation stage '{normalized_retry_stage}' is not failed and cannot be retried.")
+        elif candidate_record.get("status") != "failed":
+            raise ValueError(f"Generation stage '{normalized_retry_stage}' is not failed and cannot be retried.")
+        prior_generation_run = candidate_run
     has_prompt = bool(prompt_text)
     if not has_prompt and not image_data:
         raise ValueError("Provide a prompt or reference image.")
@@ -849,6 +885,9 @@ def build_generation_response(
                     "data_sources": normalized_data_sources,
                     "past_jobs_context": past_jobs_metadata,
                     "project_prompt": prompt_text,
+                    "retry_stage": normalized_retry_stage,
+                    "prior_generation_run": prior_generation_run,
+                    "retry_stage_replay": retry_stage_replay,
                 },
             )
             ensure_agent_pipeline_active()
@@ -913,6 +952,10 @@ def build_generation_response(
                 "project_ir": ir.model_dump(),
                 "mermaid_code": generate_mermaid_chart(ir),
                 "svg_schematic": generate_svg_schematic(ir),
+                "generation_status": (ir.assembly_metadata or {}).get("generation_status", "succeeded"),
+                "project_readiness": (ir.assembly_metadata or {}).get("project_readiness", "complete"),
+                "generation_stages": ((ir.assembly_metadata or {}).get("generation_run") or {}).get("records", {}),
+                "idempotent_stage_replay": bool((ir.assembly_metadata or {}).get("retry_stage_replay")),
             }
             update_observation(
                 root_observation,
@@ -985,6 +1028,7 @@ async def call_blueprint_action(action: str, payload: Dict[str, Any]) -> Dict[st
             data_sources,
             past_job_context,
             payload.get("project_id"),
+            payload.get("retry_stage"),
         )
 
     if normalized == "debug_config":
@@ -1087,7 +1131,16 @@ async def _process_server_message(message: A2AMessage) -> None:
             cancellation_check=lambda: JOB_STORE.is_cancelled(message.job_id),
         ):
             result = await call_blueprint_action(message.action, message.payload)
-        JOB_STORE.mark_succeeded(message.job_id, result)
+        generation_status = str(result.get("generation_status") or "succeeded").lower()
+        if generation_status == "partial":
+            JOB_STORE.mark_partial(message.job_id, result)
+        elif generation_status == "failed":
+            JOB_STORE.mark_failed(
+                message.job_id,
+                "A required root generation stage failed; partial diagnostics were preserved.",
+            )
+        else:
+            JOB_STORE.mark_succeeded(message.job_id, result)
         event = A2AEvent(
             job_id=message.job_id,
             message_id=message.message_id,
@@ -1247,6 +1300,14 @@ def _mcp_tools() -> List[Dict[str, Any]]:
                 "type": "object",
                 "properties": {
                     "prompt": {"type": "string"},
+                    "project_id": {
+                        "type": "string",
+                        "description": "Existing project ID when retrying a failed generation stage.",
+                    },
+                    "retry_stage": {
+                        "type": "string",
+                        "description": "Failed web_research stage to retry while reusing successful artifacts.",
+                    },
                     "workflow": {
                         "type": "string",
                         "enum": ["default", "web_research"],

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -628,6 +628,7 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
     payload = {
         "prompt": request.prompt,
         "project_id": request.project_id,
+        "retry_stage": request.retry_stage,
         "workflow": request.workflow,
         "image_data": request.image_data,
         "generate_image": request.generate_image,
@@ -683,10 +684,17 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
                 data_sources=request.data_sources,
                 past_job_context=past_job_context,
                 project_id=request.project_id,
+                retry_stage=request.retry_stage,
             )
         if JOB_STORE.is_cancelled(job_id):
             raise JobCancelledError(f"Job {job_id} was cancelled.")
-        JOB_STORE.mark_succeeded(job_id, response)
+        generation_status = str(response.get("generation_status") or "succeeded").lower()
+        if generation_status == "partial":
+            JOB_STORE.mark_partial(job_id, response)
+        elif generation_status == "failed":
+            JOB_STORE.mark_failed(job_id, "A required root generation stage failed; partial diagnostics were preserved.")
+        else:
+            JOB_STORE.mark_succeeded(job_id, response)
         job = JOB_STORE.get_job(job_id)
         if str((job or {}).get("status") or "").lower() in {"cancelled", "canceled"}:
             raise JobCancelledError(f"Job {job_id} was cancelled.")
@@ -1620,6 +1628,8 @@ def _project_summary_response(project: Any, current_user_id: Optional[str] = Non
         "product_image_model": hydrated_metadata.get("product_image_model") or hydrated_metadata.get("image_output_model"),
         "product_visual_sequence": sequence if isinstance(sequence, list) else [],
         "image_output_status": hydrated_metadata.get("image_output_status"),
+        "generation_status": metadata.get("generation_status", "succeeded"),
+        "project_readiness": metadata.get("project_readiness", "complete"),
     }
 
 
@@ -1872,6 +1882,9 @@ def get_project_endpoint(project_id: str, user: UserContext = Depends(optional_u
             "project_object": build_project_object(ir).model_dump(mode="json"),
             "mermaid_code": generate_mermaid_chart(ir),
             "svg_schematic": generate_svg_schematic(ir),
+            "generation_status": (ir.assembly_metadata or {}).get("generation_status", "succeeded"),
+            "project_readiness": (ir.assembly_metadata or {}).get("project_readiness", "complete"),
+            "generation_stages": ((ir.assembly_metadata or {}).get("generation_run") or {}).get("records", {}),
         }
     _require_project_reader(project, user)
 
@@ -1905,6 +1918,9 @@ def get_project_endpoint(project_id: str, user: UserContext = Depends(optional_u
             "project_object": None,
             "mermaid_code": None,
             "svg_schematic": None,
+            "generation_status": (response_metadata or {}).get("generation_status", "succeeded"),
+            "project_readiness": (response_metadata or {}).get("project_readiness", "complete"),
+            "generation_stages": ((response_metadata or {}).get("generation_run") or {}).get("records", {}),
         }
 
     try:
@@ -1941,7 +1957,10 @@ def get_project_endpoint(project_id: str, user: UserContext = Depends(optional_u
             "project_ir": response_ir.model_dump(),
             "project_object": build_project_object(response_ir).model_dump(mode="json"),
             "mermaid_code": mermaid_code,
-            "svg_schematic": svg_schematic
+            "svg_schematic": svg_schematic,
+            "generation_status": (ir.assembly_metadata or {}).get("generation_status", "succeeded"),
+            "project_readiness": (ir.assembly_metadata or {}).get("project_readiness", "complete"),
+            "generation_stages": ((ir.assembly_metadata or {}).get("generation_run") or {}).get("records", {}),
         }
     except HTTPException:
         raise

--- a/apps/web/app/blueprint-workspace/admin-panels.tsx
+++ b/apps/web/app/blueprint-workspace/admin-panels.tsx
@@ -258,7 +258,7 @@ export function JobsPanel({
   }, [jobs, searchQuery, userFilter]);
   const sortedJobs = useMemo(() => sortAdminJobs(filteredJobs, sortMode), [filteredJobs, sortMode]);
   const visibleJobs = compact ? sortedJobs.slice(0, 2) : sortedJobs;
-  const filters = ["all", "queued", "running", "succeeded", "failed"];
+  const filters = ["all", "queued", "running", "partial", "succeeded", "failed"];
   const panelDescription = description || `Generation and example job metadata. Polling every ${Math.round(pollIntervalMs / 1000)}s.`;
 
   return (
@@ -602,7 +602,7 @@ export function JobRow({
         <div className="min-w-0 flex-1">
           <div className="mb-2 flex flex-wrap items-center gap-2">
             <span className={`inline-flex items-center gap-1.5 border px-2 py-1 text-[11px] font-black uppercase ${tone}`}>
-              {job.status === "succeeded" ? <CheckCircle className="h-3.5 w-3.5" /> : job.status === "failed" ? <AlertTriangle className="h-3.5 w-3.5" /> : <RefreshCw className="h-3.5 w-3.5" />}
+              {job.status === "succeeded" ? <CheckCircle className="h-3.5 w-3.5" /> : ["partial", "failed"].includes(job.status) ? <AlertTriangle className="h-3.5 w-3.5" /> : <RefreshCw className="h-3.5 w-3.5" />}
               {job.status}
             </span>
             {sourceLabel !== "-" && (

--- a/apps/web/app/listening-jobs/listening-jobs-page.tsx
+++ b/apps/web/app/listening-jobs/listening-jobs-page.tsx
@@ -335,7 +335,7 @@ export default function ListeningJobsPage() {
           )}
 
           <div className="mb-4 flex flex-wrap gap-2">
-            {["all", "pending", "succeeded", "failed"].map((status) => (
+            {["all", "pending", "partial", "succeeded", "failed"].map((status) => (
               <button
                 key={status}
                 type="button"

--- a/blueprint_core/agents/pipeline.py
+++ b/blueprint_core/agents/pipeline.py
@@ -2,11 +2,18 @@ from __future__ import annotations
 
 import contextlib
 import contextvars
+import hashlib
+import json
 from datetime import datetime, timezone
 from dataclasses import asdict, dataclass
-from typing import Any, Callable, Iterator, List, Optional
+from enum import Enum
+from typing import Any, Callable, Iterator, List, Mapping, Optional
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from blueprint_core.jobs.source_usage import DEFAULT_WORKFLOW_ID, WEB_RESEARCH_WORKFLOW_ID, normalize_generation_workflow_id
+from blueprint_core.workspaces.projects.state import ProjectArtifact
 
 
 @dataclass(frozen=True)
@@ -39,6 +46,281 @@ class AgentPipelineEvent:
 
 PipelineEventCallback = Callable[[AgentPipelineEvent], None]
 PipelineCancellationCheck = Callable[[], bool]
+
+
+class GenerationStageStatus(str, Enum):
+    NOT_STARTED = "not_started"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    BLOCKED = "blocked"
+
+
+class GenerationStageSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    stage_id: str
+    dependencies: List[str] = Field(default_factory=list)
+
+
+class GenerationStageRecord(BaseModel):
+    """Persistable lifecycle and artifact payload for one generation stage."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    stage_id: str
+    status: GenerationStageStatus = GenerationStageStatus.NOT_STARTED
+    dependencies: List[str] = Field(default_factory=list)
+    input_artifact_ids: List[str] = Field(default_factory=list)
+    artifact_id: Optional[str] = None
+    artifact: Optional[ProjectArtifact] = None
+    output: Any = None
+    attempt: int = Field(default=0, ge=0)
+    error: Optional[dict[str, Any]] = None
+    started_at: Optional[str] = None
+    completed_at: Optional[str] = None
+    attempt_history: List[dict[str, Any]] = Field(default_factory=list)
+
+
+GenerationStagePersistence = Callable[["GenerationStageRun"], None]
+
+
+class GenerationStageRun:
+    """Dependency-aware stage runner that checkpoints every lifecycle transition."""
+
+    def __init__(
+        self,
+        workflow: str,
+        specs: List[GenerationStageSpec],
+        *,
+        run_id: Optional[str] = None,
+        prior_records: Optional[Mapping[str, Any]] = None,
+        retry_stage: Optional[str] = None,
+        replay_retry: bool = False,
+        persist: Optional[GenerationStagePersistence] = None,
+    ) -> None:
+        self.workflow = pipeline_workflow_id(workflow)
+        self.run_id = str(run_id or f"generation_{uuid4().hex}")
+        self.specs = {spec.stage_id: spec for spec in specs}
+        self.persist = persist
+        self.retry_stage = str(retry_stage or "").strip() or None
+        if self.retry_stage and self.retry_stage not in self.specs:
+            raise ValueError(f"Unknown generation stage '{self.retry_stage}'.")
+        self.records: dict[str, GenerationStageRecord] = {}
+        for stage_id, spec in self.specs.items():
+            raw = (prior_records or {}).get(stage_id)
+            if raw:
+                record = GenerationStageRecord.model_validate(raw)
+                if record.dependencies != spec.dependencies:
+                    record.dependencies = list(spec.dependencies)
+                self.records[stage_id] = record
+            else:
+                self.records[stage_id] = GenerationStageRecord(
+                    stage_id=stage_id,
+                    dependencies=list(spec.dependencies),
+                )
+        self.invalidated = self._retry_closure(self.retry_stage) if self.retry_stage and not replay_retry else set()
+        for stage_id in self.invalidated:
+            record = self.records[stage_id]
+            record.status = GenerationStageStatus.NOT_STARTED
+            record.artifact_id = None
+            record.artifact = None
+            record.output = None
+            record.error = None
+            record.started_at = None
+            record.completed_at = None
+
+    def _retry_closure(self, stage_id: Optional[str]) -> set[str]:
+        if not stage_id:
+            return set()
+        invalidated = {stage_id}
+        changed = True
+        while changed:
+            changed = False
+            for candidate, spec in self.specs.items():
+                if candidate not in invalidated and any(dep in invalidated for dep in spec.dependencies):
+                    invalidated.add(candidate)
+                    changed = True
+        if stage_id != "package_project" and "package_project" in self.specs:
+            invalidated.add("package_project")
+        return invalidated
+
+    def checkpoint(self) -> None:
+        if self.persist is not None:
+            self.persist(self)
+
+    def snapshot(self, *, include_outputs: bool = True) -> dict[str, Any]:
+        records = {
+            stage_id: record.model_dump(mode="json", exclude={"output"} if not include_outputs else None)
+            for stage_id, record in self.records.items()
+        }
+        return {
+            "generation_run_id": self.run_id,
+            "workflow": self.workflow,
+            "retry_stage": self.retry_stage,
+            "status": self.overall_status,
+            "records": records,
+        }
+
+    @property
+    def overall_status(self) -> str:
+        statuses = {record.status for record in self.records.values()}
+        if statuses and statuses <= {GenerationStageStatus.SUCCEEDED}:
+            return "succeeded"
+        if GenerationStageStatus.FAILED in statuses:
+            return "partial" if GenerationStageStatus.SUCCEEDED in statuses else "failed"
+        if GenerationStageStatus.BLOCKED in statuses and GenerationStageStatus.SUCCEEDED in statuses:
+            return "partial"
+        return "running"
+
+    def output(self, stage_id: str, schema: Any = None) -> Any:
+        record = self.records[stage_id]
+        if record.status != GenerationStageStatus.SUCCEEDED:
+            return None
+        return schema.model_validate(record.output) if schema is not None else record.output
+
+    def run(self, stage_id: str, producer: Callable[[], Any], *, schema: Any = None) -> Any:
+        ensure_agent_pipeline_active()
+        if stage_id not in self.records:
+            raise ValueError(f"Unknown generation stage '{stage_id}'.")
+        record = self.records[stage_id]
+        if record.status == GenerationStageStatus.SUCCEEDED:
+            return self.output(stage_id, schema)
+
+        unsatisfied = [
+            dependency
+            for dependency in record.dependencies
+            if self.records[dependency].status != GenerationStageStatus.SUCCEEDED
+        ]
+        if unsatisfied:
+            record.status = GenerationStageStatus.BLOCKED
+            record.error = {
+                "code": "generation_stage_dependency_failed",
+                "message": "One or more required generation stages did not succeed.",
+                "dependency_stage_ids": unsatisfied,
+            }
+            record.completed_at = _utc_now()
+            self._archive_attempt(record)
+            self._commit(record)
+            emit_agent_pipeline_event(
+                self.workflow,
+                stage_id,
+                "blocked",
+                details={"generation_stage": record.model_dump(mode="json")},
+            )
+            return None
+
+        previous_attempt = record.attempt
+        record.status = GenerationStageStatus.RUNNING
+        record.attempt = previous_attempt + 1
+        record.input_artifact_ids = [
+            str(self.records[dependency].artifact_id)
+            for dependency in record.dependencies
+            if self.records[dependency].artifact_id
+        ]
+        record.error = None
+        record.started_at = _utc_now()
+        record.completed_at = None
+        self._commit(record)
+        emit_agent_pipeline_event(
+            self.workflow,
+            stage_id,
+            "started",
+            details={"attempt": record.attempt, "input_artifact_ids": record.input_artifact_ids},
+        )
+        try:
+            result = producer()
+            record.output = _stage_json_value(result)
+            record.artifact_id = f"{self.run_id}:{stage_id}:attempt:{record.attempt}"
+            record.artifact = ProjectArtifact(
+                artifact_id=record.artifact_id,
+                kind=f"generation-stage:{stage_id}",
+                uri=f"forma://generation-runs/{self.run_id}/stages/{stage_id}/attempts/{record.attempt}",
+                media_type="application/json",
+                checksum=_stage_output_checksum(record.output),
+                metadata={
+                    "generation_run_id": self.run_id,
+                    "stage_id": stage_id,
+                    "attempt": record.attempt,
+                    "dependencies": list(record.dependencies),
+                    "input_artifact_ids": list(record.input_artifact_ids),
+                },
+            )
+            record.status = GenerationStageStatus.SUCCEEDED
+            record.completed_at = _utc_now()
+            self._archive_attempt(record)
+            self._commit(record)
+        except PipelineCancelledError:
+            raise
+        except Exception as exc:
+            record.output = None
+            record.artifact_id = None
+            record.artifact = None
+            record.status = GenerationStageStatus.FAILED
+            record.error = {
+                "code": "generation_stage_failed",
+                "message": str(exc) or exc.__class__.__name__,
+                "exception_type": exc.__class__.__name__,
+            }
+            record.completed_at = _utc_now()
+            self._archive_attempt(record)
+            self._commit(record)
+            emit_agent_pipeline_event(
+                self.workflow,
+                stage_id,
+                "failed",
+                details={"generation_stage": record.model_dump(mode="json")},
+            )
+            return None
+
+        emit_agent_pipeline_event(
+            self.workflow,
+            stage_id,
+            "completed",
+            details={"generation_stage": record.model_dump(mode="json")},
+        )
+        return schema.model_validate(record.output) if schema is not None else result
+
+    def _commit(self, record: GenerationStageRecord) -> None:
+        if self.persist is not None:
+            self.persist(self)
+
+    @staticmethod
+    def _archive_attempt(record: GenerationStageRecord) -> None:
+        entry = {
+            "attempt": record.attempt,
+            "status": record.status.value,
+            "artifact_id": record.artifact_id,
+            "artifact": record.artifact.model_dump(mode="json") if record.artifact is not None else None,
+            "output": record.output,
+            "error": record.error,
+            "started_at": record.started_at,
+            "completed_at": record.completed_at,
+        }
+        if record.attempt_history and (
+            record.attempt_history[-1].get("attempt") == record.attempt
+            and record.attempt_history[-1].get("status") == record.status.value
+        ):
+            record.attempt_history[-1] = entry
+        else:
+            record.attempt_history.append(entry)
+
+
+def _stage_json_value(value: Any) -> Any:
+    if isinstance(value, BaseModel):
+        return value.model_dump(mode="json")
+    if isinstance(value, list):
+        return [_stage_json_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_stage_json_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _stage_json_value(item) for key, item in value.items()}
+    return value
+
+
+def _stage_output_checksum(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str).encode("utf-8")
+    return f"sha256:{hashlib.sha256(payload).hexdigest()}"
 
 
 class PipelineCancelledError(RuntimeError):

--- a/blueprint_core/agents/web_research_workflow.py
+++ b/blueprint_core/agents/web_research_workflow.py
@@ -47,7 +47,14 @@ from blueprint_core.workspaces.projects.models import (
     expand_component_instances,
 )
 from blueprint_core.observability import serialize_for_langfuse, start_observation, update_observation
-from blueprint_core.agents.pipeline import PipelineCancelledError, agent_pipeline_step, emit_agent_pipeline_event, ensure_agent_pipeline_active
+from blueprint_core.agents.pipeline import (
+    GenerationStageRun,
+    GenerationStageSpec,
+    PipelineCancelledError,
+    agent_pipeline_step,
+    emit_agent_pipeline_event,
+    ensure_agent_pipeline_active,
+)
 from blueprint_core.runtime import (
     AlphaGenerationUnavailableError,
     deployment_mode_enabled,
@@ -93,6 +100,29 @@ class CompletenessAudit(BaseModel):
     possible_risks: List[str] = Field(default_factory=list)
     recommended_next_checks: List[str] = Field(default_factory=list)
     summary: str = ""
+
+
+class ValidationStageOutput(BaseModel):
+    nets: List[ConnectionNet]
+    pin_mappings: List[PinMappingEntry]
+    issues: List[ValidationIssue]
+    is_valid: bool
+
+
+WEB_GENERATION_STAGE_SPECS = [
+    GenerationStageSpec(stage_id="external_research"),
+    GenerationStageSpec(stage_id="web_architect", dependencies=["external_research"]),
+    GenerationStageSpec(stage_id="web_component_sourcing", dependencies=["web_architect"]),
+    GenerationStageSpec(stage_id="wiring_netlist", dependencies=["web_component_sourcing"]),
+    GenerationStageSpec(stage_id="validation_repair", dependencies=["wiring_netlist"]),
+    GenerationStageSpec(stage_id="mechanical_fabrication", dependencies=["web_component_sourcing"]),
+    GenerationStageSpec(stage_id="assembly", dependencies=["wiring_netlist", "mechanical_fabrication"]),
+    GenerationStageSpec(
+        stage_id="completeness_audit",
+        dependencies=["validation_repair", "mechanical_fabrication", "assembly"],
+    ),
+    GenerationStageSpec(stage_id="package_project"),
+]
 
 
 class WebResearchHardwarePipeline:
@@ -284,6 +314,13 @@ class WebResearchHardwarePipeline:
             "has_human_context": "HUMAN-IN-THE-LOOP CONTEXT:" in user_prompt,
         }):
             pass
+        if self._active_generation_metadata.get("legacy_atomic_generation") is not True:
+            return self._generate_staged_project(
+                user_prompt,
+                image_bytes=image_bytes,
+                image_mime_type=image_mime_type,
+                model_validation=model_validation,
+            )
         logger.info("Starting Web Research Pipeline Execution...")
         logger.info("Invoking External Source Research Agent...")
         # Past-job context belongs in the architecture prompts, not in external
@@ -408,6 +445,278 @@ class WebResearchHardwarePipeline:
             project_ir = build_mechanical_render_data(project_ir)
             self._save_project_to_db(user_prompt, project_ir)
         return project_ir
+
+    def _generate_staged_project(
+        self,
+        user_prompt: str,
+        *,
+        image_bytes: Optional[bytes],
+        image_mime_type: Optional[str],
+        model_validation: LLMProviderValidation,
+    ) -> HardwareIR:
+        """Run artifact-producing stages independently and checkpoint each result."""
+
+        metadata = self._active_generation_metadata
+        metadata["project_id"] = canonical_project_uuid(metadata.get("project_id"))
+        prior_run = metadata.get("prior_generation_run")
+        prior_run = prior_run if isinstance(prior_run, dict) else {}
+
+        def persist_stage_run(stage_run: GenerationStageRun) -> None:
+            snapshot = self._project_ir_from_stage_run(
+                stage_run,
+                user_prompt=user_prompt,
+                model_validation=model_validation,
+            )
+            if not self._save_project_to_db(user_prompt, snapshot):
+                raise RuntimeError("Generation stage checkpoint could not be persisted.")
+
+        stage_run = GenerationStageRun(
+            self.workflow_id,
+            WEB_GENERATION_STAGE_SPECS,
+            run_id=prior_run.get("generation_run_id") or metadata.get("frontend_job_id"),
+            prior_records=prior_run.get("records") if isinstance(prior_run.get("records"), dict) else None,
+            retry_stage=metadata.get("retry_stage"),
+            replay_retry=bool(metadata.get("retry_stage_replay")),
+            persist=persist_stage_run,
+        )
+        # The project and generation run become durable before the first costly call.
+        stage_run.checkpoint()
+
+        research_prompt = str(metadata.get("project_prompt") or user_prompt)
+        research_queries = self._research_queries(research_prompt)
+        research = stage_run.run(
+            "external_research",
+            lambda: self._research(research_queries),
+            schema=ExternalSourceLibrary,
+        )
+        research_context = research.as_prompt_context() if research is not None else ""
+
+        plan = stage_run.run(
+            "web_architect",
+            lambda: self._plan_project(
+                user_prompt,
+                research_context,
+                image_bytes,
+                image_mime_type,
+            ),
+            schema=WebProjectPlan,
+        )
+        selection = stage_run.run(
+            "web_component_sourcing",
+            lambda: self._select_components(user_prompt, plan, research_context),
+            schema=WebComponentSelection,
+        )
+        components = expand_component_instances(selection.components) if selection is not None else []
+        components_json = json.dumps(
+            [component_detail_payload(component) for component in components],
+            indent=2,
+        )
+        wiring = stage_run.run(
+            "wiring_netlist",
+            lambda: self._wire_project(user_prompt, plan, components_json),
+            schema=WiringWrapper,
+        )
+
+        def validate_and_repair() -> ValidationStageOutput:
+            nets = list(wiring.nets)
+            pin_mappings = list(wiring.pin_mappings)
+            issues = validate_circuit(components, nets, plan.requirements, prompt=user_prompt)
+            is_valid = not any(issue.severity.upper() == "CRITICAL" for issue in issues)
+            if not is_valid:
+                corrected = self._repair_wiring(plan, components_json, nets, issues)
+                nets = corrected.nets
+                pin_mappings = corrected.pin_mappings
+                issues = validate_circuit(components, nets, plan.requirements, prompt=user_prompt)
+                is_valid = not any(issue.severity.upper() == "CRITICAL" for issue in issues)
+            return ValidationStageOutput(
+                nets=nets,
+                pin_mappings=pin_mappings,
+                issues=issues,
+                is_valid=is_valid,
+            )
+
+        validation = stage_run.run(
+            "validation_repair",
+            validate_and_repair,
+            schema=ValidationStageOutput,
+        )
+        mechanical = stage_run.run(
+            "mechanical_fabrication",
+            lambda: self._generate_mechanical(plan, components_json, research_context),
+            schema=MechanicalNotes,
+        )
+        assembly_wrapper = stage_run.run(
+            "assembly",
+            lambda: AssemblyWrapper(steps=self._generate_assembly(
+                plan,
+                components_json,
+                list(validation.nets if validation is not None else wiring.nets),
+                mechanical,
+            )),
+            schema=AssemblyWrapper,
+        )
+        assembly = assembly_wrapper.steps if assembly_wrapper is not None else []
+        validation_issues = validation.issues if validation is not None else []
+        stage_run.run(
+            "completeness_audit",
+            lambda: self._audit_output(
+                plan,
+                components,
+                list(validation.nets),
+                mechanical,
+                assembly,
+                validation_issues,
+            ),
+            schema=CompletenessAudit,
+        )
+        stage_run.run(
+            "package_project",
+            lambda: {
+                "project_id": metadata["project_id"],
+                "project_readiness": self._project_readiness(stage_run),
+            },
+        )
+        return self._project_ir_from_stage_run(
+            stage_run,
+            user_prompt=user_prompt,
+            model_validation=model_validation,
+        )
+
+    def _project_ir_from_stage_run(
+        self,
+        stage_run: GenerationStageRun,
+        *,
+        user_prompt: str,
+        model_validation: LLMProviderValidation,
+    ) -> HardwareIR:
+        plan = stage_run.output("web_architect", WebProjectPlan)
+        selection = stage_run.output("web_component_sourcing", WebComponentSelection)
+        components = expand_component_instances(selection.components) if selection is not None else []
+        wiring = stage_run.output("wiring_netlist", WiringWrapper)
+        validation = stage_run.output("validation_repair", ValidationStageOutput)
+        mechanical = stage_run.output("mechanical_fabrication", MechanicalNotes)
+        assembly_wrapper = stage_run.output("assembly", AssemblyWrapper)
+        audit = stage_run.output("completeness_audit", CompletenessAudit)
+        research = stage_run.output("external_research", ExternalSourceLibrary)
+
+        nets = list(validation.nets if validation is not None else (wiring.nets if wiring is not None else []))
+        pin_mappings = list(
+            validation.pin_mappings
+            if validation is not None
+            else (wiring.pin_mappings if wiring is not None else [])
+        )
+        validation_issues = list(validation.issues if validation is not None else [])
+        all_issues = [*validation_issues, *(self._audit_to_validation_issues(audit) if audit is not None else [])]
+        assembly = list(assembly_wrapper.steps if assembly_wrapper is not None else [])
+        constraints = []
+        if plan is not None:
+            constraints = [
+                *plan.requirements.physical_constraints,
+                f"Operating Voltage: {plan.requirements.operating_voltage}V",
+            ]
+            plan.overview.estimated_cost = round(
+                sum(component.unit_price * component_instance_count(component) for component in components),
+                2,
+            )
+
+        generation_status = self._generation_status(stage_run)
+        stage_snapshot = stage_run.snapshot(include_outputs=True)
+        public_generation_metadata = {
+            key: value
+            for key, value in self._active_generation_metadata.items()
+            if key not in {"owner_user_id", "project_prompt", "prior_generation_run"}
+        }
+        failed_stages = [
+            record.model_dump(mode="json", exclude={"output"})
+            for record in stage_run.records.values()
+            if record.status.value in {"failed", "blocked"}
+        ]
+        project_ir = HardwareIR(
+            overview=plan.overview if plan is not None else None,
+            requirements=plan.requirements if plan is not None else None,
+            system_architecture=plan.system_architecture if plan is not None else None,
+            components=components,
+            nets=nets,
+            buses=extract_buses(nets),
+            pin_mappings=pin_mappings,
+            assembly=assembly,
+            mechanical=mechanical,
+            constraints=constraints,
+            power_rails=extract_power_rails(components, nets),
+            estimated_current_draw_ma=estimate_current_draw(components),
+            fabrication_notes=mechanical.fabrication_details if mechanical is not None else [],
+            assembly_metadata={
+                **public_generation_metadata,
+                "generated_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "revision": 1,
+                "model_name": self.model_name,
+                "fallback_mode": model_validation.fallback_active,
+                "requested_model": model_validation.requested_model,
+                "actual_model": model_validation.actual_model,
+                "llm_provider": model_validation.provider,
+                "runtime_provider": self.runtime_config.provider,
+                "runtime_model": self.runtime_config.model,
+                "workflow": self.workflow_id,
+                "generation_status": generation_status,
+                "project_readiness": self._project_readiness(stage_run),
+                "generation_run": stage_snapshot,
+                "generation_stage_failures": failed_stages,
+                "source_usage": source_usage_for_workflow(
+                    self.workflow_id,
+                    external_provider=research.provider if research is not None else self.research_client.provider_name,
+                ),
+                "external_research": research.source_metadata() if research is not None else None,
+                "sourcing_notes": selection.sourcing_notes if selection is not None else [],
+                "completeness_audit": audit.model_dump(mode="json") if audit is not None else None,
+            },
+            project_version_history=[{
+                "version": "0.2",
+                "description": "Dependency-aware staged web research generation",
+            }],
+            validation=build_validation_summary(all_issues),
+            is_valid=bool(validation is not None and validation.is_valid and not any(
+                issue.severity.upper() == "CRITICAL" for issue in all_issues
+            )),
+        )
+        if mechanical is not None:
+            project_ir = build_mechanical_render_data(project_ir)
+        return project_ir
+
+    @staticmethod
+    def _generation_status(stage_run: GenerationStageRun) -> str:
+        architecture = stage_run.records["web_architect"].status.value
+        if architecture in {"failed", "blocked"}:
+            return "failed"
+        return stage_run.overall_status
+
+    @staticmethod
+    def _project_readiness(stage_run: GenerationStageRun) -> str:
+        statuses = {stage_id: record.status.value for stage_id, record in stage_run.records.items()}
+        if statuses.get("web_architect") != "succeeded":
+            return "draft"
+        non_package_statuses = [
+            status for stage_id, status in statuses.items()
+            if stage_id != "package_project"
+        ]
+        package_status = statuses.get("package_project")
+        if (
+            non_package_statuses
+            and all(status == "succeeded" for status in non_package_statuses)
+            and package_status in {"running", "succeeded"}
+        ):
+            return "complete"
+        if all(statuses.get(stage_id) == "succeeded" for stage_id in (
+            "web_architect",
+            "web_component_sourcing",
+            "wiring_netlist",
+            "validation_repair",
+        )):
+            return "core_ready"
+        if any(status == "succeeded" for status in statuses.values()) and any(
+            status in {"failed", "blocked"} for status in statuses.values()
+        ):
+            return "partial"
+        return "draft"
 
     def _research_queries(self, user_prompt: str) -> List[str]:
         return [
@@ -735,7 +1044,7 @@ class WebResearchHardwarePipeline:
         public_generation_metadata = {
             key: value
             for key, value in generation_metadata.items()
-            if key not in {"owner_user_id", "project_prompt"}
+            if key not in {"owner_user_id", "project_prompt", "prior_generation_run"}
         }
         ir.assembly_metadata = {
             **(ir.assembly_metadata or {}),

--- a/blueprint_core/jobs/metrics.py
+++ b/blueprint_core/jobs/metrics.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, Iterable, Optional
 
 SUCCESS_STATUSES = {"succeeded", "success", "completed", "complete", "done"}
 FAILED_STATUSES = {"failed", "failure", "error"}
+PARTIAL_STATUSES = {"partial"}
 
 
 def _utc_datetime(value: Any) -> Optional[datetime]:
@@ -65,6 +66,7 @@ def summarize_job_metrics(
         for index in range(hours)
     }
     failed_jobs = 0
+    partial_jobs = 0
     completed_jobs = 0
     jobs_last_hour = 0
     total_jobs = 0
@@ -87,6 +89,9 @@ def summarize_job_metrics(
             elif status in FAILED_STATUSES:
                 completed_jobs += 1
                 failed_jobs += 1
+            elif status in PARTIAL_STATUSES:
+                completed_jobs += 1
+                partial_jobs += 1
 
         if created_at >= hourly_start:
             hour_key = _iso_hour(created_at.replace(minute=0, second=0, microsecond=0))
@@ -109,10 +114,11 @@ def summarize_job_metrics(
         "jobs_last_hour": jobs_last_hour,
         "completed_jobs": completed_jobs,
         "failed_jobs": failed_jobs,
+        "partial_jobs": partial_jobs,
         "failure_rate": round((failed_jobs / completed_jobs) * 100, 1) if completed_jobs else 0.0,
         "daily": daily,
         "hourly": hourly,
     }
 
 
-__all__ = ["FAILED_STATUSES", "SUCCESS_STATUSES", "summarize_job_metrics"]
+__all__ = ["FAILED_STATUSES", "PARTIAL_STATUSES", "SUCCESS_STATUSES", "summarize_job_metrics"]

--- a/blueprint_core/jobs/repositories.py
+++ b/blueprint_core/jobs/repositories.py
@@ -11,7 +11,7 @@ from blueprint_core.persistence.providers.sqlite import SQLiteProvider
 from blueprint_core.agents.pipeline import PipelineCancelledError
 
 
-TERMINAL_JOB_STATUSES = {"succeeded", "failed", "cancelled", "canceled"}
+TERMINAL_JOB_STATUSES = {"succeeded", "partial", "failed", "cancelled", "canceled"}
 
 
 class JobCancelledError(PipelineCancelledError):
@@ -295,7 +295,7 @@ class SQLiteJobRepository:
                 """
                 UPDATE a2a_jobs
                 SET status = ?, started_at = COALESCE(started_at, ?), updated_at = ?
-                WHERE job_id = ? AND status NOT IN ('succeeded', 'failed', 'cancelled', 'canceled')
+                WHERE job_id = ? AND status NOT IN ('succeeded', 'partial', 'failed', 'cancelled', 'canceled')
                 """,
                 ("running", now, now, job_id),
             )
@@ -324,7 +324,7 @@ class SQLiteJobRepository:
                 """
                 UPDATE a2a_jobs
                 SET status = ?, completed_at = ?, updated_at = ?, error = ?
-                WHERE job_id = ? AND status NOT IN ('succeeded', 'failed', 'cancelled', 'canceled')
+                WHERE job_id = ? AND status NOT IN ('succeeded', 'partial', 'failed', 'cancelled', 'canceled')
                 """,
                 ("cancelled", now, now, reason, job_id),
             )

--- a/blueprint_core/jobs/store.py
+++ b/blueprint_core/jobs/store.py
@@ -34,16 +34,18 @@ def _redact_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
 
 def _operation_summary(operations: List[Dict[str, Any]]) -> Dict[str, Any]:
     failed = sum(1 for operation in operations if operation.get("status") == "failed")
+    partial = sum(1 for operation in operations if operation.get("status") == "partial")
     succeeded = sum(1 for operation in operations if operation.get("status") == "succeeded")
     pending = sum(1 for operation in operations if operation.get("status") == "pending")
     not_requested = sum(1 for operation in operations if operation.get("status") == "not_requested")
     return {
         "total": len(operations),
         "failed": failed,
+        "partial": partial,
         "succeeded": succeeded,
         "pending": pending,
         "not_requested": not_requested,
-        "ok": failed == 0,
+        "ok": failed == 0 and partial == 0,
     }
 
 
@@ -53,12 +55,13 @@ def _result_operation_statuses(project_ir: Dict[str, Any], metadata: Dict[str, A
     operation_ids = {str(item.get("id") or "") for item in operations}
     if "hardware_generation" not in operation_ids:
         validation = project_ir.get("validation") or {}
+        generation_status = str(metadata.get("generation_status") or "succeeded").lower()
         operations.insert(
             0,
             {
                 "id": "hardware_generation",
                 "label": "Hardware generation",
-                "status": "succeeded",
+                "status": generation_status,
                 "provider": metadata.get("runtime_provider") or metadata.get("llm_provider"),
                 "model": metadata.get("runtime_model") or metadata.get("model_name"),
                 "details": {
@@ -121,6 +124,10 @@ def summarize_result(result: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any
         "workflow": metadata.get("workflow"),
         "source_usage": source_usage,
         "pipeline": metadata.get("pipeline"),
+        "generation_status": metadata.get("generation_status", "succeeded"),
+        "project_readiness": metadata.get("project_readiness", "complete"),
+        "generation_stages": ((metadata.get("generation_run") or {}).get("records") or {}),
+        "generation_stage_failures": metadata.get("generation_stage_failures") or [],
     }
 
 
@@ -262,6 +269,18 @@ class JobMetadataStore:
         self._update_status(job_id, "routed")
 
     def mark_succeeded(self, job_id: str, result: Optional[Dict[str, Any]]) -> None:
+        self._mark_completed_result(job_id, result, status="succeeded")
+
+    def mark_partial(self, job_id: str, result: Optional[Dict[str, Any]]) -> None:
+        self._mark_completed_result(job_id, result, status="partial")
+
+    def _mark_completed_result(
+        self,
+        job_id: str,
+        result: Optional[Dict[str, Any]],
+        *,
+        status: str,
+    ) -> None:
         self.init_db()
         now = _utc_now()
         result_summary = summarize_result(result)
@@ -280,7 +299,7 @@ class JobMetadataStore:
             job_id,
             str(current.get("status") or ""),
             {
-                "status": "succeeded",
+                "status": status,
                 "completed_at": now,
                 "updated_at": now,
                 "result_summary_json": result_summary,

--- a/blueprint_core/workers/contracts.py
+++ b/blueprint_core/workers/contracts.py
@@ -34,6 +34,7 @@ class WorkerProgressStatus(str, Enum):
 
 class WorkerResultStatus(str, Enum):
     SUCCEEDED = "succeeded"
+    PARTIAL = "partial"
     FAILED = "failed"
     CANCELLED = "cancelled"
 
@@ -156,6 +157,8 @@ class WorkerResult(WorkerContract):
     def validate_terminal_shape(self) -> "WorkerResult":
         if self.status == WorkerResultStatus.FAILED and self.error is None:
             raise ValueError("A failed WorkerResult requires error details.")
+        if self.status == WorkerResultStatus.PARTIAL and (self.error is None or not self.artifacts):
+            raise ValueError("A partial WorkerResult requires both an error and successful artifacts.")
         if self.status == WorkerResultStatus.SUCCEEDED and self.error is not None:
             raise ValueError("A successful WorkerResult cannot include an error.")
         for artifact in self.artifacts:

--- a/blueprint_core/workers/generation.py
+++ b/blueprint_core/workers/generation.py
@@ -205,6 +205,22 @@ def build_generation_draft(design_brief: DesignBrief, state: HardwareIR) -> Proj
             media_type="application/json",
         ))
 
+    generation_run = (state.assembly_metadata or {}).get("generation_run") or {}
+    generation_records = generation_run.get("records") if isinstance(generation_run, dict) else {}
+    generation_records = generation_records if isinstance(generation_records, dict) else {}
+    known_artifact_ids = {artifact.artifact_id for artifact in artifacts}
+    for record in generation_records.values():
+        artifact_payload = record.get("artifact") if isinstance(record, dict) else None
+        if not isinstance(artifact_payload, dict):
+            continue
+        try:
+            stage_artifact = ProjectArtifact.model_validate(artifact_payload)
+        except ValidationError:
+            continue
+        if stage_artifact.artifact_id not in known_artifact_ids:
+            artifacts.append(stage_artifact)
+            known_artifact_ids.add(stage_artifact.artifact_id)
+
     assumptions = list(dict.fromkeys([
         *design_brief.assumptions,
         "Generated component selections and topology remain provisional until validation.",
@@ -415,10 +431,22 @@ def _success_result(request: WorkerRequest, outcome: ProjectRevisionOutcome) -> 
         )
         for artifact in revision.artifacts
     ]
+    generation_status = str((revision.state.assembly_metadata or {}).get("generation_status") or "succeeded")
+    partial_error = None
+    if generation_status == "partial":
+        partial_error = WorkerError(
+            **context,
+            code="generation_partial",
+            message="One or more generation stages failed; successful artifacts were preserved.",
+            retryable=True,
+            details={
+                "stage_failures": (revision.state.assembly_metadata or {}).get("generation_stage_failures") or [],
+            },
+        )
     return WorkerResult(
         **context,
         output_contract_version=GENERATION_OUTPUT_VERSION,
-        status=WorkerResultStatus.SUCCEEDED,
+        status=WorkerResultStatus.PARTIAL if partial_error is not None else WorkerResultStatus.SUCCEEDED,
         output={
             "project_revision": revision.model_dump(mode="json"),
             "components": [item.model_dump(mode="json") for item in revision.components],
@@ -428,6 +456,7 @@ def _success_result(request: WorkerRequest, outcome: ProjectRevisionOutcome) -> 
             "idempotent_replay": outcome.idempotent_replay,
         },
         artifacts=artifacts,
+        error=partial_error,
     )
 
 

--- a/blueprint_core/workers/orchestration.py
+++ b/blueprint_core/workers/orchestration.py
@@ -35,6 +35,7 @@ class OrchestrationTaskStatus(str, Enum):
     QUEUED = "queued"
     RUNNING = "running"
     SUCCEEDED = "succeeded"
+    PARTIAL = "partial"
     FAILED = "failed"
     BLOCKED = "blocked"
     CANCELLED = "cancelled"
@@ -44,18 +45,21 @@ class WorkerPlanStatus(str, Enum):
     PLANNED = "planned"
     RUNNING = "running"
     SUCCEEDED = "succeeded"
+    PARTIAL = "partial"
     FAILED = "failed"
     CANCELLED = "cancelled"
 
 
 TERMINAL_JOB_STATUSES = frozenset({
     OrchestrationTaskStatus.SUCCEEDED,
+    OrchestrationTaskStatus.PARTIAL,
     OrchestrationTaskStatus.FAILED,
     OrchestrationTaskStatus.BLOCKED,
     OrchestrationTaskStatus.CANCELLED,
 })
 TERMINAL_PLAN_STATUSES = frozenset({
     WorkerPlanStatus.SUCCEEDED,
+    WorkerPlanStatus.PARTIAL,
     WorkerPlanStatus.FAILED,
     WorkerPlanStatus.CANCELLED,
 })
@@ -314,13 +318,16 @@ class WorkerOrchestrator:
         plan.aggregate = {
             job_id: job.result.model_dump(mode="json")
             for job_id, job in plan.jobs.items()
-            if job.status == OrchestrationTaskStatus.SUCCEEDED and job.result is not None
+            if job.status in {OrchestrationTaskStatus.SUCCEEDED, OrchestrationTaskStatus.PARTIAL}
+            and job.result is not None
         }
         plan.status = (
             WorkerPlanStatus.CANCELLED
             if any(job.status == OrchestrationTaskStatus.CANCELLED for job in plan.jobs.values())
             else WorkerPlanStatus.SUCCEEDED
             if all(job.status == OrchestrationTaskStatus.SUCCEEDED for job in plan.jobs.values())
+            else WorkerPlanStatus.PARTIAL
+            if any(job.status == OrchestrationTaskStatus.PARTIAL for job in plan.jobs.values())
             else WorkerPlanStatus.FAILED
         )
         plan.completed_at = _utc_now()
@@ -352,7 +359,7 @@ class WorkerOrchestrator:
         """Reset failed work so a user can make another execution attempt."""
 
         plan = self.get_plan(plan_id, owner_user_id)
-        if plan.status != WorkerPlanStatus.FAILED:
+        if plan.status not in {WorkerPlanStatus.FAILED, WorkerPlanStatus.PARTIAL}:
             raise WorkerPlanningError(
                 "worker_plan_not_failed",
                 "Only a failed worker plan can be reset.",
@@ -360,7 +367,11 @@ class WorkerOrchestrator:
             )
 
         for job in plan.jobs.values():
-            if job.status not in {OrchestrationTaskStatus.FAILED, OrchestrationTaskStatus.BLOCKED}:
+            if job.status not in {
+                OrchestrationTaskStatus.PARTIAL,
+                OrchestrationTaskStatus.FAILED,
+                OrchestrationTaskStatus.BLOCKED,
+            }:
                 continue
             job.status = OrchestrationTaskStatus.QUEUED
             job.progress = []
@@ -381,6 +392,61 @@ class WorkerOrchestrator:
             actor_id=plan.owner_user_id,
             reason=f"User reset failed worker execution plan {plan.plan_id} for another attempt.",
             idempotency_key=f"worker-plan:{plan.plan_id}:attempt:{plan.attempt}:reset",
+        )
+        await self._persist(plan)
+        return plan
+
+    async def reset_job(self, plan_id: str, owner_user_id: str, job_id: str) -> WorkerExecutionPlan:
+        """Retry one failed stage plus only the downstream work invalidated by it."""
+
+        plan = self.get_plan(plan_id, owner_user_id)
+        target = plan.jobs.get(job_id)
+        if target is None:
+            raise WorkerPlanningError("worker_job_not_found", f"Worker job '{job_id}' was not found.")
+        if target.status not in {OrchestrationTaskStatus.FAILED, OrchestrationTaskStatus.PARTIAL}:
+            raise WorkerPlanningError(
+                "worker_job_not_failed",
+                "Only a failed worker job can be retried independently.",
+                context={"job_id": job_id, "status": target.status.value},
+            )
+
+        invalidated = {job_id}
+        changed = True
+        while changed:
+            changed = False
+            for candidate_id, candidate in plan.jobs.items():
+                if candidate_id in invalidated:
+                    continue
+                if any(dependency.job_id in invalidated for dependency in candidate.request.dependencies):
+                    invalidated.add(candidate_id)
+                    changed = True
+
+        for candidate_id in invalidated:
+            job = plan.jobs[candidate_id]
+            job.status = OrchestrationTaskStatus.QUEUED
+            job.progress = []
+            job.result = None
+            job.error = None
+            job.started_at = None
+            job.completed_at = None
+        plan.attempt += 1
+        plan.status = WorkerPlanStatus.PLANNED
+        plan.aggregate = {
+            candidate_id: job.result.model_dump(mode="json")
+            for candidate_id, job in plan.jobs.items()
+            if candidate_id not in invalidated
+            and job.status in {OrchestrationTaskStatus.SUCCEEDED, OrchestrationTaskStatus.PARTIAL}
+            and job.result is not None
+        }
+        plan.completed_at = None
+        self._workflow.transition(
+            plan.project_id,
+            plan.owner_user_id,
+            ProjectWorkflowState.BUILDING,
+            actor_type=WorkflowActorType.USER,
+            actor_id=plan.owner_user_id,
+            reason=f"User retried worker job {job_id} in execution plan {plan.plan_id}.",
+            idempotency_key=f"worker-plan:{plan.plan_id}:attempt:{plan.attempt}:retry:{job_id}",
         )
         await self._persist(plan)
         return plan
@@ -407,6 +473,7 @@ class WorkerOrchestrator:
                 if dependency.required
                 and plan.jobs[dependency.job_id].status in {
                     OrchestrationTaskStatus.FAILED,
+                    OrchestrationTaskStatus.PARTIAL,
                     OrchestrationTaskStatus.BLOCKED,
                 }
             ]
@@ -470,6 +537,8 @@ class WorkerOrchestrator:
                 state.status = (
                     OrchestrationTaskStatus.SUCCEEDED
                     if result.status == WorkerResultStatus.SUCCEEDED
+                    else OrchestrationTaskStatus.PARTIAL
+                    if result.status == WorkerResultStatus.PARTIAL
                     else OrchestrationTaskStatus.CANCELLED
                     if result.status == WorkerResultStatus.CANCELLED
                     else OrchestrationTaskStatus.FAILED

--- a/blueprint_core/workspaces/projects/models.py
+++ b/blueprint_core/workspaces/projects/models.py
@@ -625,6 +625,10 @@ class GenerateProjectRequest(BaseModel):
         None,
         description="Optional context project id whose workflow authorizes this generation.",
     )
+    retry_stage: Optional[str] = Field(
+        None,
+        description="Retry one failed web-research generation stage using persisted upstream artifacts.",
+    )
     workflow: str = Field(
         "default",
         description="Generation workflow id: default or web_research"
@@ -672,7 +676,7 @@ class GenerateProjectRequest(BaseModel):
         description="Maximum number of relevant completed jobs to include when data_sources contains past_jobs.",
     )
 
-    @field_validator("provider", "model", "project_id", "chat_id", "source_project_id", "client_job_id", "external_source_provider", mode="before")
+    @field_validator("provider", "model", "project_id", "retry_stage", "chat_id", "source_project_id", "client_job_id", "external_source_provider", mode="before")
     @classmethod
     def strip_optional_generation_selector(cls, value: Any) -> Any:
         if isinstance(value, str):

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -82,6 +82,8 @@ Each line sent to the socket is an `A2AMessage` JSON object. Each line returned 
 
 Available tools:
 - `blueprint.generate_project`
+
+For a web-research project with a failed stage, call `blueprint.generate_project` again with the same `project_id`, `workflow: "web_research"`, and `retry_stage` (for example `wiring_netlist`). Forma reloads the persisted generation run, reuses successful upstream and independent artifacts, and reruns only the named stage and invalidated dependents. Reusing the same client job ID returns the completed retry idempotently.
 - `blueprint.debug_config`
 - `blueprint.validate_circuit`
 - `blueprint.a2a.send_message`

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,6 +1,6 @@
 # Agents
 
-Forma uses an **ADK-style** sequential multi-agent workflow (implemented in `apps/api/agents/orchestrator.py`). Each agent consumes the prior agent’s output and writes structured data into the Hardware IR.
+Forma uses an **ADK-style** multi-agent workflow implemented in `blueprint_core/agents`. Each agent writes structured artifacts into the Hardware IR.
 
 ## Pipeline overview
 0. Context clarification → 1. Safety guardrails → 2. Intent Parser → 3. Requirements → 4. System Architecture → 5. Component Selection → 6. Wiring/Netlist (+ repair loop) → 7. BOM → 8. Mechanical/Fabrication → 9. Assembly Instructions → 10. Mechanical render enrichment
@@ -84,7 +84,7 @@ flowchart LR
 ```
 
 ## Notes
-- Agents run **sequentially** for determinism and traceability.
+- Web-research artifact stages run as a dependency graph. Successful outputs are checkpointed independently, failed dependencies block only downstream work, and unrelated stages continue.
 - Validation can trigger a **repair loop** that re-invokes the wiring agent.
 - If a live LLM provider isn’t configured (or generation fails), the backend uses a deterministic **simulation fallback** backed by the example projects.
 - The pipeline is designed to swap models or add agents without rewriting the core IR schema.

--- a/docs/generation-worker.md
+++ b/docs/generation-worker.md
@@ -22,6 +22,10 @@ The `project-revision.v1` result identifies:
 - every declared or generation-time assumption;
 - the exact project, revision, DesignBrief, and source job identities.
 
+Web-research generation also exposes a durable `generation_run` in Hardware IR metadata. Every artifact-producing stage records its dependencies, status, attempt, input artifact references, output, error, and timestamps. Successful stages reuse `ProjectArtifact` references with stable Forma URIs and SHA-256 checksums, which flow into worker artifacts. The project record is created before structured generation, and each successful output is checkpointed before dependent work starts.
+
+Stage failures produce `PARTIAL` when useful artifacts remain. Required dependents become `BLOCKED`, while independent work continues; for example, mechanical generation can complete after wiring fails. Project readiness (`draft`, `partial`, `core_ready`, or `complete`) is independent from the overall job result.
+
 ## Shared project-state boundary
 
 `ProjectStateService` is the only write boundary used by the worker. Initial revisions are immutable, owner-scoped, and atomically inserted into `project_revisions`. A generated state that names another project or a revision other than 1 is rejected.
@@ -33,3 +37,5 @@ The source worker job is an idempotency identity. Replaying a successful job ret
 Failures use `WorkerError` inside a failed `WorkerResult`. Invalid payloads, mismatched frozen briefs, and cross-project writes are non-retryable. Provider and transient persistence failures are marked retryable. The orchestrator persists both shapes with the execution plan and advances the terminal workflow to `awaiting_feedback`.
 
 `HardwareIRGenerationEngine` adapts the existing structured generation pipeline with its legacy direct database write disabled. The engine receives only a prompt constructed from the frozen DesignBrief; the Generation worker commits the returned state through `ProjectStateService`.
+
+`WorkerResultStatus.PARTIAL` carries both preserved artifacts and stage failure details. A named failed stage can be retried without rerunning successful upstream or independent stages; only that stage and its transitive dependents are invalidated. Attempt history remains in the stage record, and replaying the same retry job is idempotent.

--- a/docs/worker-orchestration.md
+++ b/docs/worker-orchestration.md
@@ -21,11 +21,13 @@ Ready jobs run concurrently up to the plan's `max_concurrency`. A job becomes re
 
 Workers implement `worker_definition()` plus `execute(request, report_progress)`. Their progress and terminal results must preserve the request identity and declare compatible output versions. Exceptions and invalid results become durable `WorkerError` records.
 
-Successful outputs are aggregated by job ID from validated `WorkerResult` values. The orchestrator does not reinterpret the original conversation.
+Successful and partial outputs are aggregated by job ID from validated `WorkerResult` values. `PARTIAL` is terminal and retains successful artifacts alongside a structured error. The orchestrator does not reinterpret the original conversation.
 
 ## Persistence and recovery
 
 The `worker_execution_plans` record contains the validated requests and every job's status, progress events, result, artifacts, and error, along with the aggregate output. A new orchestrator instance can reload and resume a plan after process restart. Completed jobs are retained; jobs that were running when the process stopped are safely requeued.
+
+`reset_job()` retries one failed or partial job and resets only its transitive dependents. Successful upstream and independent results remain persisted and are not executed again.
 
 When all jobs are terminal, the project workflow advances from `building` to `awaiting_feedback` with an idempotent system transition. Both successful and failed terminal plans preserve their results for feedback and diagnosis.
 

--- a/tests/agents/test_generation_stages.py
+++ b/tests/agents/test_generation_stages.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from blueprint_core.agents.pipeline import GenerationStageRun, GenerationStageSpec
+from blueprint_core.agents.web_research_workflow import (
+    AssemblyWrapper,
+    CompletenessAudit,
+    WebComponentSelection,
+    WebProjectPlan,
+    WebResearchHardwarePipeline,
+    WiringWrapper,
+)
+from blueprint_core.external_sources import ExternalSourceLibrary
+from blueprint_core.workspaces.projects.models import (
+    ComponentInstance,
+    FunctionalRequirements,
+    MechanicalNotes,
+    ProjectOverview,
+    SystemArchitecture,
+    SystemNode,
+)
+
+
+def project_plan() -> WebProjectPlan:
+    return WebProjectPlan(
+        overview=ProjectOverview(
+            title="Partial robot",
+            description="A small independently driven robot.",
+            difficulty="Intermediate",
+            category="Robotics",
+        ),
+        requirements=FunctionalRequirements(
+            requirements=["Drive four wheels"],
+            power_needs="Low-voltage battery",
+        ),
+        system_architecture=SystemArchitecture(
+            summary="Robot system",
+            root=SystemNode(
+                system_id="product",
+                name="Robot",
+                domain="product",
+                purpose="Move on four wheels.",
+            ),
+        ),
+    )
+
+
+def component_selection() -> WebComponentSelection:
+    return WebComponentSelection(components=[
+        ComponentInstance(
+            ref_des="U1",
+            part_number="MCU-TEST",
+            name="Test controller",
+            category="Microcontroller",
+            unit_price=4.0,
+            rationale="Controls the robot.",
+        )
+    ])
+
+
+def mechanical_plan() -> MechanicalNotes:
+    return MechanicalNotes(
+        enclosure_type="Open frame",
+        mounting_guidance="Mount the controller above the chassis.",
+        manufacturability_rating="Easy",
+        fabrication_details=["Use a flat chassis plate."],
+    )
+
+
+class GenerationStageRunTests(unittest.TestCase):
+    def test_stage_failure_blocks_dependents_but_runs_independent_work(self) -> None:
+        checkpoints: list[dict] = []
+        run = GenerationStageRun(
+            "web_research",
+            [
+                GenerationStageSpec(stage_id="components"),
+                GenerationStageSpec(stage_id="wiring", dependencies=["components"]),
+                GenerationStageSpec(stage_id="validation", dependencies=["wiring"]),
+                GenerationStageSpec(stage_id="mechanical", dependencies=["components"]),
+            ],
+            persist=lambda current: checkpoints.append(current.snapshot()),
+        )
+
+        run.run("components", lambda: {"refs": ["U1"]})
+        run.run("wiring", lambda: (_ for _ in ()).throw(TimeoutError("wiring timed out")))
+        run.run("validation", lambda: {"valid": True})
+        run.run("mechanical", lambda: {"enclosure": "open-frame"})
+
+        self.assertEqual("succeeded", run.records["components"].status.value)
+        self.assertEqual("failed", run.records["wiring"].status.value)
+        self.assertEqual("blocked", run.records["validation"].status.value)
+        self.assertEqual("succeeded", run.records["mechanical"].status.value)
+        self.assertEqual("partial", run.overall_status)
+        self.assertEqual("generation-stage:components", run.records["components"].artifact.kind)
+        self.assertTrue(run.records["components"].artifact.checksum.startswith("sha256:"))
+        self.assertTrue(any(
+            snapshot["records"]["components"]["status"] == "succeeded"
+            for snapshot in checkpoints
+        ))
+
+
+class WebResearchPartialGenerationTests(unittest.TestCase):
+    def pipeline(self) -> tuple[WebResearchHardwarePipeline, list[dict]]:
+        pipeline = WebResearchHardwarePipeline.__new__(WebResearchHardwarePipeline)
+        pipeline.runtime_config = SimpleNamespace(
+            provider="test",
+            model="test-model",
+            requested_provider="test",
+            requested_model="test-model",
+            provider_overridden=False,
+            model_overridden=False,
+        )
+        pipeline.model_name = "test-model"
+        pipeline.research_client = SimpleNamespace(provider_name="test-search")
+        pipeline._active_generation_metadata = {
+            "project_id": "11111111-1111-4111-8111-111111111111",
+            "frontend_job_id": "job-stage-test",
+            "owner_user_id": "stage-owner",
+            "project_prompt": "Build a four wheel robot",
+        }
+        saved: list[dict] = []
+        pipeline._save_project_to_db = lambda prompt, ir: (
+            saved.append(ir.model_dump(mode="json"))
+            or "11111111-1111-4111-8111-111111111111"
+        )
+        pipeline._research = lambda queries: ExternalSourceLibrary(
+            provider="test-search",
+            configured=True,
+            searches_attempted=len(queries),
+        )
+        pipeline._plan_project = lambda *args: project_plan()
+        pipeline._select_components = lambda *args: component_selection()
+        pipeline._generate_mechanical = lambda *args: mechanical_plan()
+        pipeline._generate_assembly = lambda *args: []
+        pipeline._audit_output = lambda *args: CompletenessAudit(
+            completeness_score=1.0,
+            summary="Complete",
+        )
+        return pipeline, saved
+
+    @staticmethod
+    def model_validation() -> SimpleNamespace:
+        return SimpleNamespace(
+            fallback_active=False,
+            requested_model="test-model",
+            actual_model="test-model",
+            provider="test",
+        )
+
+    def test_wiring_failure_preserves_bom_and_mechanical_artifacts(self) -> None:
+        pipeline, saved = self.pipeline()
+        pipeline._wire_project = lambda *args: (_ for _ in ()).throw(TimeoutError("wiring timed out"))
+
+        ir = pipeline._generate_staged_project(
+            "Build a four wheel robot",
+            image_bytes=None,
+            image_mime_type=None,
+            model_validation=self.model_validation(),
+        )
+
+        records = ir.assembly_metadata["generation_run"]["records"]
+        self.assertEqual("partial", ir.assembly_metadata["generation_status"])
+        self.assertEqual("partial", ir.assembly_metadata["project_readiness"])
+        self.assertEqual("succeeded", records["web_architect"]["status"])
+        self.assertEqual("succeeded", records["web_component_sourcing"]["status"])
+        self.assertEqual("failed", records["wiring_netlist"]["status"])
+        self.assertEqual("blocked", records["validation_repair"]["status"])
+        self.assertEqual("succeeded", records["mechanical_fabrication"]["status"])
+        self.assertEqual("blocked", records["assembly"]["status"])
+        self.assertEqual(1, len(ir.bom))
+        self.assertIsNotNone(ir.mechanical)
+        self.assertGreater(len(saved), 4)
+        component_checkpoint = next(
+            item for item in saved
+            if ((item.get("assembly_metadata") or {}).get("generation_run") or {})
+            .get("records", {})
+            .get("web_component_sourcing", {})
+            .get("status") == "succeeded"
+        )
+        self.assertEqual(1, len(component_checkpoint["bom"]))
+
+    def test_retry_reuses_upstream_and_independent_artifacts(self) -> None:
+        pipeline, _ = self.pipeline()
+        pipeline._wire_project = lambda *args: (_ for _ in ()).throw(TimeoutError("first attempt"))
+        partial = pipeline._generate_staged_project(
+            "Build a four wheel robot",
+            image_bytes=None,
+            image_mime_type=None,
+            model_validation=self.model_validation(),
+        )
+
+        prior_run = partial.assembly_metadata["generation_run"]
+        pipeline._active_generation_metadata.update({
+            "retry_stage": "wiring_netlist",
+            "prior_generation_run": prior_run,
+        })
+        pipeline._research = lambda *_: (_ for _ in ()).throw(AssertionError("research repeated"))
+        pipeline._plan_project = lambda *_: (_ for _ in ()).throw(AssertionError("architecture repeated"))
+        pipeline._select_components = lambda *_: (_ for _ in ()).throw(AssertionError("components repeated"))
+        pipeline._generate_mechanical = lambda *_: (_ for _ in ()).throw(AssertionError("mechanical repeated"))
+        pipeline._wire_project = lambda *args: WiringWrapper(nets=[], pin_mappings=[])
+
+        completed = pipeline._generate_staged_project(
+            "Build a four wheel robot",
+            image_bytes=None,
+            image_mime_type=None,
+            model_validation=self.model_validation(),
+        )
+
+        records = completed.assembly_metadata["generation_run"]["records"]
+        self.assertEqual("succeeded", completed.assembly_metadata["generation_status"])
+        self.assertEqual("complete", completed.assembly_metadata["project_readiness"])
+        self.assertEqual(1, records["web_architect"]["attempt"])
+        self.assertEqual(1, records["web_component_sourcing"]["attempt"])
+        self.assertEqual(1, records["mechanical_fabrication"]["attempt"])
+        self.assertEqual(2, records["wiring_netlist"]["attempt"])
+        self.assertEqual(2, records["package_project"]["attempt"])
+        self.assertEqual(
+            ["failed", "succeeded"],
+            [entry["status"] for entry in records["wiring_netlist"]["attempt_history"]],
+        )
+
+        pipeline._active_generation_metadata.update({
+            "prior_generation_run": completed.assembly_metadata["generation_run"],
+            "retry_stage_replay": True,
+        })
+        pipeline._wire_project = lambda *_: (_ for _ in ()).throw(AssertionError("wiring repeated"))
+        replayed = pipeline._generate_staged_project(
+            "Build a four wheel robot",
+            image_bytes=None,
+            image_mime_type=None,
+            model_validation=self.model_validation(),
+        )
+
+        replayed_records = replayed.assembly_metadata["generation_run"]["records"]
+        self.assertEqual(2, replayed_records["wiring_netlist"]["attempt"])
+        self.assertEqual("succeeded", replayed.assembly_metadata["generation_status"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/agents/test_generation_worker.py
+++ b/tests/agents/test_generation_worker.py
@@ -228,6 +228,29 @@ class GenerationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
                 ],
             )
 
+    def test_generation_draft_reuses_persisted_stage_artifact_references(self) -> None:
+        stage_artifact = ProjectArtifact(
+            artifact_id="run-1:web_architect:attempt:1",
+            kind="generation-stage:web_architect",
+            uri="forma://generation-runs/run-1/stages/web_architect/attempts/1",
+            media_type="application/json",
+            checksum="sha256:abc123",
+        )
+        state = HardwareIR(assembly_metadata={
+            "generation_run": {
+                "records": {
+                    "web_architect": {
+                        "status": "succeeded",
+                        "artifact": stage_artifact.model_dump(mode="json"),
+                    }
+                }
+            }
+        })
+
+        draft = build_generation_draft(self.brief, state)
+
+        self.assertIn(stage_artifact, draft.artifacts)
+
     def tearDown(self) -> None:
         self.directory.cleanup()
 

--- a/tests/agents/test_worker_contracts.py
+++ b/tests/agents/test_worker_contracts.py
@@ -157,12 +157,21 @@ class WorkerContractTests(unittest.TestCase):
             output={"rail_count": 2},
             artifacts=[artifact],
         )
+        partial = WorkerResult(
+            **contract_context(),
+            output_contract_version="electrical-plan.v1",
+            status="partial",
+            output={"preserved": True},
+            artifacts=[artifact],
+            error=error,
+        )
 
         self.assertEqual(progress, WorkerProgress.model_validate_json(progress.model_dump_json()))
         self.assertEqual(artifact, WorkerArtifact.model_validate_json(artifact.model_dump_json()))
         self.assertEqual(error, WorkerError.model_validate_json(error.model_dump_json()))
         self.assertEqual(failed, WorkerResult.model_validate_json(failed.model_dump_json()))
         self.assertEqual(succeeded, WorkerResult.model_validate_json(succeeded.model_dump_json()))
+        self.assertEqual(partial, WorkerResult.model_validate_json(partial.model_dump_json()))
 
     def test_envelopes_reject_unsupported_versions_with_a_structured_error(self) -> None:
         with self.assertRaises(ValidationError) as raised:

--- a/tests/agents/test_worker_orchestrator.py
+++ b/tests/agents/test_worker_orchestrator.py
@@ -275,6 +275,46 @@ class WorkerOrchestratorIntegrationTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual("worker_plan_not_failed", raised.exception.code)
 
+    async def test_named_job_retry_preserves_successful_upstream_results(self) -> None:
+        self.enter_building()
+        source = FakeWorker("source")
+        flaky = FakeWorker("flaky", fail=True)
+        downstream = FakeWorker("downstream")
+        orchestrator = WorkerOrchestrator(
+            self.repository,
+            [source, flaky, downstream],
+            workflow_service=self.workflow,
+        )
+        plan = orchestrator.create_plan(
+            [
+                make_request("source", "job-source"),
+                make_request(
+                    "flaky",
+                    "job-flaky",
+                    dependencies=[WorkerDependency(job_id="job-source", required=True)],
+                ),
+                make_request(
+                    "downstream",
+                    "job-downstream",
+                    dependencies=[WorkerDependency(job_id="job-flaky", required=True)],
+                ),
+            ],
+            OWNER,
+        )
+        await orchestrator.execute(plan.plan_id, OWNER)
+
+        reset = await orchestrator.reset_job(plan.plan_id, OWNER, "job-flaky")
+
+        self.assertEqual(OrchestrationTaskStatus.SUCCEEDED, reset.jobs["job-source"].status)
+        self.assertEqual(OrchestrationTaskStatus.QUEUED, reset.jobs["job-flaky"].status)
+        self.assertEqual(OrchestrationTaskStatus.QUEUED, reset.jobs["job-downstream"].status)
+        flaky.fail = False
+        completed = await orchestrator.execute(plan.plan_id, OWNER)
+        self.assertEqual(1, source.execution_count)
+        self.assertEqual(2, flaky.execution_count)
+        self.assertEqual(1, downstream.execution_count)
+        self.assertEqual(WorkerPlanStatus.SUCCEEDED, completed.status)
+
     async def test_planned_build_can_be_cancelled_without_running_workers(self) -> None:
         self.enter_building()
         worker = FakeWorker("generation")

--- a/tests/jobs/test_job_metrics.py
+++ b/tests/jobs/test_job_metrics.py
@@ -12,7 +12,7 @@ class JobMetricsTests(unittest.TestCase):
     def test_sqlite_job_store_reports_persisted_metrics(self) -> None:
         with tempfile.NamedTemporaryFile(suffix=".db") as file:
             store = JobMetadataStore(file.name, backend="sqlite")
-            for job_id in ("job_success", "job_failure"):
+            for job_id in ("job_success", "job_partial", "job_failure"):
                 store.create_job(
                     job_id=job_id,
                     message_id=f"message_{job_id}",
@@ -24,15 +24,17 @@ class JobMetricsTests(unittest.TestCase):
                     server_owned=True,
                 )
             store.mark_succeeded("job_success", {"project_ir": {}})
+            store.mark_partial("job_partial", {"project_ir": {}})
             store.mark_failed("job_failure", "provider failed")
 
             metrics = store.get_metrics(days=7, hours=24)
 
-        self.assertEqual(2, metrics["jobs_today"])
-        self.assertEqual(2, metrics["jobs_last_hour"])
-        self.assertEqual(2, metrics["completed_jobs"])
+        self.assertEqual(3, metrics["jobs_today"])
+        self.assertEqual(3, metrics["jobs_last_hour"])
+        self.assertEqual(3, metrics["completed_jobs"])
         self.assertEqual(1, metrics["failed_jobs"])
-        self.assertEqual(50.0, metrics["failure_rate"])
+        self.assertEqual(1, metrics["partial_jobs"])
+        self.assertEqual(33.3, metrics["failure_rate"])
 
     def test_sqlite_job_store_merges_durable_worker_plan_rows(self) -> None:
         with tempfile.NamedTemporaryFile(suffix=".db") as file:

--- a/tests/jobs/test_job_progress.py
+++ b/tests/jobs/test_job_progress.py
@@ -46,6 +46,16 @@ class JobProgressTests(unittest.TestCase):
 
         self.assertEqual("job_frontend_abc-123", request.client_job_id)
 
+    def test_generate_request_accepts_named_stage_retry(self) -> None:
+        request = GenerateProjectRequest(
+            prompt="retry wiring",
+            project_id="11111111-1111-4111-8111-111111111111",
+            workflow="web_research",
+            retry_stage=" wiring_netlist ",
+        )
+
+        self.assertEqual("wiring_netlist", request.retry_stage)
+
     def test_cancelled_job_stays_cancelled_and_stops_progress(self) -> None:
         with tempfile.NamedTemporaryFile(suffix=".db") as file:
             store = JobMetadataStore(file.name, backend="sqlite")


### PR DESCRIPTION
Closes #299

## Summary
- add dependency-aware generation stage lifecycle, durable checkpoints, ProjectArtifact references, and attempt history
- preserve partial HardwareIR/BOM/mechanical output while blocking only failed dependents
- add PARTIAL job and worker states plus named, idempotent stage retries
- expose readiness, stages, and failures through project/A2A APIs and admin filters

## Verification
- 50 focused generation, worker, retry, job, and contract tests passed
- 531 broader tests passed, 1 skipped, with the unrelated imported FastAPI route test_image_model deselected because pytest collects it as a test
- Next.js production build passed
- git diff --check passed