### PR TITLE
Share settings headings and hide live pipeline events

### DIFF
--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -7025,35 +7025,37 @@ function AgentPipelineProgressView({
         ))}
       </div>
 
-      <div className="mt-3 border-t border-[#25272e] pt-3">
-        <div className="mb-2 flex items-center justify-between gap-2">
-          <span className="text-[10px] font-black uppercase tracking-[0.14em] text-slate-600">Recent events</span>
-          <span className="font-mono text-[10px] text-slate-600">{events.length}</span>
-        </div>
-        {visibleEvents.length ? (
-          <div className="space-y-1.5">
-            {visibleEvents.map((event, index) => {
-              const details = formatPipelineDetails(event.details);
-              return (
-                <div key={`${event.step_id}-${event.status}-${event.observed_at || index}`} className="min-w-0 border border-[#25272e] bg-[#0f1014] px-2 py-1.5">
-                  <div className="flex min-w-0 flex-wrap items-center gap-2 text-[10px] uppercase">
-                    <span className="max-w-[160px] truncate font-black text-slate-300">{event.label || event.step_id}</span>
-                    <span className={`${isFailedPipelineStatus(event.status) ? "text-rose-300" : isCompletedPipelineStatus(event.status) ? "text-emerald-300" : "text-cyan-300"}`}>
-                      {String(event.status).replace(/_/g, " ")}
-                    </span>
-                    <span className="text-slate-600">{formatPipelineAge(event.observed_at, nowMs)} ago</span>
+      {!isLoading && (
+        <div className="mt-3 border-t border-[#25272e] pt-3">
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <span className="text-[10px] font-black uppercase tracking-[0.14em] text-slate-600">Recent events</span>
+            <span className="font-mono text-[10px] text-slate-600">{events.length}</span>
+          </div>
+          {visibleEvents.length ? (
+            <div className="space-y-1.5">
+              {visibleEvents.map((event, index) => {
+                const details = formatPipelineDetails(event.details);
+                return (
+                  <div key={`${event.step_id}-${event.status}-${event.observed_at || index}`} className="min-w-0 border border-[#25272e] bg-[#0f1014] px-2 py-1.5">
+                    <div className="flex min-w-0 flex-wrap items-center gap-2 text-[10px] uppercase">
+                      <span className="max-w-[160px] truncate font-black text-slate-300">{event.label || event.step_id}</span>
+                      <span className={`${isFailedPipelineStatus(event.status) ? "text-rose-300" : isCompletedPipelineStatus(event.status) ? "text-emerald-300" : "text-cyan-300"}`}>
+                        {String(event.status).replace(/_/g, " ")}
+                      </span>
+                      <span className="text-slate-600">{formatPipelineAge(event.observed_at, nowMs)} ago</span>
+                    </div>
+                    {details && !compact && <div className="mt-1 line-clamp-2 text-[10px] leading-4 text-slate-500">{details}</div>}
                   </div>
-                  {details && !compact && <div className="mt-1 line-clamp-2 text-[10px] leading-4 text-slate-500">{details}</div>}
-                </div>
-              );
-            })}
-          </div>
-        ) : (
-          <div className="border border-[#25272e] bg-[#0f1014] px-2 py-2 text-[11px] leading-4 text-slate-500">
-            Polling job metadata. Backend pipeline events will appear here as agents report progress.
-          </div>
-        )}
-      </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="border border-[#25272e] bg-[#0f1014] px-2 py-2 text-[11px] leading-4 text-slate-500">
+              Polling job metadata. Backend pipeline events will appear here as agents report progress.
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/web/app/user/user-integrations-page.tsx
+++ b/apps/web/app/user/user-integrations-page.tsx
@@ -1298,6 +1298,28 @@ function navBodyId(collapseKey: string) {
   return `settings-nav-${collapseKey.replace(/[^a-z0-9]+/gi, "-")}`;
 }
 
+function SettingsHeading({
+  as: TitleTag = "h2",
+  icon: Icon,
+  title,
+  description,
+}: {
+  as?: "h1" | "h2";
+  icon: React.ComponentType<{ className?: string }>;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="min-w-0">
+      <div className="flex items-center gap-2">
+        <Icon className="h-4 w-4 shrink-0 text-cyan-300" />
+        <TitleTag className="truncate text-sm font-black uppercase tracking-wide text-white">{title}</TitleTag>
+      </div>
+      <p className="mt-1 text-xs leading-5 text-slate-500">{description}</p>
+    </div>
+  );
+}
+
 function SettingsNavSection({
   collapseKey,
   title,
@@ -1882,15 +1904,12 @@ export default function UserIntegrationsPage() {
               <ArrowLeft className="h-4 w-4" />
               Home
             </Link>
-            <div className="min-w-0">
-              <div className="flex items-center gap-2">
-                <KeyRound className="h-4 w-4 text-cyan-300" />
-                <h1 className="truncate text-lg font-black uppercase tracking-wide text-white">Settings</h1>
-              </div>
-              <p className="mt-1 text-xs leading-5 text-slate-500">
-                Appearance, provider credentials, model defaults, and account data preferences for your Forma workspace.
-              </p>
-            </div>
+            <SettingsHeading
+              as="h1"
+              icon={KeyRound}
+              title="Settings"
+              description="Appearance, provider credentials, model defaults, and account data preferences for your Forma workspace."
+            />
           </div>
           {!isLocalSettingsView && (
             <button
@@ -1944,11 +1963,11 @@ export default function UserIntegrationsPage() {
         <section className="mx-auto grid w-full max-w-7xl gap-5 px-4 py-5 lg:grid-cols-[360px_minmax(0,1fr)]">
         <aside className="min-h-0 border border-[#2c2f37] bg-[#17181d]">
           <div className="border-b border-[#2c2f37] p-4">
-            <div className="inline-flex items-center gap-2 text-sm font-black uppercase tracking-wide text-white">
-              <SlidersHorizontal className="h-4 w-4 text-cyan-300" />
-              Settings Navigation
-            </div>
-            <p className="mt-3 text-xs leading-5 text-slate-500">Choose a settings area, then a category and its specific page.</p>
+            <SettingsHeading
+              icon={SlidersHorizontal}
+              title="Settings Navigation"
+              description="Choose a settings area, then a category and its specific page."
+            />
           </div>
 
           <nav aria-label="Settings" className="max-h-[calc(100vh-220px)] space-y-3 overflow-y-auto p-3">


### PR DESCRIPTION
## Summary
- Extracts a shared `SettingsHeading` for the settings page title and sidebar navigation.
- Hides the agent pipeline recent-events log while a hardware-plan build is running, and shows it again after the run finishes, fails, or is stopped.

## Test plan
- [ ] Open `/settings` and confirm the page title and sidebar heading match.
- [ ] Start a hardware-plan build and confirm Recent events is hidden while agents are running.
- [ ] After the build completes, fails, or is stopped, confirm Recent events is visible again.


Made with [Cursor](https://cursor.com)