### PR TITLE
Fix inconsistent failed-build recovery rendering

### DIFF
--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -23,6 +23,11 @@ import {
   humanContextSkipChatSummary,
   humanContextSkipPromptSection,
 } from "../lib/human-context-defaults";
+import {
+  contextBuildControls,
+  latestRetryableContextBuildMessage,
+  shouldOfferFailedBuildRetry,
+} from "../lib/conversation-build-state";
 import CopyButton from "../components/copy-button";
 import {
   useAdminSession,
@@ -52,6 +57,9 @@ import {
   isFinalVideoStatus,
 } from "./forma-workspace/admin-panels";
 import HomeChatView from "./forma-workspace/home-chat-view";
+import ConversationMessageList, {
+  type ConversationMessage,
+} from "./forma-workspace/conversation-message-list";
 import useChatAutoScroll from "./forma-workspace/use-chat-auto-scroll";
 import useChromeHeaderScroll from "./forma-workspace/use-chrome-header-scroll";
 import {
@@ -417,12 +425,6 @@ function newFrontendJobId() {
 
 function chatTimestamp() {
   return new Date().toISOString();
-}
-
-function formatChatTimestamp(value: string) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "";
-  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
 function initialChatMessages(timestamp: string = INITIAL_CHAT_TIMESTAMP): ChatMessage[] {
@@ -2414,12 +2416,7 @@ export function FormaWorkspace({
     [chatMessages],
   );
   const retryableContextBuildMessage = useMemo(() => {
-    const latestBuildMessage = [...chatMessages].reverse().find((message) => (
-      Boolean(message.buildPlanId)
-      && Boolean(message.buildJobId)
-      && Boolean(message.contextProjectId)
-    ));
-    return latestBuildMessage?.status === "error" ? latestBuildMessage : null;
+    return latestRetryableContextBuildMessage(chatMessages);
   }, [chatMessages]);
 
   const latestAgentOperation = useMemo(() => {
@@ -3587,6 +3584,24 @@ export function FormaWorkspace({
     } finally {
       setResettingBuildMessageId(null);
     }
+  };
+
+  const renderConversationPipelineProgress = (message: ConversationMessage) => {
+    const buildMessage = message as ChatMessage;
+    const controls = contextBuildControls(
+      buildMessage,
+      Boolean(activeGeneration || pendingContextBuildMessage),
+    );
+    return (
+      <AgentPipelineProgressView
+        progress={buildMessage.pipelineProgress}
+        status={buildMessage.status}
+        compact
+        onStop={controls.canStop ? () => stopContextBuildMessage(buildMessage) : undefined}
+        onReset={controls.canReset ? () => void resetFailedContextBuild(buildMessage) : undefined}
+        resetting={resettingBuildMessageId === buildMessage.id}
+      />
+    );
   };
 
   useEffect(() => {
@@ -4805,6 +4820,10 @@ export function FormaWorkspace({
     () => currentProjectChatId ? chatThreads[currentProjectChatId] || [] : [],
     [chatThreads, currentProjectChatId]
   );
+  const retryableProjectBuildMessage = useMemo(
+    () => latestRetryableContextBuildMessage(currentProjectChatMessages),
+    [currentProjectChatMessages],
+  );
   const projectImageCandidates = useMemo(() => {
     const chatReference =
       hardwareReferenceSrcFromChatMessages(currentProjectChatMessages) ||
@@ -5456,29 +5475,7 @@ export function FormaWorkspace({
                 ) : null
               }
               messages={chatMessages}
-              renderPipelineProgress={(message) => (
-                <AgentPipelineProgressView
-                  progress={message.pipelineProgress as AgentPipelineProgress | null}
-                  status={message.status}
-                  compact
-                  onStop={
-                    message.status === "loading" && message.buildPlanId && message.contextProjectId
-                      ? () => stopContextBuildMessage(message as ChatMessage)
-                      : undefined
-                  }
-                  onReset={
-                    message.status === "error"
-                    && message.buildPlanId
-                    && message.buildJobId
-                    && message.contextProjectId
-                    && !activeGeneration
-                    && !pendingContextBuildMessage
-                      ? () => void resetFailedContextBuild(message as ChatMessage)
-                      : undefined
-                  }
-                  resetting={resettingBuildMessageId === message.id}
-                />
-              )}
+              renderPipelineProgress={renderConversationPipelineProgress}
               projectArtifact={
                 projectIR && inlineChatProjectId && currentProjectId === inlineChatProjectId
                   ? (
@@ -5640,12 +5637,18 @@ export function FormaWorkspace({
                 projectTitle={projectTitle}
                 onRenameTitle={currentUserOwnsProject ? (title) => { void commitOwnedWorkspaceTitle(title); } : undefined}
                 messages={currentProjectChatMessages}
+                renderPipelineProgress={renderConversationPipelineProgress}
                 input={projectChatInput}
                 setInput={setProjectChatInput}
                 onSubmit={handleProjectChatGenerate}
                 isLoading={isLoading}
                 canStop={activeGeneration?.kind === "project-chat"}
                 onStop={stopActiveGeneration}
+                canRetryFailedBuild={Boolean(retryableProjectBuildMessage)}
+                retryingFailedBuild={resettingBuildMessageId === retryableProjectBuildMessage?.id}
+                onRetryFailedBuild={() => {
+                  if (retryableProjectBuildMessage) void resetFailedContextBuild(retryableProjectBuildMessage);
+                }}
                 canChat={currentUserOwnsProject}
                 namespaceTabs={visibleWorkspaceTabs}
                 activeNamespace={activeWorkspaceTab.id}
@@ -6990,12 +6993,16 @@ function ChatWorkspace({
   projectTitle,
   onRenameTitle,
   messages,
+  renderPipelineProgress,
   input,
   setInput,
   onSubmit,
   isLoading,
   canStop,
   onStop,
+  canRetryFailedBuild,
+  retryingFailedBuild,
+  onRetryFailedBuild,
   canChat,
   namespaceTabs,
   activeNamespace,
@@ -7010,12 +7017,16 @@ function ChatWorkspace({
   projectTitle: string;
   onRenameTitle?: (title: string) => void;
   messages: ChatMessage[];
+  renderPipelineProgress: (message: ConversationMessage) => React.ReactNode;
   input: string;
   setInput: (value: string) => void;
   onSubmit: (event: React.FormEvent) => void;
   isLoading: boolean;
   canStop: boolean;
   onStop: () => void;
+  canRetryFailedBuild: boolean;
+  retryingFailedBuild: boolean;
+  onRetryFailedBuild: () => void;
   canChat: boolean;
   namespaceTabs: typeof workspaceTabs;
   activeNamespace: string;
@@ -7026,6 +7037,17 @@ function ChatWorkspace({
 }) {
   const { containerRef, endRef, handleScroll } = useChatAutoScroll(chatId || projectId || "project-chat", messages);
   const { headerAway, updateFromContainer } = useChromeHeaderScroll(chatId || projectId || "project-chat");
+  const hasInput = Boolean(input.trim());
+  const retryMode = shouldOfferFailedBuildRetry({
+    canRetryFailedBuild,
+    hasInput,
+    generationActive: canStop,
+  });
+  const primaryActionLabel = canStop
+    ? "Stop project update"
+    : retryMode
+      ? "Try failed build again"
+      : "Apply change to project, or press Enter";
 
   const onChatScroll = () => {
     handleScroll();
@@ -7061,50 +7083,12 @@ function ChatWorkspace({
               className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-3 pb-5 pt-16 sm:px-5 sm:pb-6 sm:pt-16"
             >
               <div className="mx-auto flex w-full min-w-0 max-w-6xl flex-col gap-3">
-                {messages.length ? (
-                  messages.map((message) => {
-                    const isUser = message.role === "user";
-                    const isSystem = message.role === "system";
-                    return (
-                      <div key={message.id} className={`mx-auto flex w-full min-w-0 max-w-3xl ${isUser ? "justify-end" : "justify-start"}`}>
-                        <div
-                          className={`min-w-0 max-w-[92%] overflow-hidden rounded-xl border px-4 py-3 ${
-                            isUser
-                              ? "border-emerald-500/20 bg-emerald-500/10 text-zinc-100"
-                              : message.status === "error"
-                                ? "border-rose-400/30 bg-rose-950/25 text-rose-100"
-                                : message.status === "cancelled"
-                                  ? "border-amber-300/30 bg-amber-950/20 text-amber-50"
-                                : isSystem
-                                  ? "border-white/5 bg-black/25 text-zinc-400"
-                                  : "border-white/5 bg-[#181b22] text-zinc-200"
-                          }`}
-                        >
-                          <div className="mb-2 flex flex-wrap items-center gap-2 text-[10px] font-medium text-zinc-500">
-                            <span>{isUser ? "You" : isSystem ? "Context" : "Forma"}</span>
-                            <span className="text-zinc-700">·</span>
-                            <span suppressHydrationWarning>{formatChatTimestamp(message.timestamp)}</span>
-                            {message.status === "loading" && <RefreshCw className="h-3 w-3 animate-spin text-emerald-400" />}
-                            {message.status === "cancelled" && <Square className="h-3 w-3 fill-current text-amber-300" />}
-                            <CopyButton
-                              value={message.content}
-                              label={isUser ? "Copy your message" : isSystem ? "Copy context message" : "Copy Forma's message"}
-                              className="ml-auto"
-                            />
-                          </div>
-                          <p className="break-anywhere whitespace-pre-wrap text-sm leading-6">{message.content}</p>
-                          {!message.projectId && (
-                            <AgentPipelineProgressView progress={message.pipelineProgress} status={message.status} compact />
-                          )}
-                        </div>
-                      </div>
-                    );
-                  })
-                ) : (
-                  <div className="mx-auto w-full max-w-3xl rounded-xl border border-white/5 bg-[#181b22] p-5 text-sm leading-6 text-zinc-500">
-                    This chat has no project messages yet.
-                  </div>
-                )}
+                <ConversationMessageList
+                  messages={messages}
+                  renderPipelineProgress={renderPipelineProgress}
+                  variant="project"
+                  emptyMessage="This chat has no project messages yet."
+                />
                 <div ref={endRef} />
                 <ChatProjectArtifact
                   projectId={projectId}
@@ -7129,6 +7113,10 @@ function ChatWorkspace({
                       if (event.key === "Enter" && !event.shiftKey) {
                         event.preventDefault();
                         if (isLoading) return;
+                        if (retryMode) {
+                          onRetryFailedBuild();
+                          return;
+                        }
                         event.currentTarget.form?.requestSubmit();
                       }
                     }}
@@ -7136,22 +7124,30 @@ function ChatWorkspace({
                     className="min-h-[72px] w-full resize-none border-none bg-transparent text-sm leading-6 text-zinc-100 outline-none placeholder:text-zinc-500"
                   />
                   <div className="mt-1 flex items-center justify-end gap-1.5">
-                    {!canStop && !isLoading && Boolean(input.trim()) && (
+                    {!canStop && !retryMode && !isLoading && hasInput && (
                       <span className="prompt-composer-enter-hint hidden sm:inline" aria-hidden="true">
                         Enter
                       </span>
                     )}
                     <button
-                      type={canStop ? "button" : "submit"}
-                      onClick={canStop ? onStop : undefined}
-                      disabled={!canStop && (isLoading || !projectId || !input.trim())}
+                      type={canStop || retryMode ? "button" : "submit"}
+                      onClick={canStop ? onStop : retryMode ? onRetryFailedBuild : undefined}
+                      disabled={retryMode ? retryingFailedBuild : !canStop && (isLoading || !projectId || !hasInput)}
                       className={`prompt-composer-send inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed ${
-                        !canStop && !isLoading && input.trim() ? "is-ready" : ""
+                        retryMode || (!canStop && !isLoading && hasInput) ? "is-ready" : ""
                       }`}
-                      aria-label={canStop ? "Stop project update" : "Apply change to project, or press Enter"}
-                      title={canStop ? "Stop project update" : `Apply change to ${activeNamespaceName} · Enter`}
+                      aria-label={primaryActionLabel}
+                      title={retryMode || canStop ? primaryActionLabel : `Apply change to ${activeNamespaceName} · Enter`}
                     >
-                      {canStop ? <Square className="h-3.5 w-3.5 fill-current" /> : isLoading ? <RefreshCw className="h-3.5 w-3.5 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
+                      {canStop ? (
+                        <Square className="h-3.5 w-3.5 fill-current" />
+                      ) : retryMode ? (
+                        <RefreshCw className={`h-3.5 w-3.5 ${retryingFailedBuild ? "animate-spin" : ""}`} />
+                      ) : isLoading ? (
+                        <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <ArrowRight className="h-4 w-4" />
+                      )}
                     </button>
                   </div>
                 </div>

--- a/apps/web/app/forma-workspace/conversation-message-list.tsx
+++ b/apps/web/app/forma-workspace/conversation-message-list.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import type { ReactNode } from "react";
+import {
+  AlertTriangle,
+  ArrowRight,
+  CheckCircle,
+  Cpu,
+  RefreshCw,
+  Square,
+} from "lucide-react";
+
+import CopyButton from "../../components/copy-button";
+
+export type ConversationMessage = {
+  id: string;
+  role: "assistant" | "user" | "system";
+  content: string;
+  status?: "idle" | "loading" | "success" | "error" | "cancelled";
+  timestamp: string;
+  projectId?: string | null;
+  pipelineProgress?: unknown;
+  imagePreview?: string | null;
+  contextProjectId?: string | null;
+  workflowState?: string | null;
+  contextQuestions?: string[];
+  contextSuggestions?: string[];
+  buildPlanId?: string | null;
+  buildJobId?: string | null;
+};
+
+function formatTimestamp(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export default function ConversationMessageList({
+  messages,
+  renderPipelineProgress,
+  variant = "home",
+  emptyMessage,
+  onSelectContextSuggestion,
+  isLoading = false,
+  canBuildNow = false,
+  buildNowLoading = false,
+  onBuildNow,
+}: {
+  messages: ConversationMessage[];
+  renderPipelineProgress: (message: ConversationMessage) => ReactNode;
+  variant?: "home" | "project";
+  emptyMessage?: string;
+  onSelectContextSuggestion?: (suggestion: string) => void;
+  isLoading?: boolean;
+  canBuildNow?: boolean;
+  buildNowLoading?: boolean;
+  onBuildNow?: () => void;
+}) {
+  const latestChoiceMessageId = onSelectContextSuggestion
+    ? [...messages]
+      .reverse()
+      .find((message) => message.role === "assistant" && Boolean(message.contextSuggestions?.length))?.id
+    : null;
+  const projectLayout = variant === "project";
+
+  if (!messages.length && emptyMessage) {
+    return (
+      <div className="mx-auto w-full max-w-3xl rounded-xl border border-white/5 bg-[#181b22] p-5 text-sm leading-6 text-zinc-500">
+        {emptyMessage}
+      </div>
+    );
+  }
+
+  return messages.map((message) => {
+    const isUser = message.role === "user";
+    const isSystem = message.role === "system";
+    const statusTone =
+      message.status === "error"
+        ? "border-rose-400/40 bg-rose-950/30 text-rose-100"
+        : message.status === "success"
+          ? "border-emerald-400/35 bg-emerald-950/25 text-emerald-50"
+          : message.status === "cancelled"
+            ? "border-amber-300/35 bg-amber-950/20 text-amber-50"
+            : isUser
+              ? "border-emerald-500/20 bg-emerald-500/10 text-zinc-100"
+              : isSystem
+                ? "border-white/5 bg-black/25 text-zinc-400"
+                : "border-white/5 bg-[#181b22] text-zinc-100";
+    const showPipeline = Boolean(message.pipelineProgress)
+      && (!message.projectId || message.status === "error" || message.status === "cancelled");
+
+    return (
+      <div
+        key={message.id}
+        className={`flex min-w-0 ${isUser ? "justify-end" : "justify-start"} ${projectLayout ? "mx-auto w-full max-w-3xl" : ""}`}
+      >
+        <div className={`min-w-0 max-w-[92%] overflow-hidden rounded-xl border px-3 py-2.5 sm:max-w-[86%] sm:px-4 sm:py-3 ${statusTone}`}>
+          <div className="mb-2 flex min-w-0 flex-wrap items-center gap-2 text-[10px] font-medium text-zinc-500">
+            {message.status === "loading" ? (
+              <RefreshCw className="h-3.5 w-3.5 animate-spin text-emerald-400" />
+            ) : message.status === "success" ? (
+              <CheckCircle className="h-3.5 w-3.5 text-emerald-300" />
+            ) : message.status === "error" ? (
+              <AlertTriangle className="h-3.5 w-3.5 text-rose-300" />
+            ) : message.status === "cancelled" ? (
+              <Square className="h-3.5 w-3.5 fill-current text-amber-300" />
+            ) : isUser ? (
+              <ArrowRight className="h-3.5 w-3.5 text-emerald-400" />
+            ) : (
+              <Cpu className="h-3.5 w-3.5 text-zinc-400" />
+            )}
+            <span>{isUser ? "You" : isSystem ? "Context" : "Forma"}</span>
+            <span className="text-zinc-700">·</span>
+            <span suppressHydrationWarning>{formatTimestamp(message.timestamp)}</span>
+            <CopyButton
+              value={message.content}
+              label={isUser ? "Copy your message" : isSystem ? "Copy context message" : "Copy Forma's message"}
+              className="ml-auto"
+            />
+          </div>
+          <p className="break-anywhere whitespace-pre-wrap text-sm leading-6">{message.content}</p>
+          {!isUser && message.id === latestChoiceMessageId && Boolean(message.contextSuggestions?.length) && (
+            <div className="mt-3 grid gap-2 sm:grid-cols-2" aria-label="Suggested answers">
+              {message.contextSuggestions?.map((suggestion) => (
+                <button
+                  key={suggestion}
+                  type="button"
+                  onClick={() => onSelectContextSuggestion?.(suggestion)}
+                  disabled={isLoading}
+                  className="flex min-h-12 items-center gap-2 rounded-lg border border-white/10 bg-[#0f1117] px-3 py-2 text-left text-xs font-medium text-zinc-300 transition-colors hover:border-emerald-500/30 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  <ArrowRight className="h-3.5 w-3.5 shrink-0" />
+                  <span className="break-words">{suggestion}</span>
+                </button>
+              ))}
+            </div>
+          )}
+          {!isUser && canBuildNow && (message.workflowState === "gathering_context" || Boolean(message.contextProjectId)) && (
+            <button
+              type="button"
+              onClick={onBuildNow}
+              disabled={buildNowLoading || isLoading}
+              className="mt-3 inline-flex h-8 items-center justify-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 text-xs font-medium text-emerald-400 transition-colors hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+              aria-label="Default — proceed with safe prototype defaults"
+              title="Default — proceed with safe prototype defaults"
+            >
+              {buildNowLoading ? <RefreshCw className="h-3.5 w-3.5 animate-spin" /> : <ArrowRight className="h-3.5 w-3.5" />}
+              Default
+            </button>
+          )}
+          {message.imagePreview && (
+            <img
+              src={message.imagePreview}
+              alt="Hardware reference thumbnail"
+              className="mt-3 h-24 w-36 rounded-lg border border-white/10 object-cover"
+            />
+          )}
+          {showPipeline && renderPipelineProgress(message)}
+        </div>
+      </div>
+    );
+  });
+}

--- a/apps/web/app/forma-workspace/home-chat-view.tsx
+++ b/apps/web/app/forma-workspace/home-chat-view.tsx
@@ -7,8 +7,6 @@ import {
   AlertTriangle,
   ArrowRight,
   ArrowUpRight,
-  CheckCircle,
-  Cpu,
   KeyRound,
   Paperclip,
   RefreshCw,
@@ -17,32 +15,16 @@ import {
   X,
 } from "lucide-react";
 
-import CopyButton from "../../components/copy-button";
+import { shouldOfferFailedBuildRetry } from "../../lib/conversation-build-state";
+import ConversationMessageList, { type ConversationMessage } from "./conversation-message-list";
 import useChatAutoScroll from "./use-chat-auto-scroll";
-
-type HomeChatMessage = {
-  id: string;
-  role: "assistant" | "user" | "system";
-  content: string;
-  status?: "idle" | "loading" | "success" | "error" | "cancelled";
-  timestamp: string;
-  projectId?: string | null;
-  pipelineProgress?: unknown;
-  imagePreview?: string | null;
-  contextProjectId?: string | null;
-  workflowState?: string | null;
-  contextQuestions?: string[];
-  contextSuggestions?: string[];
-  buildPlanId?: string | null;
-  buildJobId?: string | null;
-};
 
 type HomeChatViewProps = {
   started: boolean;
   conversationKey: string;
   workspaceTitle?: ReactNode;
-  messages: HomeChatMessage[];
-  renderPipelineProgress: (message: HomeChatMessage) => ReactNode;
+  messages: ConversationMessage[];
+  renderPipelineProgress: (message: ConversationMessage) => ReactNode;
   projectArtifact?: ReactNode;
   examples: string[];
   onSelectExample: (example: string) => void;
@@ -71,12 +53,6 @@ type HomeChatViewProps = {
   onImageChange: ChangeEventHandler<HTMLInputElement>;
   onImagePaste: ClipboardEventHandler<HTMLTextAreaElement>;
 };
-
-function formatTimestamp(value: string) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "";
-  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-}
 
 export default function HomeChatView({
   started,
@@ -114,10 +90,11 @@ export default function HomeChatView({
 }: HomeChatViewProps) {
   const { containerRef, endRef, handleScroll } = useChatAutoScroll(conversationKey, messages);
   const promptRef = useRef<HTMLTextAreaElement>(null);
-  const latestChoiceMessageId = [...messages]
-    .reverse()
-    .find((message) => message.role === "assistant" && Boolean(message.contextSuggestions?.length))?.id;
-  const retryMode = canRetryFailedBuild && !hasGenerationInput && !generationActive;
+  const retryMode = shouldOfferFailedBuildRetry({
+    canRetryFailedBuild,
+    hasInput: hasGenerationInput,
+    generationActive,
+  });
   const promptRunning = isLoading || generationActive;
   const canFinishPrompt = !generationActive && !retryMode && hasGenerationInput && generationReady && !isLoading;
   const primaryActionLabel = generationActive
@@ -169,86 +146,15 @@ export default function HomeChatView({
             onScroll={handleScroll}
             className="min-h-0 flex-1 space-y-4 overflow-x-hidden overflow-y-auto px-3 pb-5 pt-16 sm:px-4 sm:pb-6 md:pt-5"
           >
-            {messages.map((message) => {
-              const isUser = message.role === "user";
-              const statusTone =
-                message.status === "error"
-                  ? "border-rose-400/40 bg-rose-950/30 text-rose-100"
-                  : message.status === "success"
-                    ? "border-emerald-400/35 bg-emerald-950/25 text-emerald-50"
-                    : message.status === "cancelled"
-                      ? "border-amber-300/35 bg-amber-950/20 text-amber-50"
-                      : isUser
-                        ? "border-emerald-500/20 bg-emerald-500/10 text-zinc-100"
-                        : "border-white/5 bg-[#181b22] text-zinc-100";
-              return (
-                <div key={message.id} className={`flex min-w-0 ${isUser ? "justify-end" : "justify-start"}`}>
-                  <div className={`min-w-0 max-w-[92%] overflow-hidden rounded-xl border px-3 py-2.5 sm:max-w-[86%] sm:px-4 sm:py-3 ${statusTone}`}>
-                    <div className="mb-2 flex min-w-0 flex-wrap items-center gap-2 text-[10px] font-medium text-zinc-500">
-                      {message.status === "loading" ? (
-                        <RefreshCw className="h-3.5 w-3.5 animate-spin text-emerald-400" />
-                      ) : message.status === "success" ? (
-                        <CheckCircle className="h-3.5 w-3.5 text-emerald-300" />
-                      ) : message.status === "error" ? (
-                        <AlertTriangle className="h-3.5 w-3.5 text-rose-300" />
-                      ) : message.status === "cancelled" ? (
-                        <Square className="h-3.5 w-3.5 fill-current text-amber-300" />
-                      ) : isUser ? (
-                        <ArrowRight className="h-3.5 w-3.5 text-emerald-400" />
-                      ) : (
-                        <Cpu className="h-3.5 w-3.5 text-zinc-400" />
-                      )}
-                      <span>{isUser ? "You" : "Forma"}</span>
-                      <span className="text-zinc-700">·</span>
-                      <span suppressHydrationWarning>{formatTimestamp(message.timestamp)}</span>
-                      <CopyButton
-                        value={message.content}
-                        label={isUser ? "Copy your message" : "Copy Forma's message"}
-                        className="ml-auto"
-                      />
-                    </div>
-                    <p className="break-anywhere whitespace-pre-wrap text-sm leading-6">{message.content}</p>
-                    {!isUser && message.id === latestChoiceMessageId && Boolean(message.contextSuggestions?.length) && (
-                      <div className="mt-3 grid gap-2 sm:grid-cols-2" aria-label="Suggested answers">
-                        {message.contextSuggestions?.map((suggestion) => (
-                          <button
-                            key={suggestion}
-                            type="button"
-                            onClick={() => onSelectContextSuggestion(suggestion)}
-                            disabled={isLoading}
-                            className="flex min-h-12 items-center gap-2 rounded-lg border border-white/10 bg-[#0f1117] px-3 py-2 text-left text-xs font-medium text-zinc-300 transition-colors hover:border-emerald-500/30 hover:text-zinc-100 disabled:cursor-not-allowed disabled:opacity-50"
-                          >
-                            <ArrowRight className="h-3.5 w-3.5 shrink-0" />
-                            <span className="break-words">{suggestion}</span>
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                    {!isUser && canBuildNow && (message.workflowState === "gathering_context" || Boolean(message.contextProjectId)) && (
-                      <button
-                        type="button"
-                        onClick={onBuildNow}
-                        disabled={buildNowLoading || isLoading}
-                        className="mt-3 inline-flex h-8 items-center justify-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-3 text-xs font-medium text-emerald-400 transition-colors hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-50"
-                        aria-label="Default — proceed with safe prototype defaults"
-                        title="Default — proceed with safe prototype defaults"
-                      >
-                        {buildNowLoading ? <RefreshCw className="h-3.5 w-3.5 animate-spin" /> : <ArrowRight className="h-3.5 w-3.5" />}
-                        Default
-                      </button>
-                    )}
-                    {message.imagePreview && (
-                      <img
-                        src={message.imagePreview}
-                        alt="Hardware reference thumbnail"
-                        className="mt-3 h-24 w-36 rounded-lg border border-white/10 object-cover"
-                      />
-                    )}
-                    {!message.projectId && renderPipelineProgress(message)}
-                  </div>
-                </div>
-              );
-            })}
+            <ConversationMessageList
+              messages={messages}
+              renderPipelineProgress={renderPipelineProgress}
+              onSelectContextSuggestion={onSelectContextSuggestion}
+              isLoading={isLoading}
+              canBuildNow={canBuildNow}
+              buildNowLoading={buildNowLoading}
+              onBuildNow={onBuildNow}
+            />
             {projectArtifact}
             <div ref={endRef} />
           </div>

--- a/apps/web/lib/conversation-build-state.ts
+++ b/apps/web/lib/conversation-build-state.ts
@@ -1,0 +1,49 @@
+export type ConversationBuildMessage = {
+  status?: "idle" | "loading" | "success" | "error" | "cancelled";
+  projectId?: string | null;
+  contextProjectId?: string | null;
+  buildPlanId?: string | null;
+  buildJobId?: string | null;
+};
+
+export function contextBuildControls(
+  message: ConversationBuildMessage,
+  recoveryBlocked = false,
+) {
+  const hasProject = Boolean(message.contextProjectId);
+  const hasPlan = Boolean(message.buildPlanId);
+  const hasJob = Boolean(message.buildJobId);
+
+  return {
+    canStop: message.status === "loading" && hasProject && hasPlan,
+    canReset:
+      message.status === "error"
+      && hasProject
+      && hasPlan
+      && hasJob
+      && !recoveryBlocked,
+  };
+}
+
+export function latestRetryableContextBuildMessage<T extends ConversationBuildMessage>(
+  messages: T[],
+): T | null {
+  const latestBuildMessage = [...messages].reverse().find((message) => (
+    Boolean(message.contextProjectId)
+    && Boolean(message.buildPlanId)
+    && Boolean(message.buildJobId)
+  ));
+  return latestBuildMessage?.status === "error" ? latestBuildMessage : null;
+}
+
+export function shouldOfferFailedBuildRetry({
+  canRetryFailedBuild,
+  hasInput,
+  generationActive,
+}: {
+  canRetryFailedBuild: boolean;
+  hasInput: boolean;
+  generationActive: boolean;
+}) {
+  return canRetryFailedBuild && !hasInput && !generationActive;
+}

--- a/apps/web/test/conversation-build-state.test.ts
+++ b/apps/web/test/conversation-build-state.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  contextBuildControls,
+  latestRetryableContextBuildMessage,
+  shouldOfferFailedBuildRetry,
+} from "../lib/conversation-build-state.ts";
+
+const failedBuild = {
+  id: "failed-build",
+  status: "error" as const,
+  contextProjectId: "project-1",
+  buildPlanId: "plan-1",
+  buildJobId: "job-1",
+};
+
+test("failed build recovery does not depend on whether a project artifact is loaded", () => {
+  assert.equal(contextBuildControls(failedBuild).canReset, true);
+  assert.equal(contextBuildControls({ ...failedBuild, projectId: "project-1" }).canReset, true);
+});
+
+test("active work blocks reset until the terminal plan state settles", () => {
+  assert.equal(contextBuildControls(failedBuild, true).canReset, false);
+  assert.equal(contextBuildControls({ ...failedBuild, status: "loading" }).canStop, true);
+});
+
+test("latest retryable build selection is shared across conversation layouts", () => {
+  const messages = [
+    failedBuild,
+    { ...failedBuild, id: "later-success", status: "success" as const },
+  ];
+  assert.equal(latestRetryableContextBuildMessage(messages), null);
+  assert.equal(latestRetryableContextBuildMessage([messages[1], failedBuild])?.id, "failed-build");
+});
+
+test("an empty idle composer offers retry while typed input preserves normal submission", () => {
+  assert.equal(shouldOfferFailedBuildRetry({
+    canRetryFailedBuild: true,
+    hasInput: false,
+    generationActive: false,
+  }), true);
+  assert.equal(shouldOfferFailedBuildRetry({
+    canRetryFailedBuild: true,
+    hasInput: true,
+    generationActive: false,
+  }), false);
+});


### PR DESCRIPTION
## Summary

- render conversation build progress through one shared message-list path
- use shared build-state helpers for retry and reset eligibility
- expose the same reset/retry controls after root-generation and project-stage failures
- add focused coverage for failed-build recovery with and without a project artifact

## Verification

- `node --experimental-strip-types --test apps/web/test/conversation-build-state.test.ts`
- `npx tsc --noEmit -p apps/web/tsconfig.json --allowImportingTsExtensions`
- `npm --prefix apps/web run lint -- --quiet`
- `npm --prefix apps/web run build`
- `git diff --check`