### PR TITLE
Release caid-forma-core 0.3.4

### DIFF
--- a/forma_core/_version.py
+++ b/forma_core/_version.py
@@ -1,3 +1,3 @@
 """Package version for forma-core."""
 
-__version__ = "0.3.3"
+__version__ = "0.3.4"


### PR DESCRIPTION
## Summary

- bump `caid-forma-core` from 0.3.3 to 0.3.4
- prepare the GitHub `v0.3.4` release and matching PyPI publication

## Verification

- package import reports `0.3.4`
- wheel and source distribution build successfully from a clean Git archive
- `twine check` passes for both artifacts
- wheel metadata identifies `caid-forma-core==0.3.4`