### PR TITLE
Fix duplicate power rail system IDs

### DIFF
--- a/forma_core/agents/orchestrator.py
+++ b/forma_core/agents/orchestrator.py
@@ -305,7 +305,11 @@ def extract_power_rails(components: List[ComponentInstance], nets: List[Connecti
                 source = "U1"
             
             rails.append(PowerRail(
-                rail_id=f"RAIL_{str(net.voltage).replace('.', 'V')}",
+                # Separate nets can intentionally carry the same nominal voltage
+                # (for example, always-on logic power and switched actuator power).
+                # The net ID identifies the electrical domain; voltage alone does
+                # not and can produce duplicate ProjectSystem IDs downstream.
+                rail_id=f"RAIL_{net.net_id}",
                 voltage=net.voltage,
                 max_current_capacity_ma=500.0 if net.voltage == 3.3 else 1000.0,
                 source_component=source

--- a/tests/agents/test_generation_worker.py
+++ b/tests/agents/test_generation_worker.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import Mock, patch
 
-from forma_core.agents.orchestrator import HardwarePipelineOrchestrator
+from forma_core.agents.orchestrator import HardwarePipelineOrchestrator, extract_power_rails
 from forma_core.agents.pipeline import emit_agent_pipeline_event
 from forma_core.database import list_project_generation_jobs
 from forma_core.persistence.providers import create_sqlite_provider
@@ -301,6 +301,41 @@ class GenerationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
                     )
                 ],
             )
+
+    def test_generation_draft_keeps_same_voltage_power_nets_as_unique_systems(self) -> None:
+        component = ComponentInstance(
+            ref_des="U1",
+            part_number="ESP32-DEVKIT",
+            name="ESP32 controller",
+            category="Microcontroller",
+            rationale="Provides processing and connectivity.",
+        )
+        nets = [
+            ConnectionNet(
+                net_id="NET_VCC_5V",
+                name="Always-on logic power",
+                net_type="Power",
+                voltage=5.0,
+                pins=[PinReference(ref_des="U1", pin_id="VIN")],
+            ),
+            ConnectionNet(
+                net_id="NET_SERVO_VCC",
+                name="Switched servo power",
+                net_type="Power",
+                voltage=5.0,
+                pins=[PinReference(ref_des="U1", pin_id="VIN")],
+            ),
+        ]
+        rails = extract_power_rails([component], nets)
+        state = HardwareIR(components=[component], nets=nets, power_rails=rails)
+
+        draft = build_generation_draft(self.brief, state)
+
+        self.assertEqual(["RAIL_NET_VCC_5V", "RAIL_NET_SERVO_VCC"], [rail.rail_id for rail in rails])
+        self.assertEqual(
+            ["system-primary", "power-RAIL_NET_VCC_5V", "power-RAIL_NET_SERVO_VCC"],
+            [system.system_id for system in draft.systems],
+        )
 
     def test_generation_draft_reuses_persisted_stage_artifact_references(self) -> None:
         stage_artifact = ProjectArtifact(


### PR DESCRIPTION
## Summary

- derive generated power rail IDs from their electrical net IDs
- preserve distinct same-voltage domains such as logic and switched actuator power
- add regression coverage through ProjectRevisionDraft construction

## Root cause

Power rails were identified only by nominal voltage. Two distinct 5 V nets therefore both became RAIL_5V0 and produced duplicate power-RAIL_5V0 revision system IDs.

## Test plan

- .venv/bin/python -m unittest discover -s tests/agents -t .
- 89 tests passed