### PR TITLE
Update Gemini Flash catalog to 3.7

### DIFF
--- a/apps/web/lib/provider-model-catalog.ts
+++ b/apps/web/lib/provider-model-catalog.ts
@@ -26,7 +26,7 @@ export const LLM_MODEL_OPTIONS: Record<string, ProviderModelOption[]> = {
     model("gpt-5.5", "GPT-5.5", "Previous-generation model"),
   ],
   gemini: [
-    model("gemini-3.6-flash", "Gemini 3.6 Flash", "Agentic and multimodal workloads"),
+    model("gemini-3.7-flash", "Gemini 3.7 Flash", "Agentic and multimodal workloads"),
     model("gemini-3.5-flash", "Gemini 3.5 Flash", "Coding and sustained agentic tasks"),
     model("gemini-3.5-flash-lite", "Gemini 3.5 Flash-Lite", "High-throughput, cost-efficient tasks"),
     model("gemini-3.1-flash-lite", "Gemini 3.1 Flash-Lite", "Fast general-purpose model"),
@@ -34,7 +34,7 @@ export const LLM_MODEL_OPTIONS: Record<string, ProviderModelOption[]> = {
     model("gemini-2.5-flash", "Gemini 2.5 Flash", "Stable previous-generation flash model"),
   ],
   vertex: [
-    model("gemini-3.6-flash", "Gemini 3.6 Flash", "Vertex AI agentic and multimodal workloads"),
+    model("gemini-3.7-flash", "Gemini 3.7 Flash", "Vertex AI agentic and multimodal workloads"),
     model("gemini-3.5-flash", "Gemini 3.5 Flash", "Vertex AI coding and sustained agentic tasks"),
     model("gemini-3.5-flash-lite", "Gemini 3.5 Flash-Lite", "Vertex AI high-throughput workloads"),
     model("gemini-3.1-flash-lite", "Gemini 3.1 Flash-Lite", "Vertex AI fast general-purpose model"),


### PR DESCRIPTION
## Summary

- replace Gemini 3.6 Flash with Gemini 3.7 Flash in the Gemini model picker
- replace Gemini 3.6 Flash with Gemini 3.7 Flash in the Vertex AI model picker
- update both display labels and provider model IDs

## Test plan

- npm run lint -- lib/provider-model-catalog.ts
- 0 errors; 8 existing no-img-element warnings elsewhere in the frontend