### PR TITLE
Resume interrupted context builds and split the workspace shell

### DIFF
--- a/apps/api/context_builds.py
+++ b/apps/api/context_builds.py
@@ -12,6 +12,7 @@ from forma_core.database import (
     initiate_project_build,
 )
 from forma_core.config import config
+from forma_core.workers.orchestration import TERMINAL_PLAN_STATUSES
 from forma_core.workspaces.context import ContextBuildExecution
 from forma_core.workspaces.readiness import BuildMode, ReadinessStatus
 from forma_core.workspaces.workflow import ProjectWorkflow
@@ -57,7 +58,8 @@ class ContextBuildDispatcher:
         )
         plan = create_project_generation_plan(outcome.build, owner_user_id)
         job_id = next(iter(plan.jobs))
-        if plan.status.value == "planned" and not self.requires_request_bound_execution():
+        request_bound_execution = self.requires_request_bound_execution()
+        if plan.status.value == "planned" and not request_bound_execution:
             self._launch(plan.plan_id, owner_user_id)
         return (
             ContextBuildExecution(
@@ -65,6 +67,7 @@ class ContextBuildDispatcher:
                 plan_id=plan.plan_id,
                 job_id=job_id,
                 status=plan.status.value,
+                request_bound_execution=request_bound_execution,
             ),
             outcome.workflow,
         )
@@ -74,6 +77,44 @@ class ContextBuildDispatcher:
         """Return whether the runtime can discard work after an HTTP response."""
 
         return str(config.get("VERCEL") or "").strip() == "1"
+
+    @classmethod
+    def owns_plan(cls, plan_id: str) -> bool:
+        with cls._cancellation_lock:
+            return plan_id in cls._cancellation_events
+
+    @classmethod
+    def launch_once(cls, plan_id: str, owner_user_id: str) -> bool:
+        """Start detached execution if this process does not already own the plan."""
+
+        if cls.requires_request_bound_execution():
+            return False
+
+        oidc_token = current_vertex_oidc_token()
+        with cls._cancellation_lock:
+            if plan_id in cls._cancellation_events:
+                return False
+            cancellation_event = Event()
+            cls._cancellation_events[plan_id] = cancellation_event
+
+        def run() -> None:
+            context_token = bind_vertex_oidc_token(oidc_token)
+            try:
+                asyncio.run(execute_project_generation_plan(
+                    plan_id,
+                    owner_user_id,
+                    cancellation_check=cancellation_event.is_set,
+                ))
+            except Exception:
+                logger.exception("Detached generation plan failed: plan_id=%s", plan_id)
+            finally:
+                reset_vertex_oidc_token(context_token)
+                with cls._cancellation_lock:
+                    if cls._cancellation_events.get(plan_id) is cancellation_event:
+                        cls._cancellation_events.pop(plan_id, None)
+
+        Thread(target=run, name=f"forma-build-{plan_id}", daemon=True).start()
+        return True
 
     @classmethod
     async def execute(cls, plan_id: str, owner_user_id: str):
@@ -97,31 +138,20 @@ class ContextBuildDispatcher:
                     cls._cancellation_events.pop(plan_id, None)
 
     @classmethod
-    def _launch(cls, plan_id: str, owner_user_id: str) -> None:
+    def _launch(cls, plan_id: str, owner_user_id: str) -> bool:
         """Run independently of the HTTP response lifecycle so the UI can begin polling immediately."""
 
-        cancellation_event = Event()
-        oidc_token = current_vertex_oidc_token()
-        with cls._cancellation_lock:
-            cls._cancellation_events[plan_id] = cancellation_event
+        return cls.launch_once(plan_id, owner_user_id)
 
-        def run() -> None:
-            context_token = bind_vertex_oidc_token(oidc_token)
-            try:
-                asyncio.run(execute_project_generation_plan(
-                    plan_id,
-                    owner_user_id,
-                    cancellation_check=cancellation_event.is_set,
-                ))
-            except Exception:
-                logger.exception("Detached generation plan failed: plan_id=%s", plan_id)
-            finally:
-                reset_vertex_oidc_token(context_token)
-                with cls._cancellation_lock:
-                    if cls._cancellation_events.get(plan_id) is cancellation_event:
-                        cls._cancellation_events.pop(plan_id, None)
+    @classmethod
+    def resume(cls, plan_id: str, owner_user_id: str):
+        """Relaunch a nonterminal detached plan if this process no longer owns it."""
 
-        Thread(target=run, name=f"forma-build-{plan_id}", daemon=True).start()
+        plan = get_project_generation_plan(plan_id, owner_user_id)
+        if plan.status in TERMINAL_PLAN_STATUSES or cls.requires_request_bound_execution():
+            return plan
+        cls.launch_once(plan_id, owner_user_id)
+        return get_project_generation_plan(plan_id, owner_user_id)
 
     @classmethod
     def signal_cancel(cls, plan_id: str) -> bool:

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -710,6 +710,29 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
                 update_generated_project_hardware_ir(project_id, response["project_ir"])
             except Exception:
                 logger.warning("Failed to persist generation timing metadata for project_id=%s", project_id, exc_info=debug_mode_enabled())
+        if generation_status == "failed":
+            generation_error = metadata.get("generation_error") if isinstance(metadata, dict) else None
+            error_message = (
+                generation_error.get("message")
+                if isinstance(generation_error, dict) and isinstance(generation_error.get("message"), str)
+                else "A required generation stage failed before a usable project could be produced."
+            )
+            raise HTTPException(
+                status_code=status.HTTP_424_FAILED_DEPENDENCY,
+                detail=api_error_detail(
+                    code="generation_stage_failed",
+                    message=error_message,
+                    job_id=job_id,
+                    provider=request.provider,
+                    model=request.model,
+                    context={
+                        "generation_status": generation_status,
+                        "project_id": project_id,
+                        "chat_id": metadata.get("chat_id"),
+                        "generation_stages": response.get("generation_stages"),
+                    },
+                ),
+            )
         return {
             **response,
             "project_id": project_id,
@@ -732,6 +755,8 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
                 model=request.model,
             ),
         ) from e
+    except HTTPException:
+        raise
     except ValueError as e:
         error_debug = exception_debug_payload(e, context=payload) if debug_mode_enabled() else None
         JOB_STORE.mark_failed(job_id, runtime_safe_error_message(str(e), provider=request.provider, model=request.model), error_debug)

--- a/apps/api/worker_plans_api.py
+++ b/apps/api/worker_plans_api.py
@@ -24,19 +24,23 @@ def _owner(user: UserContext) -> str:
     return owner
 
 
+def _owned_plan(project_id: UUID, plan_id: str, owner: str) -> WorkerExecutionPlan:
+    try:
+        plan = get_project_generation_plan(plan_id, owner)
+    except WorkerPlanningError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.as_dict()) from exc
+    if str(plan.project_id) != str(project_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Build execution not found.")
+    return plan
+
+
 @router.get("/plans/{plan_id}", response_model=WorkerExecutionPlan)
 def get_build_plan_endpoint(
     project_id: UUID,
     plan_id: str,
     user: UserContext = Depends(require_user_context),
 ) -> WorkerExecutionPlan:
-    try:
-        plan = get_project_generation_plan(plan_id, _owner(user))
-    except WorkerPlanningError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.as_dict()) from exc
-    if str(plan.project_id) != str(project_id):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Build execution not found.")
-    return plan
+    return _owned_plan(project_id, plan_id, _owner(user))
 
 
 @router.post("/plans/{plan_id}/execute", response_model=WorkerExecutionPlan)
@@ -48,13 +52,21 @@ async def execute_build_plan_endpoint(
     """Execute a plan inside this request so serverless runtimes keep it alive."""
 
     owner = _owner(user)
-    try:
-        plan = get_project_generation_plan(plan_id, owner)
-    except WorkerPlanningError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.as_dict()) from exc
-    if str(plan.project_id) != str(project_id):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Build execution not found.")
+    _owned_plan(project_id, plan_id, owner)
     return await ContextBuildDispatcher.execute(plan_id, owner)
+
+
+@router.post("/plans/{plan_id}/resume", response_model=WorkerExecutionPlan)
+def resume_build_plan_endpoint(
+    project_id: UUID,
+    plan_id: str,
+    user: UserContext = Depends(require_user_context),
+) -> WorkerExecutionPlan:
+    """Relaunch a detached plan when this process no longer owns it."""
+
+    owner = _owner(user)
+    _owned_plan(project_id, plan_id, owner)
+    return ContextBuildDispatcher.resume(plan_id, owner)
 
 
 @router.post("/plans/{plan_id}/cancel", response_model=WorkerExecutionPlan)
@@ -64,12 +76,7 @@ async def cancel_build_plan_endpoint(
     user: UserContext = Depends(require_user_context),
 ) -> WorkerExecutionPlan:
     owner = _owner(user)
-    try:
-        plan = get_project_generation_plan(plan_id, owner)
-    except WorkerPlanningError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.as_dict()) from exc
-    if str(plan.project_id) != str(project_id):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Build execution not found.")
+    _owned_plan(project_id, plan_id, owner)
     ContextBuildDispatcher.signal_cancel(plan_id)
     return await cancel_project_generation_plan(plan_id, owner)
 
@@ -83,16 +90,14 @@ async def reset_build_plan_endpoint(
     """Reset a failed generation plan so the current user can try it again."""
 
     owner = _owner(user)
+    _owned_plan(project_id, plan_id, owner)
     try:
-        plan = get_project_generation_plan(plan_id, owner)
-    except WorkerPlanningError as exc:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=exc.as_dict()) from exc
-    if str(plan.project_id) != str(project_id):
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Build execution not found.")
-    try:
-        return await reset_project_generation_plan(plan_id, owner)
+        reset_plan = await reset_project_generation_plan(plan_id, owner)
     except WorkerPlanningError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=exc.as_dict()) from exc
+    if reset_plan.status.value == "planned" and not ContextBuildDispatcher.requires_request_bound_execution():
+        ContextBuildDispatcher._launch(plan_id, owner)
+    return reset_plan
 
 
 __all__ = ["router"]

--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -10,20 +10,13 @@ import {
   shouldShowProductImageSection,
 } from "../lib/active-llms";
 import { buildProjectDocsMarkdown, docsExportFilename } from "../lib/docs-export";
-import { normalizeContextSuggestions } from "../lib/context-suggestions";
 import { usableRuntimeLlmOptions, webConfig, type RuntimeConfigContract } from "../lib/config";
 import { calculateProjectCostMetrics, resolveProjectComponentInstances } from "../lib/project-cost-metrics";
 import { useFormaAuth } from "../lib/forma-auth";
 import {
   isAuthOrSecurityHttpStatus,
   workspaceStatusBadge,
-  WORKSPACE_STATUS_STALE_AFTER_MS,
 } from "../lib/connection-status";
-import {
-  humanContextSkipChatSummary,
-  humanContextSkipPromptSection,
-} from "../lib/human-context-defaults";
-import CopyButton from "../components/copy-button";
 import {
   useAdminSession,
   useBackendLogs,
@@ -34,25 +27,15 @@ import { useDeferredTask } from "./forma-workspace/use-deferred-task";
 import {
   useVideoModels,
   type VideoGenerationMode,
-  type VideoModelOption,
 } from "./forma-workspace/use-video-models";
 import {
-  VIDEO_PROMPT_MAX_CHARS,
   useProjectVideo,
-  videoIdentity,
-  videoLabel,
-  videoPromptText,
-  videoSourceUrl,
-  type StoredVideoInfo,
 } from "./forma-workspace/use-project-video";
 import {
   JobsPanel,
   LogsPanel,
-  formatBytes,
-  isFinalVideoStatus,
 } from "./forma-workspace/admin-panels";
 import HomeChatView from "./forma-workspace/home-chat-view";
-import useChatAutoScroll from "./forma-workspace/use-chat-auto-scroll";
 import useChromeHeaderScroll from "./forma-workspace/use-chrome-header-scroll";
 import {
   hardwareReferenceSrcFromChatMessages,
@@ -65,58 +48,141 @@ import {
   ProjectGallery,
   PROJECT_GALLERY_PAGE_SIZE,
   buildProjectGalleryItems,
-  previewableImageSrc,
   type ProjectGalleryItem,
 } from "./forma-workspace/project-gallery";
 import {
-  AssemblyPanel,
-  BomPanel,
-  MechanicalPanel,
-  OverviewPanel,
-} from "./forma-workspace/project-detail-panels";
-import {
-  ChatSidebar,
   EditableWorkspaceTitle,
-  MobileSidebarButton,
-  MobileSidebarDrawer,
   MobileWorkspaceBar,
   type ChatListItem,
 } from "./forma-workspace/sidebar";
-import WorkspaceFrame from "./forma-workspace/workspace-frame";
-import UserIntegrationsPage from "./user/user-integrations-page";
-import AboutView from "./forma-workspace/about-view";
+import { WorkspaceSidebarShell } from "./forma-workspace/workspace-sidebar-shell";
+import { ProjectTabContent } from "./forma-workspace/project-tab-content";
+import { ChatWorkspace, ChatProjectArtifact, ProjectDetailWorkspace } from "./forma-workspace/project-workspace";
+import { AgentPipelineProgressView } from "./forma-workspace/pipeline-progress-view";
 import {
-  Sparkles,
-  Cpu,
-  ShieldCheck,
-  AlertTriangle,
-  CheckCircle,
-  History,
-  RefreshCw,
-  Eye,
-  Film,
-  ArrowRight,
-  ArrowLeft,
-  Layers,
-  Paperclip,
-  ExternalLink,
-  KeyRound,
-  Terminal,
-  MessageSquare,
-  Square,
-  Maximize2,
-  Minimize2,
-  Trash2,
-  Settings,
-  Handshake,
+  AuthRequiredRouteScreen,
+  ChatRouteFallbackPanel,
+  ProjectDeletionDialog,
+  ProjectRouteFallbackPanel,
+  WorkspaceChromeIdentity,
+  WorkspacePageHeading,
+} from "./forma-workspace/route-shell-ui";
+import { useContextBuildController } from "./forma-workspace/use-context-build-controller";
+import type {
+  ActiveGenerationRun,
+  ActiveGenerationState,
+  AgentPipelineProgress,
+  AgentPipelineStep,
+  ChatMessage,
+  ChatRouteTransition,
+  GenerationWorkflowOption,
+  HomeProps,
+  ImageGenerationConfig,
+  PendingProjectDeletion,
+  ProviderSetupState,
+  VideoGenerationConfig,
+} from "./forma-workspace/types";
+import {
+  ACTIVE_JOB_PROGRESS_POLL_INTERVAL_MS,
+  DEFAULT_WORKFLOW_ID,
+  defaultAgentPipelineSteps,
+  defaultGenerationWorkflows,
+  generationLlmLabel,
+  JOB_POLL_INTERVAL_MS,
+  LOG_POLL_INTERVAL_MS,
+  MAX_CHAT_INDEX_ITEMS,
+  MAX_PROJECT_CHAT_MESSAGES,
+  NEW_PROJECT_TITLE,
+  RECOVERY_JOB_BATCH_SIZE,
+  RECOVERY_JOB_MAX_BACKOFF_MS,
+  samplePrompts,
+  WEB_RESEARCH_WORKFLOW_ID,
+} from "./forma-workspace/workspace-constants";
+import { API_URL, DEFAULT_SHOW_DEVELOPER_TOOLS, downloadBrowserFile } from "./forma-workspace/workspace-api";
+import { readApiError, readApiErrorMessage } from "./forma-workspace/lib/api-errors";
+import {
+  createAgentPipelineProgress,
+  isCompletedPipelineStatus,
+  mergeMessagePipelineProgressFromJob,
+  mergeMessagesWithJobs,
+  normalizeAgentPipelineEvents,
+  normalizeAgentPipelineSteps,
+  patchChangesMessage,
+  pipelineEventCursor,
+  sameAgentPipelineProgress,
+  terminalJobMessagePatch,
+  compactDiagnosticText,
+  advancePipelineMessages,
+} from "./forma-workspace/lib/agent-pipeline";
+import {
+  chatHasStarted,
+  chatIsWaiting,
+  chatMessageIdentityKey,
+  chatTitleFromMessages,
+  initialProjectChatMessages,
+  hydrateRoutedChatMessages,
+  mergeFetchedChatMessages,
+  messagesWithoutMissingProject,
+  persistableChatMessages,
+  normalizeChatMessage,
+} from "./forma-workspace/lib/chat-normalize";
+import {
+  chatTimestamp,
+  formatChatTimestamp,
+  initialChatMessages,
+  newBuildChatId,
+  newChatMessageId,
+} from "./forma-workspace/lib/chat-ids";
+import {
+  readPinnedChatIds,
+  readStoredChatIndex,
+  readStoredChatThread,
+  removeStoredChatThread,
+  writePinnedChatIds,
+  writeStoredChatIndex,
+  writeStoredChatThread,
+  normalizeChatListItem,
+} from "./forma-workspace/lib/chat-storage";
+import {
+  buildChatListItems,
+  latestChatListItemDate,
+  mergeChatListItems,
+  mergeProjectRecords,
+  normalizePrivateChatItems,
+  normalizeProjectHistoryRecord,
+  normalizeProjectListPage,
+  projectRecordsFromChatItems,
+  sameStringList,
+  sortChatListItems,
+  upsertChatListItem,
+} from "./forma-workspace/lib/chat-list";
+import { validateGenerationInput } from "./forma-workspace/lib/generation-input";
+import {
+  chatRoute,
+  normalizeTab,
+  projectRoute,
+  safeDecodeChatId,
+  safeDecodeProjectId,
+  workspaceNamespaceForTab,
+  workspaceTabMeta,
+  workspaceTabs,
+} from "./forma-workspace/lib/workspace-routes";
+import {
+  canChatWithProjectIR,
+  chatIdFromIR,
+  chatIdFromJob,
+  formatDurationSeconds,
+  projectIdFromIR,
+  withProjectResponseMetadata,
+} from "./forma-workspace/lib/project-metadata";
+import {
   Database,
-  ChevronDown,
-  LayoutDashboard,
-  ClipboardList,
-  Cuboid,
-  CircuitBoard,
-  BookOpen,
-  Clapperboard,
+  Handshake,
+  History,
+  Layers,
+  MessageSquare,
+  Settings,
+  Terminal,
 } from "lucide-react";
 
 const SchematicCanvas = dynamic(() => import("../components/schematic-canvas"), {
@@ -128,1525 +194,36 @@ const SchematicCanvas = dynamic(() => import("../components/schematic-canvas"), 
   ),
 });
 
-const API_URL = normalizeApiUrl(webConfig.apiBaseUrl);
-const DEFAULT_SHOW_DEVELOPER_TOOLS = webConfig.publicDeveloperTools;
-const DEFAULT_WORKFLOW_ID = "default";
-const WEB_RESEARCH_WORKFLOW_ID = "web_research";
-const JOB_POLL_INTERVAL_MS = 5000;
-const ACTIVE_JOB_PROGRESS_POLL_INTERVAL_MS = 1200;
-const PIPELINE_UI_HEARTBEAT_MS = 5000;
-const PIPELINE_STALE_AFTER_MS = WORKSPACE_STATUS_STALE_AFTER_MS;
-const RECOVERY_JOB_BATCH_SIZE = 3;
-const RECOVERY_JOB_MAX_BACKOFF_MS = 60000;
-const LOG_POLL_INTERVAL_MS = 5000;
-const CHAT_THREAD_STORAGE_PREFIX = "forma.chat.";
-const CHAT_INDEX_STORAGE_KEY = "forma.chatIndex";
-const PINNED_CHATS_STORAGE_KEY = "forma.pinnedChats";
-const LEGACY_PROJECT_CHAT_STORAGE_PREFIX = "forma.projectChat.";
-const MAX_PROJECT_CHAT_MESSAGES = 80;
-const MAX_CHAT_INDEX_ITEMS = 200;
-const INITIAL_CHAT_TIMESTAMP = "2000-01-01T00:00:00.000Z";
-const NEW_PROJECT_TITLE = "New project";
+const UserIntegrationsPage = dynamic(() => import("./user/user-integrations-page"), {
+  ssr: false,
+  loading: () => (
+    <div className="rounded-xl border border-white/5 bg-[#181b22] p-6 text-sm text-zinc-400">
+      Loading settings...
+    </div>
+  ),
+});
+
+const AboutView = dynamic(() => import("./forma-workspace/about-view"), {
+  loading: () => (
+    <div className="rounded-xl border border-white/5 bg-[#181b22] p-6 text-sm text-zinc-400">
+      Loading about...
+    </div>
+  ),
+});
+
+const VideoPanel = dynamic(
+  () => import("./forma-workspace/video-panel").then((mod) => mod.VideoPanel),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-full min-h-[320px] items-center justify-center bg-[var(--forma-page)] text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">
+        Loading media...
+      </div>
+    ),
+  },
+);
 
 let lastKnownServerStatus: "connected" | "disconnected" | null = null;
-
-type GenerationWorkflowOption = {
-  id: string;
-  label: string;
-  description?: string;
-  uses_catalog?: boolean;
-  uses_web_research?: boolean;
-  uses_firecrawl_mcp?: boolean;
-  uses_external_sources?: boolean;
-};
-
-type AgentPipelineStep = {
-  id: string;
-  agent: string;
-  label: string;
-  description: string;
-  duration_ms?: number;
-  optional?: boolean;
-};
-
-type AgentPipelineEvent = {
-  workflow?: string;
-  step_id: string;
-  status: "started" | "completed" | "failed" | "skipped" | string;
-  agent?: string;
-  label?: string;
-  description?: string;
-  observed_at?: string;
-  details?: Record<string, any>;
-};
-
-type AgentPipelineProgress = {
-  startedAt: string;
-  steps: AgentPipelineStep[];
-  currentStepIndex: number;
-  estimated: boolean;
-  synced?: boolean;
-  jobId?: string | null;
-  events?: AgentPipelineEvent[];
-  uiUpdatedAt?: string;
-};
-
-type ChatMessage = {
-  id: string;
-  role: "assistant" | "user" | "system";
-  content: string;
-  status?: "idle" | "loading" | "success" | "error" | "cancelled";
-  timestamp: string;
-  projectId?: string | null;
-  pipelineProgress?: AgentPipelineProgress | null;
-  imagePreview?: string | null;
-  contextProjectId?: string | null;
-  workflowState?: string | null;
-  contextQuestions?: string[];
-  contextSuggestions?: string[];
-  buildPlanId?: string | null;
-  buildJobId?: string | null;
-};
-
-type ActiveGenerationRun = {
-  kind: "chat" | "project-chat" | "context-build";
-  controller: AbortController;
-  jobId: string | null;
-  planId?: string | null;
-  projectId?: string | null;
-  chatId: string;
-  assistantMessageId: string | null;
-  cancelled: boolean;
-};
-
-type ActiveGenerationState = Pick<ActiveGenerationRun, "kind" | "jobId">;
-
-type HumanContextQuestion = {
-  id: string;
-  label: string;
-  question: string;
-  placeholder: string;
-  suggestions: string[];
-};
-
-type PendingHumanContext = {
-  basePrompt: string;
-  questions: HumanContextQuestion[];
-  answers: Record<string, string>;
-};
-
-type PendingProjectDeletion = {
-  projectId: string;
-  title: string;
-};
-
-const defaultGenerationWorkflows: GenerationWorkflowOption[] = [
-  { id: DEFAULT_WORKFLOW_ID, label: "Catalog", description: "Catalog workflow", uses_catalog: true },
-  { id: WEB_RESEARCH_WORKFLOW_ID, label: "Web Research", description: "Live web research workflow", uses_web_research: true, uses_firecrawl_mcp: true, uses_external_sources: true },
-];
-
-const RUNPOD_PARTI_BASE_MODEL = "caid-technologies/parti-base";
-const BASETEN_GLM_MODEL = "zai-org/GLM-5.2";
-const BASETEN_DEEPSEEK_MODEL = "deepseek-ai/DeepSeek-V4-Pro";
-const ANTHROPIC_OPUS_MODEL = "claude-opus-5";
-const ANTHROPIC_SONNET_MODEL = "claude-sonnet-5";
-const GEMINI_FLASH_MODEL = "gemini-3.7-flash";
-const CLOUDFLARE_GEMMA_MODEL = "@cf/google/gemma-4-26b-a4b-it";
-const NVIDIA_GLM_MODEL = "nvidia/z-ai/glm-5.2";
-const NVIDIA_QWEN_CODER_32B_MODEL = "qwen/qwen2.5-coder-32b-instruct";
-const NVIDIA_LLAMA_8B_MODEL = "meta/llama-3.1-8b-instruct";
-
-const defaultAgentPipelineSteps: AgentPipelineStep[] = [
-  {
-    id: "safety_guardrail",
-    agent: "Safety Guardrail",
-    label: "Checking safe build scope",
-    description: "Screening the request for low-voltage maker hardware constraints.",
-    duration_ms: 3500,
-  },
-  {
-    id: "context_clarifier",
-    agent: "Context Clarifier Agent",
-    label: "Clarifying build context",
-    description: "Checking whether user-provided answers should be folded into generation.",
-    duration_ms: 2500,
-  },
-  {
-    id: "intent_parser",
-    agent: "Intent Parser Agent",
-    label: "Parsing the hardware idea",
-    description: "Converting the prompt into project intent and category.",
-    duration_ms: 5500,
-  },
-  {
-    id: "requirements",
-    agent: "Requirements Agent",
-    label: "Extracting requirements",
-    description: "Capturing functions, voltage, constraints, and safety notes.",
-    duration_ms: 5500,
-  },
-  {
-    id: "system_architecture",
-    agent: "System Architecture Agent",
-    label: "Decomposing the complete system",
-    description: "Building a purpose-driven tree of electrical, mechanical, firmware, and nested subsystems.",
-    duration_ms: 5500,
-  },
-  {
-    id: "component_selection",
-    agent: "Component Selection Agent",
-    label: "Selecting compatible parts",
-    description: "Choosing parts by system role before exact catalog pins are hydrated.",
-    duration_ms: 6500,
-  },
-  {
-    id: "wiring_netlist",
-    agent: "Wiring/Netlist Agent",
-    label: "Drafting nets and pin mappings",
-    description: "Connecting power, ground, buses, controller pins, and peripherals.",
-    duration_ms: 6500,
-  },
-  {
-    id: "validation_repair",
-    agent: "Validation + Auto-Correction Agent",
-    label: "Validating and repairing wiring",
-    description: "Checking shorts, voltage mismatches, unpowered parts, and pin conflicts.",
-    duration_ms: 5500,
-  },
-  {
-    id: "bom",
-    agent: "BOM Agent",
-    label: "Calculating BOM and cost",
-    description: "Summing selected components and updating the project estimate.",
-    duration_ms: 3000,
-  },
-  {
-    id: "mechanical_fabrication",
-    agent: "Mechanical/Fabrication Agent",
-    label: "Designing enclosure and placement",
-    description: "Generating mounting, fabrication, CAD, and 3D placement details.",
-    duration_ms: 6500,
-  },
-  {
-    id: "assembly",
-    agent: "Assembly Instruction Agent",
-    label: "Writing build steps",
-    description: "Producing sequential assembly instructions and safety flags.",
-    duration_ms: 5500,
-  },
-  {
-    id: "package_project",
-    agent: "Project Packager",
-    label: "Packaging project artifacts",
-    description: "Building the HardwareIR, diagrams, validation summary, and saved record.",
-    duration_ms: 3500,
-  },
-];
-
-const optionalImagePipelineStep: AgentPipelineStep = {
-  id: "image_generation",
-  agent: "Product Image Agent",
-  label: "Generating product visuals",
-  description: "Creating optional concept images from the completed HardwareIR visual spec.",
-  duration_ms: 8000,
-  optional: true,
-};
-
-const CHAT_DIAGNOSTIC_CHARACTER_LIMIT = 420;
-
-function generationLlmLabel(provider: string, model: string) {
-  if (provider === "runpod-serverless" && model === RUNPOD_PARTI_BASE_MODEL) return RUNPOD_PARTI_BASE_MODEL;
-  if (provider === "runpod" && model === RUNPOD_PARTI_BASE_MODEL) return "Runpod Parti Base";
-  if (provider === "baseten" && model === BASETEN_GLM_MODEL) return "GLM 5.2";
-  if (provider === "baseten" && model === BASETEN_DEEPSEEK_MODEL) return "Baseten DeepSeek V4 Pro";
-  if (provider === "anthropic" && model === ANTHROPIC_OPUS_MODEL) return "Claude Opus 5";
-  if (provider === "anthropic" && model === ANTHROPIC_SONNET_MODEL) return "Claude Sonnet 5";
-  if (provider === "gemini" && model === GEMINI_FLASH_MODEL) return "Gemini 3.7 Flash";
-  if (provider === "vertex" && model === GEMINI_FLASH_MODEL) return "Vertex Gemini 3.7 Flash";
-  if (provider === "huggingface") return `Hugging Face ${model}`;
-  if (provider === "gmi" && model === "anthropic/claude-fable-5") return "GMI Claude Fable 5";
-  if (provider === "cloudflare" && model === CLOUDFLARE_GEMMA_MODEL) return "Cloudflare Gemma 4 26B A4B";
-  if (provider === "nvidia" && model === NVIDIA_GLM_MODEL) return "NVIDIA GLM 5.2";
-  if (provider === "nvidia" && model === NVIDIA_QWEN_CODER_32B_MODEL) return "NVIDIA Qwen2.5 Coder 32B";
-  if (provider === "nvidia" && model === NVIDIA_LLAMA_8B_MODEL) return "NVIDIA Llama 3.1 8B";
-  if (provider === "simulation") return "Local Simulation";
-  return `${provider} ${model}`.trim();
-}
-
-function normalizeApiUrl(value: string) {
-  const trimmed = value.trim().replace(/\/+$/, "");
-  if (!trimmed) return "/api";
-  return trimmed.endsWith("/api") ? trimmed : `${trimmed}/api`;
-}
-
-function downloadBrowserFile(contents: string, filename: string, mimeType: string) {
-  const blob = new Blob([contents], { type: mimeType });
-  const url = URL.createObjectURL(blob);
-  const link = document.createElement("a");
-  link.href = url;
-  link.download = filename;
-  document.body.appendChild(link);
-  link.click();
-  link.remove();
-  URL.revokeObjectURL(url);
-}
-
-const samplePrompts = [
-  "Compact handheld device with display, controls, USB-C power, and enclosure",
-  "Environmental monitor with sensor feedback, display, and battery power",
-  "Small controller for a low-voltage actuator or relay",
-];
-
-function newChatMessageId() {
-  return `chat-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-}
-
-function newBuildChatId() {
-  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-    return crypto.randomUUID();
-  }
-  return `chat-${Date.now()}-${Math.random().toString(16).slice(2)}`;
-}
-
-function newFrontendJobId() {
-  const suffix = typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
-    ? crypto.randomUUID()
-    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
-  return `job_frontend_${suffix.replace(/[^A-Za-z0-9_.:-]/g, "_")}`;
-}
-
-function chatTimestamp() {
-  return new Date().toISOString();
-}
-
-function formatChatTimestamp(value: string) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return "";
-  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-}
-
-function initialChatMessages(timestamp: string = INITIAL_CHAT_TIMESTAMP): ChatMessage[] {
-  return [
-    {
-      id: "assistant-welcome",
-      role: "assistant",
-      content:
-        "Tell me what you want to build. I can turn it into a project with parts, wiring, mechanical notes, validation, jobs, and optional product images.",
-      status: "idle",
-      timestamp,
-    },
-  ];
-}
-
-function validChatStatus(value: any): ChatMessage["status"] {
-  return ["idle", "loading", "success", "error", "cancelled"].includes(value) ? value : "idle";
-}
-
-function validChatRole(value: any): ChatMessage["role"] {
-  return ["assistant", "user", "system"].includes(value) ? value : "assistant";
-}
-
-function normalizeChatMessage(value: any): ChatMessage | null {
-  if (!value || typeof value !== "object" || typeof value.content !== "string") return null;
-  const buildExecutionStatus = typeof value.buildExecution?.status === "string"
-    ? value.buildExecution.status
-    : "";
-  const normalizedStatus = buildExecutionStatus === "planned" || buildExecutionStatus === "running"
-    ? "loading"
-    : validChatStatus(value.status);
-  return {
-    id: typeof value.id === "string" && value.id ? value.id : newChatMessageId(),
-    role: validChatRole(value.role),
-    content: value.content,
-    status: normalizedStatus,
-    timestamp: typeof value.timestamp === "string" && value.timestamp ? value.timestamp : chatTimestamp(),
-    projectId: typeof value.projectId === "string" ? value.projectId : null,
-    pipelineProgress: normalizeAgentPipelineProgress(value.pipelineProgress),
-    imagePreview: typeof value.imagePreview === "string" ? value.imagePreview : null,
-    contextProjectId: typeof value.contextProjectId === "string"
-      ? value.contextProjectId
-      : typeof value.context_project_id === "string"
-        ? value.context_project_id
-        : null,
-    workflowState: typeof value.workflowState === "string"
-      ? value.workflowState
-      : typeof value.workflow_state === "string"
-        ? value.workflow_state
-        : null,
-    contextQuestions: (Array.isArray(value.contextQuestions) ? value.contextQuestions : value.questions)
-      ?.filter((question: unknown): question is string => typeof question === "string" && Boolean(question.trim()))
-      .map((question: string) => question.trim()) || [],
-    contextSuggestions: normalizeContextSuggestions(value.contextSuggestions ?? value.suggestions),
-    buildPlanId: typeof value.buildPlanId === "string"
-      ? value.buildPlanId
-      : typeof value.build_plan_id === "string"
-        ? value.build_plan_id
-        : typeof value.buildExecution?.plan_id === "string"
-          ? value.buildExecution.plan_id
-          : null,
-    buildJobId: typeof value.buildJobId === "string"
-      ? value.buildJobId
-      : typeof value.build_job_id === "string"
-        ? value.build_job_id
-        : typeof value.buildExecution?.job_id === "string"
-          ? value.buildExecution.job_id
-          : null,
-  };
-}
-
-function chatHasStarted(messages: ChatMessage[]) {
-  return messages.some((message) => message.role === "user" || Boolean(message.projectId));
-}
-
-function chatTitleFromMessages(messages: ChatMessage[], fallback = NEW_PROJECT_TITLE) {
-  const firstUserMessage = messages.find((message) => message.role === "user" && message.content.trim());
-  const title = firstUserMessage?.content.trim().replace(/\s+/g, " ");
-  if (!title) return fallback;
-  return title.length > 80 ? `${title.slice(0, 77)}...` : title;
-}
-
-function persistableChatMessages(messages: ChatMessage[]): ChatMessage[] {
-  return messages
-    .map(normalizeChatMessage)
-    .filter((message: ChatMessage | null): message is ChatMessage => Boolean(message))
-    .slice(-MAX_PROJECT_CHAT_MESSAGES);
-}
-
-function mergeFetchedChatMessages(remoteMessages: ChatMessage[], localMessages: ChatMessage[]): ChatMessage[] {
-  const localById = new Map(localMessages.map((message) => [message.id, message]));
-  const seen = new Set<string>();
-  const merged: ChatMessage[] = [];
-
-  remoteMessages.forEach((remote) => {
-    if (seen.has(remote.id)) return;
-    seen.add(remote.id);
-    const local = localById.get(remote.id);
-    if (!local) {
-      merged.push(remote);
-      return;
-    }
-
-    const localIsTerminal = ["success", "error", "cancelled"].includes(local.status || "");
-    const remoteRegressed = localIsTerminal && remote.status === "loading";
-    merged.push({
-      ...local,
-      ...remote,
-      content: remoteRegressed ? local.content : remote.content,
-      status: remoteRegressed ? local.status : remote.status,
-      timestamp: remoteRegressed ? local.timestamp : remote.timestamp,
-      projectId: remote.projectId || local.projectId || null,
-      pipelineProgress: remote.pipelineProgress || local.pipelineProgress || null,
-      contextProjectId: remote.contextProjectId || local.contextProjectId || null,
-      buildPlanId: remote.buildPlanId || local.buildPlanId || null,
-      buildJobId: remote.buildJobId || local.buildJobId || null,
-      imagePreview: remote.imagePreview || local.imagePreview || null,
-    });
-  });
-
-  localMessages.forEach((local) => {
-    if (!seen.has(local.id)) merged.push(local);
-  });
-  return merged.slice(-MAX_PROJECT_CHAT_MESSAGES);
-}
-
-function chatIsWaiting(messages: ChatMessage[]) {
-  return messages.some((message) => message.status === "loading");
-}
-
-function chatMessageIdentityKey(messages: ChatMessage[]) {
-  return messages.map((message) => message.id).join("|");
-}
-
-function normalizeProjectHistoryRecord(value: any): any | null {
-  if (!value || typeof value !== "object") return null;
-  const projectId = typeof value.project_id === "string" ? value.project_id.trim() : "";
-  if (!projectId) return null;
-  const creatorDisplay =
-    typeof value.creator_username === "string" && value.creator_username.trim()
-      ? value.creator_username.trim()
-      : typeof value.creator_display === "string" && value.creator_display.trim()
-        ? value.creator_display.trim()
-        : "unknown";
-  const creatorImageUrl =
-    typeof value.creator_image_url === "string" && value.creator_image_url.trim()
-      ? value.creator_image_url.trim()
-      : typeof value.creatorImageUrl === "string" && value.creatorImageUrl.trim()
-        ? value.creatorImageUrl.trim()
-        : null;
-  return {
-    ...value,
-    project_id: projectId,
-    chat_id: typeof value.chat_id === "string" ? value.chat_id.trim() : "",
-    title: typeof value.title === "string" && value.title.trim() ? value.title.trim() : "Untitled project",
-    prompt: typeof value.prompt === "string" ? value.prompt : "",
-    created_at: typeof value.created_at === "string" && value.created_at ? value.created_at : chatTimestamp(),
-    visibility: value.visibility === "private" ? "private" : "public",
-    can_chat: Boolean(value.can_chat ?? value.canChat),
-    creator_display: creatorDisplay,
-    creator_username: creatorDisplay,
-    creator_image_url: creatorImageUrl,
-    parts_count: Math.max(0, Number(value.parts_count || value.partsCount || 0)),
-    save_count: Math.max(0, Number(value.save_count || value.saveCount || 0)),
-    remix_count: Math.max(0, Number(value.remix_count || value.remixCount || 0)),
-    saved: Boolean(value.saved),
-  };
-}
-
-function normalizeAgentPipelineStep(value: any): AgentPipelineStep | null {
-  if (!value || typeof value !== "object") return null;
-  const id = typeof value.id === "string" && value.id.trim() ? value.id.trim() : "";
-  const label = typeof value.label === "string" && value.label.trim() ? value.label.trim() : "";
-  if (!id || !label) return null;
-  return {
-    id,
-    label,
-    agent: typeof value.agent === "string" && value.agent.trim() ? value.agent.trim() : label,
-    description: typeof value.description === "string" ? value.description : "",
-    duration_ms: Number.isFinite(Number(value.duration_ms)) ? Math.max(1000, Number(value.duration_ms)) : undefined,
-    optional: Boolean(value.optional),
-  };
-}
-
-function normalizeAgentPipelineSteps(value: any): AgentPipelineStep[] {
-  const rawSteps = Array.isArray(value?.steps) ? value.steps : Array.isArray(value) ? value : [];
-  const steps = rawSteps.map(normalizeAgentPipelineStep).filter(Boolean) as AgentPipelineStep[];
-  return steps.length ? steps : defaultAgentPipelineSteps;
-}
-
-function normalizeAgentPipelineProgress(value: any): AgentPipelineProgress | null {
-  if (!value || typeof value !== "object") return null;
-  const steps = normalizeAgentPipelineSteps(value.steps);
-  const events = normalizeAgentPipelineEvents(value.events);
-  return {
-    startedAt: typeof value.startedAt === "string" && value.startedAt ? value.startedAt : chatTimestamp(),
-    steps,
-    currentStepIndex: Math.min(Math.max(Number(value.currentStepIndex || 0), 0), Math.max(steps.length - 1, 0)),
-    estimated: value.estimated !== false,
-    synced: Boolean(value.synced),
-    jobId: typeof value.jobId === "string" ? value.jobId : null,
-    events,
-    uiUpdatedAt: typeof value.uiUpdatedAt === "string" && value.uiUpdatedAt ? value.uiUpdatedAt : chatTimestamp(),
-  };
-}
-
-function normalizeAgentPipelineEvents(value: any): AgentPipelineEvent[] {
-  const rawEvents = Array.isArray(value) ? value : [];
-  return rawEvents
-    .map((event) => {
-      if (!event || typeof event !== "object" || typeof event.step_id !== "string") return null;
-      return {
-        workflow: typeof event.workflow === "string" ? event.workflow : undefined,
-        step_id: event.step_id,
-        status: typeof event.status === "string" ? event.status : "started",
-        agent: typeof event.agent === "string" ? event.agent : undefined,
-        label: typeof event.label === "string" ? event.label : undefined,
-        description: typeof event.description === "string" ? event.description : undefined,
-        observed_at: typeof event.observed_at === "string" ? event.observed_at : undefined,
-        details: event.details && typeof event.details === "object" ? event.details : undefined,
-      };
-    })
-    .filter(Boolean) as AgentPipelineEvent[];
-}
-
-function stepsForPipelineRun(steps: AgentPipelineStep[], includeImage: boolean) {
-  const normalized = steps.length ? steps : defaultAgentPipelineSteps;
-  const baseSteps = normalized.filter((step) => !step.optional || includeImage);
-  if (includeImage && !baseSteps.some((step) => step.id === optionalImagePipelineStep.id)) {
-    return [...baseSteps, optionalImagePipelineStep];
-  }
-  return baseSteps;
-}
-
-function createAgentPipelineProgress(
-  steps: AgentPipelineStep[],
-  includeImage: boolean,
-  startedAt: string = chatTimestamp(),
-  jobId: string | null = null
-): AgentPipelineProgress {
-  return {
-    startedAt,
-    steps: stepsForPipelineRun(steps, includeImage),
-    currentStepIndex: 0,
-    estimated: true,
-    synced: false,
-    jobId,
-    events: [],
-    uiUpdatedAt: startedAt,
-  };
-}
-
-function shouldPulsePipelineUi(progress: AgentPipelineProgress, nowMs: number) {
-  const lastUiMs = timestampMs(progress.uiUpdatedAt);
-  return lastUiMs === null || nowMs - lastUiMs >= PIPELINE_UI_HEARTBEAT_MS;
-}
-
-function agentPipelineStepIndex(progress: AgentPipelineProgress, nowMs: number) {
-  const startedMs = Date.parse(progress.startedAt);
-  const elapsedMs = Math.max(0, nowMs - (Number.isNaN(startedMs) ? nowMs : startedMs));
-  let accumulatedMs = 0;
-  for (let index = 0; index < progress.steps.length; index += 1) {
-    accumulatedMs += progress.steps[index].duration_ms || 5500;
-    if (elapsedMs < accumulatedMs) return index;
-  }
-  return Math.max(0, progress.steps.length - 1);
-}
-
-function advanceAgentPipelineProgress(progress: AgentPipelineProgress, nowMs: number): AgentPipelineProgress {
-  if (progress.synced || progress.estimated === false) {
-    return shouldPulsePipelineUi(progress, nowMs)
-      ? { ...progress, uiUpdatedAt: new Date(nowMs).toISOString() }
-      : progress;
-  }
-  const currentStepIndex = agentPipelineStepIndex(progress, nowMs);
-  if (currentStepIndex !== progress.currentStepIndex) {
-    return { ...progress, currentStepIndex, uiUpdatedAt: new Date(nowMs).toISOString() };
-  }
-  return shouldPulsePipelineUi(progress, nowMs)
-    ? { ...progress, uiUpdatedAt: new Date(nowMs).toISOString() }
-    : progress;
-}
-
-function pipelineEventCursor(events: AgentPipelineEvent[] | undefined) {
-  const normalizedEvents = normalizeAgentPipelineEvents(events);
-  const lastEvent = normalizedEvents[normalizedEvents.length - 1];
-  return [
-    normalizedEvents.length,
-    lastEvent?.observed_at || "",
-    lastEvent?.step_id || "",
-    lastEvent?.status || "",
-  ].join(":");
-}
-
-function isFailedPipelineStatus(status: any) {
-  return String(status || "").toLowerCase().includes("failed");
-}
-
-function isCompletedPipelineStatus(status: any) {
-  const normalized = String(status || "").toLowerCase();
-  return normalized === "completed" || normalized === "provider_response_received";
-}
-
-function failedPipelineEvent(events: AgentPipelineEvent[] | undefined) {
-  const normalizedEvents = normalizeAgentPipelineEvents(events);
-  return [...normalizedEvents].reverse().find((event) => isFailedPipelineStatus(event.status)) || null;
-}
-
-function pipelineEventsFromWorkerTask(task: any): AgentPipelineEvent[] {
-  if (!Array.isArray(task?.progress)) return [];
-  return normalizeAgentPipelineEvents(
-    task.progress.map((item: any) => item?.metadata?.pipeline_event).filter(Boolean),
-  );
-}
-
-function compactDiagnosticText(value: any, limit: number = CHAT_DIAGNOSTIC_CHARACTER_LIMIT) {
-  const original = String(value || "").trim();
-  if (!original) return "";
-
-  const normalized = original
-    .replace(/\r\n/g, "\n")
-    .replace(/https:\/\/errors\.pydantic\.dev\/\S+/g, "")
-    .replace(/,\s*input_value=(?:'[^']*'|"[^"]*"|[^\]\n]*)/g, "")
-    .replace(/,\s*input_type=[^\]\n]+/g, "")
-    .replace(/\[type=([^,\]\s]+)[^\]]*\]/g, "[type=$1]");
-
-  const lines = normalized
-    .split("\n")
-    .map((line) => line.replace(/[ \t]+/g, " ").trim())
-    .filter(Boolean)
-    .filter((line) => !/^for further information visit/i.test(line))
-    .filter((line) => !/^input_(value|type)=/i.test(line));
-  const text = lines.join("\n") || original;
-
-  if (text.length <= limit) return text;
-  const clipped = text.slice(0, limit).replace(/\s+\S*$/, "").trimEnd();
-  return `${clipped || text.slice(0, limit).trimEnd()}...`;
-}
-
-function generationFailureChatMessage(message: string, includeJobsHint = false) {
-  const compact = compactDiagnosticText(message);
-  const content = compact
-    ? /^generation failed\b/i.test(compact)
-      ? compact
-      : `Generation failed: ${compact}`
-    : "Generation failed.";
-  return includeJobsHint ? `${content}\nFull diagnostics are available in Jobs.` : content;
-}
-
-function jobFailureMessage(job: A2AJob) {
-  const event = failedPipelineEvent(job.progress_events);
-  const eventDetails = event?.details || {};
-  const reason = job.error || eventDetails.error || eventDetails.reason || eventDetails.message;
-  if (reason) return String(reason);
-  if (event?.label) return `${event.label} failed.`;
-  return "Generation failed.";
-}
-
-function terminalJobMessagePatch(job: A2AJob, message: ChatMessage): Partial<Omit<ChatMessage, "id">> | null {
-  if (message.status !== "loading") return null;
-  if (["cancelled", "canceled"].includes(String(job.status || "").toLowerCase())) {
-    return {
-      content: "Generation stopped by you.",
-      status: "cancelled",
-    };
-  }
-  if (job.status === "failed") {
-    return {
-      content: generationFailureChatMessage(jobFailureMessage(job), true),
-      status: "error",
-    };
-  }
-  if (job.status === "succeeded") {
-    const title = job.result_summary?.title || "Project";
-    const projectId = typeof job.result_summary?.project_id === "string" ? job.result_summary.project_id : null;
-    return {
-      content: `${title} is ready.`,
-      status: "success",
-      projectId,
-    };
-  }
-  return null;
-}
-
-function patchChangesMessage(message: ChatMessage, patch: Partial<Omit<ChatMessage, "id">> | null) {
-  if (!patch) return false;
-  return Object.entries(patch).some(([key, value]) => (message as any)[key] !== value);
-}
-
-function sameAgentPipelineProgress(left: AgentPipelineProgress | null | undefined, right: AgentPipelineProgress | null | undefined) {
-  if (left === right) return true;
-  if (!left || !right) return false;
-  return (
-    left.currentStepIndex === right.currentStepIndex &&
-    left.estimated === right.estimated &&
-    Boolean(left.synced) === Boolean(right.synced) &&
-    (left.jobId || null) === (right.jobId || null) &&
-    pipelineEventCursor(left.events) === pipelineEventCursor(right.events)
-  );
-}
-
-function progressFromJobEvents(
-  job: A2AJob | null,
-  fallback: AgentPipelineProgress,
-  includeImage: boolean
-): AgentPipelineProgress | null {
-  const events = normalizeAgentPipelineEvents(job?.progress_events);
-  if (!events.length) return null;
-  const previousEvents = normalizeAgentPipelineEvents(fallback.events);
-  if (fallback.synced && previousEvents.length > events.length) return fallback;
-  const steps = stepsForPipelineRun(fallback.steps, includeImage);
-  const indexByStep = new Map(steps.map((step, index) => [step.id, index]));
-  let currentStepIndex = fallback.currentStepIndex;
-  for (const event of events) {
-    const eventIndex = indexByStep.get(event.step_id);
-    if (eventIndex === undefined) continue;
-    if (isCompletedPipelineStatus(event.status) || event.status === "skipped") {
-      currentStepIndex = Math.min(eventIndex + 1, Math.max(steps.length - 1, 0));
-    } else {
-      currentStepIndex = eventIndex;
-    }
-  }
-  if (fallback.synced && previousEvents.length >= events.length && currentStepIndex < fallback.currentStepIndex) {
-    return fallback;
-  }
-  return {
-    ...fallback,
-    startedAt: job?.started_at || fallback.startedAt,
-    steps,
-    currentStepIndex,
-    estimated: false,
-    synced: true,
-    jobId: job?.job_id || fallback.jobId || null,
-    events,
-    uiUpdatedAt: chatTimestamp(),
-  };
-}
-
-function mergeMessagePipelineProgressFromJob(
-  message: ChatMessage,
-  job: A2AJob,
-  seedProgress: AgentPipelineProgress,
-  includeImage: boolean
-) {
-  const nextProgress = progressFromJobEvents(job, message.pipelineProgress || seedProgress, includeImage);
-  const terminalPatch = terminalJobMessagePatch(job, message);
-  const progressChanged = Boolean(nextProgress && !sameAgentPipelineProgress(message.pipelineProgress, nextProgress));
-  const patchChanged = patchChangesMessage(message, terminalPatch);
-  if (!progressChanged && !patchChanged) return message;
-  return {
-    ...message,
-    ...(terminalPatch || {}),
-    pipelineProgress: nextProgress || message.pipelineProgress || null,
-    timestamp: chatTimestamp(),
-  };
-}
-
-function progressIncludesImageStep(progress: AgentPipelineProgress | null | undefined) {
-  return Boolean(progress?.steps?.some((step) => step.id === optionalImagePipelineStep.id || step.optional));
-}
-
-function mergeMessagesWithJobs(
-  messages: ChatMessage[],
-  jobsById: Map<string, A2AJob>,
-  includeImageDefault: boolean
-) {
-  let changed = false;
-  const nextMessages = messages.map((message) => {
-    const jobId = message.pipelineProgress?.jobId;
-    if (!jobId) return message;
-    const job = jobsById.get(jobId);
-    if (!job || !message.pipelineProgress) return message;
-    const includeImage = includeImageDefault || progressIncludesImageStep(message.pipelineProgress);
-    const nextMessage = mergeMessagePipelineProgressFromJob(message, job, message.pipelineProgress, includeImage);
-    if (nextMessage !== message) changed = true;
-    return nextMessage;
-  });
-  return changed ? nextMessages : messages;
-}
-
-function advancePipelineMessages(messages: ChatMessage[], nowMs: number) {
-  let changed = false;
-  const nextMessages = messages.map((message) => {
-    if (message.status !== "loading" || !message.pipelineProgress) return message;
-    const nextProgress = advanceAgentPipelineProgress(message.pipelineProgress, nowMs);
-    if (nextProgress === message.pipelineProgress) return message;
-    changed = true;
-    return { ...message, pipelineProgress: nextProgress };
-  });
-  return changed ? nextMessages : messages;
-}
-
-function pipelineEventTimestampMs(event: AgentPipelineEvent | null | undefined): number | null {
-  return timestampMs(event?.observed_at);
-}
-
-function latestPipelineEvent(events: AgentPipelineEvent[]) {
-  const normalizedEvents = normalizeAgentPipelineEvents(events);
-  return normalizedEvents[normalizedEvents.length - 1] || null;
-}
-
-function pipelineStepForEvent(progress: AgentPipelineProgress, event: AgentPipelineEvent | null | undefined) {
-  if (!event) return null;
-  return progress.steps.find((step) => step.id === event.step_id) || null;
-}
-
-function activePipelineStep(progress: AgentPipelineProgress) {
-  const events = normalizeAgentPipelineEvents(progress.events);
-  const lastEvent = latestPipelineEvent(events);
-  const stepFromEvent = pipelineStepForEvent(progress, lastEvent);
-  if (lastEvent && !isCompletedPipelineStatus(lastEvent.status) && lastEvent.status !== "skipped") {
-    return stepFromEvent || progress.steps[progress.currentStepIndex] || progress.steps[0] || null;
-  }
-  return progress.steps[progress.currentStepIndex] || stepFromEvent || progress.steps[0] || null;
-}
-
-function completedPipelineStepCount(progress: AgentPipelineProgress) {
-  const completed = new Set<string>();
-  normalizeAgentPipelineEvents(progress.events).forEach((event) => {
-    if (isCompletedPipelineStatus(event.status) || event.status === "skipped") completed.add(event.step_id);
-    if (isFailedPipelineStatus(event.status)) completed.delete(event.step_id);
-  });
-  if (completed.size) return completed.size;
-  return progress.estimated ? Math.max(0, progress.currentStepIndex) : 0;
-}
-
-function pipelineStepStatus(
-  progress: AgentPipelineProgress,
-  step: AgentPipelineStep,
-  activeStepId: string | null,
-  isRunning: boolean = false
-) {
-  const events = normalizeAgentPipelineEvents(progress.events);
-  const stepEvents = events.filter((event) => event.step_id === step.id);
-  const lastStepEvent = stepEvents[stepEvents.length - 1];
-  // A failed attempt may be followed by a retry while the job remains active.
-  // Keep the current step neutral until the job itself reaches a failed state.
-  if (isRunning && activeStepId === step.id) return "active";
-  if (isFailedPipelineStatus(lastStepEvent?.status)) return "failed";
-  if (lastStepEvent?.status === "skipped") return "skipped";
-  if (isCompletedPipelineStatus(lastStepEvent?.status)) return "completed";
-  if (activeStepId === step.id) return "active";
-  return "pending";
-}
-
-function formatPipelineAge(value?: string | null, nowMs: number = Date.now()) {
-  const ms = timestampMs(value);
-  if (ms === null) return "-";
-  return formatDurationSeconds(Math.max(1, Math.round((nowMs - ms) / 1000)));
-}
-
-function formatPipelineDetails(details: Record<string, any> | undefined) {
-  if (!details || typeof details !== "object") return "";
-  return Object.entries(details)
-    .filter(([, value]) => value !== null && value !== undefined && value !== "")
-    .slice(0, 3)
-    .map(([key, value]) => {
-      const rawText = typeof value === "string" ? value : JSON.stringify(value);
-      const text = typeof rawText === "string" ? rawText : String(value);
-      return `${key.replace(/_/g, " ")}: ${text.length > 80 ? `${text.slice(0, 77)}...` : text}`;
-    })
-    .join(" / ");
-}
-
-function PipelineStepDot({ status }: { status: string }) {
-  const tone =
-    status === "completed"
-      ? "border-emerald-400 bg-emerald-400"
-      : status === "failed"
-        ? "border-rose-400 bg-rose-400"
-        : status === "skipped"
-          ? "border-slate-600 bg-slate-800"
-          : status === "active"
-            ? "border-cyan-300 bg-cyan-300"
-            : "border-slate-700 bg-black";
-  return <span className={`h-2.5 w-2.5 shrink-0 border ${tone}`} />;
-}
-
-function chatThreadStorageKey(chatId: string, scope = "local") {
-  return scope === "local"
-    ? `${CHAT_THREAD_STORAGE_PREFIX}${chatId}`
-    : `${CHAT_THREAD_STORAGE_PREFIX}${encodeURIComponent(scope)}.${chatId}`;
-}
-
-function legacyProjectChatStorageKey(projectId: string) {
-  return `${LEGACY_PROJECT_CHAT_STORAGE_PREFIX}${projectId}`;
-}
-
-function readStoredChatThread(chatId: string, legacyProjectId?: string | null, scope = "local"): ChatMessage[] {
-  if (typeof window === "undefined" || !chatId) return [];
-  try {
-    const raw = window.localStorage.getItem(chatThreadStorageKey(chatId, scope))
-      || (scope === "local" && legacyProjectId ? window.localStorage.getItem(legacyProjectChatStorageKey(legacyProjectId)) : null);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.map(normalizeChatMessage).filter(Boolean) as ChatMessage[] : [];
-  } catch {
-    return [];
-  }
-}
-
-function writeStoredChatThread(chatId: string, messages: ChatMessage[], scope = "local") {
-  if (typeof window === "undefined" || !chatId) return;
-  try {
-    window.localStorage.setItem(chatThreadStorageKey(chatId, scope), JSON.stringify(messages.slice(-MAX_PROJECT_CHAT_MESSAGES)));
-  } catch {
-    // Local chat history is best-effort.
-  }
-}
-
-function normalizeChatListItem(value: any): ChatListItem | null {
-  if (!value || typeof value !== "object") return null;
-  const chatId = typeof value.chatId === "string" ? value.chatId.trim() : "";
-  if (!chatId) return null;
-  return {
-    chatId,
-    title: typeof value.title === "string" && value.title.trim() ? value.title.trim() : NEW_PROJECT_TITLE,
-    projectId: typeof value.projectId === "string" ? value.projectId : "",
-    createdAt: typeof value.createdAt === "string" && value.createdAt ? value.createdAt : chatTimestamp(),
-    projectCount: Math.max(0, Number(value.projectCount || 0)),
-  };
-}
-
-function chatIndexStorageKey(scope = "local") {
-  return scope === "local"
-    ? CHAT_INDEX_STORAGE_KEY
-    : `${CHAT_INDEX_STORAGE_KEY}.${encodeURIComponent(scope)}`;
-}
-
-function readStoredChatIndex(scope = "local"): ChatListItem[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = window.localStorage.getItem(chatIndexStorageKey(scope));
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.map(normalizeChatListItem).filter(Boolean) as ChatListItem[] : [];
-  } catch {
-    return [];
-  }
-}
-
-function writeStoredChatIndex(items: ChatListItem[], scope = "local") {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(chatIndexStorageKey(scope), JSON.stringify(items.slice(0, MAX_CHAT_INDEX_ITEMS)));
-  } catch {
-    // Local chat index is best-effort.
-  }
-}
-
-function pinnedChatsStorageKey(scope = "local") {
-  return scope === "local"
-    ? PINNED_CHATS_STORAGE_KEY
-    : `${PINNED_CHATS_STORAGE_KEY}.${encodeURIComponent(scope)}`;
-}
-
-function readPinnedChatIds(scope = "local"): string[] {
-  if (typeof window === "undefined") return [];
-  try {
-    const raw = window.localStorage.getItem(pinnedChatsStorageKey(scope));
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed)
-      ? parsed.filter((value: unknown): value is string => typeof value === "string" && Boolean(value.trim()))
-      : [];
-  } catch {
-    return [];
-  }
-}
-
-function writePinnedChatIds(ids: Iterable<string>, scope = "local") {
-  if (typeof window === "undefined") return;
-  try {
-    window.localStorage.setItem(pinnedChatsStorageKey(scope), JSON.stringify(Array.from(ids)));
-  } catch {
-    // Pinned chat ids are best-effort.
-  }
-}
-
-function removeStoredChatThread(chatId: string, scope = "local") {
-  if (typeof window === "undefined" || !chatId) return;
-  try {
-    window.localStorage.removeItem(chatThreadStorageKey(chatId, scope));
-  } catch {
-    // Local chat history is best-effort.
-  }
-}
-
-function chatListItemTime(value: string | null | undefined): number {
-  const normalizedValue = value?.trim() || "";
-  // Project creation timestamps have historically been emitted as UTC without a
-  // timezone suffix. Treat them as UTC so they compare correctly with chat
-  // updated_at values, which include "Z".
-  const timestamp = Date.parse(
-    normalizedValue && !/(?:z|[+-]\d{2}:?\d{2})$/i.test(normalizedValue)
-      ? `${normalizedValue}Z`
-      : normalizedValue
-  );
-  return Number.isNaN(timestamp) ? 0 : timestamp;
-}
-
-function latestChatListItemDate(
-  left: string | null | undefined,
-  right: string | null | undefined
-): string | null {
-  return chatListItemTime(right) > chatListItemTime(left) ? right || null : left || right || null;
-}
-
-function sortChatListItems(items: ChatListItem[]): ChatListItem[] {
-  return [...items].sort((left, right) => {
-    if (Boolean(left.pinned) !== Boolean(right.pinned)) return left.pinned ? -1 : 1;
-    return chatListItemTime(right.createdAt) - chatListItemTime(left.createdAt);
-  });
-}
-
-function upsertChatListItem(items: ChatListItem[], item: Partial<ChatListItem> & { chatId: string }): ChatListItem[] {
-  const existing = items.find((current) => current.chatId === item.chatId);
-  const incomingTitle = item.title?.trim() || "";
-  const existingTitle = existing?.title?.trim() || "";
-  const keepExistingTitle =
-    incomingTitle === NEW_PROJECT_TITLE && Boolean(existingTitle) && existingTitle !== NEW_PROJECT_TITLE;
-  const incomingProjectId = typeof item.projectId === "string" ? item.projectId : undefined;
-  const nextItem: ChatListItem = {
-    chatId: item.chatId,
-    title: keepExistingTitle ? existingTitle : incomingTitle || existingTitle || NEW_PROJECT_TITLE,
-    projectId: incomingProjectId === undefined ? existing?.projectId || "" : incomingProjectId || existing?.projectId || "",
-    createdAt: item.createdAt || existing?.createdAt || chatTimestamp(),
-    projectCount: Math.max(item.projectCount ?? existing?.projectCount ?? 0, 0),
-  };
-  return sortChatListItems([nextItem, ...items.filter((current) => current.chatId !== item.chatId)])
-    .slice(0, MAX_CHAT_INDEX_ITEMS);
-}
-
-function initialProjectChatMessages(projectId: string, title: string, sourcePrompt?: string | null): ChatMessage[] {
-  const messages: ChatMessage[] = [];
-  if (sourcePrompt?.trim()) {
-    messages.push({
-      id: newChatMessageId(),
-      role: "user",
-      content: sourcePrompt.trim(),
-      status: "idle",
-      timestamp: chatTimestamp(),
-      projectId,
-    });
-  }
-  messages.push({
-    id: newChatMessageId(),
-    role: "assistant",
-    content: `${title || "Project"} is the active project for this chat.`,
-    status: "success",
-    timestamp: chatTimestamp(),
-    projectId,
-  });
-  return messages;
-}
-
-function missingProjectNotice(projectId: string) {
-  return `This chat pointed at project ${projectId}, but that project is no longer available in the project database. The chat history is still here; generate again to create a new project.`;
-}
-
-function messagesWithoutMissingProject(messages: ChatMessage[], projectId: string): ChatMessage[] {
-  const notice = missingProjectNotice(projectId);
-  const normalizedMessages = messages.map((message) =>
-    message.projectId === projectId ? { ...message, projectId: null } : message
-  );
-  if (normalizedMessages.some((message) => message.role === "assistant" && message.content === notice)) {
-    return normalizedMessages;
-  }
-  const noticeMessage: ChatMessage = {
-    id: newChatMessageId(),
-    role: "assistant",
-    content: notice,
-    status: "error",
-    timestamp: chatTimestamp(),
-    projectId: null,
-  };
-  return [...normalizedMessages, noticeMessage].slice(-MAX_PROJECT_CHAT_MESSAGES);
-}
-
-function humanContextQuestionsForPrompt(promptText: string, hasImage = false): HumanContextQuestion[] {
-  const lower = promptText.toLowerCase();
-  const physicalFormQuestion: HumanContextQuestion = {
-    id: "physical_form",
-    label: "Shape / Form Factor",
-    question: "What overall shape, silhouette, or form factor should the system have?",
-    placeholder: hasImage
-      ? "Example: preserve the reference silhouette, but make it handheld with a curved grip..."
-      : "Example: curved handheld pod, cylindrical wearable, folded frame, or exposed open assembly...",
-    suggestions: ["Curved handheld", "Cylindrical / radial", "Open frame"],
-  };
-  if (/(lab[-\s]?on[-\s]?a[-\s]?chip|microfluid|assay|cartridge|diagnostic|reagent|sample)/.test(lower)) {
-    return [
-      {
-        id: "sample_assay",
-        label: "Sample / Assay",
-        question: "What sample, analyte, or assay workflow should this support?",
-        placeholder: "Example: water sample, colorimetric nitrate assay, 3 reagent chambers...",
-        suggestions: ["Water quality", "Colorimetric assay", "Fluorescence readout"],
-      },
-      physicalFormQuestion,
-      {
-        id: "instrumentation",
-        label: "Reader / Detection",
-        question: "What detection and control method should the reader use?",
-        placeholder: "Example: LED + photodiode absorbance, heater, pressure sensor, peristaltic pump...",
-        suggestions: ["Optical absorbance", "Fluorescence", "Pressure-driven flow"],
-      },
-    ];
-  }
-
-  if (/(tent|deploy|self[-\s]?assembl|fold|frame|shelter|weatherproof|structure)/.test(lower)) {
-    return [
-      {
-        id: "environment",
-        label: "Environment",
-        question: "Where will this operate, and what weather or load should it survive?",
-        placeholder: "Example: camping rain/wind, sandy soil, one-person field setup, 35 mph gust target...",
-        suggestions: ["Rain and wind", "Field work", "Portable camping"],
-      },
-      physicalFormQuestion,
-      {
-        id: "motion_power",
-        label: "Motion / Power",
-        question: "How should deployment be powered and limited for safety?",
-        placeholder: "Example: 12V battery, low-force servos, clutch release, manual crank fallback...",
-        suggestions: ["12V battery", "Low-force actuators", "Manual release"],
-      },
-    ];
-  }
-
-  if (/(wire|wiring|schematic|pcb|sensor|relay|motor|driver|esp32|arduino|pin|gpio)/.test(lower)) {
-    return [
-      {
-        id: "controller_modules",
-        label: "Controller / Modules",
-        question: "Which controller and major modules should be treated as fixed?",
-        placeholder: "Example: ESP32-S3, SSD1306 OLED, SHT41, 5V relay module...",
-        suggestions: ["ESP32", "Arduino", "Use generated choice"],
-      },
-      physicalFormQuestion,
-      {
-        id: "power",
-        label: "Power",
-        question: "What power rails, battery, or adapter constraints matter?",
-        placeholder: "Example: USB-C 5V only, 3S LiPo, no mains, separate motor rail...",
-        suggestions: ["USB-C 5V", "Battery powered", "No mains"],
-      },
-    ];
-  }
-
-  return [
-    {
-      id: "use_case",
-      label: "Use Case",
-      question: "Who uses it, and where does it operate?",
-      placeholder: "Example: bench prototype, outdoor field tool, wearable, classroom demo...",
-      suggestions: ["Bench prototype", "Field tool", "Consumer device"],
-    },
-    physicalFormQuestion,
-    {
-      id: "constraints",
-      label: "Constraints",
-      question: "What hard constraints should the design preserve?",
-      placeholder: "Example: USB-C only, under $100, waterproof, no enclosure, safe low voltage...",
-      suggestions: ["Low voltage", "Low cost", "Weatherproof"],
-    },
-  ];
-}
-
-function normalizeHumanContextQuestions(value: any): HumanContextQuestion[] {
-  const rawQuestions = Array.isArray(value?.questions) ? value.questions : Array.isArray(value) ? value : [];
-  return rawQuestions
-    .map((question: any): HumanContextQuestion | null => {
-      if (!question || typeof question !== "object") return null;
-      const id = typeof question.id === "string" && question.id.trim() ? question.id.trim() : "";
-      const label = typeof question.label === "string" && question.label.trim() ? question.label.trim() : id;
-      const text = typeof question.question === "string" && question.question.trim() ? question.question.trim() : "";
-      if (!id || !label || !text) return null;
-      return {
-        id,
-        label,
-        question: text,
-        placeholder: typeof question.placeholder === "string" ? question.placeholder : "",
-        suggestions: Array.isArray(question.suggestions)
-          ? question.suggestions.filter((suggestion: any) => typeof suggestion === "string" && suggestion.trim()).slice(0, 4)
-          : [],
-      };
-    })
-    .filter((question: HumanContextQuestion | null): question is HumanContextQuestion => Boolean(question));
-}
-
-async function requestHumanContextQuestions(promptText: string, workflow: string, hasImage: boolean, signal?: AbortSignal) {
-  try {
-    const res = await fetch(`${API_URL}/clarifying-questions`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      signal,
-      body: JSON.stringify({
-        prompt: promptText,
-        workflow,
-        has_image: hasImage,
-        max_questions: 3,
-        force: true,
-      }),
-    });
-    if (!res.ok) throw new Error(await readApiErrorMessage(res));
-    const data = await res.json();
-    const questions = normalizeHumanContextQuestions(data);
-    return {
-      shouldAsk: Boolean(data?.should_ask) && questions.length > 0,
-      reason: typeof data?.reason === "string" ? data.reason : "",
-      questions,
-    };
-  } catch (error) {
-    if (signal?.aborted || (error instanceof Error && error.name === "AbortError")) throw error;
-    console.warn("Context Clarifier Agent unavailable; using local fallback questions.", error);
-    const questions = humanContextQuestionsForPrompt(promptText, hasImage);
-    return {
-      shouldAsk: questions.length > 0,
-      reason: "Context Clarifier Agent is using local fallback questions.",
-      questions,
-    };
-  }
-}
-
-function humanContextPromptSection(context: PendingHumanContext, finalNotes: string) {
-  const lines = context.questions.map((question) => {
-    const answer = (context.answers[question.id] || "").trim() || "not specified";
-    return `- ${question.label}: ${answer}`;
-  });
-  if (finalNotes.trim()) {
-    lines.push(`- Additional human notes: ${finalNotes.trim()}`);
-  }
-  return [
-    context.basePrompt,
-    "",
-    "HUMAN-IN-THE-LOOP CONTEXT:",
-    ...lines,
-    "",
-    "Treat this human context as explicit project requirements. If something is still unspecified, say so in project docs instead of inventing hidden constraints.",
-  ].join("\n");
-}
-
-function humanContextChatSummary(context: PendingHumanContext, finalNotes: string) {
-  const answered = context.questions
-    .map((question) => {
-      const answer = (context.answers[question.id] || "").trim();
-      return answer ? `${question.label}: ${answer}` : null;
-    })
-    .filter(Boolean);
-  if (finalNotes.trim()) answered.push(`Additional notes: ${finalNotes.trim()}`);
-  return answered.length ? `Context added:\n${answered.map((item) => `- ${item}`).join("\n")}` : "Build with no extra human context.";
-}
-
-function validateGenerationInput(value: string, hasImage: boolean) {
-  const promptText = value.trim();
-  if (!promptText) {
-    return {
-      isValid: hasImage,
-      message: hasImage ? null : "Provide a prompt or reference image.",
-    };
-  }
-
-  return {
-    isValid: true,
-    message: null,
-  };
-}
-
-type ApiErrorDetails = {
-  message: string;
-  code?: string;
-  reason?: string;
-  provider?: string;
-  model?: string;
-  job_id?: string;
-  debug?: Record<string, any>;
-};
-
-function normalizeApiErrorDetails(value: any, fallback: string): ApiErrorDetails {
-  if (typeof value === "string" && value.trim()) {
-    return { message: value.trim() };
-  }
-
-  if (Array.isArray(value)) {
-    const messages = value
-      .map((item: any) => item?.msg || item?.message || item?.detail)
-      .filter(Boolean);
-    if (messages.length) return { message: messages.join("; ") };
-  }
-
-  if (value && typeof value === "object") {
-    const message =
-      typeof value.message === "string"
-        ? value.message
-        : typeof value.detail === "string"
-          ? value.detail
-          : fallback;
-    const reason = typeof value.reason === "string" ? value.reason : undefined;
-    const provider = typeof value.provider === "string" ? value.provider : undefined;
-    const model = typeof value.model === "string" ? value.model : undefined;
-    return {
-      message,
-      code: typeof value.code === "string" ? value.code : undefined,
-      reason,
-      provider,
-      model,
-      job_id: typeof value.job_id === "string" ? value.job_id : undefined,
-      debug: value.debug && typeof value.debug === "object" ? value.debug : undefined,
-    };
-  }
-
-  return { message: fallback };
-}
-
-async function readApiError(response: Response): Promise<ApiErrorDetails> {
-  const fallback = `Server returned ${response.status}`;
-  try {
-    const body = await response.json();
-    if (body?.detail !== undefined) return normalizeApiErrorDetails(body.detail, fallback);
-    if (body?.message !== undefined) return normalizeApiErrorDetails(body.message, fallback);
-    if (body?.error !== undefined) return normalizeApiErrorDetails(body.error, fallback);
-  } catch {
-    // Fall through to a generic message.
-  }
-
-  return { message: fallback };
-}
-
-async function readApiErrorMessage(response: Response) {
-  return (await readApiError(response)).message;
-}
-
-const communityProjects = [
-  {
-    title: "Portable device",
-    description: "Reference design for a compact handheld product with display, controls, and enclosure notes.",
-    file: "pocket_mp3_player.json",
-  },
-  {
-    title: "Monitoring kit",
-    description: "General-purpose sensing and control example with power, wiring, and enclosure guidance.",
-    file: "plant_watering.json",
-  },
-  {
-    title: "Control module",
-    description: "Compact controller example with display, sensor, and validated power rails.",
-    file: "smart_thermostat.json",
-  },
-];
-
-type ChatRouteTransition = {
-  chatId: string;
-  title: string;
-  projectId: string;
-  error?: string | null;
-};
-
-type VideoGenerationConfig = {
-  configured: boolean | null;
-  reason: string | null;
-};
-
-type ImageGenerationConfig = {
-  configured: boolean | null;
-  requestCapable: boolean | null;
-  provider: string | null;
-  reason: string | null;
-};
-
-type ProviderSetupState = {
-  llmRequired: boolean;
-  imageRequired: boolean;
-};
-
-const workspaceTabs = [
-  { id: "overview", label: "Overview", icon: LayoutDashboard },
-  { id: "bom", label: "Billing Materials", icon: ClipboardList },
-  { id: "mechanical", label: "Mechanical", icon: Cuboid },
-  { id: "schematic", label: "Electrical", icon: CircuitBoard },
-  { id: "assembly", label: "Documentation", icon: BookOpen },
-  { id: "video", label: "Media", icon: Clapperboard },
-];
-
-const workspaceTabNamespaces: Record<string, string> = {
-  overview: "product.overview",
-  bom: "product.bom",
-  mechanical: "product.mech",
-  schematic: "product.electrical",
-  assembly: "project.docs",
-  video: "product.visuals.video",
-  jobs: "project.history.jobs",
-  logs: "project.runtime.logs",
-};
-
-function normalizeTab(tab: string | null) {
-  if (!tab) return null;
-  const aliases: Record<string, string> = {
-    chat: "overview",
-    concept: "overview",
-    info: "overview",
-    image: "overview",
-    mech: "mechanical",
-    wire: "schematic",
-    electrical: "schematic",
-    docs: "assembly",
-    documentation: "assembly",
-    billing: "bom",
-    materials: "bom",
-    media: "video",
-  };
-  const normalized = aliases[tab] || tab;
-  return workspaceTabs.some((item) => item.id === normalized) ? normalized : null;
-}
-
-function workspaceTabMeta(tab: string | null) {
-  const normalized = normalizeTab(tab);
-  return workspaceTabs.find((item) => item.id === normalized) || workspaceTabs[0];
-}
-
-function workspaceNamespaceForTab(tab: string | null) {
-  const meta = workspaceTabMeta(tab);
-  return workspaceTabNamespaces[meta.id] || meta.id;
-}
-
-function withProjectResponseMetadata(ir: any, response: any) {
-  if (!ir) return ir;
-  const timingMetadata = generationTimingMetadataFromJob(response?.job);
-  return {
-    ...ir,
-    assembly_metadata: {
-      ...(ir.assembly_metadata || {}),
-      project_id: ir.assembly_metadata?.project_id || response?.project_id,
-      chat_id: ir.assembly_metadata?.chat_id || response?.chat_id,
-      can_chat: Boolean(response?.can_chat ?? response?.canChat ?? ir.assembly_metadata?.can_chat ?? ir.assembly_metadata?.canChat),
-      frontend_job_id: ir.assembly_metadata?.frontend_job_id || response?.job_id,
-      source_prompt: ir.assembly_metadata?.source_prompt || response?.prompt,
-      ...timingMetadata,
-    },
-  };
-}
-
-function timestampMs(value: any): number | null {
-  if (typeof value !== "string" || !value.trim()) return null;
-  const ms = new Date(value).getTime();
-  return Number.isNaN(ms) ? null : ms;
-}
-
-function durationSecondsBetween(startValue: any, endValue: any): number | null {
-  const start = timestampMs(startValue);
-  const end = timestampMs(endValue);
-  if (start === null || end === null || end < start) return null;
-  return Math.max(1, Math.round((end - start) / 1000));
-}
-
-function generationTimingMetadataFromJob(job: A2AJob | null | undefined): Record<string, any> {
-  const seconds = durationSecondsBetween(job?.started_at, job?.completed_at);
-  if (seconds === null) return {};
-  return {
-    total_generation_time_seconds: seconds,
-    total_generation_started_at: job?.started_at || null,
-    total_generation_completed_at: job?.completed_at || null,
-  };
-}
-
-function formatDurationSeconds(value: any) {
-  const seconds = Number(value);
-  if (!Number.isFinite(seconds) || seconds <= 0) return "-";
-  const totalSeconds = Math.max(1, Math.round(seconds));
-  const hours = Math.floor(totalSeconds / 3600);
-  const minutes = Math.floor((totalSeconds % 3600) / 60);
-  const remainingSeconds = totalSeconds % 60;
-  if (hours) return `${hours}h ${minutes}m ${remainingSeconds}s`;
-  if (minutes) return `${minutes}m ${remainingSeconds}s`;
-  return `${remainingSeconds}s`;
-}
-
-function projectIdFromIR(ir: any) {
-  return ir?.assembly_metadata?.project_id || null;
-}
-
-function chatIdFromIR(ir: any) {
-  return ir?.assembly_metadata?.chat_id || null;
-}
-
-function canChatWithProjectIR(ir: any) {
-  return Boolean(ir?.assembly_metadata?.can_chat ?? ir?.assembly_metadata?.canChat);
-}
-
-function chatIdFromJob(job: A2AJob) {
-  const rawChatId = job.payload?.chat_id || job.result_summary?.chat_id;
-  return typeof rawChatId === "string" ? rawChatId.trim() : "";
-}
-
-function projectRoute(projectId: string) {
-  return `/project/${encodeURIComponent(projectId)}`;
-}
-
-function chatRoute(chatId: string) {
-  return `/chat/${encodeURIComponent(chatId)}`;
-}
-
-function safeDecodeProjectId(projectId: string) {
-  try {
-    return decodeURIComponent(projectId);
-  } catch {
-    return projectId;
-  }
-}
-
-function safeDecodeChatId(chatId: string) {
-  try {
-    return decodeURIComponent(chatId);
-  } catch {
-    return chatId;
-  }
-}
-
-type HomeProps = {
-  routeProjectId?: string | null;
-  routeChatId?: string | null;
-  showDeveloperTools?: boolean;
-  homeView?: "chat" | "projects" | "my-projects" | "jobs" | "logs" | "settings" | "about";
-};
 
 export function FormaWorkspace({
   routeProjectId = null,
@@ -1675,13 +252,6 @@ export function FormaWorkspace({
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [chatMessages, setChatMessages] = useState<ChatMessage[]>(() => initialChatMessages());
-  const [pendingHumanContext, setPendingHumanContext] = useState<PendingHumanContext | null>(null);
-  const contextProjectIdsRef = useRef<Record<string, string>>({});
-  const contextBuildWatchersRef = useRef<Set<string>>(new Set());
-  const [contextWorkflowStates, setContextWorkflowStates] = useState<Record<string, string>>({});
-  const [contextBuildStarting, setContextBuildStarting] = useState(false);
-  const [resettingBuildMessageId, setResettingBuildMessageId] = useState<string | null>(null);
-  const [contextSubmitting, setContextSubmitting] = useState(false);
   const [chatThreads, setChatThreads] = useState<Record<string, ChatMessage[]>>({});
   const [projectChatInput, setProjectChatInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -1772,8 +342,12 @@ export function FormaWorkspace({
   const projectsSectionRef = useRef<HTMLElement>(null);
   const chatPersistenceTimersRef = useRef<Record<string, number>>({});
   const projectHistoryRequestIdRef = useRef(0);
+  const projectHistoryAbortRef = useRef<AbortController | null>(null);
   const myProjectHistoryRequestIdRef = useRef(0);
+  const myProjectHistoryAbortRef = useRef<AbortController | null>(null);
+  const privateChatsAbortRef = useRef<AbortController | null>(null);
   const generationLlmRequestIdRef = useRef(0);
+  const runtimeConfigAbortRef = useRef<AbortController | null>(null);
   const pipelineStepsRequestIdRef = useRef(0);
   const pipelineStepsAbortRef = useRef<AbortController | null>(null);
   const pipelineStepsRequestStartedRef = useRef(false);
@@ -1854,10 +428,10 @@ export function FormaWorkspace({
     return null;
   }, [activeChatId, chatMessages, chatThreads]);
   const generationInputValidation = useMemo(
-    () => validateGenerationInput(pendingHumanContext?.basePrompt || prompt, Boolean(selectedImage)),
-    [pendingHumanContext, prompt, selectedImage]
+    () => validateGenerationInput(prompt, Boolean(selectedImage)),
+    [prompt, selectedImage]
   );
-  const hasGenerationInput = Boolean(prompt.trim() || selectedImage || pendingHumanContext);
+  const hasGenerationInput = Boolean(prompt.trim() || selectedImage);
   const selectedGenerationWorkflow = useMemo(
     () => generationWorkflows.find((workflow) => workflow.id === generationWorkflow) || generationWorkflows[0] || defaultGenerationWorkflows[0],
     [generationWorkflow, generationWorkflows]
@@ -1896,6 +470,7 @@ export function FormaWorkspace({
       contextSuggestions: message.contextSuggestions || [],
       buildPlanId: message.buildPlanId || null,
       buildJobId: message.buildJobId || null,
+      buildRequiresRequestBoundExecution: Boolean(message.buildRequiresRequestBoundExecution),
       timestamp: chatTimestamp(),
     };
     setChatMessages((current) => [...current, nextMessage]);
@@ -1950,6 +525,7 @@ export function FormaWorkspace({
       contextSuggestions: message.contextSuggestions || [],
       buildPlanId: message.buildPlanId || null,
       buildJobId: message.buildJobId || null,
+      buildRequiresRequestBoundExecution: Boolean(message.buildRequiresRequestBoundExecution),
       timestamp: chatTimestamp(),
     };
     setChatThreads((current) => {
@@ -2092,24 +668,6 @@ export function FormaWorkspace({
       writeStoredChatIndex(nextItems, chatStorageScope);
       return nextItems;
     });
-  };
-
-  const updateHumanContextAnswer = (questionId: string, value: string) => {
-    setPendingHumanContext((current) =>
-      current
-        ? {
-            ...current,
-            answers: {
-              ...current.answers,
-              [questionId]: value,
-            },
-          }
-        : current
-    );
-  };
-  const clearHumanContextCheckpoint = () => {
-    if (pendingHumanContext) setPrompt(pendingHumanContext.basePrompt);
-    setPendingHumanContext(null);
   };
 
   const requireSignedInForGeneration = async () => {
@@ -2405,22 +963,6 @@ export function FormaWorkspace({
     Object.values(chatThreads).forEach(collect);
     return Array.from(jobIds).join("\n");
   }, [activeGeneration?.jobId, chatMessages, chatThreads]);
-  const pendingContextBuildMessage = useMemo(
-    () => [...chatMessages].reverse().find((message) => (
-      message.status === "loading"
-      && Boolean(message.buildPlanId)
-      && Boolean(message.contextProjectId)
-    )) || null,
-    [chatMessages],
-  );
-  const retryableContextBuildMessage = useMemo(() => {
-    const latestBuildMessage = [...chatMessages].reverse().find((message) => (
-      Boolean(message.buildPlanId)
-      && Boolean(message.buildJobId)
-      && Boolean(message.contextProjectId)
-    ));
-    return latestBuildMessage?.status === "error" ? latestBuildMessage : null;
-  }, [chatMessages]);
 
   const latestAgentOperation = useMemo(() => {
     return [...chatMessages].reverse().find((message) => (
@@ -2511,7 +1053,6 @@ export function FormaWorkspace({
     setChatMessages(initialChatMessages());
     setPrompt("");
     setProjectChatInput("");
-    setPendingHumanContext(null);
     setGenerationInputNotice(null);
     setSelectedImage(null);
     setSelectedImageSource("upload");
@@ -2614,6 +1155,16 @@ export function FormaWorkspace({
   }, [authRequired, chatStorageScope]);
 
   useEffect(() => {
+    return () => {
+      privateChatsAbortRef.current?.abort();
+      myProjectHistoryAbortRef.current?.abort();
+      runtimeConfigAbortRef.current?.abort();
+      projectHistoryAbortRef.current?.abort();
+      pipelineStepsAbortRef.current?.abort();
+    };
+  }, []);
+
+  useEffect(() => {
     if (homeView !== "projects") return;
     void fetchProjectHistory(projectHistoryPage, projectSearchQuery);
     // Public gallery data becomes critical only when its route is active.
@@ -2680,6 +1231,9 @@ export function FormaWorkspace({
     setMyProjectHistoryPage(0);
     setPrivateChatsLoaded(false);
     void fetchPrivateChats();
+    return () => {
+      privateChatsAbortRef.current?.abort();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authIdentityKey, authLoaded, authRequired, isSignedIn]);
 
@@ -2689,6 +1243,9 @@ export function FormaWorkspace({
       return;
     }
     void fetchMyProjectHistory(myProjectHistoryPage);
+    return () => {
+      myProjectHistoryAbortRef.current?.abort();
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [authIdentityKey, authLoaded, authRequired, isSignedIn, myProjectHistoryPage]);
 
@@ -2742,9 +1299,13 @@ export function FormaWorkspace({
   const fetchRuntimeConfig = async () => {
     const requestId = ++generationLlmRequestIdRef.current;
     const requestIsCurrent = () => generationLlmRequestIdRef.current === requestId;
+    runtimeConfigAbortRef.current?.abort();
+    const runtimeController = new AbortController();
+    runtimeConfigAbortRef.current = runtimeController;
     try {
       const res = await fetch(`${API_URL}/runtime/config`, {
         cache: "no-store",
+        signal: runtimeController.signal,
         headers: await optionalAuthHeaders(),
       });
       if (!res.ok) return;
@@ -2790,14 +1351,14 @@ export function FormaWorkspace({
 
       const workflows = Array.isArray(config.workflow.options) ? config.workflow.options : [];
       if (workflows.length > 0) {
+        const nextWorkflow = workflows.some((workflow) => workflow.id === config.workflow.default_id)
+          ? config.workflow.default_id
+          : workflows[0].id;
         setGenerationWorkflows(workflows);
-        setGenerationWorkflow(
-          workflows.some((workflow) => workflow.id === config.workflow.default_id)
-            ? config.workflow.default_id
-            : workflows[0].id,
-        );
+        setGenerationWorkflow(nextWorkflow);
       }
     } catch (e) {
+      if (runtimeController.signal.aborted) return;
       if (requestIsCurrent()) console.error("Error fetching runtime config", e);
     } finally {
       if (requestIsCurrent()) {
@@ -2837,6 +1398,9 @@ export function FormaWorkspace({
   ) => {
     const requestId = projectHistoryRequestIdRef.current + 1;
     projectHistoryRequestIdRef.current = requestId;
+    projectHistoryAbortRef.current?.abort();
+    const projectHistoryController = new AbortController();
+    projectHistoryAbortRef.current = projectHistoryController;
     setProjectHistoryLoaded(false);
     try {
       const params = new URLSearchParams({
@@ -2846,6 +1410,7 @@ export function FormaWorkspace({
       const normalizedSearch = search.trim();
       if (normalizedSearch) params.set("q", normalizedSearch);
       const res = await fetch(`${API_URL}/projects?${params.toString()}`, {
+        signal: projectHistoryController.signal,
         headers: await optionalAuthHeaders(),
       });
       if (projectHistoryRequestIdRef.current !== requestId) return;
@@ -2863,15 +1428,21 @@ export function FormaWorkspace({
         }
       }
     } catch (e) {
+      if (projectHistoryController.signal.aborted) return;
       console.error("Error fetching project history", e);
     } finally {
-      if (projectHistoryRequestIdRef.current === requestId) setProjectHistoryLoaded(true);
+      if (projectHistoryRequestIdRef.current === requestId && !projectHistoryController.signal.aborted) {
+        setProjectHistoryLoaded(true);
+      }
     }
   };
 
   const fetchMyProjectHistory = async (page: number = myProjectHistoryPage) => {
     const requestId = myProjectHistoryRequestIdRef.current + 1;
     myProjectHistoryRequestIdRef.current = requestId;
+    myProjectHistoryAbortRef.current?.abort();
+    const myProjectHistoryController = new AbortController();
+    myProjectHistoryAbortRef.current = myProjectHistoryController;
     if (authRequired && !authLoaded) {
       setMyProjectHistoryLoaded(false);
       return;
@@ -2890,6 +1461,7 @@ export function FormaWorkspace({
         offset: String(Math.max(0, page) * PROJECT_GALLERY_PAGE_SIZE),
       });
       const res = await fetch(`${API_URL}/my/projects?${params.toString()}`, {
+        signal: myProjectHistoryController.signal,
         headers: await generationRequestHeaders(),
       });
       if (myProjectHistoryRequestIdRef.current !== requestId) return;
@@ -2907,13 +1479,19 @@ export function FormaWorkspace({
         throw new Error(await readApiErrorMessage(res));
       }
     } catch (e) {
+      if (myProjectHistoryController.signal.aborted) return;
       console.error("Error fetching my project history", e);
     } finally {
-      if (myProjectHistoryRequestIdRef.current === requestId) setMyProjectHistoryLoaded(true);
+      if (myProjectHistoryRequestIdRef.current === requestId && !myProjectHistoryController.signal.aborted) {
+        setMyProjectHistoryLoaded(true);
+      }
     }
   };
 
   const fetchPrivateChats = async () => {
+    privateChatsAbortRef.current?.abort();
+    const privateChatsController = new AbortController();
+    privateChatsAbortRef.current = privateChatsController;
     if (authRequired && !authLoaded) {
       setPrivateChatsLoaded(false);
       return;
@@ -2927,6 +1505,7 @@ export function FormaWorkspace({
 
     try {
       const res = await fetch(`${API_URL}/chats`, {
+        signal: privateChatsController.signal,
         headers: await generationRequestHeaders(),
       });
       if (res.ok) {
@@ -2964,9 +1543,10 @@ export function FormaWorkspace({
         throw new Error(await readApiErrorMessage(res));
       }
     } catch (e) {
+      if (privateChatsController.signal.aborted) return;
       console.error("Error fetching private chats", e);
     } finally {
-      setPrivateChatsLoaded(true);
+      if (!privateChatsController.signal.aborted) setPrivateChatsLoaded(true);
     }
   };
 
@@ -3221,22 +1801,6 @@ export function FormaWorkspace({
     }
   };
 
-  const beginContextBuildRun = (
-    projectId: string,
-    planId: string,
-    jobId: string,
-    chatId: string,
-    assistantMessageId: string,
-  ) => {
-    const active = activeGenerationRef.current;
-    if (active?.kind === "context-build" && active.planId === planId) return active;
-    const run = beginGenerationRun("context-build", chatId);
-    run.projectId = projectId;
-    run.planId = planId;
-    setGenerationRunJob(run, jobId, assistantMessageId);
-    return run;
-  };
-
   const finishGenerationRun = (run: ActiveGenerationRun) => {
     if (activeGenerationRef.current !== run) return;
     activeGenerationRef.current = null;
@@ -3262,67 +1826,7 @@ export function FormaWorkspace({
     }
   };
 
-  const cancelContextBuild = async (projectId: string, planId: string) => {
-    try {
-      const response = await fetch(
-        `${API_URL}/projects/${encodeURIComponent(projectId)}/build/plans/${encodeURIComponent(planId)}/cancel`,
-        { method: "POST", headers: await generationRequestHeaders() },
-      );
-      if (!response.ok) throw new Error(await readApiErrorMessage(response));
-    } catch (error) {
-      console.warn("Could not notify the backend that the build was stopped.", error);
-      setGenerationInputNotice(error instanceof Error ? error.message : "Could not stop the build.");
-    }
-  };
-
-  const executeContextBuild = async (
-    projectId: string,
-    planId: string,
-    run?: ActiveGenerationRun,
-  ) => {
-    for (let attempt = 1; attempt <= 4; attempt += 1) {
-      try {
-        const response = await fetch(
-          `${API_URL}/projects/${encodeURIComponent(projectId)}/build/plans/${encodeURIComponent(planId)}/execute`,
-          {
-            method: "POST",
-            headers: await generationRequestHeaders(),
-            signal: run?.controller.signal,
-          },
-        );
-        if (!response.ok) throw new Error(await readApiErrorMessage(response));
-        return;
-      } catch (error) {
-        if (run?.cancelled || run?.controller.signal.aborted) return;
-        console.warn("The build execution request ended before the plan reached a terminal state.", error);
-        if (attempt === 4) {
-          setGenerationInputNotice(
-            error instanceof Error ? error.message : "The build execution request ended unexpectedly.",
-          );
-          return;
-        }
-        setGenerationInputNotice("Build connection interrupted. Resuming from the latest saved stage…");
-        await new Promise((resolve) => window.setTimeout(resolve, 1500));
-      }
-    }
-  };
-
-  const stopContextBuildMessage = (message: ChatMessage) => {
-    const projectId = message.contextProjectId;
-    const planId = message.buildPlanId;
-    if (!projectId || !planId) return;
-    const active = activeGenerationRef.current;
-    if (active?.kind === "context-build" && active.planId === planId) {
-      stopActiveGeneration();
-      return;
-    }
-    const stoppedMessage = "Build stopped by you. Your project brief is preserved.";
-    updateChatMessage(message.id, { content: stoppedMessage, status: "cancelled" });
-    updateThreadMessage(activeChatId, message.id, { content: stoppedMessage, status: "cancelled" });
-    setGenerationInputNotice("Build stopped. Your project brief is preserved.");
-    setIsLoading(false);
-    void cancelContextBuild(projectId, planId);
-  };
+  const cancelContextBuildRef = useRef<(projectId: string, planId: string) => Promise<void> | void>(async () => {});
 
   const stopActiveGeneration = () => {
     const run = activeGenerationRef.current;
@@ -3346,916 +1850,66 @@ export function FormaWorkspace({
         : "Generation stopped. You can send another message whenever you're ready.",
     );
     if (run.kind === "context-build" && run.projectId && run.planId) {
-      void cancelContextBuild(run.projectId, run.planId);
+      void cancelContextBuildRef.current(run.projectId, run.planId);
     } else if (run.jobId) {
       void cancelGenerationJob(run.jobId);
     }
     finishGenerationRun(run);
   };
 
-  const watchContextBuild = (
-    projectId: string,
-    planId: string,
-    jobId: string,
-    chatId: string,
-    assistantMessageId: string,
-    run?: ActiveGenerationRun,
-  ) => {
-    const watcherKey = `${projectId}:${planId}`;
-    if (contextBuildWatchersRef.current.has(watcherKey)) return;
-    contextBuildWatchersRef.current.add(watcherKey);
-    void executeContextBuild(projectId, planId, run);
-    let attempts = 0;
-    const poll = async () => {
-      if (run?.cancelled || run?.controller.signal.aborted) {
-        contextBuildWatchersRef.current.delete(watcherKey);
-        return;
-      }
-      attempts += 1;
-      try {
-        const response = await fetch(
-          `${API_URL}/projects/${encodeURIComponent(projectId)}/build/plans/${encodeURIComponent(planId)}`,
-          { headers: await generationRequestHeaders(), signal: run?.controller.signal },
-        );
-        if (!response.ok) throw new Error(await readApiErrorMessage(response));
-        const plan = await response.json();
-        const planStatus = typeof plan?.status === "string" ? plan.status : "";
-        const task = plan?.jobs?.[jobId];
-        const progressEvents = pipelineEventsFromWorkerTask(task);
-        let synchronizedProgress: AgentPipelineProgress | null = null;
-        if (progressEvents.length) {
-          const seedProgress = createAgentPipelineProgress(
-            defaultAgentPipelineSteps,
-            false,
-            typeof task?.started_at === "string" ? task.started_at : chatTimestamp(),
-            jobId,
-          );
-          const progressJob: A2AJob = {
-            job_id: jobId,
-            action: "forma.generate_project",
-            sender: "worker-orchestrator",
-            recipient: "forma",
-            status: "running",
-            started_at: typeof task?.started_at === "string" ? task.started_at : null,
-            progress_events: progressEvents,
-          };
-          synchronizedProgress = progressFromJobEvents(progressJob, seedProgress, false);
-          applyChatPipelineProgressFromJob(assistantMessageId, progressJob, seedProgress, false);
-          applyThreadPipelineProgressFromJob(chatId, assistantMessageId, progressJob, seedProgress, false);
-        }
-        if (planStatus === "succeeded") {
-          const projectResponse = await fetch(`${API_URL}/projects/${encodeURIComponent(projectId)}`, {
-            headers: await optionalAuthHeaders(),
-          });
-          if (!projectResponse.ok) throw new Error(await readApiErrorMessage(projectResponse));
-          const projectData = await projectResponse.json();
-          const ir = withProjectResponseMetadata(projectData.project_ir, projectData);
-          const title = ir?.overview?.title || "Project";
-          setProjectIR(ir);
-          setContextWorkflowStates((current) => ({ ...current, [chatId]: "awaiting_feedback" }));
-          rememberProjectRecord({
-            project_id: projectId,
-            chat_id: chatId,
-            title,
-            prompt: projectData.prompt || title,
-            created_at: projectData.created_at || chatTimestamp(),
-            can_chat: true,
-            creator_display: "you",
-            creator_image_url: userImageUrl,
-            parts_count: Array.isArray(ir?.components) ? ir.components.length : 0,
-            save_count: 0,
-            remix_count: 0,
-            saved: false,
-          });
-          rememberChatItem({
-            chatId,
-            title,
-            projectId,
-            createdAt: chatTimestamp(),
-            projectCount: 1,
-          });
-          const readyMessage = `${title} is ready. The first structured design revision is available for review.`;
-          updateChatMessage(assistantMessageId, {
-            content: readyMessage,
-            status: "success",
-            pipelineProgress: synchronizedProgress,
-            projectId,
-            contextProjectId: projectId,
-            workflowState: "awaiting_feedback",
-          });
-          updateThreadMessage(chatId, assistantMessageId, {
-            content: readyMessage,
-            status: "success",
-            pipelineProgress: synchronizedProgress,
-            projectId,
-            contextProjectId: projectId,
-            workflowState: "awaiting_feedback",
-          });
-          setGenerationInputNotice("Design ready for review.");
-          void fetchProjectHistory();
-          if (!authRequired || isSignedIn) void fetchMyProjectHistory();
-          contextBuildWatchersRef.current.delete(watcherKey);
-          if (run) finishGenerationRun(run);
-          return;
-        }
-        if (planStatus === "cancelled" || planStatus === "canceled") {
-          const stoppedMessage = "Build stopped by you. Your project brief is preserved.";
-          updateChatMessage(assistantMessageId, { content: stoppedMessage, status: "cancelled" });
-          updateThreadMessage(chatId, assistantMessageId, { content: stoppedMessage, status: "cancelled" });
-          setGenerationInputNotice("Build stopped. Your project brief is preserved.");
-          contextBuildWatchersRef.current.delete(watcherKey);
-          if (run) finishGenerationRun(run);
-          return;
-        }
-        if (planStatus === "partial") {
-          try {
-            const projectResponse = await fetch(`${API_URL}/projects/${encodeURIComponent(projectId)}`, {
-              headers: await optionalAuthHeaders(),
-            });
-            if (projectResponse.ok) {
-              const projectData = await projectResponse.json();
-              setProjectIR(withProjectResponseMetadata(projectData.project_ir, projectData));
-            }
-          } catch (error) {
-            console.warn("Could not load the preserved partial project.", error);
-          }
-          const failedStage = task?.result?.metadata?.generation_retry?.retry_stage;
-          const partialMessage = typeof failedStage === "string" && failedStage
-            ? `The ${failedStage.replaceAll("_", " ")} stage failed. Earlier and independent work was preserved.`
-            : "One build stage failed. Earlier and independent work was preserved.";
-          updateChatMessage(assistantMessageId, {
-            content: partialMessage,
-            status: "error",
-            pipelineProgress: synchronizedProgress,
-            projectId,
-            workflowState: "awaiting_feedback",
-          });
-          updateThreadMessage(chatId, assistantMessageId, {
-            content: partialMessage,
-            status: "error",
-            pipelineProgress: synchronizedProgress,
-            projectId,
-            workflowState: "awaiting_feedback",
-          });
-          setGenerationInputNotice("Partial design saved. Retry will resume from the failed stage.");
-          contextBuildWatchersRef.current.delete(watcherKey);
-          if (run) finishGenerationRun(run);
-          return;
-        }
-        if (planStatus === "failed") {
-          const failureMessage = typeof task?.error?.message === "string"
-            ? task.error.message
-            : "The design build stopped after an agent failure.";
-          updateChatMessage(assistantMessageId, { content: failureMessage, status: "error", workflowState: "awaiting_feedback" });
-          updateThreadMessage(chatId, assistantMessageId, { content: failureMessage, status: "error", workflowState: "awaiting_feedback" });
-          setGenerationInputNotice(failureMessage);
-          contextBuildWatchersRef.current.delete(watcherKey);
-          if (run) finishGenerationRun(run);
-          return;
-        }
-      } catch (error) {
-        if (run?.controller.signal.aborted) {
-          contextBuildWatchersRef.current.delete(watcherKey);
-          return;
-        }
-        if (attempts >= 600) {
-          const message = error instanceof Error ? error.message : "Could not read build progress.";
-          setGenerationInputNotice(message);
-          contextBuildWatchersRef.current.delete(watcherKey);
-          return;
-        }
-      }
-      if (attempts < 600) window.setTimeout(poll, 2000);
-    };
-    window.setTimeout(poll, 750);
-  };
-
-  const resetFailedContextBuild = async (message: ChatMessage) => {
-    const projectId = message.contextProjectId;
-    const planId = message.buildPlanId;
-    const jobId = message.buildJobId;
-    const chatId = activeChatId;
-    if (!projectId || !planId || !jobId || !chatId || activeGenerationRef.current) return;
-
-    setResettingBuildMessageId(message.id);
-    setGenerationInputNotice(null);
-    try {
-      const response = await fetch(
-        `${API_URL}/projects/${encodeURIComponent(projectId)}/build/plans/${encodeURIComponent(planId)}/reset`,
-        { method: "POST", headers: await generationRequestHeaders() },
-      );
-      if (!response.ok) throw new Error(await readApiErrorMessage(response));
-
-      const resetPlan = await response.json();
-      const resetJobId = typeof resetPlan?.jobs?.[jobId]?.request?.job_id === "string"
-        ? resetPlan.jobs[jobId].request.job_id
-        : jobId;
-      const previousProgress = message.pipelineProgress;
-      const resetTask = resetPlan?.jobs?.[jobId];
-      const resetEvents = pipelineEventsFromWorkerTask(resetTask);
-      const seedProgress = createAgentPipelineProgress(
-        previousProgress?.steps || defaultAgentPipelineSteps,
-        progressIncludesImageStep(previousProgress),
-        chatTimestamp(),
-        resetJobId,
-      );
-      const progress = resetEvents.length
-        ? progressFromJobEvents({
-            job_id: resetJobId,
-            action: "forma.generate_project",
-            sender: "worker-orchestrator",
-            recipient: "forma",
-            status: "running",
-            progress_events: resetEvents,
-          }, seedProgress, false)
-        : seedProgress;
-      const patch: Partial<Omit<ChatMessage, "id">> = {
-        content: "Trying the design build again with the preserved project brief.",
-        status: "loading",
-        pipelineProgress: progress,
-        workflowState: "building",
-      };
-      updateChatMessage(message.id, patch);
-      updateThreadMessage(chatId, message.id, patch);
-      setContextWorkflowStates((current) => ({ ...current, [chatId]: "building" }));
-      setGenerationInputNotice("Job reset. The build agents are trying again.");
-
-      const run = beginContextBuildRun(projectId, planId, resetJobId, chatId, message.id);
-      watchContextBuild(projectId, planId, resetJobId, chatId, message.id, run);
-    } catch (error) {
-      setGenerationInputNotice(error instanceof Error ? error.message : "Could not reset the failed job.");
-    } finally {
-      setResettingBuildMessageId(null);
-    }
-  };
-
-  useEffect(() => {
-    const pending = [...chatMessages].reverse().find((message) => (
-      message.status === "loading"
-      && Boolean(message.buildPlanId)
-      && Boolean(message.buildJobId)
-      && Boolean(message.contextProjectId)
-      && !message.projectId
-    ));
-    if (!pending?.buildPlanId || !pending.buildJobId || !pending.contextProjectId || !activeChatId) return;
-    if (!pending.pipelineProgress) {
-      const progress = createAgentPipelineProgress(
-        defaultAgentPipelineSteps,
-        generateProductImage,
-        chatTimestamp(),
-        pending.buildJobId,
-      );
-      updateChatMessage(pending.id, { pipelineProgress: progress, status: "loading" });
-      updateThreadMessage(activeChatId, pending.id, { pipelineProgress: progress, status: "loading" });
-    }
-    const run = beginContextBuildRun(
-      pending.contextProjectId,
-      pending.buildPlanId,
-      pending.buildJobId,
-      activeChatId,
-      pending.id,
-    );
-    watchContextBuild(
-      pending.contextProjectId,
-      pending.buildPlanId,
-      pending.buildJobId,
-      activeChatId,
-      pending.id,
-      run,
-    );
-    // The watcher registry makes this restart-safe without duplicating poll loops.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeChatId, chatMessageIdentityKey(chatMessages)]);
-
-  const submitGatherContext = async (answer?: string) => {
-    if (contextSubmitting || activeGenerationRef.current) return;
-    if (!(await requireSignedInForGeneration())) return;
-
-    const submittedPrompt = answer ?? prompt;
-    const validation = validateGenerationInput(submittedPrompt, Boolean(selectedImage));
-    if (!validation.isValid) {
-      setGenerationInputNotice(validation.message);
-      return;
-    }
-
-    const requestChatId = activeChatId || newBuildChatId();
-    const requestProjectId = contextProjectIdsRef.current[requestChatId] || (
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(requestChatId)
-        ? requestChatId
-        : newBuildChatId()
-    );
-    contextProjectIdsRef.current[requestChatId] = requestProjectId;
-    const text = submittedPrompt.trim();
-    const imageData = selectedImage;
-    const userMessageId = newChatMessageId();
-    const assistantMessageId = newChatMessageId();
-    const userContent = text || "Shared a hardware reference image.";
-
-    setActiveChatId(requestChatId);
-    rememberChatItem({
-      chatId: requestChatId,
-      title: text || "Hardware reference",
-      projectId: "",
-      createdAt: chatTimestamp(),
-      projectCount: 0,
-    });
-    syncChatRoute(requestChatId);
-    appendChatMessage({ id: userMessageId, role: "user", content: userContent, imagePreview: imageData, status: "idle" });
-    appendThreadMessage(requestChatId, { id: userMessageId, role: "user", content: userContent, imagePreview: imageData, status: "idle" });
-    appendChatMessage({ id: assistantMessageId, role: "assistant", content: "Thinking…", status: "loading" });
-    appendThreadMessage(requestChatId, { id: assistantMessageId, role: "assistant", content: "Thinking…", status: "loading" });
-    setPrompt("");
-    setSelectedImage(null);
-    setSelectedImageSource("upload");
-    setGenerationInputNotice(null);
-    setContextSubmitting(true);
-
-    try {
-      const res = await fetch(`${API_URL}/projects/${encodeURIComponent(requestProjectId)}/context/messages`, {
-        method: "POST",
-        headers: await generationRequestHeaders(),
-        body: JSON.stringify({
-          conversation_id: requestChatId,
-          text,
-          attachments: imageData ? [{
-            attachment_id: `context-image-${userMessageId}`,
-            kind: "image",
-            name: "hardware-reference.png",
-            media_type: imageData.match(/^data:([^;,]+)/)?.[1] || "image/png",
-            data_url: imageData,
-            source: selectedImageSource,
-          }] : [],
-        }),
-      });
-      if (!res.ok) {
-        noteAuthResponseStatus(res.status);
-        throw new Error(await readApiErrorMessage(res));
-      }
-      const data = await res.json();
-      const turnKind = typeof data?.turn_kind === "string" ? data.turn_kind : "context";
-      const persistedProjectId = typeof data?.design_brief?.project_id === "string"
-        ? data.design_brief.project_id
-        : typeof data?.workflow?.project_id === "string"
-          ? data.workflow.project_id
-          : "";
-      const workflowState = typeof data?.workflow?.state === "string" ? data.workflow.state : "";
-      const buildPlanId = typeof data?.build_execution?.plan_id === "string"
-        ? data.build_execution.plan_id
-        : "";
-      const buildJobId = typeof data?.build_execution?.job_id === "string"
-        ? data.build_execution.job_id
-        : "";
-      const buildExecutionStatus = typeof data?.build_execution?.status === "string"
-        ? data.build_execution.status
-        : "";
-      const buildIsActive = buildExecutionStatus === "planned" || buildExecutionStatus === "running";
-      const buildPipelineProgress = buildPlanId
-        ? createAgentPipelineProgress(defaultAgentPipelineSteps, generateProductImage, chatTimestamp(), buildJobId || null)
-        : null;
-      if (persistedProjectId) contextProjectIdsRef.current[requestChatId] = persistedProjectId;
-      if (workflowState) {
-        setContextWorkflowStates((current) => ({ ...current, [requestChatId]: workflowState }));
-      }
-      const assistantContent = typeof data?.assistant_message === "string"
-        ? data.assistant_message
-        : "How can I help with your hardware idea?";
-      updateChatMessage(assistantMessageId, {
-        content: assistantContent,
-        status: buildIsActive ? "loading" : buildExecutionStatus === "failed" ? "error" : "success",
-        pipelineProgress: buildPipelineProgress,
-        contextProjectId: persistedProjectId || null,
-        workflowState: workflowState || null,
-        contextQuestions: Array.isArray(data?.questions) ? data.questions : [],
-        contextSuggestions: normalizeContextSuggestions(data?.suggestions),
-        buildPlanId: buildPlanId || null,
-        buildJobId: buildJobId || null,
-      });
-      updateThreadMessage(requestChatId, assistantMessageId, {
-        content: assistantContent,
-        status: buildIsActive ? "loading" : buildExecutionStatus === "failed" ? "error" : "success",
-        pipelineProgress: buildPipelineProgress,
-        contextProjectId: persistedProjectId || null,
-        workflowState: workflowState || null,
-        contextQuestions: Array.isArray(data?.questions) ? data.questions : [],
-        contextSuggestions: normalizeContextSuggestions(data?.suggestions),
-        buildPlanId: buildPlanId || null,
-        buildJobId: buildJobId || null,
-      });
-      setGenerationInputNotice(
-        buildPlanId
-          ? "Build started. Live agent progress is shown above."
-          : turnKind === "context"
-          ? "Project context updated."
-          : turnKind === "proceed"
-            ? "Project handed to the next agent stage."
-            : null,
-      );
-      if (buildPlanId && buildJobId && persistedProjectId) {
-        const run = beginContextBuildRun(
-          persistedProjectId,
-          buildPlanId,
-          buildJobId,
-          requestChatId,
-          assistantMessageId,
-        );
-        watchContextBuild(
-          persistedProjectId,
-          buildPlanId,
-          buildJobId,
-          requestChatId,
-          assistantMessageId,
-          run,
-        );
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "Could not save project context.";
-      updateChatMessage(assistantMessageId, { content: message, status: "error" });
-      updateThreadMessage(requestChatId, assistantMessageId, { content: message, status: "error" });
-      setGenerationInputNotice(message);
-    } finally {
-      setContextSubmitting(false);
-    }
-  };
-
-  const handleGatherContext = (event: React.FormEvent) => {
-    event.preventDefault();
-    void submitGatherContext();
-  };
-
-  const handleBuildNow = async () => {
-    if (contextBuildStarting || contextSubmitting || activeGenerationRef.current) return;
-    const requestChatId = activeChatId;
-    const availableMessages = requestChatId
-      ? chatThreads[requestChatId] || chatMessages
-      : chatMessages;
-    const persistedContextMessage = [...availableMessages]
-      .reverse()
-      .find((message) => Boolean(message.contextProjectId));
-    const projectId = requestChatId
-      ? contextProjectIdsRef.current[requestChatId] || persistedContextMessage?.contextProjectId || ""
-      : "";
-    if (!requestChatId || !projectId) {
-      setGenerationInputNotice("Share the initial project context before starting the build.");
-      return;
-    }
-
-    setContextBuildStarting(true);
-    setGenerationInputNotice(null);
-    try {
-      const response = await fetch(`${API_URL}/projects/${encodeURIComponent(projectId)}/context/messages`, {
-        method: "POST",
-        headers: await generationRequestHeaders(),
-        body: JSON.stringify({
-          conversation_id: requestChatId,
-          requested_tool: "build_project",
-        }),
-      });
-      if (!response.ok) {
-        noteAuthResponseStatus(response.status);
-        throw new Error(await readApiErrorMessage(response));
-      }
-      const outcome = await response.json();
-      const workflowState = typeof outcome?.workflow?.state === "string"
-        ? outcome.workflow.state
-        : "building";
-      const buildPlanId = typeof outcome?.build_execution?.plan_id === "string"
-        ? outcome.build_execution.plan_id
-        : "";
-      const buildJobId = typeof outcome?.build_execution?.job_id === "string"
-        ? outcome.build_execution.job_id
-        : "";
-      const buildStatus = typeof outcome?.build_execution?.status === "string"
-        ? outcome.build_execution.status
-        : "planned";
-      const buildIsActive = buildStatus === "planned" || buildStatus === "running";
-      const pipelineProgress = buildPlanId
-        ? createAgentPipelineProgress(defaultAgentPipelineSteps, generateProductImage, chatTimestamp(), buildJobId || null)
-        : null;
-      contextProjectIdsRef.current[requestChatId] = projectId;
-      setContextWorkflowStates((current) => ({ ...current, [requestChatId]: workflowState }));
-      const message: ChatMessage = {
-        id: newChatMessageId(),
-        role: "assistant",
-        content: typeof outcome?.assistant_message === "string"
-          ? outcome.assistant_message
-          : buildIsActive
-            ? "I’ve started the design build."
-            : "The first design revision is ready for review.",
-        status: buildIsActive ? "loading" : buildStatus === "failed" ? "error" : "success",
-        timestamp: chatTimestamp(),
-        contextProjectId: projectId,
-        workflowState,
-        pipelineProgress,
-        buildPlanId: buildPlanId || null,
-        buildJobId: buildJobId || null,
-      };
-      appendChatMessage(message);
-      appendThreadMessage(requestChatId, message);
-      setGenerationInputNotice(
-        buildIsActive ? "Build started. Live agent progress is shown above." : "Design ready for review.",
-      );
-      if (buildPlanId && buildJobId) {
-        const run = beginContextBuildRun(projectId, buildPlanId, buildJobId, requestChatId, message.id);
-        watchContextBuild(projectId, buildPlanId, buildJobId, requestChatId, message.id, run);
-      }
-    } catch (error) {
-      setGenerationInputNotice(error instanceof Error ? error.message : "Could not start the build.");
-    } finally {
-      setContextBuildStarting(false);
-    }
-  };
-
-  const handleGenerate = async (event: React.FormEvent) => {
-    event.preventDefault();
-    if (activeGenerationRef.current) return;
-    if (!(await requireSignedInForGeneration())) return;
-    if (!selectedGenerationLlm) {
-      setGenerationInputNotice("Turn on at least one model provider in Settings before building.");
-      return;
-    }
-    if (
-      selectedImage &&
-      (selectedGenerationLlm.supports_image_input ?? generationLlmImageSupport(selectedGenerationLlm)) === false
-    ) {
-      const message = `${selectedGenerationLlm.label} cannot read reference images. Choose a vision-capable model or remove the image.`;
-      setGenerationInputNotice(message);
-      appendChatMessage({
-        role: "assistant",
-        content: message,
-        status: "error",
-      });
-      return;
-    }
-    const contextCheckpoint = pendingHumanContext;
-    const submitter = (event.nativeEvent as SubmitEvent).submitter as HTMLButtonElement | null;
-    const skipHumanContext = Boolean(
-      contextCheckpoint && submitter?.name === "humanContextAction" && submitter.value === "skip"
-    );
-    const validationSubject = contextCheckpoint ? contextCheckpoint.basePrompt : prompt;
-    const validation = validateGenerationInput(validationSubject, Boolean(selectedImage));
-    if (!validation.isValid) {
-      setGenerationInputNotice(validation.message);
-      if (validation.message) {
-        appendChatMessage({
-          role: "assistant",
-          content: validation.message,
-          status: "error",
-        });
-      }
-      return;
-    }
-
-    const rawPromptText = contextCheckpoint
-      ? contextCheckpoint.basePrompt
-      : validationSubject.trim() || "Infer a buildable hardware project from the uploaded reference image.";
-    const imageData = selectedImage;
-    const requestChatId = activeChatId || newBuildChatId();
-    const generationRun = beginGenerationRun("chat", requestChatId);
-
-    if (!contextCheckpoint) {
-      setGenerationInputNotice(null);
-      try {
-        const clarification = await requestHumanContextQuestions(
-          validationSubject.trim(),
-          generationWorkflow,
-          Boolean(imageData),
-          generationRun.controller.signal
-        );
-        if (generationRun.cancelled) return;
-        if (clarification.shouldAsk) {
-          const answers = Object.fromEntries(clarification.questions.map((question) => [question.id, ""]));
-          setActiveChatId(requestChatId);
-          rememberChatItem({
-            chatId: requestChatId,
-            title: rawPromptText,
-            projectId: "",
-            createdAt: chatTimestamp(),
-            projectCount: 0,
-          });
-          syncChatRoute(requestChatId);
-          appendChatMessage({
-            role: "user",
-            content: rawPromptText,
-            status: "idle",
-          });
-          appendThreadMessage(requestChatId, {
-            role: "user",
-            content: rawPromptText,
-            status: "idle",
-          });
-          appendChatMessage({
-            role: "assistant",
-            content: [
-              "A few quick questions before I build.",
-              "",
-              ...clarification.questions.map((question) => `- ${question.label}: ${question.question}`),
-            ].join("\n"),
-            status: "idle",
-          });
-          appendThreadMessage(requestChatId, {
-            role: "assistant",
-            content: [
-              "A few quick questions before I build.",
-              "",
-              ...clarification.questions.map((question) => `- ${question.label}: ${question.question}`),
-            ].join("\n"),
-            status: "idle",
-          });
-          setPendingHumanContext({
-            basePrompt: rawPromptText,
-            questions: clarification.questions,
-            answers,
-          });
-          setPrompt("");
-          setGenerationInputNotice(clarification.reason || "Answer the context questions, then build.");
-          finishGenerationRun(generationRun);
-          return;
-        }
-      } catch (error) {
-        if (generationRun.cancelled || (error instanceof Error && error.name === "AbortError")) return;
-        finishGenerationRun(generationRun);
-        throw error;
-      }
-    }
-
-    if (generationRun.cancelled) return;
-
-    const finalContextNotes = contextCheckpoint ? prompt.trim() : "";
-    const promptText = contextCheckpoint
-      ? skipHumanContext
-        ? humanContextSkipPromptSection(contextCheckpoint.basePrompt, contextCheckpoint.questions, finalContextNotes)
-        : humanContextPromptSection(contextCheckpoint, finalContextNotes)
-      : rawPromptText;
-    const userMessageContent = contextCheckpoint
-      ? skipHumanContext
-        ? humanContextSkipChatSummary(contextCheckpoint.questions, finalContextNotes)
-        : humanContextChatSummary(contextCheckpoint, finalContextNotes)
-      : rawPromptText;
-    let generatedProject = false;
-    let generatedProjectId: string | null = null;
-    const frontendJobId = newFrontendJobId();
-    const userMessageId = newChatMessageId();
-    const assistantMessageId = newChatMessageId();
-    const pipelineProgress = createAgentPipelineProgress(agentPipelineSteps, generateProductImage, chatTimestamp(), frontendJobId);
-    const workflowLabel = selectedGenerationWorkflow?.label || generationWorkflow;
-    const providerSuffix = selectedWorkflowUsesExternalSources ? " via live web sources" : "";
-    const loadingMessage = formaDevMode
-      ? `Running ${workflowLabel}${providerSuffix} with ${selectedGenerationLlm.label}.`
-      : `Running ${workflowLabel}${providerSuffix}.`;
-    let progressPollId: number | null = null;
-    const syncProgressFromJob = async () => {
-      const job = await fetchA2aJob(frontendJobId);
-      if (!job) return;
-      applyChatPipelineProgressFromJob(assistantMessageId, job, pipelineProgress, generateProductImage);
-      applyThreadPipelineProgressFromJob(requestChatId, assistantMessageId, job, pipelineProgress, generateProductImage);
-    };
-    setActiveChatId(requestChatId);
-    rememberChatItem({
-      chatId: requestChatId,
-      title: rawPromptText,
-      projectId: "",
-      createdAt: chatTimestamp(),
-      projectCount: 0,
-    });
-    syncChatRoute(requestChatId);
-    appendChatMessage({
-      id: userMessageId,
-      role: "user",
-      content: userMessageContent,
-      status: "idle",
-    });
-    appendThreadMessage(requestChatId, {
-      id: userMessageId,
-      role: "user",
-      content: userMessageContent,
-      status: "idle",
-    });
-    appendChatMessage({
-      id: assistantMessageId,
-      role: "assistant",
-      content: loadingMessage,
-      status: "loading",
-      pipelineProgress,
-    });
-    appendThreadMessage(requestChatId, {
-      id: assistantMessageId,
-      role: "assistant",
-      content: loadingMessage,
-      status: "loading",
-      pipelineProgress,
-    });
-    setGenerationRunJob(generationRun, frontendJobId, assistantMessageId);
-
-    setGenerationInputNotice(null);
-    setPendingHumanContext(null);
-    setPrompt("");
-    checkServerStatus();
-    progressPollId = window.setInterval(() => {
-      void syncProgressFromJob();
-    }, ACTIVE_JOB_PROGRESS_POLL_INTERVAL_MS);
-    void syncProgressFromJob();
-
-    try {
-      const res = await fetch(`${API_URL}/generate`, {
-        method: "POST",
-        headers: await generationRequestHeaders(),
-        signal: generationRun.controller.signal,
-        body: JSON.stringify({
-          prompt: promptText,
-          workflow: generationWorkflow,
-          provider: selectedGenerationLlm.provider,
-          model: selectedGenerationLlm.model,
-          chat_id: requestChatId,
-          client_job_id: frontendJobId,
-          image_data: imageData || null,
-          generate_image: generateProductImage,
-        }),
-      });
-
-      if (!res.ok) {
-        noteAuthResponseStatus(res.status);
-        const apiError = await readApiError(res);
-        if (apiError.debug) {
-          console.error("Forma API debug trace", apiError);
-        }
-        const errorMessage = apiError.message;
-        const displayErrorMessage = compactDiagnosticText(errorMessage) || errorMessage;
-        if (res.status === 400) {
-          setGenerationInputNotice(displayErrorMessage);
-          updateChatMessage(assistantMessageId, {
-            content: displayErrorMessage,
-            status: "error",
-          });
-          updateThreadMessage(requestChatId, assistantMessageId, {
-            content: displayErrorMessage,
-            status: "error",
-          });
-          return;
-        }
-        if (apiError.code === "llm_output_invalid" || apiError.code === "llm_generation_unavailable") {
-          setGenerationInputNotice(displayErrorMessage);
-          updateChatMessage(assistantMessageId, {
-            content: displayErrorMessage,
-            status: "error",
-          });
-          updateThreadMessage(requestChatId, assistantMessageId, {
-            content: displayErrorMessage,
-            status: "error",
-          });
-          return;
-        }
-        if (res.status === 503) {
-          setGenerationInputNotice(displayErrorMessage);
-          updateChatMessage(assistantMessageId, {
-            content: displayErrorMessage,
-            status: "error",
-          });
-          updateThreadMessage(requestChatId, assistantMessageId, {
-            content: displayErrorMessage,
-            status: "error",
-          });
-          return;
-        }
-        throw new Error(errorMessage);
-      }
-
-      const data = await res.json();
-      if (data.job) {
-        applyChatPipelineProgressFromJob(assistantMessageId, data.job, pipelineProgress, generateProductImage);
-        applyThreadPipelineProgressFromJob(requestChatId, assistantMessageId, data.job, pipelineProgress, generateProductImage);
-      }
-      const ir = withProjectResponseMetadata(data.project_ir, data);
-      setProjectIR(ir);
-      const projectId = projectIdFromIR(ir);
-      const responseChatId = chatIdFromIR(ir) || data.chat_id || requestChatId;
-      generatedProjectId = projectId;
-      setActiveChatId(responseChatId);
-      rememberProjectRecord({
-        project_id: projectId,
-        chat_id: responseChatId,
-        title: ir?.overview?.title || rawPromptText,
-        prompt: promptText,
-        created_at: data.created_at || chatTimestamp(),
-        can_chat: true,
-        creator_display: "you",
-        creator_image_url: userImageUrl,
-        parts_count: Array.isArray(ir?.components) ? ir.components.length : 0,
-        save_count: 0,
-        remix_count: 0,
-        saved: false,
-      });
-      const successMessage = `${ir?.overview?.title || "Project"} is ready. I generated the project object, wiring view, BOM, docs, and validation metadata.`;
-      rememberChatItem({
-        chatId: responseChatId,
-        title: ir?.overview?.title || rawPromptText,
-        projectId: projectId || "",
-        createdAt: chatTimestamp(),
-        projectCount: projectId ? 1 : 0,
-      });
-      updateChatMessage(assistantMessageId, {
-        content: successMessage,
-        status: "success",
-        projectId,
-      });
-      if (projectId) {
-        updateThreadMessage(requestChatId, userMessageId, {
-          projectId,
-        });
-        updateThreadMessage(requestChatId, assistantMessageId, {
-          content: successMessage,
-          status: "success",
-          projectId,
-        });
-      }
-      refreshProjectAndChatLists();
-      fetchA2aJobs(jobStatusFilter, { silent: true });
-      generatedProject = true;
-    } catch (error) {
-      if (generationRun.cancelled || (error instanceof Error && error.name === "AbortError")) {
-        updateChatMessage(assistantMessageId, {
-          content: "Generation stopped by you.",
-          status: "cancelled",
-        });
-        updateThreadMessage(requestChatId, assistantMessageId, {
-          content: "Generation stopped by you.",
-          status: "cancelled",
-        });
-        return;
-      }
-      console.warn("Using local simulation fallback", error);
-      try {
-        const mockRes = await runMockCompilation(promptText, imageData);
-        mockRes.project_ir.assembly_metadata = {
-          ...(mockRes.project_ir.assembly_metadata || {}),
-          chat_id: requestChatId,
-          can_chat: true,
-        };
-        setProjectIR(mockRes.project_ir);
-        const fallbackProjectId = projectIdFromIR(mockRes.project_ir);
-        generatedProjectId = fallbackProjectId;
-        const fallbackMessage = `${mockRes.project_ir?.overview?.title || "Local example"} is loaded from local fallback because live generation failed.`;
-        rememberProjectRecord({
-          project_id: fallbackProjectId,
-          chat_id: requestChatId,
-          title: mockRes.project_ir?.overview?.title || rawPromptText,
-          prompt: promptText,
-          created_at: chatTimestamp(),
-          can_chat: true,
-          creator_display: "you",
-          creator_image_url: userImageUrl,
-          parts_count: Array.isArray(mockRes.project_ir?.components) ? mockRes.project_ir.components.length : 0,
-          save_count: 0,
-          remix_count: 0,
-          saved: false,
-        });
-        rememberChatItem({
-          chatId: requestChatId,
-          title: mockRes.project_ir?.overview?.title || rawPromptText,
-          projectId: fallbackProjectId || "",
-          createdAt: chatTimestamp(),
-          projectCount: fallbackProjectId ? 1 : 0,
-        });
-        updateChatMessage(assistantMessageId, {
-          content: fallbackMessage,
-          status: "success",
-          projectId: fallbackProjectId,
-        });
-        if (fallbackProjectId) {
-          updateThreadMessage(requestChatId, userMessageId, {
-            projectId: fallbackProjectId,
-          });
-          updateThreadMessage(requestChatId, assistantMessageId, {
-            content: fallbackMessage,
-            status: "success",
-            projectId: fallbackProjectId,
-          });
-        }
-        generatedProject = true;
-      } catch (fallbackError) {
-        const message = fallbackError instanceof Error ? fallbackError.message : "Local example fallback failed.";
-        const errorMessage = generationFailureChatMessage(`Generation failed and local fallback was unavailable: ${message}`);
-        setGenerationInputNotice(errorMessage);
-        updateChatMessage(assistantMessageId, {
-          content: errorMessage,
-          status: "error",
-        });
-        updateThreadMessage(requestChatId, assistantMessageId, {
-          content: errorMessage,
-          status: "error",
-        });
-      }
-    } finally {
-      if (progressPollId !== null) window.clearInterval(progressPollId);
-      if (generatedProject) {
-        setSelectedImage(null);
-        setActiveTab("overview");
-      }
-      if (generatedProjectId) {
-        refreshProjectAndChatLists();
-      }
-      finishGenerationRun(generationRun);
-    }
-  };
+  const contextBuild = useContextBuildController({
+    activeChatId,
+    setActiveChatId,
+    chatMessages,
+    chatThreads,
+    prompt,
+    setPrompt,
+    selectedImage,
+    setSelectedImage,
+    selectedImageSource,
+    setSelectedImageSource,
+    generateProductImage,
+    authRequired,
+    isSignedIn,
+    userImageUrl,
+    generationRequestHeaders,
+    optionalAuthHeaders,
+    requireSignedInForGeneration,
+    noteAuthResponseStatus,
+    appendChatMessage,
+    updateChatMessage,
+    appendThreadMessage,
+    updateThreadMessage,
+    applyChatPipelineProgressFromJob,
+    applyThreadPipelineProgressFromJob,
+    rememberChatItem,
+    rememberProjectRecord,
+    setProjectIR,
+    setGenerationInputNotice,
+    setIsLoading,
+    activeGenerationRef,
+    beginGenerationRun,
+    finishGenerationRun,
+    setGenerationRunJob,
+    stopActiveGeneration,
+    syncChatRoute,
+    fetchProjectHistory,
+    fetchMyProjectHistory,
+  });
+  const {
+    contextWorkflowStates,
+    contextBuildStarting,
+    contextSubmitting,
+    resettingBuildMessageId,
+    pendingContextBuildMessage,
+    retryableContextBuildMessage,
+    submitGatherContext,
+    handleGatherContext,
+    handleBuildNow,
+    resetFailedContextBuild,
+    stopContextBuildMessage,
+  } = contextBuild;
+  cancelContextBuildRef.current = contextBuild.cancelContextBuild;
 
   const handleProjectChatGenerate = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -4420,42 +2074,6 @@ export function FormaWorkspace({
     });
   }, []);
 
-
-  const runMockCompilation = async (userPrompt: string, imageData?: string | null): Promise<any> => {
-    const promptLower = userPrompt.toLowerCase();
-    let file = "biometric_deadbolt.json";
-
-    if (
-      imageData ||
-      promptLower.includes("mp3") ||
-      promptLower.includes("audio") ||
-      promptLower.includes("music") ||
-      promptLower.includes("player") ||
-      promptLower.includes("pocket")
-    ) {
-      file = "pocket_mp3_player.json";
-    } else if (promptLower.includes("water") || promptLower.includes("plant") || promptLower.includes("soil") || promptLower.includes("garden")) {
-      file = "plant_watering.json";
-    } else if (promptLower.includes("thermostat") || promptLower.includes("temperature") || promptLower.includes("weather")) {
-      file = "smart_thermostat.json";
-    }
-
-    const res = await fetch(`/examples/${file}`);
-    if (!res.ok) {
-      throw new Error(`Could not load local example ${file}.`);
-    }
-    const ir = await res.json();
-    ir.assembly_metadata = {
-      ...(ir.assembly_metadata || {}),
-      reference_image_data: imageData || ir.assembly_metadata?.reference_image_data || null,
-      input_mode: imageData ? "prompt_image" : "prompt",
-      image_features: ir.assembly_metadata?.image_features || ir.constraints || [],
-    };
-    return {
-      project_ir: ir,
-    };
-  };
-
   const loadOldProject = async (
     projectId: string,
     options: { syncRoute?: boolean; signal?: AbortSignal; tab?: string | null; hydrateChat?: boolean } = {}
@@ -4595,12 +2213,17 @@ export function FormaWorkspace({
     setActiveChatId(chatId);
     setActiveTab("overview");
     setRouteProjectError(null);
-    if (storedMessages.length) {
-      setChatThreads((current) => ({ ...current, [chatId]: storedMessages }));
-      setChatMessages(storedMessages);
-    } else {
-      setChatMessages(initialChatMessages());
-    }
+    const alreadyShowingThisChat = activeChatId === chatId;
+    setChatThreads((current) => {
+      const existing = current[chatId] || [];
+      const merged = hydrateRoutedChatMessages(storedMessages, existing, { sameChat: true });
+      if (!merged.length) return current;
+      return { ...current, [chatId]: merged };
+    });
+    setChatMessages((current) => {
+      const merged = hydrateRoutedChatMessages(storedMessages, current, { sameChat: alreadyShowingThisChat });
+      return merged.length ? merged : initialChatMessages();
+    });
 
     if (!chatSourcesReady) {
       setChatRouteTransition({ chatId, title: "Opening chat", projectId: "", error: null });
@@ -4772,7 +2395,7 @@ export function FormaWorkspace({
     downloadBrowserFile(markdown, docsExportFilename(title), "text/markdown;charset=utf-8");
   };
 
-  const metrics = calculateProjectCostMetrics(projectIR);
+  const metrics = useMemo(() => calculateProjectCostMetrics(projectIR), [projectIR]);
   const components = useMemo(() => resolveProjectComponentInstances(projectIR), [projectIR]);
   const bomLineItems = projectIR?.bom?.length ? projectIR.bom : components;
   const schematicProject = useMemo(
@@ -4868,9 +2491,12 @@ export function FormaWorkspace({
   const currentProjectJobId = projectIR?.assembly_metadata?.frontend_job_id || null;
   const activeSidebarChatId = routedProjectId ? null : (currentProjectChatId || activeChatId);
   const activeSidebarChatItem = chatListItems.find((item) => item.chatId === activeSidebarChatId);
+  const displayedHomeChatMessages = activeChatId && chatThreads[activeChatId]?.length
+    ? chatThreads[activeChatId]
+    : chatMessages;
   const activeSidebarChatStarted = Boolean(
     projectIR ||
-    chatHasStarted(projectIR ? currentProjectChatMessages : chatMessages) ||
+    chatHasStarted(projectIR ? currentProjectChatMessages : displayedHomeChatMessages) ||
     activeSidebarChatItem?.projectId ||
     activeSidebarChatItem?.projectCount
   );
@@ -4975,95 +2601,51 @@ export function FormaWorkspace({
   const activeWorkspaceTab = workspaceTabMeta(activeTab);
   const activeWorkspaceNamespace = workspaceNamespaceForTab(activeTab);
   const displayedWorkspaceNamespace = activeWorkspaceNamespace;
-  const projectNamespaceContent = (() => {
-    switch (activeWorkspaceTab.id) {
-      case "overview":
-        return (
-          <OverviewPanel
-            title={projectTitle}
-            description={projectDescription}
-            imageCandidates={projectImageCandidates}
-            features={imageFeatures}
-            metrics={metrics}
-            metadata={projectIR?.assembly_metadata || {}}
-            systemArchitecture={projectIR?.system_architecture || null}
-            showModelName={formaDevMode}
-            showImageSection={showProductImageSection}
-          />
-        );
-      case "bom":
-        return (
-          <BomPanel
-            components={bomLineItems}
-            metrics={metrics}
-            cadSources={(projectIR?.mechanical && Array.isArray(projectIR.mechanical.cad_sources)) ? projectIR.mechanical.cad_sources : []}
-            fabricationCost={Number(projectIR?.mechanical?.fabrication_cost_estimate_usd || 0)}
-            canDownloadAssets={currentProjectCanDownloadAssets}
-          />
-        );
-      case "mechanical":
-        return (
-          <MechanicalPanel
-            toggles={mechToggles}
-            setToggles={setMechToggles}
-            electricalActive={mechElectricalActive}
-            setElectricalActive={setMechElectricalActive}
-            components={components}
-            features={imageFeatures}
-            metadata={projectIR?.assembly_metadata || {}}
-            mechanical={projectIR?.mechanical || {}}
-          />
-        );
-      case "schematic":
-        return <SchematicCanvas project={schematicProject} />;
-      case "assembly":
-        return (
-          <AssemblyPanel
-            assembly={assembly}
-            issues={issues}
-            onDownloadJSON={downloadJSONIR}
-            onDownloadMarkdown={downloadMarkdownDocs}
-            canDownloadAssets={currentProjectCanDownloadAssets}
-          />
-        );
-      case "video":
-        return (
-          <VideoPanel {...projectVideo} />
-        );
-      case "jobs":
-        return (
-          <JobsPanel
-            jobs={projectJobs}
-            loading={jobsLoading}
-            error={jobsError}
-            statusFilter={jobStatusFilter}
-            onStatusFilterChange={changeJobStatusFilter}
-            onRefresh={() => fetchA2aJobs(jobStatusFilter)}
-            onOpenProject={loadProjectForJob}
-            findProjectForJob={findProjectForJob}
-            lastUpdatedAt={jobsLastUpdatedAt}
-            pollIntervalMs={JOB_POLL_INTERVAL_MS}
-            title="Project Jobs"
-            description="Only jobs tied to this project are shown here."
-            emptyMessage="No jobs recorded for this project and filter."
-            formatLlmLabel={generationLlmLabel}
-          />
-        );
-      case "logs":
-        return canViewAdminTools ? (
-          <LogsPanel
-            logs={backendLogs}
-            loading={logsLoading}
-            error={logsError}
-            lastUpdatedAt={logsLastUpdatedAt}
-            onRefresh={() => fetchBackendLogs()}
-            pollIntervalMs={LOG_POLL_INTERVAL_MS}
-          />
-        ) : null;
-      default:
-        return null;
-    }
-  })();
+  const projectNamespaceContent = (
+    <ProjectTabContent
+      tabId={activeWorkspaceTab.id}
+      title={projectTitle}
+      description={projectDescription}
+      imageCandidates={projectImageCandidates}
+      features={imageFeatures}
+      metrics={metrics}
+      metadata={projectIR?.assembly_metadata || {}}
+      systemArchitecture={projectIR?.system_architecture || null}
+      showModelName={formaDevMode}
+      showImageSection={showProductImageSection}
+      components={components}
+      bomComponents={bomLineItems}
+      cadSources={(projectIR?.mechanical && Array.isArray(projectIR.mechanical.cad_sources)) ? projectIR.mechanical.cad_sources : []}
+      fabricationCost={Number(projectIR?.mechanical?.fabrication_cost_estimate_usd || 0)}
+      canDownloadAssets={currentProjectCanDownloadAssets}
+      mechToggles={mechToggles}
+      setMechToggles={setMechToggles}
+      mechElectricalActive={mechElectricalActive}
+      setMechElectricalActive={setMechElectricalActive}
+      mechanical={projectIR?.mechanical || {}}
+      schematic={<SchematicCanvas project={schematicProject} />}
+      assembly={assembly}
+      issues={issues}
+      onDownloadJSON={downloadJSONIR}
+      onDownloadMarkdown={downloadMarkdownDocs}
+      videoContent={activeWorkspaceTab.id === "video" ? <VideoPanel {...projectVideo} /> : null}
+      jobs={projectJobs}
+      jobsLoading={jobsLoading}
+      jobsError={jobsError}
+      jobStatusFilter={jobStatusFilter}
+      onStatusFilterChange={changeJobStatusFilter}
+      onRefreshJobs={() => fetchA2aJobs(jobStatusFilter)}
+      onOpenProject={loadProjectForJob}
+      findProjectForJob={findProjectForJob}
+      jobsLastUpdatedAt={jobsLastUpdatedAt}
+      logs={backendLogs}
+      logsLoading={logsLoading}
+      logsError={logsError}
+      onRefreshLogs={() => fetchBackendLogs()}
+      logsLastUpdatedAt={logsLastUpdatedAt}
+      canViewAdminTools={canViewAdminTools}
+    />
+  );
 
   useEffect(() => {
     if (routedProjectId) return;
@@ -5109,56 +2691,41 @@ export function FormaWorkspace({
     );
   }
 
+
+  const workspaceShell = (activeId: string | null, children: React.ReactNode, homeMobileTopPadding = false) => (
+    <WorkspaceSidebarShell
+      collapsed={sidebarCollapsed}
+      mobileSidebarOpen={mobileSidebarOpen}
+      onMobileSidebarClose={() => setMobileSidebarOpen(false)}
+      onToggleCollapsed={() => setSidebarCollapsed((value) => !value)}
+      onHome={goHome}
+      chats={chatListItems}
+      activeChatId={activeId}
+      onNewChat={startNewProjectChat}
+      newChatDisabled={newChatDisabled}
+      onOpenChat={openChatItem}
+      onRenameChat={renameSidebarChat}
+      onPinChat={togglePinnedChat}
+      onDeleteChat={deleteSidebarChat}
+      waitingChatIds={waitingChatIds}
+      chatsLoading={sidebarChatsLoading}
+      showJobs={canViewJobs}
+      jobsPending={sidebarJobsPending}
+      showDeveloperTools={showDeveloperTools}
+      authRequired={authRequired}
+      workspaceStatus={workspaceStatus}
+      homeMobileTopPadding={homeMobileTopPadding}
+    >
+      {children}
+    </WorkspaceSidebarShell>
+  );
+
   if (showChatRouteFallback && visibleChatRouteTransition) {
     return (
-      <WorkspaceFrame
-        collapsed={sidebarCollapsed}
-        workspaceStatus={workspaceStatus}
-        mobileSidebar={(
-          <MobileSidebarDrawer
-            open={mobileSidebarOpen}
-            onClose={() => setMobileSidebarOpen(false)}
-            collapsed={sidebarCollapsed}
-            onToggle={() => setSidebarCollapsed((value) => !value)}
-            onHome={goHome}
-            chats={chatListItems}
-            activeChatId={visibleChatRouteTransition.chatId}
-            onNewChat={startNewProjectChat}
-            newChatDisabled={newChatDisabled}
-            onOpenChat={openChatItem}
-            onRenameChat={renameSidebarChat}
-            onPinChat={togglePinnedChat}
-            onDeleteChat={deleteSidebarChat}
-            waitingChatIds={waitingChatIds}
-            chatsLoading={sidebarChatsLoading}
-            showJobs={canViewJobs}
-            jobsPending={sidebarJobsPending}
-            showDeveloperTools={showDeveloperTools}
-            authRequired={authRequired}
-          />
-        )}
-        desktopSidebar={(
-          <ChatSidebar
-            collapsed={sidebarCollapsed}
-            onToggle={() => setSidebarCollapsed((value) => !value)}
-            onHome={goHome}
-            chats={chatListItems}
-            activeChatId={visibleChatRouteTransition.chatId}
-            onNewChat={startNewProjectChat}
-            newChatDisabled={newChatDisabled}
-            onOpenChat={openChatItem}
-            onRenameChat={renameSidebarChat}
-            onPinChat={togglePinnedChat}
-            onDeleteChat={deleteSidebarChat}
-            waitingChatIds={waitingChatIds}
-            chatsLoading={sidebarChatsLoading}
-            showJobs={canViewJobs}
-            jobsPending={sidebarJobsPending}
-            showDeveloperTools={showDeveloperTools}
-            authRequired={authRequired}
-          />
-        )}
-      >
+      workspaceShell(
+        visibleChatRouteTransition.chatId,
+        (
+        <>
         <ChatRouteFallbackPanel
           transition={visibleChatRouteTransition}
           onHome={goHome}
@@ -5175,60 +2742,19 @@ export function FormaWorkspace({
           onCancel={closeProjectDeletion}
           onConfirm={confirmProjectDeletion}
         />
-      </WorkspaceFrame>
+        </>
+        ),
+        false,
+      )
     );
   }
 
   if (routedProjectId && loadedProjectId !== routedProjectId) {
     return (
-      <WorkspaceFrame
-        collapsed={sidebarCollapsed}
-        workspaceStatus={workspaceStatus}
-        mobileSidebar={(
-          <MobileSidebarDrawer
-            open={mobileSidebarOpen}
-            onClose={() => setMobileSidebarOpen(false)}
-            collapsed={sidebarCollapsed}
-            onToggle={() => setSidebarCollapsed((value) => !value)}
-            onHome={goHome}
-            chats={chatListItems}
-            activeChatId={null}
-            onNewChat={startNewProjectChat}
-            newChatDisabled={newChatDisabled}
-            onOpenChat={openChatItem}
-            onRenameChat={renameSidebarChat}
-            onPinChat={togglePinnedChat}
-            onDeleteChat={deleteSidebarChat}
-            waitingChatIds={waitingChatIds}
-            chatsLoading={sidebarChatsLoading}
-            showJobs={canViewJobs}
-            jobsPending={sidebarJobsPending}
-            showDeveloperTools={showDeveloperTools}
-            authRequired={authRequired}
-          />
-        )}
-        desktopSidebar={(
-          <ChatSidebar
-            collapsed={sidebarCollapsed}
-            onToggle={() => setSidebarCollapsed((value) => !value)}
-            onHome={goHome}
-            chats={chatListItems}
-            activeChatId={null}
-            onNewChat={startNewProjectChat}
-            newChatDisabled={newChatDisabled}
-            onOpenChat={openChatItem}
-            onRenameChat={renameSidebarChat}
-            onPinChat={togglePinnedChat}
-            onDeleteChat={deleteSidebarChat}
-            waitingChatIds={waitingChatIds}
-            chatsLoading={sidebarChatsLoading}
-            showJobs={canViewJobs}
-            jobsPending={sidebarJobsPending}
-            showDeveloperTools={showDeveloperTools}
-            authRequired={authRequired}
-          />
-        )}
-      >
+      workspaceShell(
+        null,
+        (
+        <>
         <ProjectRouteFallbackPanel
           projectId={routedProjectId}
           error={routeProjectError}
@@ -5246,61 +2772,19 @@ export function FormaWorkspace({
           onCancel={closeProjectDeletion}
           onConfirm={confirmProjectDeletion}
         />
-      </WorkspaceFrame>
+        </>
+        ),
+        false,
+      )
     );
   }
 
   if (homeView !== "chat" || !projectIR) {
     return (
-      <WorkspaceFrame
-        collapsed={sidebarCollapsed}
-        workspaceStatus={workspaceStatus}
-        homeMobileTopPadding
-        mobileSidebar={(
-          <MobileSidebarDrawer
-            open={mobileSidebarOpen}
-            onClose={() => setMobileSidebarOpen(false)}
-            collapsed={sidebarCollapsed}
-            onToggle={() => setSidebarCollapsed((value) => !value)}
-            onHome={goHome}
-            chats={chatListItems}
-            activeChatId={activeChatId}
-            onNewChat={startNewProjectChat}
-            newChatDisabled={newChatDisabled}
-            onOpenChat={openChatItem}
-            onRenameChat={renameSidebarChat}
-            onPinChat={togglePinnedChat}
-            onDeleteChat={deleteSidebarChat}
-            waitingChatIds={waitingChatIds}
-            chatsLoading={sidebarChatsLoading}
-            showJobs={canViewJobs}
-            jobsPending={sidebarJobsPending}
-            showDeveloperTools={showDeveloperTools}
-            authRequired={authRequired}
-          />
-        )}
-        desktopSidebar={(
-          <ChatSidebar
-            collapsed={sidebarCollapsed}
-            onToggle={() => setSidebarCollapsed((value) => !value)}
-            onHome={goHome}
-            chats={chatListItems}
-            activeChatId={activeChatId}
-            onNewChat={startNewProjectChat}
-            newChatDisabled={newChatDisabled}
-            onOpenChat={openChatItem}
-            onRenameChat={renameSidebarChat}
-            onPinChat={togglePinnedChat}
-            onDeleteChat={deleteSidebarChat}
-            waitingChatIds={waitingChatIds}
-            chatsLoading={sidebarChatsLoading}
-            showJobs={canViewJobs}
-            jobsPending={sidebarJobsPending}
-            showDeveloperTools={showDeveloperTools}
-            authRequired={authRequired}
-          />
-        )}
-      >
+      workspaceShell(
+        activeChatId,
+        (
+        <>
         <div ref={homeChromeRef} className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         <MobileWorkspaceBar onOpenSidebar={() => setMobileSidebarOpen(true)} headerAway={homeHeaderAway}>
           {homeView === "settings" ? (
@@ -5455,7 +2939,7 @@ export function FormaWorkspace({
                   />
                 ) : null
               }
-              messages={chatMessages}
+              messages={displayedHomeChatMessages}
               renderPipelineProgress={(message) => (
                 <AgentPipelineProgressView
                   progress={message.pipelineProgress as AgentPipelineProgress | null}
@@ -5498,8 +2982,7 @@ export function FormaWorkspace({
               examples={samplePrompts}
               onSelectExample={(example) => {
                 setGenerationInputNotice(null);
-                setPendingHumanContext(null);
-                setPrompt(example);
+                            setPrompt(example);
               }}
               onSubmit={handleGatherContext}
               canBuildNow={(() => {
@@ -5557,59 +3040,17 @@ export function FormaWorkspace({
           onCancel={closeProjectDeletion}
           onConfirm={confirmProjectDeletion}
         />
-      </WorkspaceFrame>
+        </>
+        ),
+        true,
+      )
     );
   }
 
-  return (
-    <WorkspaceFrame
-      collapsed={sidebarCollapsed}
-      workspaceStatus={workspaceStatus}
-      mobileSidebar={(
-        <MobileSidebarDrawer
-          open={mobileSidebarOpen}
-          onClose={() => setMobileSidebarOpen(false)}
-          collapsed={sidebarCollapsed}
-          onToggle={() => setSidebarCollapsed((value) => !value)}
-          onHome={goHome}
-          chats={chatListItems}
-          activeChatId={activeSidebarChatId}
-          onNewChat={startNewProjectChat}
-          newChatDisabled={newChatDisabled}
-          onOpenChat={openChatItem}
-          onRenameChat={renameSidebarChat}
-          onPinChat={togglePinnedChat}
-          onDeleteChat={deleteSidebarChat}
-          waitingChatIds={waitingChatIds}
-          chatsLoading={sidebarChatsLoading}
-          showJobs={canViewJobs}
-          jobsPending={sidebarJobsPending}
-          showDeveloperTools={showDeveloperTools}
-          authRequired={authRequired}
-        />
-      )}
-      desktopSidebar={(
-        <ChatSidebar
-          collapsed={sidebarCollapsed}
-          onToggle={() => setSidebarCollapsed((value) => !value)}
-          onHome={goHome}
-          chats={chatListItems}
-          activeChatId={activeSidebarChatId}
-          onNewChat={startNewProjectChat}
-          newChatDisabled={newChatDisabled}
-          onOpenChat={openChatItem}
-          onRenameChat={renameSidebarChat}
-          onPinChat={togglePinnedChat}
-          onDeleteChat={deleteSidebarChat}
-          waitingChatIds={waitingChatIds}
-          chatsLoading={sidebarChatsLoading}
-          showJobs={canViewJobs}
-          jobsPending={sidebarJobsPending}
-          showDeveloperTools={showDeveloperTools}
-          authRequired={authRequired}
-        />
-      )}
-    >
+  return workspaceShell(
+    activeSidebarChatId,
+    (
+      <>
       <main className="flex min-h-0 min-w-0 flex-col">
         <input
           ref={projectVideo.fileInputRef}
@@ -5668,1936 +3109,9 @@ export function FormaWorkspace({
         onCancel={closeProjectDeletion}
         onConfirm={confirmProjectDeletion}
       />
-    </WorkspaceFrame>
+      </>
+    ),
   );
 }
 
 export default FormaWorkspace;
-
-function ProjectDeletionDialog({
-  project,
-  acknowledged,
-  contribute,
-  busy,
-  error,
-  onAcknowledgedChange,
-  onContributeChange,
-  onCancel,
-  onConfirm,
-}: {
-  project: PendingProjectDeletion | null;
-  acknowledged: boolean;
-  contribute: boolean;
-  busy: boolean;
-  error: string | null;
-  onAcknowledgedChange: (value: boolean) => void;
-  onContributeChange: (value: boolean) => void;
-  onCancel: () => void;
-  onConfirm: () => void;
-}) {
-  if (!project) return null;
-  return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm" role="presentation">
-      <section
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="delete-project-title"
-        className="w-full max-w-xl rounded-2xl border border-white/5 bg-[#181b22] p-6 text-zinc-100 shadow-2xl"
-      >
-        <div className="flex items-start gap-3">
-          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-red-500/10 text-red-300">
-            <Trash2 className="h-5 w-5" />
-          </span>
-          <div className="min-w-0">
-            <h2 id="delete-project-title" className="text-lg font-semibold tracking-tight text-zinc-100">
-              Delete this project?
-            </h2>
-            <p className="mt-1 break-words text-sm text-zinc-400">{project.title}</p>
-          </div>
-        </div>
-        <p className="mt-5 text-sm leading-6 text-zinc-300">
-          Removed from your workspace now. Permanently deleted after 30 days.
-        </p>
-        <label className="mt-5 flex cursor-pointer items-start gap-3 rounded-lg border border-white/10 bg-[#0f1117] p-4 text-sm leading-5 text-zinc-300">
-          <input
-            type="checkbox"
-            checked={acknowledged}
-            onChange={(event) => onAcknowledgedChange(event.target.checked)}
-            disabled={busy}
-            className="mt-0.5 h-4 w-4 accent-red-400"
-          />
-          <span>I understand I will lose access to this project.</span>
-        </label>
-        <div className="mt-4 rounded-lg border border-emerald-500/20 bg-emerald-500/[0.06] p-4">
-          <label className="flex cursor-pointer items-start gap-3 text-sm font-medium leading-5 text-zinc-200">
-            <input
-              type="checkbox"
-              checked={contribute}
-              onChange={(event) => onContributeChange(event.target.checked)}
-              disabled={busy}
-              className="mt-0.5 h-4 w-4 accent-emerald-400"
-            />
-            <span>Keep a sanitized copy for product research.</span>
-          </label>
-          <p className="mt-3 text-xs leading-5 text-zinc-500">
-            Personal details are removed. You can withdraw until the copy is anonymized.
-          </p>
-          <div className="mt-3 flex flex-wrap gap-4 text-xs font-medium">
-            <a href="/legal/privacy-policy" target="_blank" rel="noreferrer" className="text-emerald-400 transition-colors hover:text-emerald-300">Privacy policy</a>
-            <a href="/legal/data-contribution-terms" target="_blank" rel="noreferrer" className="text-emerald-400 transition-colors hover:text-emerald-300">Data contribution terms</a>
-          </div>
-        </div>
-        {error && <p className="mt-4 rounded-lg border border-red-400/30 bg-red-400/10 p-3 text-sm text-red-200">{error}</p>}
-        <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
-          <button
-            type="button"
-            onClick={onCancel}
-            disabled={busy}
-            className="inline-flex h-9 items-center justify-center rounded-lg border border-white/10 px-4 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-800/40 hover:text-zinc-100 disabled:opacity-50"
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            onClick={onConfirm}
-            disabled={!acknowledged || busy}
-            className="inline-flex h-9 items-center justify-center rounded-lg bg-red-500 px-4 text-xs font-medium text-white transition-colors hover:bg-red-400 disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            {busy ? "Deleting..." : "Delete project"}
-          </button>
-        </div>
-      </section>
-    </div>
-  );
-}
-
-function buildChatListItems(projectHistory: any[], localChatItems: ChatListItem[] = []): ChatListItem[] {
-  const groups = new Map<string, { latest: any; projectCount: number }>();
-
-  projectHistory
-    .filter((project: any) => project?.project_id)
-    .forEach((project: any) => {
-      const projectId = String(project.project_id);
-      const chatId = String(project.chat_id || projectId).trim();
-      if (!chatId) return;
-
-      const existing = groups.get(chatId);
-      if (!existing) {
-        groups.set(chatId, { latest: project, projectCount: 1 });
-        return;
-      }
-
-      const currentTime = Date.parse(existing.latest?.created_at || "");
-      const nextTime = Date.parse(project.created_at || "");
-      groups.set(chatId, {
-        latest: Number.isNaN(nextTime) || nextTime <= (Number.isNaN(currentTime) ? 0 : currentTime)
-          ? existing.latest
-          : project,
-        projectCount: existing.projectCount + 1,
-      });
-    });
-
-  const savedItems = Array.from(groups.entries())
-    .map(([chatId, group]) => ({
-      chatId,
-      title: group.latest?.title || "Untitled chat",
-      projectId: String(group.latest?.project_id || ""),
-      createdAt: typeof group.latest?.created_at === "string" ? group.latest.created_at : null,
-      projectCount: group.projectCount,
-    }));
-
-  const merged = new Map<string, ChatListItem>();
-  localChatItems.forEach((item) => {
-    if (item.chatId) merged.set(item.chatId, item);
-  });
-  savedItems.forEach((item) => {
-    const existing = merged.get(item.chatId);
-    merged.set(item.chatId, {
-      ...existing,
-      ...item,
-      createdAt: latestChatListItemDate(existing?.createdAt, item.createdAt),
-      projectCount: Math.max(existing?.projectCount || 0, item.projectCount),
-    });
-  });
-
-  return sortChatListItems(Array.from(merged.values()));
-}
-
-function normalizePrivateChatItems(value: any): ChatListItem[] {
-  const chats = Array.isArray(value) ? value : [];
-  return chats
-    .map((chat: any): ChatListItem | null => {
-      const chatId = typeof chat?.chat_id === "string" ? chat.chat_id.trim() : "";
-      if (!chatId) return null;
-      const messages = persistableChatMessages(Array.isArray(chat?.messages) ? chat.messages : []);
-      const projectId = [...messages].reverse().find((message) => message.projectId)?.projectId || "";
-      return {
-        chatId,
-        title: typeof chat.title === "string" && chat.title.trim() ? chat.title.trim() : NEW_PROJECT_TITLE,
-        projectId,
-        createdAt: typeof chat.updated_at === "string" ? chat.updated_at : typeof chat.created_at === "string" ? chat.created_at : null,
-        projectCount: 0,
-      };
-    })
-    .filter((item: ChatListItem | null): item is ChatListItem => Boolean(item));
-}
-
-function normalizeProjectListPage(value: any): { items: any[]; total: number } {
-  if (Array.isArray(value)) return { items: value, total: value.length };
-  const items = Array.isArray(value?.items) ? value.items : [];
-  const parsedTotal = Number(value?.total);
-  return {
-    items,
-    total: Number.isFinite(parsedTotal) ? Math.max(items.length, Math.trunc(parsedTotal)) : items.length,
-  };
-}
-
-function mergeChatListItems(primary: ChatListItem[], secondary: ChatListItem[]): ChatListItem[] {
-  const merged = new Map<string, ChatListItem>();
-  secondary.forEach((item) => {
-    if (item.chatId) merged.set(item.chatId, item);
-  });
-  primary.forEach((item) => {
-    if (!item.chatId) return;
-    const existing = merged.get(item.chatId);
-    merged.set(item.chatId, {
-      ...existing,
-      ...item,
-      createdAt: latestChatListItemDate(existing?.createdAt, item.createdAt),
-      projectCount: Math.max(existing?.projectCount || 0, item.projectCount),
-    });
-  });
-  return sortChatListItems(Array.from(merged.values()));
-}
-
-function mergeProjectRecords(primary: any[], secondary: any[]): any[] {
-  const merged = new Map<string, any>();
-  primary.forEach((project: any) => {
-    const projectId = project?.project_id ? String(project.project_id) : "";
-    if (projectId) merged.set(projectId, project);
-  });
-  secondary.forEach((project: any) => {
-    const projectId = project?.project_id ? String(project.project_id) : "";
-    if (projectId) merged.set(projectId, project);
-  });
-  return Array.from(merged.values());
-}
-
-function sameStringList(left: string[], right: string[]): boolean {
-  return left.length === right.length && left.every((value, index) => value === right[index]);
-}
-
-function projectRecordsFromChatItems(chatItems: ChatListItem[]): any[] {
-  return chatItems
-    .filter((item) => item.projectId)
-    .map((item) => ({
-      project_id: item.projectId,
-      chat_id: item.chatId,
-      title: item.title || "Untitled project",
-      prompt: item.title || "",
-      created_at: item.createdAt || chatTimestamp(),
-      can_chat: true,
-      creator_display: "unknown",
-      creator_username: "unknown",
-      creator_image_url: null,
-      parts_count: 0,
-      save_count: 0,
-      remix_count: 0,
-      saved: false,
-    }));
-}
-
-function WorkspaceChromeIdentity({
-  icon: Icon,
-  badge,
-  title,
-}: {
-  icon: React.ElementType<{ className?: string }>;
-  badge: string;
-  title: React.ReactNode;
-}) {
-  return (
-    <div className="min-w-0 flex-1">
-      <div className="flex min-w-0 items-center gap-2">
-        <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-400">
-          <Icon className="h-3 w-3" />
-          {badge}
-        </span>
-        {typeof title === "string" ? (
-          <h2 className="truncate text-sm font-semibold tracking-tight text-zinc-100">{title}</h2>
-        ) : title}
-      </div>
-    </div>
-  );
-}
-
-function WorkspacePageHeading({
-  icon: Icon,
-  title,
-  description,
-}: {
-  icon: React.ElementType<{ className?: string }>;
-  title: string;
-  description: string;
-}) {
-  return (
-    <section className="mb-6 border-b border-white/5 pb-5">
-      <div className="hidden min-w-0 items-center gap-3 md:flex">
-        <div className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10 text-emerald-400">
-          <Icon className="h-5 w-5" />
-        </div>
-        <div className="min-w-0">
-          <h1 className="truncate text-xl font-semibold tracking-tight text-zinc-100">{title}</h1>
-          <p className="mt-1 max-w-2xl text-sm leading-6 text-zinc-500">{description}</p>
-        </div>
-      </div>
-      <p className="max-w-2xl text-sm leading-6 text-zinc-500 md:hidden">{description}</p>
-    </section>
-  );
-}
-
-function ProjectRouteFallbackPanel({
-  projectId,
-  error,
-  onHome,
-  onOpenSidebar,
-}: {
-  projectId: string;
-  error: string | null;
-  onHome: () => void;
-  onOpenSidebar: () => void;
-}) {
-  return (
-    <main className="flex min-h-0 min-w-0 flex-col">
-      <header className="flex h-12 items-center gap-3 border-b border-white/5 bg-[#0f1117]/80 px-4 backdrop-blur-md">
-        <MobileSidebarButton onClick={onOpenSidebar} />
-        <div className="flex min-w-0 flex-1 items-baseline gap-2">
-          <div className="truncate text-sm font-semibold tracking-tight text-zinc-100">
-            {error ? "Project unavailable" : "Opening project"}
-          </div>
-          <div className="truncate font-mono text-[10px] text-zinc-600">{projectId}</div>
-        </div>
-      </header>
-
-      <section className="flex min-h-0 flex-1 items-center justify-center p-5">
-        <div className="w-full max-w-md rounded-2xl border border-white/5 bg-[#181b22] p-6 text-center shadow-2xl shadow-black/30">
-          <div className="mx-auto flex h-11 w-11 items-center justify-center rounded-lg bg-emerald-500/10">
-            {error ? <AlertTriangle className="h-5 w-5 text-amber-300" /> : <RefreshCw className="h-5 w-5 animate-spin text-emerald-400" />}
-          </div>
-          <h1 className="mt-5 text-lg font-semibold tracking-tight text-zinc-100">
-            {error ? "Project unavailable" : "Opening project"}
-          </h1>
-          <p className="mt-3 text-sm leading-6 text-zinc-500">
-            {error || "Loading the saved hardware plan."}
-          </p>
-          {error && (
-            <button
-              type="button"
-              onClick={onHome}
-              className="mt-5 inline-flex h-9 items-center gap-2 rounded-lg border border-white/10 px-4 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-800/40 hover:text-zinc-100"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              Back home
-            </button>
-          )}
-        </div>
-      </section>
-    </main>
-  );
-}
-
-function AuthRequiredRouteScreen({
-  loading,
-  title,
-  message,
-  onHome,
-}: {
-  loading: boolean;
-  title: string;
-  message: string;
-  onHome: () => void;
-}) {
-  const { openSignIn } = useFormaAuth();
-  return (
-    <div className="flex min-h-screen w-full items-center justify-center bg-[#0f1117] px-5 font-sans text-zinc-100">
-      <div className="w-full max-w-md rounded-2xl border border-white/5 bg-[#181b22] p-6 shadow-2xl">
-        <div className="flex items-center gap-3">
-          <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-500/10 text-emerald-400">
-            <KeyRound className="h-5 w-5" />
-          </span>
-          <div className="min-w-0">
-            <h1 className="truncate text-lg font-semibold tracking-tight text-zinc-100">{title}</h1>
-            <p className="mt-1 text-sm text-zinc-500">{loading ? "Checking session..." : message}</p>
-          </div>
-        </div>
-        <div className="mt-6 grid grid-cols-2 gap-2">
-          <button
-            type="button"
-            onClick={onHome}
-            className="inline-flex h-9 items-center justify-center rounded-lg border border-white/10 px-3 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-800/40 hover:text-zinc-100"
-          >
-            Home
-          </button>
-          <button
-            type="button"
-            disabled={loading}
-            onClick={() => openSignIn({ redirectUrl: typeof window !== "undefined" ? window.location.href : "/" })}
-            className="inline-flex h-9 items-center justify-center rounded-lg bg-emerald-500 px-3 text-xs font-semibold text-zinc-950 transition-colors hover:bg-emerald-400 disabled:cursor-wait disabled:opacity-50"
-          >
-            Sign in
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function ChatRouteFallbackPanel({
-  transition,
-  onHome,
-  onOpenSidebar,
-}: {
-  transition: ChatRouteTransition;
-  onHome: () => void;
-  onOpenSidebar: () => void;
-}) {
-  const hasProjectTarget = Boolean(transition.projectId);
-  return (
-    <main className="flex min-h-0 min-w-0 flex-col">
-      <header className="flex h-12 min-w-0 items-center gap-2 overflow-hidden border-b border-white/5 bg-[#0f1117]/80 px-3 backdrop-blur-md sm:gap-3 sm:px-4">
-        <MobileSidebarButton onClick={onOpenSidebar} />
-        <div className="flex min-w-0 flex-1 items-baseline gap-2">
-          <div className="truncate text-sm font-semibold tracking-tight text-zinc-100">{transition.title || "Opening chat"}</div>
-          <span className="truncate font-mono text-[10px] text-zinc-600">{transition.projectId || transition.chatId}</span>
-        </div>
-      </header>
-
-      <section className="flex min-h-0 flex-1 items-center justify-center p-5">
-        <div className="w-full max-w-md rounded-2xl border border-white/5 bg-[#181b22] p-6 text-center shadow-2xl shadow-black/30">
-          <div className="mx-auto flex h-11 w-11 items-center justify-center rounded-lg bg-emerald-500/10">
-            {transition.error ? <AlertTriangle className="h-5 w-5 text-amber-300" /> : <RefreshCw className="h-5 w-5 animate-spin text-emerald-400" />}
-          </div>
-          <h1 className="mt-5 text-lg font-semibold tracking-tight text-zinc-100">
-            {transition.error ? "Chat unavailable" : hasProjectTarget ? "Opening project chat" : "Opening chat"}
-          </h1>
-          <p className="mt-3 text-sm leading-6 text-zinc-500">
-            {transition.error || (hasProjectTarget ? "Loading the active project for this chat." : "Preparing the chat workspace.")}
-          </p>
-          <div className="mt-4 space-y-2">
-            <div className="truncate rounded-lg border border-white/5 bg-[#0f1117] px-3 py-2 font-mono text-xs text-zinc-500">
-              {transition.chatId}
-            </div>
-            {transition.projectId && (
-              <div className="truncate rounded-lg border border-emerald-500/20 bg-emerald-500/[0.06] px-3 py-2 font-mono text-xs text-emerald-100">
-                {transition.projectId}
-              </div>
-            )}
-          </div>
-          {transition.error && (
-            <button
-              type="button"
-              onClick={onHome}
-              className="mt-5 inline-flex h-9 items-center gap-2 rounded-lg border border-white/10 px-4 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-800/40 hover:text-zinc-100"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              Back home
-            </button>
-          )}
-        </div>
-      </section>
-    </main>
-  );
-}
-
-
-function videoStatusTone(status: string) {
-  const normalized = status.toLowerCase();
-  if (normalized === "succeeded" || normalized === "success") {
-    return "border-[rgb(var(--forma-green-rgb)/0.35)] bg-[rgb(var(--forma-green-rgb)/0.1)] text-[rgb(var(--forma-green-rgb))]";
-  }
-  if (normalized === "failed" || normalized === "failure" || normalized === "error") {
-    return "border-[rgb(var(--forma-red-rgb)/0.35)] bg-[rgb(var(--forma-red-rgb)/0.1)] text-[rgb(var(--forma-red-rgb))]";
-  }
-  if (normalized === "running" || normalized === "loading" || normalized === "reviewing") {
-    return "border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] text-[rgb(var(--forma-cyan-rgb))]";
-  }
-  if (normalized === "queued") {
-    return "border-[rgb(var(--forma-yellow-rgb)/0.35)] bg-[rgb(var(--forma-yellow-rgb)/0.1)] text-[rgb(var(--forma-yellow-rgb))]";
-  }
-  return "border-[var(--forma-border)] bg-[var(--forma-surface-muted)] text-[var(--forma-text-muted)]";
-}
-
-function VideoPanel({
-  projectId,
-  readOnly,
-  models,
-  modelsLoading,
-  modelsError,
-  selectedModel,
-  setSelectedModel,
-  mode,
-  setMode,
-  imageInput,
-  setImageInput,
-  imageOptions,
-  selectedImageSources,
-  setSelectedImageSources,
-  defaultImage,
-  sourceVideoUrl,
-  setSourceVideoUrl,
-  prompt,
-  setPrompt,
-  duration,
-  setDuration,
-  aspectRatio,
-  setAspectRatio,
-  aspectRatios,
-  status,
-  statusMessage,
-  requestId,
-  storedVideo,
-  gallery,
-  galleryLoading,
-  galleryError,
-  generationAvailable,
-  generationUnavailableReason,
-  reviewStatus,
-  reviewMessage,
-  reviewAvailable,
-  reviewUnavailableReason,
-  selectedReviewVideoKey,
-  setSelectedReviewVideoKey,
-  makeNewVideo,
-  setMakeNewVideo,
-  promptGenerating,
-  promptMessage,
-  onGenerate,
-  onGeneratePrompt,
-  onReview,
-  onReviewVideo,
-  onUploadImage,
-  onUseProjectImage,
-  onRefreshGallery,
-  canGenerate,
-  canReview,
-  canMakeNewVideo,
-  canGeneratePrompt,
-}: {
-  projectId: string | null;
-  readOnly: boolean;
-  models: VideoModelOption[];
-  modelsLoading: boolean;
-  modelsError: string | null;
-  selectedModel: string;
-  setSelectedModel: (value: string) => void;
-  mode: VideoGenerationMode;
-  setMode: (value: VideoGenerationMode) => void;
-  imageInput: string;
-  setImageInput: (value: string) => void;
-  imageOptions: ProjectImageCandidate[];
-  selectedImageSources: string[];
-  setSelectedImageSources: (value: string[]) => void;
-  defaultImage: string;
-  sourceVideoUrl: string;
-  setSourceVideoUrl: (value: string) => void;
-  prompt: string;
-  setPrompt: (value: string) => void;
-  duration: string;
-  setDuration: (value: string) => void;
-  aspectRatio: string;
-  setAspectRatio: (value: string) => void;
-  aspectRatios: string[];
-  status: string;
-  statusMessage: string | null;
-  requestId: string | null;
-  storedVideo: StoredVideoInfo | null;
-  gallery: StoredVideoInfo[];
-  galleryLoading: boolean;
-  galleryError: string | null;
-  generationAvailable: boolean;
-  generationUnavailableReason: string | null;
-  reviewStatus: string;
-  reviewMessage: string | null;
-  reviewAvailable: boolean;
-  reviewUnavailableReason: string | null;
-  selectedReviewVideoKey: string | null;
-  setSelectedReviewVideoKey: (value: string | null) => void;
-  makeNewVideo: boolean;
-  setMakeNewVideo: (value: boolean) => void;
-  promptGenerating: boolean;
-  promptMessage: string | null;
-  onGenerate: () => void;
-  onGeneratePrompt: () => void;
-  onReview: () => void;
-  onReviewVideo: (video: StoredVideoInfo) => void;
-  onUploadImage: () => void;
-  onUseProjectImage: () => void;
-  onRefreshGallery: () => void;
-  canGenerate: boolean;
-  canReview: boolean;
-  canMakeNewVideo: boolean;
-  canGeneratePrompt: boolean;
-}) {
-  const modeModels = models.filter((model) => model.mode === mode);
-  const sourceVideos = gallery
-    .map((video, index) => ({
-      video,
-      url: videoSourceUrl(video),
-      label: videoLabel(video, `Video ${index + 1}`),
-    }))
-    .filter((item) => item.url);
-  const videoToVideoAvailable = sourceVideos.length > 0;
-  const selectedImagePreviewSource = selectedImageSources[0] || imageInput;
-  const imagePreview = mode === "image-to-video" ? previewableImageSrc(selectedImagePreviewSource) : null;
-  const sourceVideoPreview = mode === "video-to-video" ? sourceVideoUrl : "";
-  const isGenerating = status === "loading" || Boolean(requestId && !storedVideo && !isFinalVideoStatus(status));
-  const isReviewing = reviewStatus === "loading";
-  const generateDisabled = !canGenerate || isGenerating || !modeModels.length;
-  const reviewDisabled = !canReview || isReviewing;
-  const savedHref = readOnly ? null : storedVideo?.publicUrl || null;
-  const allProjectImagesSelected = imageOptions.length > 0 && imageOptions.every((candidate) => selectedImageSources.includes(candidate.src));
-  const toggleImageSource = (source: string) => {
-    setSelectedImageSources(
-      selectedImageSources.includes(source)
-        ? selectedImageSources.filter((item) => item !== source)
-        : [...selectedImageSources, source]
-    );
-  };
-
-  if (!generationAvailable) {
-    return (
-      <div className="h-full min-w-0 overflow-y-auto overflow-x-hidden bg-[var(--forma-page)] px-4 py-5 text-[var(--forma-text)] sm:px-5 sm:py-6">
-        <div className="mx-auto min-w-0 max-w-[890px]">
-          <section className="rounded-xl border border-[var(--forma-border)] bg-[var(--forma-surface)] p-4 sm:p-5">
-            <div className="flex flex-col gap-4 border-b border-[var(--forma-border)] pb-4 sm:flex-row sm:items-start sm:justify-between">
-              <div className="flex min-w-0 items-start gap-3">
-                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] text-[rgb(var(--forma-cyan-rgb))]">
-                  <Film className="h-4 w-4" />
-                </span>
-                <div className="min-w-0">
-                  <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Media</div>
-                  <h2 className="mt-1 text-sm font-semibold tracking-tight text-[var(--forma-text-strong)]">Video</h2>
-                  <div className="mt-1.5 truncate font-mono text-[10px] text-[var(--forma-text-muted)]">{projectId || "No project id"}</div>
-                </div>
-              </div>
-              <button
-                type="button"
-                onClick={onReview}
-                disabled={reviewDisabled}
-                className="inline-flex h-9 shrink-0 items-center justify-center gap-2 rounded-md border border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] px-3 text-xs font-medium text-[rgb(var(--forma-cyan-rgb))] transition-colors hover:border-[rgb(var(--forma-cyan-rgb)/0.55)] disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                {isReviewing ? <RefreshCw className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
-                Review
-              </button>
-            </div>
-
-            {readOnly && (
-              <div className="mt-5 rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-3 text-xs leading-5 text-[var(--forma-text-secondary)]">
-                Read-only project. Video actions are available only to the owner.
-              </div>
-            )}
-
-            <div className="mt-5 rounded-lg border border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] p-4">
-              <div className="flex items-start gap-3">
-                <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-[rgb(var(--forma-cyan-rgb))]" />
-                <div className="min-w-0">
-                  <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-[rgb(var(--forma-cyan-rgb))]">Alpha</div>
-                  <p className="mt-2 text-sm leading-6 text-[var(--forma-text-body)]">
-                    We are in alpha and video generation is coming soon.
-                  </p>
-                  {generationUnavailableReason && (
-                    <p className="mt-2 break-words text-xs leading-5 text-[var(--forma-text-secondary)]">{generationUnavailableReason}</p>
-                  )}
-                </div>
-              </div>
-            </div>
-
-            <VideoReviewStatus
-              status={reviewStatus}
-              message={reviewMessage}
-              available={reviewAvailable}
-              unavailableReason={reviewUnavailableReason}
-              isReviewing={isReviewing}
-              makeNewVideo={makeNewVideo}
-              setMakeNewVideo={setMakeNewVideo}
-              canMakeNewVideo={canMakeNewVideo}
-            />
-
-            <VideoGallery
-              videos={gallery}
-              loading={galleryLoading}
-              error={galleryError}
-              onRefresh={onRefreshGallery}
-              selectedKey={selectedReviewVideoKey}
-              onSelect={setSelectedReviewVideoKey}
-              onReview={onReviewVideo}
-              canReview={canReview}
-              canOpenAssets={!readOnly}
-              reviewing={isReviewing}
-            />
-          </section>
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="h-full min-w-0 overflow-y-auto overflow-x-hidden bg-[var(--forma-page)] px-4 py-5 text-[var(--forma-text)] sm:px-5 sm:py-6">
-      <div className="mx-auto flex min-w-0 max-w-[890px] flex-col gap-4">
-        <section className="min-w-0 rounded-xl border border-[var(--forma-border)] bg-[var(--forma-surface)] p-4 sm:p-5">
-          <div className="mb-5 flex flex-col gap-4 border-b border-[var(--forma-border)] pb-4 sm:flex-row sm:items-start sm:justify-between">
-            <div className="flex min-w-0 items-start gap-3">
-              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] text-[rgb(var(--forma-cyan-rgb))]">
-                <Film className="h-4 w-4" />
-              </span>
-              <div className="min-w-0">
-                <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Media</div>
-                <h2 className="mt-1 text-sm font-semibold tracking-tight text-[var(--forma-text-strong)]">Video</h2>
-                <div className="mt-1.5 truncate font-mono text-[10px] text-[var(--forma-text-muted)]">{projectId || "No project id"}</div>
-              </div>
-            </div>
-            <div className="flex shrink-0 flex-wrap gap-2">
-              <button
-                type="button"
-                onClick={onReview}
-                disabled={reviewDisabled}
-                className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] px-3 text-xs font-medium text-[rgb(var(--forma-cyan-rgb))] transition-colors hover:border-[rgb(var(--forma-cyan-rgb)/0.55)] disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                {isReviewing ? <RefreshCw className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
-                Review
-              </button>
-              <button
-                type="button"
-                onClick={onGenerate}
-                disabled={generateDisabled}
-                className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-[var(--forma-text-strong)] bg-[var(--forma-text-strong)] px-3 text-xs font-medium text-[var(--forma-page)] transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                {isGenerating ? <RefreshCw className="h-4 w-4 animate-spin" /> : <Film className="h-4 w-4" />}
-                Generate
-              </button>
-            </div>
-          </div>
-
-          {readOnly && (
-            <div className="mb-5 rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-3 text-xs leading-5 text-[var(--forma-text-secondary)]">
-              Read-only project. Video actions are available only to the owner.
-            </div>
-          )}
-
-          <div className="mb-4 grid grid-cols-2 overflow-hidden rounded-lg border border-[var(--forma-border)]">
-            {([
-              { value: "image-to-video" as VideoGenerationMode, label: "Image" },
-              { value: "video-to-video" as VideoGenerationMode, label: "Video", disabled: !videoToVideoAvailable },
-            ]).map((item) => (
-              <button
-                key={item.value}
-                type="button"
-                onClick={() => {
-                  if (!item.disabled) setMode(item.value);
-                }}
-                disabled={item.disabled}
-                className={`flex h-10 items-center justify-center gap-2 border-r border-[var(--forma-border)] text-xs font-medium last:border-r-0 ${
-                  mode === item.value
-                    ? "bg-[var(--forma-surface)] text-[var(--forma-text-strong)]"
-                    : "bg-[var(--forma-surface-muted)] text-[var(--forma-text-muted)] hover:text-[var(--forma-text-strong)]"
-                } disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:text-[var(--forma-text-muted)]`}
-              >
-                {item.value === "video-to-video" ? <Film className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
-                {item.label}
-              </button>
-            ))}
-          </div>
-
-          <div className="grid gap-4 2xl:grid-cols-[minmax(0,1fr)_170px_180px]">
-            <label className="block text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">
-              Model
-              <select
-                value={selectedModel}
-                onChange={(event) => setSelectedModel(event.target.value)}
-                disabled={modelsLoading || !modeModels.length}
-                className="mt-2 h-10 w-full rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] px-3 text-sm font-normal tracking-normal text-[var(--forma-text-body)] outline-none focus:border-[rgb(var(--forma-cyan-rgb))] disabled:opacity-50"
-              >
-                {!modeModels.length && <option value="">No models</option>}
-                {modeModels.map((model) => (
-                  <option key={model.id} value={model.id}>
-                    {model.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label className="block text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">
-              Aspect ratio
-              <select
-                value={aspectRatio}
-                onChange={(event) => setAspectRatio(event.target.value)}
-                className="mt-2 h-10 w-full rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] px-3 text-sm font-normal tracking-normal text-[var(--forma-text-body)] outline-none focus:border-[rgb(var(--forma-cyan-rgb))]"
-              >
-                {aspectRatios.map((value) => (
-                  <option key={value} value={value}>
-                    {value}
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <div>
-              <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Duration</div>
-              <div className="mt-2 grid grid-cols-2 overflow-hidden rounded-lg border border-[var(--forma-border)]">
-                {["5", "10"].map((value) => (
-                  <button
-                    key={value}
-                    type="button"
-                    onClick={() => setDuration(value)}
-                    className={`h-10 border-r border-[var(--forma-border)] text-xs font-medium last:border-r-0 ${
-                      duration === value
-                        ? "bg-[var(--forma-surface)] text-[var(--forma-text-strong)]"
-                        : "bg-[var(--forma-surface-muted)] text-[var(--forma-text-muted)] hover:text-[var(--forma-text-strong)]"
-                    }`}
-                  >
-                    {value}s
-                  </button>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          <div className="mt-5">
-            <div className="flex flex-wrap items-center justify-between gap-2">
-              <label htmlFor="video-prompt" className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">
-                Prompt
-              </label>
-              <button
-                type="button"
-                onClick={onGeneratePrompt}
-                disabled={!canGeneratePrompt}
-                className="inline-flex h-9 items-center gap-2 rounded-md border border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] px-3 text-[11px] font-medium text-[rgb(var(--forma-cyan-rgb))] transition-colors hover:border-[rgb(var(--forma-cyan-rgb)/0.55)] disabled:cursor-not-allowed disabled:opacity-40"
-                title="Generate an image-to-video prompt from project namespaces"
-              >
-                {promptGenerating ? <RefreshCw className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
-                Generate prompt
-              </button>
-            </div>
-            <textarea
-              id="video-prompt"
-              value={prompt}
-              onChange={(event) => setPrompt(event.target.value)}
-              maxLength={VIDEO_PROMPT_MAX_CHARS}
-              placeholder="Slow orbit, reveal ports, show display glow."
-              className="mt-2 min-h-[132px] w-full resize-none rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] px-3 py-3 text-sm font-normal leading-6 tracking-normal text-[var(--forma-text-body)] outline-none placeholder:text-[var(--forma-text-muted)] focus:border-[rgb(var(--forma-cyan-rgb))]"
-            />
-            <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
-              {promptMessage ? (
-                <p className="break-words text-[11px] leading-5 text-[var(--forma-text-secondary)]">{promptMessage}</p>
-              ) : (
-                <span />
-              )}
-              <span className={`font-mono text-[10px] ${prompt.length > VIDEO_PROMPT_MAX_CHARS - 120 ? "text-[rgb(var(--forma-yellow-rgb))]" : "text-[var(--forma-text-muted)]"}`}>
-                {prompt.length}/{VIDEO_PROMPT_MAX_CHARS}
-              </span>
-            </div>
-          </div>
-
-          {mode === "image-to-video" ? (
-            <div className="mt-5 rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-3">
-              <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Image source</div>
-                <div className="flex flex-wrap gap-2">
-                  <button
-                    type="button"
-                    onClick={onUploadImage}
-                    className="inline-flex h-9 items-center gap-2 rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] px-3 text-xs font-medium text-[var(--forma-text-body)] transition-colors hover:bg-[var(--forma-page)] hover:text-[var(--forma-text-strong)]"
-                  >
-                    <Paperclip className="h-4 w-4" />
-                    Upload
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setSelectedImageSources(allProjectImagesSelected ? [] : imageOptions.map((candidate) => candidate.src))}
-                    disabled={!imageOptions.length}
-                    className="inline-flex h-9 items-center gap-2 rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] px-3 text-xs font-medium text-[var(--forma-text-body)] transition-colors hover:bg-[var(--forma-page)] hover:text-[var(--forma-text-strong)] disabled:cursor-not-allowed disabled:opacity-40"
-                  >
-                    <Layers className="h-4 w-4" />
-                    {allProjectImagesSelected ? "Clear" : "All"}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={onUseProjectImage}
-                    disabled={!defaultImage}
-                    className="inline-flex h-9 items-center gap-2 rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] px-3 text-xs font-medium text-[var(--forma-text-body)] transition-colors hover:bg-[var(--forma-page)] hover:text-[var(--forma-text-strong)] disabled:cursor-not-allowed disabled:opacity-40"
-                  >
-                    <Eye className="h-4 w-4" />
-                    First
-                  </button>
-                </div>
-              </div>
-
-              {imageOptions.length > 0 && (
-                <div className="mb-3 grid gap-2 sm:grid-cols-3">
-                  {imageOptions.map((candidate) => {
-                    const selected = selectedImageSources.includes(candidate.src);
-                    return (
-                      <button
-                        key={candidate.src}
-                        type="button"
-                        onClick={() => toggleImageSource(candidate.src)}
-                        className={`min-w-0 rounded-lg border p-2 text-left transition ${
-                          selected
-                            ? "border-[rgb(var(--forma-cyan-rgb)/0.55)] bg-[var(--forma-surface)] text-[rgb(var(--forma-cyan-rgb))]"
-                            : "border-[var(--forma-border)] bg-[var(--forma-surface)] text-[var(--forma-text-muted)] hover:border-[var(--forma-text-muted)] hover:text-[var(--forma-text-strong)]"
-                        }`}
-                        aria-pressed={selected}
-                      >
-                        <div className="relative h-20 overflow-hidden rounded-md bg-[var(--forma-surface-muted)]">
-                          <img src={candidate.src} alt={candidate.label} className="h-full w-full object-cover" />
-                          <span className={`absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-md border text-[10px] font-medium ${
-                            selected
-                              ? "border-[rgb(var(--forma-cyan-rgb))] bg-[rgb(var(--forma-cyan-rgb))] text-[var(--forma-page)]"
-                              : "border-[var(--forma-border)] bg-[rgb(var(--forma-chrome-rgb)/0.8)] text-[var(--forma-text-strong)]"
-                          }`}>
-                            {selected ? <CheckCircle className="h-3.5 w-3.5" /> : null}
-                          </span>
-                        </div>
-                        <div className="mt-2 truncate text-[10px] font-medium">{candidate.label}</div>
-                      </button>
-                    );
-                  })}
-                </div>
-              )}
-
-              <input
-                value={imageInput}
-                onChange={(event) => {
-                  setImageInput(event.target.value);
-                  setSelectedImageSources([]);
-                }}
-                placeholder="https://... or data:image/..."
-                className="h-10 w-full rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] px-3 font-mono text-xs text-[var(--forma-text-body)] outline-none placeholder:text-[var(--forma-text-muted)] focus:border-[rgb(var(--forma-cyan-rgb))]"
-              />
-              <div className="mt-2 text-[11px] leading-5 text-[var(--forma-text-secondary)]">
-                {selectedImageSources.length
-                  ? `${selectedImageSources.length} project image${selectedImageSources.length === 1 ? "" : "s"} selected.`
-                  : "No project images selected; the manual image field will be used."}
-              </div>
-            </div>
-          ) : (
-            <label className="mt-5 block text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">
-              Source video
-              <select
-                value={sourceVideoUrl}
-                onChange={(event) => setSourceVideoUrl(event.target.value)}
-                disabled={!sourceVideos.length}
-                className="mt-2 h-10 w-full rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] px-3 text-sm font-normal tracking-normal text-[var(--forma-text-body)] outline-none focus:border-[rgb(var(--forma-cyan-rgb))] disabled:opacity-50"
-              >
-                {!sourceVideos.length && <option value="">No saved videos</option>}
-                {sourceVideos.map((item) => (
-                  <option key={item.url} value={item.url}>
-                    {item.label}
-                  </option>
-                ))}
-              </select>
-            </label>
-          )}
-
-          <VideoGallery
-            videos={gallery}
-            loading={galleryLoading}
-            error={galleryError}
-            onRefresh={onRefreshGallery}
-            selectedKey={selectedReviewVideoKey}
-            onSelect={setSelectedReviewVideoKey}
-            onReview={onReviewVideo}
-            canReview={canReview}
-            canOpenAssets={!readOnly}
-            reviewing={isReviewing}
-          />
-        </section>
-
-        <aside className="min-w-0 rounded-xl border border-[var(--forma-border)] bg-[var(--forma-surface)] p-4 sm:p-5">
-          <div className="aspect-video overflow-hidden rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)]">
-            {mode === "video-to-video" && sourceVideoPreview ? (
-              <video src={sourceVideoPreview} controls preload="metadata" className="h-full w-full object-contain" />
-            ) : imagePreview ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img src={imagePreview} alt="Video source preview" className="h-full w-full object-contain" />
-            ) : (
-              <div className="flex h-full items-center justify-center text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">
-                No source
-              </div>
-            )}
-          </div>
-          {mode === "image-to-video" && selectedImageSources.length > 0 && (
-            <div className="mt-2 rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] px-3 py-2 text-[11px] leading-5 text-[var(--forma-text-secondary)]">
-              Previewing the first selected image. Generate will queue {selectedImageSources.length} image source{selectedImageSources.length === 1 ? "" : "s"}.
-            </div>
-          )}
-
-          <div className="mt-4 rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-4">
-            <div className="flex items-center justify-between gap-3">
-              <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Status</span>
-              <span className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[11px] font-medium uppercase tracking-[0.12em] ${videoStatusTone(status)}`}>
-                {status === "failed" ? <AlertTriangle className="h-3.5 w-3.5" /> : status === "succeeded" ? <CheckCircle className="h-3.5 w-3.5" /> : <RefreshCw className={`h-3.5 w-3.5 ${isGenerating ? "animate-spin" : ""}`} />}
-                {status}
-              </span>
-            </div>
-            {requestId && <div className="mt-3 truncate font-mono text-[10px] text-[var(--forma-text-muted)]">{requestId}</div>}
-            {statusMessage && <p className="mt-3 break-words text-xs leading-5 text-[var(--forma-text-secondary)]">{statusMessage}</p>}
-            {modelsError && <p className="mt-3 break-words text-xs leading-5 text-[rgb(var(--forma-yellow-rgb))]">{modelsError}</p>}
-          </div>
-
-          <VideoReviewStatus
-            status={reviewStatus}
-            message={reviewMessage}
-            available={reviewAvailable}
-            unavailableReason={reviewUnavailableReason}
-            isReviewing={isReviewing}
-            makeNewVideo={makeNewVideo}
-            setMakeNewVideo={setMakeNewVideo}
-            canMakeNewVideo={canMakeNewVideo}
-          />
-
-          {storedVideo && (
-            <div className="mt-4 rounded-lg border border-[rgb(var(--forma-green-rgb)/0.35)] bg-[rgb(var(--forma-green-rgb)/0.1)] p-4">
-              <div className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.14em] text-[rgb(var(--forma-green-rgb))]">
-                <CheckCircle className="h-4 w-4" />
-                Saved
-              </div>
-              {savedHref ? (
-                <a
-                  href={savedHref}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="mt-3 inline-flex max-w-full items-center gap-2 rounded-md border border-[rgb(var(--forma-green-rgb)/0.4)] px-3 py-2 text-xs font-medium text-[rgb(var(--forma-green-rgb))] transition-colors hover:border-[rgb(var(--forma-green-rgb)/0.6)]"
-                >
-                  <ExternalLink className="h-4 w-4 shrink-0" />
-                  Open saved video
-                </a>
-              ) : (
-                <div className="mt-3 break-all font-mono text-xs leading-5 text-[var(--forma-text-body)]">{storedVideo.s3Uri || storedVideo.key}</div>
-              )}
-              {storedVideo.key && <div className="mt-3 break-all font-mono text-[10px] leading-5 text-[var(--forma-text-muted)]">{storedVideo.key}</div>}
-            </div>
-          )}
-        </aside>
-      </div>
-    </div>
-  );
-}
-
-function VideoReviewStatus({
-  status,
-  message,
-  available,
-  unavailableReason,
-  isReviewing,
-  makeNewVideo,
-  setMakeNewVideo,
-  canMakeNewVideo,
-}: {
-  status: string;
-  message: string | null;
-  available: boolean;
-  unavailableReason: string | null;
-  isReviewing: boolean;
-  makeNewVideo: boolean;
-  setMakeNewVideo: (value: boolean) => void;
-  canMakeNewVideo: boolean;
-}) {
-  return (
-    <div className="mt-4 rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-4">
-      <div className="flex items-center justify-between gap-3">
-        <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Review</span>
-        <span className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[11px] font-medium uppercase tracking-[0.12em] ${videoStatusTone(status)}`}>
-          {status === "failed" ? (
-            <AlertTriangle className="h-3.5 w-3.5" />
-          ) : status === "succeeded" ? (
-            <CheckCircle className="h-3.5 w-3.5" />
-          ) : isReviewing ? (
-            <RefreshCw className="h-3.5 w-3.5 animate-spin" />
-          ) : (
-            <ShieldCheck className="h-3.5 w-3.5" />
-          )}
-          {status}
-        </span>
-      </div>
-      <label className={`mt-3 flex min-h-10 items-center gap-3 rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] px-3 py-2 text-xs font-medium ${
-        canMakeNewVideo ? "text-[var(--forma-text-body)]" : "text-[var(--forma-text-muted)]"
-      }`}>
-        <input
-          type="checkbox"
-          checked={makeNewVideo}
-          onChange={(event) => setMakeNewVideo(event.target.checked)}
-          disabled={!canMakeNewVideo || isReviewing}
-          className="h-4 w-4 accent-[rgb(var(--forma-cyan-rgb))] disabled:cursor-not-allowed"
-        />
-        <span>Make new video</span>
-      </label>
-      {message && <p className="mt-3 break-words text-xs leading-5 text-[var(--forma-text-secondary)]">{message}</p>}
-      {!available && unavailableReason && <p className="mt-3 break-words text-xs leading-5 text-[rgb(var(--forma-yellow-rgb))]">{unavailableReason}</p>}
-    </div>
-  );
-}
-
-function VideoGallery({
-  videos,
-  loading,
-  error,
-  onRefresh,
-  selectedKey,
-  onSelect,
-  onReview,
-  canReview,
-  canOpenAssets,
-  reviewing,
-}: {
-  videos: StoredVideoInfo[];
-  loading: boolean;
-  error: string | null;
-  onRefresh: () => void;
-  selectedKey: string | null;
-  onSelect: (value: string | null) => void;
-  onReview: (video: StoredVideoInfo) => void;
-  canReview: boolean;
-  canOpenAssets: boolean;
-  reviewing: boolean;
-}) {
-  return (
-    <div className="mt-5 rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-3">
-      <div className="mb-3 flex items-center justify-between gap-3">
-        <div className="flex items-center gap-2">
-          <Film className="h-4 w-4 text-[rgb(var(--forma-cyan-rgb))]" />
-          <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Gallery</div>
-        </div>
-        <button
-          type="button"
-          onClick={onRefresh}
-          disabled={!canOpenAssets}
-          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] text-[var(--forma-text-muted)] transition-colors hover:bg-[var(--forma-page)] hover:text-[var(--forma-text-strong)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-[var(--forma-surface)] disabled:hover:text-[var(--forma-text-muted)]"
-          title={canOpenAssets ? "Refresh gallery" : "Videos are available only on projects you generated."}
-          aria-label="Refresh gallery"
-        >
-          <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
-        </button>
-      </div>
-
-      {error && (
-        <div className="mb-3 break-words rounded-md border border-[rgb(var(--forma-yellow-rgb)/0.35)] bg-[rgb(var(--forma-yellow-rgb)/0.1)] p-3 text-xs leading-5 text-[rgb(var(--forma-yellow-rgb))]">
-          {error}
-        </div>
-      )}
-
-      {loading && !videos.length ? (
-        <div className="rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] p-4 text-xs leading-5 text-[var(--forma-text-secondary)]">
-          Loading gallery…
-        </div>
-      ) : videos.length ? (
-        <div className="grid gap-3 md:grid-cols-2">
-          {videos.map((video, index) => {
-            const key = videoIdentity(video, `video-${index}`);
-            const reviewable = Boolean(videoSourceUrl(video));
-            return (
-              <VideoGalleryItem
-                key={key}
-                video={video}
-                identity={key}
-                selected={selectedKey === key}
-                onSelect={() => onSelect(key)}
-                onReview={() => onReview(video)}
-                canReview={canReview && reviewable}
-                canOpenAssets={canOpenAssets}
-                reviewing={reviewable && reviewing && selectedKey === key}
-                reviewable={reviewable}
-              />
-            );
-          })}
-        </div>
-      ) : (
-        <div className="rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] p-4 text-xs leading-5 text-[var(--forma-text-secondary)]">
-          No videos yet.
-        </div>
-      )}
-    </div>
-  );
-}
-
-function VideoGalleryItem({
-  video,
-  identity,
-  selected,
-  onSelect,
-  onReview,
-  canReview,
-  canOpenAssets,
-  reviewing,
-  reviewable,
-}: {
-  video: StoredVideoInfo;
-  identity: string;
-  selected: boolean;
-  onSelect: () => void;
-  onReview: () => void;
-  canReview: boolean;
-  canOpenAssets: boolean;
-  reviewing: boolean;
-  reviewable: boolean;
-}) {
-  const playableUrl = canOpenAssets ? videoSourceUrl(video) || null : null;
-  const openUrl = canOpenAssets ? playableUrl || null : null;
-  const label = videoLabel(video);
-  const prompt = videoPromptText(video);
-
-  return (
-    <article className={`min-w-0 overflow-hidden rounded-lg border bg-[var(--forma-surface)] transition ${
-      selected
-        ? "border-[rgb(var(--forma-cyan-rgb)/0.55)]"
-        : "border-[var(--forma-border)]"
-    }`}>
-      <div className="aspect-video bg-[var(--forma-surface-muted)]">
-        {playableUrl ? (
-          <video src={playableUrl} controls preload="metadata" className="h-full w-full object-contain" />
-        ) : (
-          <div className="flex h-full items-center justify-center px-3 text-center text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">
-            Video saved
-          </div>
-        )}
-      </div>
-      <div className="border-t border-[var(--forma-border)] p-3">
-        <div className="flex min-w-0 items-start justify-between gap-2">
-          <div className="min-w-0">
-            <div className="truncate font-mono text-[11px] text-[var(--forma-text-secondary)]">{label}</div>
-            <div className="mt-1 truncate font-mono text-[10px] text-[var(--forma-text-muted)]">{identity}</div>
-          </div>
-          <span className={`shrink-0 rounded-md border px-2 py-1 text-[10px] font-medium uppercase tracking-[0.12em] ${
-            selected
-              ? "border-[rgb(var(--forma-cyan-rgb)/0.45)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] text-[rgb(var(--forma-cyan-rgb))]"
-              : "border-[var(--forma-border)] text-[var(--forma-text-muted)]"
-          }`}>
-            {selected ? "Selected" : reviewable ? "Reviewable" : "No URL"}
-          </span>
-        </div>
-        <div className="mt-3 rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-3">
-          <div className="text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Prompt</div>
-          <p className="mt-2 max-h-28 overflow-y-auto break-words text-xs leading-5 text-[var(--forma-text-secondary)]">
-            {prompt || "No prompt saved for this video."}
-          </p>
-        </div>
-        {video.key && <div className="mt-2 break-all font-mono text-[10px] leading-4 text-[var(--forma-text-muted)]">{video.key}</div>}
-        <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
-          <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">{formatBytes(video.sizeBytes || 0)}</span>
-          <div className="flex flex-wrap gap-2">
-            <button
-              type="button"
-              onClick={onSelect}
-              disabled={!reviewable || !canOpenAssets}
-              className="inline-flex h-8 items-center gap-1.5 rounded-md border border-[var(--forma-border)] px-2 text-[10px] font-medium text-[var(--forma-text-body)] transition-colors hover:bg-[var(--forma-surface-muted)] hover:text-[var(--forma-text-strong)] disabled:cursor-not-allowed disabled:opacity-40"
-              title={canOpenAssets ? (reviewable ? "Select video for review" : "This saved video needs an HTTP(S) URL before review") : "Videos are available only on projects you generated."}
-            >
-              {selected ? <CheckCircle className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-              Select
-            </button>
-            <button
-              type="button"
-              onClick={() => {
-                onSelect();
-                onReview();
-              }}
-              disabled={!canReview || reviewing}
-              className="inline-flex h-8 items-center gap-1.5 rounded-md border border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] px-2 text-[10px] font-medium text-[rgb(var(--forma-cyan-rgb))] transition-colors hover:border-[rgb(var(--forma-cyan-rgb)/0.55)] disabled:cursor-not-allowed disabled:opacity-40"
-              title={reviewable ? "Review selected video" : "This saved video needs an HTTP(S) URL before review"}
-            >
-              {reviewing ? <RefreshCw className="h-3.5 w-3.5 animate-spin" /> : <ShieldCheck className="h-3.5 w-3.5" />}
-              Review
-            </button>
-            {openUrl ? (
-              <a
-                href={openUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex h-8 items-center gap-1.5 rounded-md border border-[var(--forma-border)] px-2 text-[10px] font-medium text-[var(--forma-text-body)] transition-colors hover:bg-[var(--forma-surface-muted)] hover:text-[var(--forma-text-strong)]"
-              >
-                <ExternalLink className="h-3.5 w-3.5" />
-                Open
-              </a>
-            ) : (
-              <span className="truncate font-mono text-[10px] text-[var(--forma-text-muted)]">{video.s3Uri || "-"}</span>
-            )}
-          </div>
-        </div>
-      </div>
-    </article>
-  );
-}
-
-function ProjectDetailWorkspace({
-  onOpenSidebar,
-  projectId,
-  projectTitle,
-  owned,
-  onRenameTitle,
-  namespaceTabs,
-  activeNamespace,
-  onNamespaceChange,
-  projectContent,
-}: {
-  onOpenSidebar: () => void;
-  projectId: string | null;
-  projectTitle: string;
-  owned: boolean;
-  onRenameTitle?: (title: string) => void;
-  namespaceTabs: typeof workspaceTabs;
-  activeNamespace: string;
-  onNamespaceChange: (value: string) => void;
-  projectContent: React.ReactNode;
-}) {
-  return (
-    <div className="flex h-full min-h-0 min-w-0 flex-col bg-[var(--forma-page)]">
-      <header className="workspace-chrome-header flex min-h-14 min-w-0 items-center gap-3 overflow-hidden px-3 pb-5 pt-2 sm:px-4">
-        <MobileSidebarButton onClick={onOpenSidebar} />
-        <div className="min-w-0 flex-1">
-          <div className="flex min-w-0 items-center gap-2">
-            <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-[rgb(var(--forma-green-rgb)/0.12)] px-2 py-0.5 text-[10px] font-medium text-[rgb(var(--forma-green-rgb))]">
-              <Eye className="h-3 w-3" />
-              {owned ? "Your project" : "Public project"}
-            </span>
-            <EditableWorkspaceTitle
-              value={projectTitle}
-              canEdit={owned && Boolean(onRenameTitle)}
-              label="Project title"
-              onCommit={(title) => onRenameTitle?.(title)}
-            />
-          </div>
-        </div>
-      </header>
-
-      <section className="min-h-0 min-w-0 flex-1 overflow-hidden bg-[var(--forma-page)]" aria-label="Project workspace">
-        <ProjectWorkspacePanel
-          projectId={projectId}
-          namespaceTabs={namespaceTabs}
-          activeNamespace={activeNamespace}
-          onNamespaceChange={onNamespaceChange}
-        >
-          {projectContent}
-        </ProjectWorkspacePanel>
-      </section>
-    </div>
-  );
-}
-
-function ChatWorkspace({
-  onOpenSidebar,
-  projectId,
-  chatId,
-  projectTitle,
-  onRenameTitle,
-  messages,
-  input,
-  setInput,
-  onSubmit,
-  isLoading,
-  canStop,
-  onStop,
-  canChat,
-  namespaceTabs,
-  activeNamespace,
-  activeNamespaceLabel,
-  activeNamespaceName,
-  onNamespaceChange,
-  projectContent,
-}: {
-  onOpenSidebar: () => void;
-  projectId: string | null;
-  chatId: string | null;
-  projectTitle: string;
-  onRenameTitle?: (title: string) => void;
-  messages: ChatMessage[];
-  input: string;
-  setInput: (value: string) => void;
-  onSubmit: (event: React.FormEvent) => void;
-  isLoading: boolean;
-  canStop: boolean;
-  onStop: () => void;
-  canChat: boolean;
-  namespaceTabs: typeof workspaceTabs;
-  activeNamespace: string;
-  activeNamespaceLabel: string;
-  activeNamespaceName: string;
-  onNamespaceChange: (value: string) => void;
-  projectContent: React.ReactNode;
-}) {
-  const { containerRef, endRef, handleScroll } = useChatAutoScroll(chatId || projectId || "project-chat", messages);
-  const { headerAway, updateFromContainer } = useChromeHeaderScroll(chatId || projectId || "project-chat");
-
-  const onChatScroll = () => {
-    handleScroll();
-    updateFromContainer(containerRef.current);
-  };
-
-  return (
-    <div className="relative flex h-full min-h-0 min-w-0 flex-col bg-[var(--forma-page)]">
-      <header className={`workspace-chrome-header absolute inset-x-0 top-0 z-20 flex min-h-14 min-w-0 items-center gap-3 px-3 pb-5 pt-2 sm:px-4 ${headerAway ? "is-away" : ""}`}>
-        <MobileSidebarButton onClick={onOpenSidebar} />
-        <div className="min-w-0 flex-1">
-          <div className="flex min-w-0 items-center gap-2">
-            <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-[rgb(var(--forma-green-rgb)/0.12)] px-2 py-0.5 text-[10px] font-medium text-[rgb(var(--forma-green-rgb))]">
-              {canChat ? <MessageSquare className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
-              {canChat ? "Project chat" : "Read-only project"}
-            </span>
-            <EditableWorkspaceTitle
-              value={projectTitle}
-              canEdit={canChat && Boolean(onRenameTitle)}
-              label="Project chat title"
-              onCommit={(title) => onRenameTitle?.(title)}
-            />
-          </div>
-        </div>
-      </header>
-
-      <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
-        {canChat && (
-          <div className="flex h-full min-h-0 min-w-0 flex-col">
-            <div
-              ref={containerRef}
-              onScroll={onChatScroll}
-              className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-3 pb-5 pt-16 sm:px-5 sm:pb-6 sm:pt-16"
-            >
-              <div className="mx-auto flex w-full min-w-0 max-w-6xl flex-col gap-3">
-                {messages.length ? (
-                  messages.map((message) => {
-                    const isUser = message.role === "user";
-                    const isSystem = message.role === "system";
-                    return (
-                      <div key={message.id} className={`mx-auto flex w-full min-w-0 max-w-3xl ${isUser ? "justify-end" : "justify-start"}`}>
-                        <div
-                          className={`min-w-0 max-w-[92%] overflow-hidden rounded-xl border px-4 py-3 ${
-                            isUser
-                              ? "border-emerald-500/20 bg-emerald-500/10 text-zinc-100"
-                              : message.status === "error"
-                                ? "border-rose-400/30 bg-rose-950/25 text-rose-100"
-                                : message.status === "cancelled"
-                                  ? "border-amber-300/30 bg-amber-950/20 text-amber-50"
-                                : isSystem
-                                  ? "border-white/5 bg-black/25 text-zinc-400"
-                                  : "border-white/5 bg-[#181b22] text-zinc-200"
-                          }`}
-                        >
-                          <div className="mb-2 flex flex-wrap items-center gap-2 text-[10px] font-medium text-zinc-500">
-                            <span>{isUser ? "You" : isSystem ? "Context" : "Forma"}</span>
-                            <span className="text-zinc-700">·</span>
-                            <span suppressHydrationWarning>{formatChatTimestamp(message.timestamp)}</span>
-                            {message.status === "loading" && <RefreshCw className="h-3 w-3 animate-spin text-emerald-400" />}
-                            {message.status === "cancelled" && <Square className="h-3 w-3 fill-current text-amber-300" />}
-                            <CopyButton
-                              value={message.content}
-                              label={isUser ? "Copy your message" : isSystem ? "Copy context message" : "Copy Forma's message"}
-                              className="ml-auto"
-                            />
-                          </div>
-                          <p className="break-anywhere whitespace-pre-wrap text-sm leading-6">{message.content}</p>
-                          {!message.projectId && (
-                            <AgentPipelineProgressView progress={message.pipelineProgress} status={message.status} compact />
-                          )}
-                        </div>
-                      </div>
-                    );
-                  })
-                ) : (
-                  <div className="mx-auto w-full max-w-3xl rounded-xl border border-white/5 bg-[#181b22] p-5 text-sm leading-6 text-zinc-500">
-                    This chat has no project messages yet.
-                  </div>
-                )}
-                <div ref={endRef} />
-                <ChatProjectArtifact
-                  projectId={projectId}
-                  projectTitle={projectTitle}
-                  canEdit={canChat && Boolean(onRenameTitle)}
-                  onRenameTitle={onRenameTitle}
-                  namespaceTabs={namespaceTabs}
-                  activeNamespace={activeNamespace}
-                  onNamespaceChange={onNamespaceChange}
-                  projectContent={projectContent}
-                />
-              </div>
-            </div>
-
-            <form onSubmit={onSubmit} className="shrink-0 border-t border-white/5 bg-[#0f1117]/95 p-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] backdrop-blur sm:p-4">
-              <div className="mx-auto max-w-3xl">
-                <div className="w-full rounded-2xl border border-white/5 bg-[#181b22] p-3 shadow-lg transition-all focus-within:border-emerald-500/50 focus-within:ring-1 focus-within:ring-emerald-500/20">
-                  <textarea
-                    value={input}
-                    onChange={(event) => setInput(event.target.value)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter" && !event.shiftKey) {
-                        event.preventDefault();
-                        if (isLoading) return;
-                        event.currentTarget.form?.requestSubmit();
-                      }
-                    }}
-                    placeholder={`Describe a change to ${activeNamespaceLabel.toLowerCase()}...`}
-                    className="min-h-[72px] w-full resize-none border-none bg-transparent text-sm leading-6 text-zinc-100 outline-none placeholder:text-zinc-500"
-                  />
-                  <div className="mt-1 flex items-center justify-end gap-1.5">
-                    {!canStop && !isLoading && Boolean(input.trim()) && (
-                      <span className="prompt-composer-enter-hint hidden sm:inline" aria-hidden="true">
-                        Enter
-                      </span>
-                    )}
-                    <button
-                      type={canStop ? "button" : "submit"}
-                      onClick={canStop ? onStop : undefined}
-                      disabled={!canStop && (isLoading || !projectId || !input.trim())}
-                      className={`prompt-composer-send inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed ${
-                        !canStop && !isLoading && input.trim() ? "is-ready" : ""
-                      }`}
-                      aria-label={canStop ? "Stop project update" : "Apply change to project, or press Enter"}
-                      title={canStop ? "Stop project update" : `Apply change to ${activeNamespaceName} · Enter`}
-                    >
-                      {canStop ? <Square className="h-3.5 w-3.5 fill-current" /> : isLoading ? <RefreshCw className="h-3.5 w-3.5 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </form>
-          </div>
-        )}
-
-        {!canChat && (
-          <section className="absolute inset-0 min-h-0 min-w-0 overflow-hidden bg-[var(--forma-page)] pt-14" aria-label="Project workspace">
-            <ProjectWorkspacePanel
-              projectId={projectId}
-              namespaceTabs={namespaceTabs}
-              activeNamespace={activeNamespace}
-              onNamespaceChange={onNamespaceChange}
-            >
-              {projectContent}
-            </ProjectWorkspacePanel>
-          </section>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function scrollableVerticalParent(node: HTMLElement | null) {
-  let current = node?.parentElement || null;
-  while (current) {
-    const overflowY = window.getComputedStyle(current).overflowY;
-    if (/(auto|scroll)/.test(overflowY) && current.scrollHeight > current.clientHeight) return current;
-    current = current.parentElement;
-  }
-  return null;
-}
-
-function ChatProjectArtifact({
-  projectId,
-  projectTitle,
-  canEdit = false,
-  onRenameTitle,
-  namespaceTabs,
-  activeNamespace,
-  onNamespaceChange,
-  projectContent,
-}: {
-  projectId: string | null;
-  projectTitle: string;
-  canEdit?: boolean;
-  onRenameTitle?: (title: string) => void;
-  namespaceTabs: typeof workspaceTabs;
-  activeNamespace: string;
-  onNamespaceChange: (namespaceId: string) => void;
-  projectContent: React.ReactNode;
-}) {
-  const [fullScreen, setFullScreen] = useState(false);
-  const artifactRef = useRef<HTMLElement>(null);
-  const chatScrollSnapshotRef = useRef<{
-    element: HTMLElement | null;
-    top: number;
-    left: number;
-    windowX: number;
-    windowY: number;
-  } | null>(null);
-  const restoreChatScrollRef = useRef(false);
-
-  const enterFullScreen = () => {
-    const element = scrollableVerticalParent(artifactRef.current);
-    chatScrollSnapshotRef.current = {
-      element,
-      top: element?.scrollTop || 0,
-      left: element?.scrollLeft || 0,
-      windowX: window.scrollX,
-      windowY: window.scrollY,
-    };
-    setFullScreen(true);
-  };
-
-  const exitFullScreen = () => {
-    restoreChatScrollRef.current = true;
-    setFullScreen(false);
-  };
-
-  useLayoutEffect(() => {
-    if (fullScreen || !restoreChatScrollRef.current) return;
-    restoreChatScrollRef.current = false;
-    const snapshot = chatScrollSnapshotRef.current;
-    if (!snapshot) return;
-
-    const restoreScroll = () => {
-      if (snapshot.element?.isConnected) {
-        snapshot.element.scrollTo({ top: snapshot.top, left: snapshot.left, behavior: "auto" });
-      } else {
-        window.scrollTo({ top: snapshot.windowY, left: snapshot.windowX, behavior: "auto" });
-      }
-    };
-
-    restoreScroll();
-    const frameId = window.requestAnimationFrame(restoreScroll);
-    return () => window.cancelAnimationFrame(frameId);
-  }, [fullScreen]);
-
-  useEffect(() => {
-    if (!fullScreen) return;
-    const previousOverflow = document.body.style.overflow;
-    const exitOnEscape = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        restoreChatScrollRef.current = true;
-        setFullScreen(false);
-      }
-    };
-    document.body.style.overflow = "hidden";
-    window.addEventListener("keydown", exitOnEscape);
-    return () => {
-      document.body.style.overflow = previousOverflow;
-      window.removeEventListener("keydown", exitOnEscape);
-    };
-  }, [fullScreen]);
-
-  return (
-    <section
-      ref={artifactRef}
-      className={`min-w-0 overflow-hidden bg-[var(--forma-page)] ${
-        fullScreen
-          ? "fixed inset-0 z-[80] flex h-[100dvh] w-screen flex-col"
-          : "mx-auto mt-3 w-full max-w-6xl rounded-xl border border-[var(--forma-border)]"
-      }`}
-      aria-labelledby="chat-project-title"
-    >
-      <header className="flex min-h-[56px] min-w-0 shrink-0 items-center justify-between gap-3 border-b border-[var(--forma-border)] bg-[var(--forma-surface)] px-4 py-2.5">
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <Layers className="h-3.5 w-3.5 shrink-0 text-[rgb(var(--forma-green-rgb))]" />
-            <h3 id="chat-project-title" className="truncate text-[10px] font-medium text-[var(--forma-text-muted)]">
-              Project
-            </h3>
-          </div>
-          <EditableWorkspaceTitle
-            value={projectTitle}
-            canEdit={canEdit && Boolean(onRenameTitle)}
-            label="Project title"
-            element="div"
-            className="mt-0.5 truncate text-xs font-semibold text-[var(--forma-text-strong)]"
-            onCommit={(title) => onRenameTitle?.(title)}
-          />
-        </div>
-        <div className="flex min-w-0 items-center justify-end">
-          <button
-            type="button"
-            onClick={fullScreen ? exitFullScreen : enterFullScreen}
-            className="inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-lg border border-[var(--forma-border)] px-2.5 text-xs font-medium text-[var(--forma-text-body)] transition-colors hover:bg-[var(--forma-surface-muted)] hover:text-[var(--forma-text-strong)] sm:px-3"
-            aria-pressed={fullScreen}
-            aria-label={fullScreen ? "Exit project full screen" : "View project full screen"}
-            title={fullScreen ? "Exit full screen (Esc)" : "Full screen"}
-          >
-            {fullScreen ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
-            <span className="hidden md:inline">{fullScreen ? "Exit full screen" : "Full screen"}</span>
-          </button>
-        </div>
-      </header>
-
-      <div className={fullScreen ? "min-h-0 min-w-0 flex-1 overflow-hidden" : "h-[70dvh] min-h-[540px] max-h-[820px] min-w-0 overflow-hidden"}>
-        <ProjectWorkspacePanel
-          projectId={projectId}
-          namespaceTabs={namespaceTabs}
-          activeNamespace={activeNamespace}
-          onNamespaceChange={onNamespaceChange}
-        >
-          {projectContent}
-        </ProjectWorkspacePanel>
-      </div>
-    </section>
-  );
-}
-
-function ProjectWorkspacePanel({
-  projectId,
-  namespaceTabs,
-  activeNamespace,
-  onNamespaceChange,
-  children,
-}: {
-  projectId?: string | null;
-  namespaceTabs: typeof workspaceTabs;
-  activeNamespace: string;
-  onNamespaceChange: (value: string) => void;
-  children: React.ReactNode;
-}) {
-  const namespaceName = workspaceNamespaceForTab(activeNamespace);
-  return (
-    <div className="flex h-full min-h-0 min-w-0 flex-col">
-      <nav
-        className="flex min-h-[44px] min-w-0 shrink-0 items-center gap-1 overflow-x-auto border-b border-[var(--forma-border)] bg-[var(--forma-surface)] px-2"
-        aria-label="Project workspace"
-      >
-        {namespaceTabs.map((tab) => {
-          const Icon = tab.icon;
-          const active = activeNamespace === tab.id;
-          return (
-            <button
-              key={tab.id}
-              type="button"
-              onClick={() => onNamespaceChange(tab.id)}
-              className={`inline-flex h-8 shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg px-2.5 text-xs font-medium transition-colors ${
-                active
-                  ? "bg-[rgb(var(--forma-green-rgb)/0.12)] text-[rgb(var(--forma-green-rgb))]"
-                  : "text-[var(--forma-text-muted)] hover:bg-[var(--forma-surface-muted)] hover:text-[var(--forma-text-strong)]"
-              }`}
-              aria-pressed={active}
-              title={`${tab.label} / ${workspaceNamespaceForTab(tab.id)}`}
-            >
-              <Icon className="h-3.5 w-3.5 shrink-0" strokeWidth={1.75} />
-              <span className={active ? "inline" : "hidden sm:inline"}>{tab.label}</span>
-            </button>
-          );
-        })}
-      </nav>
-      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">{children}</div>
-      <div className="flex shrink-0 items-center justify-end gap-2 border-t border-[var(--forma-border)] bg-[var(--forma-surface)] px-3 py-1.5 font-mono text-[9px] text-[var(--forma-text-muted)]">
-        {projectId && (
-          <span className="max-w-[min(100%,14rem)] truncate" title={projectId}>
-            {projectId}
-          </span>
-        )}
-        {projectId && <span aria-hidden="true">·</span>}
-        <span className="max-w-48 truncate" title={namespaceName}>
-          {namespaceName}
-        </span>
-      </div>
-    </div>
-  );
-}
-
-function AgentPipelineEventsDisclosure({
-  eventCount,
-  children,
-}: {
-  eventCount: number;
-  children: React.ReactNode;
-}) {
-  const [open, setOpen] = useState(false);
-  return (
-    <details
-      className="group mt-3 border-t border-white/5 pt-3"
-      open={open}
-      onToggle={(event) => setOpen(event.currentTarget.open)}
-    >
-      <summary className="flex cursor-pointer list-none items-center justify-between gap-2 marker:content-none [&::-webkit-details-marker]:hidden">
-        <span className="inline-flex min-w-0 items-center gap-1.5">
-          <ChevronDown className="h-3 w-3 shrink-0 -rotate-90 text-zinc-600 transition-transform group-open:rotate-0" />
-          <span className="text-[10px] font-medium text-zinc-600">Recent events</span>
-        </span>
-        <span className="font-mono text-[10px] text-zinc-600">{eventCount}</span>
-      </summary>
-      <div className="mt-2">{children}</div>
-    </details>
-  );
-}
-
-function AgentPipelineProgressView({
-  progress,
-  status,
-  compact = false,
-  onStop,
-  onReset,
-  resetting = false,
-}: {
-  progress?: AgentPipelineProgress | null;
-  status?: ChatMessage["status"];
-  compact?: boolean;
-  onStop?: () => void;
-  onReset?: () => void;
-  resetting?: boolean;
-}) {
-  if (!progress) return null;
-
-  const steps = progress.steps.length ? progress.steps : defaultAgentPipelineSteps;
-  const events = normalizeAgentPipelineEvents(progress.events);
-  const lastEvent = latestPipelineEvent(events);
-  const activeStep = activePipelineStep({ ...progress, steps });
-  const activeStepId = activeStep?.id || null;
-  const nowMs = Date.now();
-  const startedMs = timestampMs(progress.startedAt);
-  const elapsedSeconds = startedMs === null ? null : Math.max(1, Math.round((nowMs - startedMs) / 1000));
-  const lastEventMs = pipelineEventTimestampMs(lastEvent);
-  const quietMs = lastEventMs === null ? null : nowMs - lastEventMs;
-  const isLoading = status === "loading";
-  const isSuccess = status === "success";
-  const isCancelled = status === "cancelled";
-  // Progress events are an audit trail and may include a failed attempt that
-  // the backend subsequently retries. Only the terminal message state means
-  // the whole pipeline failed.
-  const isError = status === "error";
-  const waitingForFirstEvent = isLoading && !events.length && startedMs !== null && nowMs - startedMs >= PIPELINE_STALE_AFTER_MS;
-  const backendQuiet = isLoading && quietMs !== null && quietMs >= PIPELINE_STALE_AFTER_MS;
-  const completedCount = completedPipelineStepCount({ ...progress, steps });
-  const progressPercent = Math.min(100, Math.max(6, Math.round((completedCount / Math.max(steps.length, 1)) * 100)));
-  const visibleEvents = events.slice(compact ? -4 : -6);
-  const signalLabel = isError
-    ? "failed"
-    : isCancelled
-    ? "stopped"
-    : isSuccess
-    ? "completed"
-    : progress.synced
-    ? backendQuiet
-      ? "waiting on provider"
-      : "backend synced"
-    : waitingForFirstEvent
-      ? "starting"
-      : "estimated";
-  const signalTone = isError
-    ? "border-rose-400/35 bg-rose-950/25 text-rose-200"
-    : isCancelled
-    ? "border-amber-300/35 bg-amber-950/20 text-amber-100"
-    : isSuccess
-    ? "border-emerald-300/35 bg-emerald-950/20 text-emerald-100"
-    : backendQuiet || waitingForFirstEvent
-    ? "border-emerald-500/25 bg-emerald-950/25 text-emerald-100"
-    : progress.synced
-      ? "border-emerald-500/25 bg-emerald-950/25 text-emerald-100"
-      : "border-slate-500/25 bg-black/25 text-slate-400";
-
-  return (
-    <div className="mt-3 rounded-xl border border-white/5 bg-black/25 p-3">
-      <div className="flex flex-wrap items-start justify-between gap-2">
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="text-[10px] font-medium text-zinc-500">Agent pipeline</span>
-            <span className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-medium ${signalTone}`}>
-              {isError ? <AlertTriangle className="h-3 w-3" /> : isCancelled ? <Square className="h-3 w-3 fill-current" /> : isLoading ? <RefreshCw className="h-3 w-3 animate-spin" /> : <CheckCircle className="h-3 w-3" />}
-              {signalLabel}
-            </span>
-          </div>
-          {progress.jobId && (
-            <div className="mt-1 truncate font-mono text-[10px] text-zinc-600">{progress.jobId}</div>
-          )}
-        </div>
-        <div className="flex shrink-0 items-start gap-2">
-          {isLoading && onStop && (
-            <button
-              type="button"
-              onClick={onStop}
-              className="inline-flex h-7 items-center gap-1 rounded-lg border border-amber-300/40 px-2 text-[10px] font-medium text-amber-100 transition-colors hover:bg-amber-300/10"
-              aria-label="Stop agent pipeline"
-              title="Stop agent pipeline"
-            >
-              <Square className="h-3 w-3 fill-current" />
-              Stop
-            </button>
-          )}
-          {isError && onReset && (
-            <button
-              type="button"
-              onClick={onReset}
-              disabled={resetting}
-              className="inline-flex h-7 items-center gap-1 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-2 text-[10px] font-medium text-emerald-400 transition-colors hover:bg-emerald-500/20 disabled:cursor-wait disabled:opacity-60"
-              aria-label="Reset failed generation job"
-              title="Reset failed generation job and try again"
-            >
-              <RefreshCw className={`h-3 w-3 ${resetting ? "animate-spin" : ""}`} />
-              {resetting ? "Resetting" : "Reset job"}
-            </button>
-          )}
-          <div className="text-right">
-            <div className="font-mono text-[11px] font-semibold text-zinc-300">{completedCount}/{steps.length}</div>
-            <div className="text-[10px] text-zinc-600">{formatDurationSeconds(elapsedSeconds)}</div>
-          </div>
-        </div>
-      </div>
-
-      <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-[#111216]">
-        <div
-          className={`h-full rounded-full ${isError ? "bg-rose-300" : isCancelled ? "bg-amber-300" : "bg-emerald-400"} ${isLoading ? "animate-pulse" : ""}`}
-          style={{ width: `${progressPercent}%` }}
-        />
-      </div>
-
-      <div className="mt-3 flex min-w-0 items-start gap-2 rounded-lg border border-white/5 bg-[#111216] p-3">
-        {isError ? <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-rose-300" /> : isCancelled ? <Square className="mt-0.5 h-4 w-4 shrink-0 fill-current text-amber-300" /> : isLoading ? <RefreshCw className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-emerald-400" /> : <Cpu className="mt-0.5 h-4 w-4 shrink-0 text-zinc-400" />}
-        <div className="min-w-0">
-          <div className="truncate text-xs font-semibold text-zinc-100">{activeStep?.label || "Preparing job"}</div>
-          <div className="mt-1 truncate text-[11px] font-medium text-emerald-400">{activeStep?.agent || "Forma runtime"}</div>
-          {activeStep?.description && !compact && (
-            <div className="mt-1 line-clamp-2 text-[11px] leading-4 text-zinc-500">{activeStep.description}</div>
-          )}
-          {lastEvent && (
-            <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-zinc-500">
-              <span>Last: {lastEvent.label || lastEvent.step_id}</span>
-              <span>{String(lastEvent.status).replace(/_/g, " ")}</span>
-              <span>{formatPipelineAge(lastEvent.observed_at, nowMs)} ago</span>
-            </div>
-          )}
-        </div>
-      </div>
-
-      {(backendQuiet || waitingForFirstEvent) && (
-        <div className="mt-2 flex gap-2 rounded-lg border border-emerald-500/20 bg-emerald-950/20 p-2 text-[11px] leading-4 text-emerald-100">
-          <RefreshCw className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin" />
-          <span>
-            {events.length
-              ? `Still working. The active provider or backend call has been running for ${formatDurationSeconds(Math.round((quietMs || 0) / 1000))} since the last progress update.`
-              : "Still starting. The job poller is active and waiting for the first backend progress update."}
-          </span>
-        </div>
-      )}
-
-      <div className="mt-3 flex flex-wrap gap-1.5">
-        {steps.map((step) => (
-          <span
-            key={step.id}
-            className="inline-flex items-center gap-1.5 rounded-full border border-white/5 bg-[#111216] px-2 py-1 text-[10px] text-zinc-500"
-            title={`${step.agent}: ${step.label}`}
-          >
-            <PipelineStepDot status={pipelineStepStatus({ ...progress, steps }, step, activeStepId, isLoading)} />
-            <span className="max-w-[120px] truncate">{step.label}</span>
-          </span>
-        ))}
-      </div>
-
-      {!isLoading && (
-        <AgentPipelineEventsDisclosure eventCount={events.length}>
-          {visibleEvents.length ? (
-            <div className="space-y-1.5">
-              {visibleEvents.map((event, index) => {
-                const details = formatPipelineDetails(event.details);
-                return (
-                  <div key={`${event.step_id}-${event.status}-${event.observed_at || index}`} className="min-w-0 rounded-lg border border-white/5 bg-[#0f1014] px-2 py-1.5">
-                    <div className="flex min-w-0 flex-wrap items-center gap-2 text-[10px]">
-                      <span className="max-w-[160px] truncate font-medium text-zinc-300">{event.label || event.step_id}</span>
-                      <span className={`${isFailedPipelineStatus(event.status) ? "text-rose-300" : isCompletedPipelineStatus(event.status) ? "text-emerald-300" : "text-emerald-400"}`}>
-                        {String(event.status).replace(/_/g, " ")}
-                      </span>
-                      <span className="text-zinc-600">{formatPipelineAge(event.observed_at, nowMs)} ago</span>
-                    </div>
-                    {details && !compact && <div className="mt-1 line-clamp-2 text-[10px] leading-4 text-zinc-500">{details}</div>}
-                  </div>
-                );
-              })}
-            </div>
-          ) : (
-            <div className="rounded-lg border border-white/5 bg-[#0f1014] px-2 py-2 text-[11px] leading-4 text-zinc-500">
-              Polling job metadata. Backend pipeline events will appear here as agents report progress.
-            </div>
-          )}
-        </AgentPipelineEventsDisclosure>
-      )}
-    </div>
-  );
-}

--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -2526,16 +2526,31 @@ export function FormaWorkspace({
         ...(projectId ? { projectId } : {}),
       });
     }
-    if (!projectId || (authRequired && !isSignedIn)) return;
-    const existingProject = myProjectHistory.find((project: any) => project?.project_id === projectId)
-      || projectHistory.find((project: any) => project?.project_id === projectId);
+    if (authRequired && !isSignedIn) return;
+    const existingProject = projectId
+      ? myProjectHistory.find((project: any) => project?.project_id === projectId)
+        || projectHistory.find((project: any) => project?.project_id === projectId)
+      : null;
     if (existingProject) rememberProjectRecord({ ...existingProject, title });
+    const persistChatTitle = () => {
+      if (!chatId) return;
+      const threadMessages = chatThreads[chatId] || (chatId === activeChatId ? chatMessages : []);
+      persistChatThread(chatId, threadMessages, title);
+    };
+    if (!projectId) {
+      persistChatTitle();
+      return;
+    }
     try {
       const res = await fetch(`${API_URL}/projects/${encodeURIComponent(projectId)}`, {
         method: "PATCH",
         headers: await generationRequestHeaders(),
         body: JSON.stringify({ title }),
       });
+      if (res.status === 404 && chatId) {
+        persistChatTitle();
+        return;
+      }
       if (!res.ok) throw new Error(await readApiErrorMessage(res));
     } catch (error) {
       console.error("Error renaming project", error);
@@ -3082,12 +3097,16 @@ export function FormaWorkspace({
                 onRenameTitle={currentUserOwnsProject ? (title) => { void commitOwnedWorkspaceTitle(title); } : undefined}
                 messages={currentProjectChatMessages}
                 input={projectChatInput}
-                setInput={setProjectChatInput}
+                setInput={(value) => {
+                  setGenerationInputNotice(null);
+                  setProjectChatInput(value);
+                }}
                 onSubmit={handleProjectChatGenerate}
                 isLoading={isLoading}
                 canStop={activeGeneration?.kind === "project-chat"}
                 onStop={stopActiveGeneration}
                 canChat={currentUserOwnsProject}
+                notice={visibleContextInputNotice}
                 namespaceTabs={visibleWorkspaceTabs}
                 activeNamespace={activeWorkspaceTab.id}
                 activeNamespaceLabel={activeWorkspaceTab.label}

--- a/apps/web/app/forma-workspace/about-view.tsx
+++ b/apps/web/app/forma-workspace/about-view.tsx
@@ -18,7 +18,8 @@ import {
 } from "../../lib/legal-docs";
 import { aboutMarqueePartners } from "../../lib/partners";
 
-const CARD_SURFACE_CLASS = "rounded-xl border border-[#2c2f37] bg-[#181b22]";
+const CARD_SURFACE_CLASS = "rounded-xl bg-[var(--forma-surface)]";
+const NESTED_SURFACE_CLASS = "rounded-xl bg-[var(--forma-surface-muted)]";
 const BUTTON_OUTLINE_CLASS =
   "inline-flex h-8 items-center gap-1.5 rounded-lg border border-[#2c2f37] px-3 text-xs font-medium text-slate-300 transition hover:bg-white/5 hover:text-white";
 const SOCIAL_ICON_CLASS =
@@ -129,7 +130,7 @@ export default function AboutView() {
           />
 
           <div className="grid gap-3 p-5 sm:grid-cols-2">
-            <div className="flex items-start gap-3 rounded-xl border border-[#2c2f37] bg-[#101115] p-3.5">
+            <div className={`flex items-start gap-3 p-3.5 ${NESTED_SURFACE_CLASS}`}>
               <div className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10 text-emerald-400">
                 <Cpu className="h-4 w-4" />
               </div>
@@ -140,7 +141,7 @@ export default function AboutView() {
                 </p>
               </div>
             </div>
-            <div className="flex items-start gap-3 rounded-xl border border-[#2c2f37] bg-[#101115] p-3.5">
+            <div className={`flex items-start gap-3 p-3.5 ${NESTED_SURFACE_CLASS}`}>
               <div className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10 text-emerald-400">
                 <ShieldCheck className="h-4 w-4" />
               </div>
@@ -166,7 +167,7 @@ export default function AboutView() {
               return (
                 <div
                   key={partner.slug}
-                  className={`flex h-20 items-center justify-center rounded-xl border border-[#2c2f37] px-6 ${
+                  className={`flex h-20 items-center justify-center rounded-xl px-6 ${
                     lightSurface ? "bg-white" : "bg-[#002b36]"
                   }`}
                   title={partner.name}
@@ -196,7 +197,7 @@ export default function AboutView() {
                 </p>
               </div>
             </summary>
-            <nav className="grid gap-1 border-t border-[#2c2f37] p-3 sm:grid-cols-2" aria-label="Legal">
+            <nav className="grid gap-1 px-3 pb-3 sm:grid-cols-2" aria-label="Legal">
               {legalDocuments.map((document) => (
                 <Link
                   key={document.slug}

--- a/apps/web/app/forma-workspace/home-chat-view.tsx
+++ b/apps/web/app/forma-workspace/home-chat-view.tsx
@@ -125,8 +125,16 @@ export default function HomeChatView({
     : retryMode
       ? "Try failed build again"
       : inputValid
-        ? "Send context"
+        ? started
+          ? "Send context"
+          : "Check hardware idea"
         : "Check hardware idea";
+  const promptLabel = selectedImage
+    ? "Describe constraints or goals for the attached hardware reference image"
+    : started
+      ? "Send project context or describe the next hardware change"
+      : "Describe the hardware idea to build";
+  const promptHasValidationError = Boolean(notice && hasGenerationInput && !inputValid);
 
   useEffect(() => {
     if (selectedImage) promptRef.current?.focus();
@@ -371,6 +379,7 @@ export default function HomeChatView({
               onChange={(event) => onPromptChange(event.target.value)}
               onPaste={onImagePaste}
               onKeyDown={(event) => {
+                if (event.nativeEvent.isComposing) return;
                 if (event.key === "Enter" && !event.shiftKey) {
                   event.preventDefault();
                   if (isLoading) return;
@@ -386,7 +395,8 @@ export default function HomeChatView({
                   ? "Add constraints, references, or what you want from this image…"
                   : "Describe the product, constraints, references, and outputs you need…"
               }
-              aria-invalid={Boolean(notice)}
+              aria-label={promptLabel}
+              aria-invalid={promptHasValidationError}
               aria-describedby={notice ? "generation-input-notice" : undefined}
               className="min-h-[64px] w-full resize-none border-none bg-transparent text-sm leading-6 text-zinc-100 outline-none placeholder:text-zinc-500 sm:min-h-[72px] sm:leading-7"
             />

--- a/apps/web/app/forma-workspace/home-chat-view.tsx
+++ b/apps/web/app/forma-workspace/home-chat-view.tsx
@@ -181,17 +181,17 @@ export default function HomeChatView({
               const isUser = message.role === "user";
               const statusTone =
                 message.status === "error"
-                  ? "border-rose-400/40 bg-rose-950/30 text-rose-100"
+                  ? "border border-rose-400/40 bg-rose-950/30 text-rose-100"
                   : message.status === "success"
-                    ? "border-emerald-400/35 bg-emerald-950/25 text-emerald-50"
+                    ? "bg-[var(--forma-surface)] text-zinc-100"
                     : message.status === "cancelled"
-                      ? "border-amber-300/35 bg-amber-950/20 text-amber-50"
+                      ? "border border-amber-300/35 bg-amber-950/20 text-amber-50"
                       : isUser
-                        ? "border-emerald-500/20 bg-emerald-500/10 text-zinc-100"
-                        : "border-white/5 bg-[#181b22] text-zinc-100";
+                        ? "bg-[var(--forma-surface-muted)] text-zinc-100"
+                        : "bg-[var(--forma-surface)] text-zinc-100";
               return (
                 <div key={message.id} className={`flex min-w-0 ${isUser ? "justify-end" : "justify-start"}`}>
-                  <div className={`min-w-0 max-w-[92%] overflow-hidden rounded-xl border px-3 py-2.5 sm:max-w-[86%] sm:px-4 sm:py-3 ${statusTone}`}>
+                  <div className={`min-w-0 max-w-[92%] overflow-hidden rounded-xl px-3 py-2.5 sm:max-w-[86%] sm:px-4 sm:py-3 ${statusTone}`}>
                     <div className="mb-2 flex min-w-0 flex-wrap items-center gap-2 text-[10px] font-medium text-zinc-500">
                       {message.status === "loading" ? (
                         <RefreshCw className="h-3.5 w-3.5 animate-spin text-emerald-400" />
@@ -288,9 +288,9 @@ export default function HomeChatView({
           onSubmit={onSubmit}
           className={`${
             started
-              ? "md:sticky md:bottom-0 md:bg-transparent md:pb-3"
-              : "md:static md:order-1 md:bg-transparent md:p-0"
-          } fixed bottom-0 left-0 right-0 z-30 max-h-[calc(100dvh-3rem)] shrink-0 overflow-y-auto overscroll-contain bg-transparent px-3 pb-[max(0.4rem,env(safe-area-inset-bottom))] pt-1 sm:px-4 md:left-auto md:right-auto md:z-20 md:max-h-none md:overflow-visible`}
+              ? "fixed bottom-3 left-3 right-3 z-30 max-h-[calc(100dvh-3rem)] shrink-0 overflow-y-auto overscroll-contain bg-transparent px-0 pb-[max(0.25rem,env(safe-area-inset-bottom))] pt-1 sm:left-4 sm:right-4 md:sticky md:bottom-3 md:left-auto md:right-auto md:z-20 md:max-h-none md:overflow-visible md:bg-transparent md:px-0 md:pb-3"
+              : "fixed bottom-0 left-0 right-0 z-30 max-h-[calc(100dvh-3rem)] shrink-0 overflow-y-auto overscroll-contain bg-transparent px-3 pb-[max(0.4rem,env(safe-area-inset-bottom))] pt-1 sm:px-4 md:static md:order-1 md:left-auto md:right-auto md:z-20 md:max-h-none md:overflow-visible md:bg-transparent md:p-0"
+          }`}
         >
           {(needsGenerationProvider || needsImageProvider) && (
             <section className="mb-3 rounded-xl border border-white/5 bg-[#181b22] p-3 text-left sm:p-4" aria-label="Bring your own key setup">
@@ -337,90 +337,131 @@ export default function HomeChatView({
             </section>
           )}
 
-          {notice && (
-            <div id="generation-input-notice" role="status" className="mb-3 flex items-start gap-2 rounded-lg border border-amber-300/30 bg-amber-300/10 px-3 py-2 text-xs leading-5 text-amber-100">
-              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-300" />
-              <span className="break-anywhere min-w-0 flex-1">{notice}</span>
-            </div>
-          )}
-
           <div
-            className={`prompt-composer w-full rounded-2xl bg-[#181b22] px-3 pb-2.5 pt-2.5 ${
-              promptRunning ? "prompt-composer-illuminate" : "prompt-composer-idle"
-            }`}
+            className={`prompt-composer w-full bg-[var(--forma-surface)] ${
+              started ? "rounded-full px-2 py-1" : "rounded-2xl px-3 pb-2.5 pt-2.5"
+            } ${promptRunning ? "prompt-composer-illuminate" : "prompt-composer-idle"}`}
           >
+            {notice ? (
+              <div
+                id="generation-input-notice"
+                role="status"
+                className={
+                  started
+                    ? "px-2.5 pb-1 pt-1 text-[11px] leading-4 text-amber-200"
+                    : "mb-2 flex items-start gap-2 text-xs leading-5 text-amber-200"
+                }
+              >
+                <span className="inline-flex items-start gap-1.5">
+                  <AlertTriangle className={`shrink-0 text-amber-300 ${started ? "mt-px h-3 w-3" : "mt-0.5 h-3.5 w-3.5"}`} />
+                  <span className={`break-anywhere min-w-0 ${started ? "line-clamp-2" : "flex-1"}`}>{notice}</span>
+                </span>
+              </div>
+            ) : !started && promptRunning ? (
+              <div role="status" className="mb-2 flex items-center gap-2 text-[11px] font-medium text-[var(--forma-text-muted)]">
+                <RefreshCw className="h-3 w-3 animate-spin text-emerald-400" />
+                {generationActive ? "Generating…" : "Waiting…"}
+              </div>
+            ) : null}
             <input ref={imageInputRef} type="file" accept="image/*" onChange={onImageChange} className="hidden" />
             {selectedImage && (
-              <div className="mb-2 flex items-start gap-2 rounded-xl border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-1.5 pr-2">
-                <img
-                  src={selectedImage}
-                  alt="Attached prompt image"
-                  className="h-16 w-16 shrink-0 rounded-lg object-cover"
-                />
-                <div className="min-w-0 flex-1 py-0.5">
-                  <div className="text-xs font-medium text-[var(--forma-text-strong)]">Image prompt</div>
-                  <div className="mt-0.5 text-[11px] leading-4 text-[var(--forma-text-muted)]">
-                    Add details below, then press Enter.
+              started ? (
+                <div className="mb-1 flex items-center gap-2 rounded-full bg-[var(--forma-surface-muted)] p-1 pr-2">
+                  <img
+                    src={selectedImage}
+                    alt="Attached prompt image"
+                    className="h-8 w-8 shrink-0 rounded-full object-cover"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <div className="truncate text-[11px] font-medium text-[var(--forma-text-strong)]">Image attached</div>
                   </div>
+                  <button
+                    type="button"
+                    onClick={onRemoveImage}
+                    className="rounded-full p-1 text-[var(--forma-text-muted)] transition-colors hover:bg-[var(--forma-page)] hover:text-[var(--forma-text-strong)]"
+                    aria-label="Remove image"
+                  >
+                    <X className="h-3.5 w-3.5" />
+                  </button>
                 </div>
+              ) : (
+                <div className="mb-2 flex items-start gap-2 rounded-xl bg-[var(--forma-surface-muted)] p-1.5 pr-2">
+                  <img
+                    src={selectedImage}
+                    alt="Attached prompt image"
+                    className="h-16 w-16 shrink-0 rounded-lg object-cover"
+                  />
+                  <div className="min-w-0 flex-1 py-0.5">
+                    <div className="text-xs font-medium text-[var(--forma-text-strong)]">Image prompt</div>
+                    <div className="mt-0.5 text-[11px] leading-4 text-[var(--forma-text-muted)]">
+                      Add details below, then press Enter.
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={onRemoveImage}
+                    className="rounded-md p-1.5 text-[var(--forma-text-muted)] transition-colors hover:bg-[var(--forma-page)] hover:text-[var(--forma-text-strong)]"
+                    aria-label="Remove image"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </div>
+              )
+            )}
+            {started ? (
+              <div className="flex items-center gap-1">
                 <button
                   type="button"
-                  onClick={onRemoveImage}
-                  className="rounded-md p-1.5 text-[var(--forma-text-muted)] transition-colors hover:bg-[var(--forma-page)] hover:text-[var(--forma-text-strong)]"
-                  aria-label="Remove image"
+                  onClick={() => imageInputRef.current?.click()}
+                  className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-zinc-400 transition-colors hover:bg-zinc-800/50 hover:text-zinc-200"
+                  aria-label="Attach image"
+                  title="Attach an image or paste one from your clipboard"
                 >
-                  <X className="h-4 w-4" />
+                  <Paperclip className="h-4 w-4" />
                 </button>
-              </div>
-            )}
-            <textarea
-              ref={promptRef}
-              value={prompt}
-              onChange={(event) => onPromptChange(event.target.value)}
-              onPaste={onImagePaste}
-              onKeyDown={(event) => {
-                if (event.nativeEvent.isComposing) return;
-                if (event.key === "Enter" && !event.shiftKey) {
-                  event.preventDefault();
-                  if (isLoading) return;
-                  if (retryMode) {
-                    onRetryFailedBuild();
-                    return;
+                <textarea
+                  ref={promptRef}
+                  value={prompt}
+                  onChange={(event) => onPromptChange(event.target.value)}
+                  onPaste={onImagePaste}
+                  onKeyDown={(event) => {
+                    if (event.nativeEvent.isComposing) return;
+                    if (event.key === "Enter" && !event.shiftKey) {
+                      event.preventDefault();
+                      if (isLoading) return;
+                      if (retryMode) {
+                        onRetryFailedBuild();
+                        return;
+                      }
+                      event.currentTarget.form?.requestSubmit();
+                    }
+                  }}
+                  rows={1}
+                  placeholder={
+                    selectedImage
+                      ? "Add constraints, references, or what you want from this image…"
+                      : "Describe the next hardware change…"
                   }
-                  event.currentTarget.form?.requestSubmit();
-                }
-              }}
-              placeholder={
-                selectedImage
-                  ? "Add constraints, references, or what you want from this image…"
-                  : "Describe the product, constraints, references, and outputs you need…"
-              }
-              aria-label={promptLabel}
-              aria-invalid={promptHasValidationError}
-              aria-describedby={notice ? "generation-input-notice" : undefined}
-              className="min-h-[64px] w-full resize-none border-none bg-transparent text-sm leading-6 text-zinc-100 outline-none placeholder:text-zinc-500 sm:min-h-[72px] sm:leading-7"
-            />
-            <div className="mt-1 flex items-center justify-between gap-2">
-              <button
-                type="button"
-                onClick={() => imageInputRef.current?.click()}
-                className="inline-flex h-7 w-7 items-center justify-center rounded-md text-zinc-400 transition-colors hover:bg-zinc-800/50 hover:text-zinc-200"
-                aria-label="Attach image"
-                title="Attach an image or paste one from your clipboard"
-              >
-                <Paperclip className="h-4 w-4" />
-              </button>
-              <div className="flex items-center gap-1.5">
+                  aria-label={promptLabel}
+                  aria-invalid={promptHasValidationError}
+                  aria-describedby={notice ? "generation-input-notice" : undefined}
+                  className="h-8 min-h-8 max-h-8 min-w-0 flex-1 resize-none overflow-y-auto border-none bg-transparent py-1.5 text-sm leading-5 text-zinc-100 outline-none placeholder:text-zinc-500"
+                />
                 {canFinishPrompt && (
                   <span className="prompt-composer-enter-hint hidden sm:inline" aria-hidden="true">
                     Enter
+                  </span>
+                )}
+                {promptRunning && (
+                  <span className="hidden text-[10px] font-medium text-[var(--forma-text-muted)] sm:inline">
+                    {generationActive ? "Generating…" : "Waiting…"}
                   </span>
                 )}
                 <button
                   type={generationActive || retryMode ? "button" : "submit"}
                   onClick={generationActive ? onStop : retryMode ? onRetryFailedBuild : undefined}
                   disabled={retryMode ? retryingFailedBuild : !generationActive && (isLoading || !hasGenerationInput || !generationReady)}
-                  className={`prompt-composer-send flex h-7 w-7 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed ${
+                  className={`prompt-composer-send flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed ${
                     canFinishPrompt || retryMode ? "is-ready" : ""
                   }`}
                   aria-label={canFinishPrompt ? `${primaryActionLabel}, or press Enter` : primaryActionLabel}
@@ -437,11 +478,79 @@ export default function HomeChatView({
                   )}
                 </button>
               </div>
-            </div>
+            ) : (
+              <>
+                <textarea
+                  ref={promptRef}
+                  value={prompt}
+                  onChange={(event) => onPromptChange(event.target.value)}
+                  onPaste={onImagePaste}
+                  onKeyDown={(event) => {
+                    if (event.nativeEvent.isComposing) return;
+                    if (event.key === "Enter" && !event.shiftKey) {
+                      event.preventDefault();
+                      if (isLoading) return;
+                      if (retryMode) {
+                        onRetryFailedBuild();
+                        return;
+                      }
+                      event.currentTarget.form?.requestSubmit();
+                    }
+                  }}
+                  placeholder={
+                    selectedImage
+                      ? "Add constraints, references, or what you want from this image…"
+                      : "Describe the product, constraints, references, and outputs you need…"
+                  }
+                  aria-label={promptLabel}
+                  aria-invalid={promptHasValidationError}
+                  aria-describedby={notice ? "generation-input-notice" : undefined}
+                  className="min-h-[64px] w-full resize-none border-none bg-transparent text-sm leading-6 text-zinc-100 outline-none placeholder:text-zinc-500 sm:min-h-[72px] sm:leading-7"
+                />
+                <div className="mt-1 flex items-center justify-between gap-2">
+                  <button
+                    type="button"
+                    onClick={() => imageInputRef.current?.click()}
+                    className="inline-flex h-7 w-7 items-center justify-center rounded-md text-zinc-400 transition-colors hover:bg-zinc-800/50 hover:text-zinc-200"
+                    aria-label="Attach image"
+                    title="Attach an image or paste one from your clipboard"
+                  >
+                    <Paperclip className="h-4 w-4" />
+                  </button>
+                  <div className="flex items-center gap-1.5">
+                    {canFinishPrompt && (
+                      <span className="prompt-composer-enter-hint hidden sm:inline" aria-hidden="true">
+                        Enter
+                      </span>
+                    )}
+                    <button
+                      type={generationActive || retryMode ? "button" : "submit"}
+                      onClick={generationActive ? onStop : retryMode ? onRetryFailedBuild : undefined}
+                      disabled={retryMode ? retryingFailedBuild : !generationActive && (isLoading || !hasGenerationInput || !generationReady)}
+                      className={`prompt-composer-send flex h-7 w-7 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed ${
+                        canFinishPrompt || retryMode ? "is-ready" : ""
+                      }`}
+                      aria-label={canFinishPrompt ? `${primaryActionLabel}, or press Enter` : primaryActionLabel}
+                      title={canFinishPrompt ? `${primaryActionLabel} · Enter` : primaryActionLabel}
+                    >
+                      {generationActive ? (
+                        <Square className="h-3.5 w-3.5 fill-current" />
+                      ) : retryMode ? (
+                        <RefreshCw className={`h-3.5 w-3.5 ${retryingFailedBuild ? "animate-spin" : ""}`} />
+                      ) : isLoading ? (
+                        <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                      ) : (
+                        <ArrowRight className="h-4 w-4" />
+                      )}
+                    </button>
+                  </div>
+                </div>
+              </>
+            )}
           </div>
 
         </form>
-        {started && <div className="h-40 shrink-0 md:hidden" aria-hidden="true" />}
+        {started && <div className="h-16 shrink-0 md:hidden" aria-hidden="true" />}
       </div>
     </section>
   );

--- a/apps/web/app/forma-workspace/lib/agent-pipeline.ts
+++ b/apps/web/app/forma-workspace/lib/agent-pipeline.ts
@@ -1,0 +1,406 @@
+import type { A2AJob } from "../use-admin-data";
+import type { AgentPipelineEvent, AgentPipelineProgress, AgentPipelineStep, ChatMessage } from "../types";
+import {
+  CHAT_DIAGNOSTIC_CHARACTER_LIMIT,
+  defaultAgentPipelineSteps,
+  optionalImagePipelineStep,
+  PIPELINE_STALE_AFTER_MS,
+  PIPELINE_UI_HEARTBEAT_MS,
+} from "../workspace-constants";
+import { chatTimestamp } from "./chat-ids";
+import { formatDurationSeconds, timestampMs } from "./project-metadata";
+
+export function normalizeAgentPipelineStep(value: any): AgentPipelineStep | null {
+  if (!value || typeof value !== "object") return null;
+  const id = typeof value.id === "string" && value.id.trim() ? value.id.trim() : "";
+  const label = typeof value.label === "string" && value.label.trim() ? value.label.trim() : "";
+  if (!id || !label) return null;
+  return {
+    id,
+    label,
+    agent: typeof value.agent === "string" && value.agent.trim() ? value.agent.trim() : label,
+    description: typeof value.description === "string" ? value.description : "",
+    duration_ms: Number.isFinite(Number(value.duration_ms)) ? Math.max(1000, Number(value.duration_ms)) : undefined,
+    optional: Boolean(value.optional),
+  };
+}
+
+export function normalizeAgentPipelineSteps(value: any): AgentPipelineStep[] {
+  const rawSteps = Array.isArray(value?.steps) ? value.steps : Array.isArray(value) ? value : [];
+  const steps = rawSteps.map(normalizeAgentPipelineStep).filter(Boolean) as AgentPipelineStep[];
+  return steps.length ? steps : defaultAgentPipelineSteps;
+}
+
+export function normalizeAgentPipelineProgress(value: any): AgentPipelineProgress | null {
+  if (!value || typeof value !== "object") return null;
+  const steps = normalizeAgentPipelineSteps(value.steps);
+  const events = normalizeAgentPipelineEvents(value.events);
+  return {
+    startedAt: typeof value.startedAt === "string" && value.startedAt ? value.startedAt : chatTimestamp(),
+    steps,
+    currentStepIndex: Math.min(Math.max(Number(value.currentStepIndex || 0), 0), Math.max(steps.length - 1, 0)),
+    estimated: value.estimated !== false,
+    synced: Boolean(value.synced),
+    jobId: typeof value.jobId === "string" ? value.jobId : null,
+    events,
+    uiUpdatedAt: typeof value.uiUpdatedAt === "string" && value.uiUpdatedAt ? value.uiUpdatedAt : chatTimestamp(),
+  };
+}
+
+export function normalizeAgentPipelineEvents(value: any): AgentPipelineEvent[] {
+  const rawEvents = Array.isArray(value) ? value : [];
+  return rawEvents
+    .map((event) => {
+      if (!event || typeof event !== "object" || typeof event.step_id !== "string") return null;
+      return {
+        workflow: typeof event.workflow === "string" ? event.workflow : undefined,
+        step_id: event.step_id,
+        status: typeof event.status === "string" ? event.status : "started",
+        agent: typeof event.agent === "string" ? event.agent : undefined,
+        label: typeof event.label === "string" ? event.label : undefined,
+        description: typeof event.description === "string" ? event.description : undefined,
+        observed_at: typeof event.observed_at === "string" ? event.observed_at : undefined,
+        details: event.details && typeof event.details === "object" ? event.details : undefined,
+      };
+    })
+    .filter(Boolean) as AgentPipelineEvent[];
+}
+
+export function stepsForPipelineRun(steps: AgentPipelineStep[], includeImage: boolean) {
+  const normalized = steps.length ? steps : defaultAgentPipelineSteps;
+  const baseSteps = normalized.filter((step) => !step.optional || includeImage);
+  if (includeImage && !baseSteps.some((step) => step.id === optionalImagePipelineStep.id)) {
+    return [...baseSteps, optionalImagePipelineStep];
+  }
+  return baseSteps;
+}
+
+export function createAgentPipelineProgress(
+  steps: AgentPipelineStep[],
+  includeImage: boolean,
+  startedAt: string = chatTimestamp(),
+  jobId: string | null = null
+): AgentPipelineProgress {
+  return {
+    startedAt,
+    steps: stepsForPipelineRun(steps, includeImage),
+    currentStepIndex: 0,
+    estimated: true,
+    synced: false,
+    jobId,
+    events: [],
+    uiUpdatedAt: startedAt,
+  };
+}
+
+export function shouldPulsePipelineUi(progress: AgentPipelineProgress, nowMs: number) {
+  const lastUiMs = timestampMs(progress.uiUpdatedAt);
+  return lastUiMs === null || nowMs - lastUiMs >= PIPELINE_UI_HEARTBEAT_MS;
+}
+
+export function agentPipelineStepIndex(progress: AgentPipelineProgress, nowMs: number) {
+  const startedMs = Date.parse(progress.startedAt);
+  const elapsedMs = Math.max(0, nowMs - (Number.isNaN(startedMs) ? nowMs : startedMs));
+  let accumulatedMs = 0;
+  for (let index = 0; index < progress.steps.length; index += 1) {
+    accumulatedMs += progress.steps[index].duration_ms || 5500;
+    if (elapsedMs < accumulatedMs) return index;
+  }
+  return Math.max(0, progress.steps.length - 1);
+}
+
+export function advanceAgentPipelineProgress(progress: AgentPipelineProgress, nowMs: number): AgentPipelineProgress {
+  if (progress.synced || progress.estimated === false) {
+    return shouldPulsePipelineUi(progress, nowMs)
+      ? { ...progress, uiUpdatedAt: new Date(nowMs).toISOString() }
+      : progress;
+  }
+  const currentStepIndex = agentPipelineStepIndex(progress, nowMs);
+  if (currentStepIndex !== progress.currentStepIndex) {
+    return { ...progress, currentStepIndex, uiUpdatedAt: new Date(nowMs).toISOString() };
+  }
+  return shouldPulsePipelineUi(progress, nowMs)
+    ? { ...progress, uiUpdatedAt: new Date(nowMs).toISOString() }
+    : progress;
+}
+
+export function pipelineEventCursor(events: AgentPipelineEvent[] | undefined) {
+  const normalizedEvents = normalizeAgentPipelineEvents(events);
+  const lastEvent = normalizedEvents[normalizedEvents.length - 1];
+  return [
+    normalizedEvents.length,
+    lastEvent?.observed_at || "",
+    lastEvent?.step_id || "",
+    lastEvent?.status || "",
+  ].join(":");
+}
+
+export function isFailedPipelineStatus(status: any) {
+  return String(status || "").toLowerCase().includes("failed");
+}
+
+export function isCompletedPipelineStatus(status: any) {
+  const normalized = String(status || "").toLowerCase();
+  return normalized === "completed" || normalized === "provider_response_received";
+}
+
+export function failedPipelineEvent(events: AgentPipelineEvent[] | undefined) {
+  const normalizedEvents = normalizeAgentPipelineEvents(events);
+  return [...normalizedEvents].reverse().find((event) => isFailedPipelineStatus(event.status)) || null;
+}
+
+export function pipelineEventsFromWorkerTask(task: any): AgentPipelineEvent[] {
+  if (!Array.isArray(task?.progress)) return [];
+  return normalizeAgentPipelineEvents(
+    task.progress.map((item: any) => item?.metadata?.pipeline_event).filter(Boolean),
+  );
+}
+
+export function compactDiagnosticText(value: any, limit: number = CHAT_DIAGNOSTIC_CHARACTER_LIMIT) {
+  const original = String(value || "").trim();
+  if (!original) return "";
+
+  const normalized = original
+    .replace(/\r\n/g, "\n")
+    .replace(/https:\/\/errors\.pydantic\.dev\/\S+/g, "")
+    .replace(/,\s*input_value=(?:'[^']*'|"[^"]*"|[^\]\n]*)/g, "")
+    .replace(/,\s*input_type=[^\]\n]+/g, "")
+    .replace(/\[type=([^,\]\s]+)[^\]]*\]/g, "[type=$1]");
+
+  const lines = normalized
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+/g, " ").trim())
+    .filter(Boolean)
+    .filter((line) => !/^for further information visit/i.test(line))
+    .filter((line) => !/^input_(value|type)=/i.test(line));
+  const text = lines.join("\n") || original;
+
+  if (text.length <= limit) return text;
+  const clipped = text.slice(0, limit).replace(/\s+\S*$/, "").trimEnd();
+  return `${clipped || text.slice(0, limit).trimEnd()}...`;
+}
+
+export function generationFailureChatMessage(message: string, includeJobsHint = false) {
+  const compact = compactDiagnosticText(message);
+  const content = compact
+    ? /^generation failed\b/i.test(compact)
+      ? compact
+      : `Generation failed: ${compact}`
+    : "Generation failed.";
+  return includeJobsHint ? `${content}\nFull diagnostics are available in Jobs.` : content;
+}
+
+export function jobFailureMessage(job: A2AJob) {
+  const event = failedPipelineEvent(job.progress_events);
+  const eventDetails = event?.details || {};
+  const reason = job.error || eventDetails.error || eventDetails.reason || eventDetails.message;
+  if (reason) return String(reason);
+  if (event?.label) return `${event.label} failed.`;
+  return "Generation failed.";
+}
+
+export function terminalJobMessagePatch(job: A2AJob, message: ChatMessage): Partial<Omit<ChatMessage, "id">> | null {
+  if (message.status !== "loading") return null;
+  if (["cancelled", "canceled"].includes(String(job.status || "").toLowerCase())) {
+    return {
+      content: "Generation stopped by you.",
+      status: "cancelled",
+    };
+  }
+  if (job.status === "failed") {
+    return {
+      content: generationFailureChatMessage(jobFailureMessage(job), true),
+      status: "error",
+    };
+  }
+  if (job.status === "succeeded") {
+    const title = job.result_summary?.title || "Project";
+    const projectId = typeof job.result_summary?.project_id === "string" ? job.result_summary.project_id : null;
+    return {
+      content: `${title} is ready.`,
+      status: "success",
+      projectId,
+    };
+  }
+  return null;
+}
+
+export function patchChangesMessage(message: ChatMessage, patch: Partial<Omit<ChatMessage, "id">> | null) {
+  if (!patch) return false;
+  return Object.entries(patch).some(([key, value]) => (message as any)[key] !== value);
+}
+
+export function sameAgentPipelineProgress(left: AgentPipelineProgress | null | undefined, right: AgentPipelineProgress | null | undefined) {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return (
+    left.currentStepIndex === right.currentStepIndex &&
+    left.estimated === right.estimated &&
+    Boolean(left.synced) === Boolean(right.synced) &&
+    (left.jobId || null) === (right.jobId || null) &&
+    pipelineEventCursor(left.events) === pipelineEventCursor(right.events)
+  );
+}
+
+export function progressFromJobEvents(
+  job: A2AJob | null,
+  fallback: AgentPipelineProgress,
+  includeImage: boolean
+): AgentPipelineProgress | null {
+  const events = normalizeAgentPipelineEvents(job?.progress_events);
+  if (!events.length) return null;
+  const previousEvents = normalizeAgentPipelineEvents(fallback.events);
+  if (fallback.synced && previousEvents.length > events.length) return fallback;
+  const steps = stepsForPipelineRun(fallback.steps, includeImage);
+  const indexByStep = new Map(steps.map((step, index) => [step.id, index]));
+  let currentStepIndex = fallback.currentStepIndex;
+  for (const event of events) {
+    const eventIndex = indexByStep.get(event.step_id);
+    if (eventIndex === undefined) continue;
+    if (isCompletedPipelineStatus(event.status) || event.status === "skipped") {
+      currentStepIndex = Math.min(eventIndex + 1, Math.max(steps.length - 1, 0));
+    } else {
+      currentStepIndex = eventIndex;
+    }
+  }
+  if (fallback.synced && previousEvents.length >= events.length && currentStepIndex < fallback.currentStepIndex) {
+    return fallback;
+  }
+  return {
+    ...fallback,
+    startedAt: job?.started_at || fallback.startedAt,
+    steps,
+    currentStepIndex,
+    estimated: false,
+    synced: true,
+    jobId: job?.job_id || fallback.jobId || null,
+    events,
+    uiUpdatedAt: chatTimestamp(),
+  };
+}
+
+export function mergeMessagePipelineProgressFromJob(
+  message: ChatMessage,
+  job: A2AJob,
+  seedProgress: AgentPipelineProgress,
+  includeImage: boolean
+) {
+  const nextProgress = progressFromJobEvents(job, message.pipelineProgress || seedProgress, includeImage);
+  const terminalPatch = terminalJobMessagePatch(job, message);
+  const progressChanged = Boolean(nextProgress && !sameAgentPipelineProgress(message.pipelineProgress, nextProgress));
+  const patchChanged = patchChangesMessage(message, terminalPatch);
+  if (!progressChanged && !patchChanged) return message;
+  return {
+    ...message,
+    ...(terminalPatch || {}),
+    pipelineProgress: nextProgress || message.pipelineProgress || null,
+    timestamp: chatTimestamp(),
+  };
+}
+
+export function progressIncludesImageStep(progress: AgentPipelineProgress | null | undefined) {
+  return Boolean(progress?.steps?.some((step) => step.id === optionalImagePipelineStep.id || step.optional));
+}
+
+export function mergeMessagesWithJobs(
+  messages: ChatMessage[],
+  jobsById: Map<string, A2AJob>,
+  includeImageDefault: boolean
+) {
+  let changed = false;
+  const nextMessages = messages.map((message) => {
+    const jobId = message.pipelineProgress?.jobId;
+    if (!jobId) return message;
+    const job = jobsById.get(jobId);
+    if (!job || !message.pipelineProgress) return message;
+    const includeImage = includeImageDefault || progressIncludesImageStep(message.pipelineProgress);
+    const nextMessage = mergeMessagePipelineProgressFromJob(message, job, message.pipelineProgress, includeImage);
+    if (nextMessage !== message) changed = true;
+    return nextMessage;
+  });
+  return changed ? nextMessages : messages;
+}
+
+export function advancePipelineMessages(messages: ChatMessage[], nowMs: number) {
+  let changed = false;
+  const nextMessages = messages.map((message) => {
+    if (message.status !== "loading" || !message.pipelineProgress) return message;
+    const nextProgress = advanceAgentPipelineProgress(message.pipelineProgress, nowMs);
+    if (nextProgress === message.pipelineProgress) return message;
+    changed = true;
+    return { ...message, pipelineProgress: nextProgress };
+  });
+  return changed ? nextMessages : messages;
+}
+
+export function pipelineEventTimestampMs(event: AgentPipelineEvent | null | undefined): number | null {
+  return timestampMs(event?.observed_at);
+}
+
+export function latestPipelineEvent(events: AgentPipelineEvent[]) {
+  const normalizedEvents = normalizeAgentPipelineEvents(events);
+  return normalizedEvents[normalizedEvents.length - 1] || null;
+}
+
+export function pipelineStepForEvent(progress: AgentPipelineProgress, event: AgentPipelineEvent | null | undefined) {
+  if (!event) return null;
+  return progress.steps.find((step) => step.id === event.step_id) || null;
+}
+
+export function activePipelineStep(progress: AgentPipelineProgress) {
+  const events = normalizeAgentPipelineEvents(progress.events);
+  const lastEvent = latestPipelineEvent(events);
+  const stepFromEvent = pipelineStepForEvent(progress, lastEvent);
+  if (lastEvent && !isCompletedPipelineStatus(lastEvent.status) && lastEvent.status !== "skipped") {
+    return stepFromEvent || progress.steps[progress.currentStepIndex] || progress.steps[0] || null;
+  }
+  return progress.steps[progress.currentStepIndex] || stepFromEvent || progress.steps[0] || null;
+}
+
+export function completedPipelineStepCount(progress: AgentPipelineProgress) {
+  const completed = new Set<string>();
+  normalizeAgentPipelineEvents(progress.events).forEach((event) => {
+    if (isCompletedPipelineStatus(event.status) || event.status === "skipped") completed.add(event.step_id);
+    if (isFailedPipelineStatus(event.status)) completed.delete(event.step_id);
+  });
+  if (completed.size) return completed.size;
+  return progress.estimated ? Math.max(0, progress.currentStepIndex) : 0;
+}
+
+export function pipelineStepStatus(
+  progress: AgentPipelineProgress,
+  step: AgentPipelineStep,
+  activeStepId: string | null,
+  isRunning: boolean = false
+) {
+  const events = normalizeAgentPipelineEvents(progress.events);
+  const stepEvents = events.filter((event) => event.step_id === step.id);
+  const lastStepEvent = stepEvents[stepEvents.length - 1];
+  // A failed attempt may be followed by a retry while the job remains active.
+  // Keep the current step neutral until the job itself reaches a failed state.
+  if (isRunning && activeStepId === step.id) return "active";
+  if (isFailedPipelineStatus(lastStepEvent?.status)) return "failed";
+  if (lastStepEvent?.status === "skipped") return "skipped";
+  if (isCompletedPipelineStatus(lastStepEvent?.status)) return "completed";
+  if (activeStepId === step.id) return "active";
+  return "pending";
+}
+
+export function formatPipelineAge(value?: string | null, nowMs: number = Date.now()) {
+  const ms = timestampMs(value);
+  if (ms === null) return "-";
+  return formatDurationSeconds(Math.max(1, Math.round((nowMs - ms) / 1000)));
+}
+
+export function formatPipelineDetails(details: Record<string, any> | undefined) {
+  if (!details || typeof details !== "object") return "";
+  return Object.entries(details)
+    .filter(([, value]) => value !== null && value !== undefined && value !== "")
+    .slice(0, 3)
+    .map(([key, value]) => {
+      const rawText = typeof value === "string" ? value : JSON.stringify(value);
+      const text = typeof rawText === "string" ? rawText : String(value);
+      return `${key.replace(/_/g, " ")}: ${text.length > 80 ? `${text.slice(0, 77)}...` : text}`;
+    })
+    .join(" / ");
+}

--- a/apps/web/app/forma-workspace/lib/api-errors.ts
+++ b/apps/web/app/forma-workspace/lib/api-errors.ts
@@ -1,0 +1,55 @@
+import type { ApiErrorDetails } from "../types";
+
+export function normalizeApiErrorDetails(value: any, fallback: string): ApiErrorDetails {
+  if (typeof value === "string" && value.trim()) {
+    return { message: value.trim() };
+  }
+
+  if (Array.isArray(value)) {
+    const messages = value
+      .map((item: any) => item?.msg || item?.message || item?.detail)
+      .filter(Boolean);
+    if (messages.length) return { message: messages.join("; ") };
+  }
+
+  if (value && typeof value === "object") {
+    const message =
+      typeof value.message === "string"
+        ? value.message
+        : typeof value.detail === "string"
+          ? value.detail
+          : fallback;
+    const reason = typeof value.reason === "string" ? value.reason : undefined;
+    const provider = typeof value.provider === "string" ? value.provider : undefined;
+    const model = typeof value.model === "string" ? value.model : undefined;
+    return {
+      message,
+      code: typeof value.code === "string" ? value.code : undefined,
+      reason,
+      provider,
+      model,
+      job_id: typeof value.job_id === "string" ? value.job_id : undefined,
+      debug: value.debug && typeof value.debug === "object" ? value.debug : undefined,
+    };
+  }
+
+  return { message: fallback };
+}
+
+export async function readApiError(response: Response): Promise<ApiErrorDetails> {
+  const fallback = `Server returned ${response.status}`;
+  try {
+    const body = await response.json();
+    if (body?.detail !== undefined) return normalizeApiErrorDetails(body.detail, fallback);
+    if (body?.message !== undefined) return normalizeApiErrorDetails(body.message, fallback);
+    if (body?.error !== undefined) return normalizeApiErrorDetails(body.error, fallback);
+  } catch {
+    // Fall through to a generic message.
+  }
+
+  return { message: fallback };
+}
+
+export async function readApiErrorMessage(response: Response) {
+  return (await readApiError(response)).message;
+}

--- a/apps/web/app/forma-workspace/lib/chat-ids.ts
+++ b/apps/web/app/forma-workspace/lib/chat-ids.ts
@@ -1,0 +1,43 @@
+import { INITIAL_CHAT_TIMESTAMP } from "../workspace-constants";
+import type { ChatMessage } from "../types";
+
+export function newChatMessageId() {
+  return `chat-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export function newBuildChatId() {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `chat-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+export function newFrontendJobId() {
+  const suffix = typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+    ? crypto.randomUUID()
+    : `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  return `job_frontend_${suffix.replace(/[^A-Za-z0-9_.:-]/g, "_")}`;
+}
+
+export function chatTimestamp() {
+  return new Date().toISOString();
+}
+
+export function formatChatTimestamp(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "";
+  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export function initialChatMessages(timestamp: string = INITIAL_CHAT_TIMESTAMP): ChatMessage[] {
+  return [
+    {
+      id: "assistant-welcome",
+      role: "assistant",
+      content:
+        "Tell me what you want to build. I can turn it into a project with parts, wiring, mechanical notes, validation, jobs, and optional product images.",
+      status: "idle",
+      timestamp,
+    },
+  ];
+}

--- a/apps/web/app/forma-workspace/lib/chat-list.ts
+++ b/apps/web/app/forma-workspace/lib/chat-list.ts
@@ -1,0 +1,221 @@
+import type { ChatListItem } from "../sidebar";
+import { MAX_CHAT_INDEX_ITEMS, NEW_PROJECT_TITLE } from "../workspace-constants";
+import { chatTimestamp } from "./chat-ids";
+import { persistableChatMessages } from "./chat-normalize";
+
+export function chatListItemTime(value: string | null | undefined): number {
+  const normalizedValue = value?.trim() || "";
+  // Project creation timestamps have historically been emitted as UTC without a
+  // timezone suffix. Treat them as UTC so they compare correctly with chat
+  // updated_at values, which include "Z".
+  const timestamp = Date.parse(
+    normalizedValue && !/(?:z|[+-]\d{2}:?\d{2})$/i.test(normalizedValue)
+      ? `${normalizedValue}Z`
+      : normalizedValue
+  );
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+export function latestChatListItemDate(
+  left: string | null | undefined,
+  right: string | null | undefined
+): string | null {
+  return chatListItemTime(right) > chatListItemTime(left) ? right || null : left || right || null;
+}
+
+export function sortChatListItems(items: ChatListItem[]): ChatListItem[] {
+  return [...items].sort((left, right) => {
+    if (Boolean(left.pinned) !== Boolean(right.pinned)) return left.pinned ? -1 : 1;
+    return chatListItemTime(right.createdAt) - chatListItemTime(left.createdAt);
+  });
+}
+
+export function upsertChatListItem(items: ChatListItem[], item: Partial<ChatListItem> & { chatId: string }): ChatListItem[] {
+  const existing = items.find((current) => current.chatId === item.chatId);
+  const incomingTitle = item.title?.trim() || "";
+  const existingTitle = existing?.title?.trim() || "";
+  const keepExistingTitle =
+    incomingTitle === NEW_PROJECT_TITLE && Boolean(existingTitle) && existingTitle !== NEW_PROJECT_TITLE;
+  const incomingProjectId = typeof item.projectId === "string" ? item.projectId : undefined;
+  const nextItem: ChatListItem = {
+    chatId: item.chatId,
+    title: keepExistingTitle ? existingTitle : incomingTitle || existingTitle || NEW_PROJECT_TITLE,
+    projectId: incomingProjectId === undefined ? existing?.projectId || "" : incomingProjectId || existing?.projectId || "",
+    createdAt: item.createdAt || existing?.createdAt || chatTimestamp(),
+    projectCount: Math.max(item.projectCount ?? existing?.projectCount ?? 0, 0),
+  };
+  return sortChatListItems([nextItem, ...items.filter((current) => current.chatId !== item.chatId)])
+    .slice(0, MAX_CHAT_INDEX_ITEMS);
+}
+
+export function buildChatListItems(projectHistory: any[], localChatItems: ChatListItem[] = []): ChatListItem[] {
+  const groups = new Map<string, { latest: any; projectCount: number }>();
+
+  projectHistory
+    .filter((project: any) => project?.project_id)
+    .forEach((project: any) => {
+      const projectId = String(project.project_id);
+      const chatId = String(project.chat_id || projectId).trim();
+      if (!chatId) return;
+
+      const existing = groups.get(chatId);
+      if (!existing) {
+        groups.set(chatId, { latest: project, projectCount: 1 });
+        return;
+      }
+
+      const currentTime = Date.parse(existing.latest?.created_at || "");
+      const nextTime = Date.parse(project.created_at || "");
+      groups.set(chatId, {
+        latest: Number.isNaN(nextTime) || nextTime <= (Number.isNaN(currentTime) ? 0 : currentTime)
+          ? existing.latest
+          : project,
+        projectCount: existing.projectCount + 1,
+      });
+    });
+
+  const savedItems = Array.from(groups.entries())
+    .map(([chatId, group]) => ({
+      chatId,
+      title: group.latest?.title || "Untitled chat",
+      projectId: String(group.latest?.project_id || ""),
+      createdAt: typeof group.latest?.created_at === "string" ? group.latest.created_at : null,
+      projectCount: group.projectCount,
+    }));
+
+  const merged = new Map<string, ChatListItem>();
+  localChatItems.forEach((item) => {
+    if (item.chatId) merged.set(item.chatId, item);
+  });
+  savedItems.forEach((item) => {
+    const existing = merged.get(item.chatId);
+    merged.set(item.chatId, {
+      ...existing,
+      ...item,
+      createdAt: latestChatListItemDate(existing?.createdAt, item.createdAt),
+      projectCount: Math.max(existing?.projectCount || 0, item.projectCount),
+    });
+  });
+
+  return sortChatListItems(Array.from(merged.values()));
+}
+
+export function normalizePrivateChatItems(value: any): ChatListItem[] {
+  const chats = Array.isArray(value) ? value : [];
+  return chats
+    .map((chat: any): ChatListItem | null => {
+      const chatId = typeof chat?.chat_id === "string" ? chat.chat_id.trim() : "";
+      if (!chatId) return null;
+      const messages = persistableChatMessages(Array.isArray(chat?.messages) ? chat.messages : []);
+      const projectId = [...messages].reverse().find((message) => message.projectId)?.projectId || "";
+      return {
+        chatId,
+        title: typeof chat.title === "string" && chat.title.trim() ? chat.title.trim() : NEW_PROJECT_TITLE,
+        projectId,
+        createdAt: typeof chat.updated_at === "string" ? chat.updated_at : typeof chat.created_at === "string" ? chat.created_at : null,
+        projectCount: 0,
+      };
+    })
+    .filter((item: ChatListItem | null): item is ChatListItem => Boolean(item));
+}
+
+export function normalizeProjectListPage(value: any): { items: any[]; total: number } {
+  if (Array.isArray(value)) return { items: value, total: value.length };
+  const items = Array.isArray(value?.items) ? value.items : [];
+  const parsedTotal = Number(value?.total);
+  return {
+    items,
+    total: Number.isFinite(parsedTotal) ? Math.max(items.length, Math.trunc(parsedTotal)) : items.length,
+  };
+}
+
+export function mergeChatListItems(primary: ChatListItem[], secondary: ChatListItem[]): ChatListItem[] {
+  const merged = new Map<string, ChatListItem>();
+  secondary.forEach((item) => {
+    if (item.chatId) merged.set(item.chatId, item);
+  });
+  primary.forEach((item) => {
+    if (!item.chatId) return;
+    const existing = merged.get(item.chatId);
+    merged.set(item.chatId, {
+      ...existing,
+      ...item,
+      createdAt: latestChatListItemDate(existing?.createdAt, item.createdAt),
+      projectCount: Math.max(existing?.projectCount || 0, item.projectCount),
+    });
+  });
+  return sortChatListItems(Array.from(merged.values()));
+}
+
+export function mergeProjectRecords(primary: any[], secondary: any[]): any[] {
+  const merged = new Map<string, any>();
+  primary.forEach((project: any) => {
+    const projectId = project?.project_id ? String(project.project_id) : "";
+    if (projectId) merged.set(projectId, project);
+  });
+  secondary.forEach((project: any) => {
+    const projectId = project?.project_id ? String(project.project_id) : "";
+    if (projectId) merged.set(projectId, project);
+  });
+  return Array.from(merged.values());
+}
+
+export function sameStringList(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+export function projectRecordsFromChatItems(chatItems: ChatListItem[]): any[] {
+  return chatItems
+    .filter((item) => item.projectId)
+    .map((item) => ({
+      project_id: item.projectId,
+      chat_id: item.chatId,
+      title: item.title || "Untitled project",
+      prompt: item.title || "",
+      created_at: item.createdAt || chatTimestamp(),
+      can_chat: true,
+      creator_display: "unknown",
+      creator_username: "unknown",
+      creator_image_url: null,
+      parts_count: 0,
+      save_count: 0,
+      remix_count: 0,
+      saved: false,
+    }));
+}
+
+export function normalizeProjectHistoryRecord(value: any): any | null {
+  if (!value || typeof value !== "object") return null;
+  const projectId = typeof value.project_id === "string" ? value.project_id.trim() : "";
+  if (!projectId) return null;
+  const creatorDisplay =
+    typeof value.creator_username === "string" && value.creator_username.trim()
+      ? value.creator_username.trim()
+      : typeof value.creator_display === "string" && value.creator_display.trim()
+        ? value.creator_display.trim()
+        : "unknown";
+  const creatorImageUrl =
+    typeof value.creator_image_url === "string" && value.creator_image_url.trim()
+      ? value.creator_image_url.trim()
+      : typeof value.creatorImageUrl === "string" && value.creatorImageUrl.trim()
+        ? value.creatorImageUrl.trim()
+        : null;
+  return {
+    ...value,
+    project_id: projectId,
+    chat_id: typeof value.chat_id === "string" ? value.chat_id.trim() : "",
+    title: typeof value.title === "string" && value.title.trim() ? value.title.trim() : "Untitled project",
+    prompt: typeof value.prompt === "string" ? value.prompt : "",
+    created_at: typeof value.created_at === "string" && value.created_at ? value.created_at : chatTimestamp(),
+    visibility: value.visibility === "private" ? "private" : "public",
+    can_chat: Boolean(value.can_chat ?? value.canChat),
+    creator_display: creatorDisplay,
+    creator_username: creatorDisplay,
+    creator_image_url: creatorImageUrl,
+    parts_count: Math.max(0, Number(value.parts_count || value.partsCount || 0)),
+    save_count: Math.max(0, Number(value.save_count || value.saveCount || 0)),
+    remix_count: Math.max(0, Number(value.remix_count || value.remixCount || 0)),
+    saved: Boolean(value.saved),
+  };
+}
+

--- a/apps/web/app/forma-workspace/lib/chat-normalize.ts
+++ b/apps/web/app/forma-workspace/lib/chat-normalize.ts
@@ -1,0 +1,205 @@
+import type { ChatMessage } from "../types";
+import { MAX_PROJECT_CHAT_MESSAGES, NEW_PROJECT_TITLE } from "../workspace-constants";
+import { normalizeAgentPipelineProgress } from "./agent-pipeline";
+import { chatTimestamp, initialChatMessages, newChatMessageId } from "./chat-ids";
+import { normalizeContextSuggestions } from "../../../lib/context-suggestions";
+
+export { chatTimestamp, formatChatTimestamp, initialChatMessages, newBuildChatId, newChatMessageId, newFrontendJobId } from "./chat-ids";
+
+export function validChatStatus(value: any): ChatMessage["status"] {
+  return ["idle", "loading", "success", "error", "cancelled"].includes(value) ? value : "idle";
+}
+
+export function validChatRole(value: any): ChatMessage["role"] {
+  return ["assistant", "user", "system"].includes(value) ? value : "assistant";
+}
+
+export function normalizeChatMessage(value: any): ChatMessage | null {
+  if (!value || typeof value !== "object" || typeof value.content !== "string") return null;
+  const buildExecutionStatus = typeof value.buildExecution?.status === "string"
+    ? value.buildExecution.status
+    : "";
+  const normalizedStatus = buildExecutionStatus === "planned" || buildExecutionStatus === "running"
+    ? "loading"
+    : validChatStatus(value.status);
+  return {
+    id: typeof value.id === "string" && value.id ? value.id : newChatMessageId(),
+    role: validChatRole(value.role),
+    content: value.content,
+    status: normalizedStatus,
+    timestamp: typeof value.timestamp === "string" && value.timestamp ? value.timestamp : chatTimestamp(),
+    projectId: typeof value.projectId === "string" ? value.projectId : null,
+    pipelineProgress: normalizeAgentPipelineProgress(value.pipelineProgress),
+    imagePreview: typeof value.imagePreview === "string" ? value.imagePreview : null,
+    contextProjectId: typeof value.contextProjectId === "string"
+      ? value.contextProjectId
+      : typeof value.context_project_id === "string"
+        ? value.context_project_id
+        : null,
+    workflowState: typeof value.workflowState === "string"
+      ? value.workflowState
+      : typeof value.workflow_state === "string"
+        ? value.workflow_state
+        : null,
+    contextQuestions: (Array.isArray(value.contextQuestions) ? value.contextQuestions : value.questions)
+      ?.filter((question: unknown): question is string => typeof question === "string" && Boolean(question.trim()))
+      .map((question: string) => question.trim()) || [],
+    contextSuggestions: normalizeContextSuggestions(value.contextSuggestions ?? value.suggestions),
+    buildPlanId: typeof value.buildPlanId === "string"
+      ? value.buildPlanId
+      : typeof value.build_plan_id === "string"
+        ? value.build_plan_id
+        : typeof value.buildExecution?.plan_id === "string"
+          ? value.buildExecution.plan_id
+          : null,
+    buildJobId: typeof value.buildJobId === "string"
+      ? value.buildJobId
+      : typeof value.build_job_id === "string"
+        ? value.build_job_id
+        : typeof value.buildExecution?.job_id === "string"
+          ? value.buildExecution.job_id
+          : null,
+    buildRequiresRequestBoundExecution: Boolean(
+      value.buildRequiresRequestBoundExecution
+      ?? value.build_request_bound_execution
+      ?? value.buildExecution?.request_bound_execution
+      ?? value.build_execution?.request_bound_execution
+      ?? false
+    ),
+  };
+}
+
+export function chatHasStarted(messages: ChatMessage[]) {
+  return messages.some((message) => message.role === "user" || Boolean(message.projectId));
+}
+
+export function chatTitleFromMessages(messages: ChatMessage[], fallback = NEW_PROJECT_TITLE) {
+  const firstUserMessage = messages.find((message) => message.role === "user" && message.content.trim());
+  const title = firstUserMessage?.content.trim().replace(/\s+/g, " ");
+  if (!title) return fallback;
+  return title.length > 80 ? `${title.slice(0, 77)}...` : title;
+}
+
+export function persistableChatMessages(messages: ChatMessage[]): ChatMessage[] {
+  return messages
+    .map(normalizeChatMessage)
+    .filter((message: ChatMessage | null): message is ChatMessage => Boolean(message))
+    .slice(-MAX_PROJECT_CHAT_MESSAGES);
+}
+
+export function mergeFetchedChatMessages(remoteMessages: ChatMessage[], localMessages: ChatMessage[]): ChatMessage[] {
+  const localById = new Map(localMessages.map((message) => [message.id, message]));
+  const seen = new Set<string>();
+  const merged: ChatMessage[] = [];
+
+  remoteMessages.forEach((remote) => {
+    if (seen.has(remote.id)) return;
+    seen.add(remote.id);
+    const local = localById.get(remote.id);
+    if (!local) {
+      merged.push(remote);
+      return;
+    }
+
+    const localIsTerminal = ["success", "error", "cancelled"].includes(local.status || "");
+    const remoteRegressed = localIsTerminal && remote.status === "loading";
+    merged.push({
+      ...local,
+      ...remote,
+      content: remoteRegressed ? local.content : remote.content,
+      status: remoteRegressed ? local.status : remote.status,
+      timestamp: remoteRegressed ? local.timestamp : remote.timestamp,
+      projectId: remote.projectId || local.projectId || null,
+      pipelineProgress: remote.pipelineProgress || local.pipelineProgress || null,
+      contextProjectId: remote.contextProjectId || local.contextProjectId || null,
+      workflowState: remoteRegressed
+        ? (local.workflowState || remote.workflowState || null)
+        : (remote.workflowState || local.workflowState || null),
+      contextQuestions: remoteRegressed && local.contextQuestions?.length
+        ? local.contextQuestions
+        : (remote.contextQuestions?.length ? remote.contextQuestions : local.contextQuestions || []),
+      contextSuggestions: remoteRegressed && local.contextSuggestions?.length
+        ? local.contextSuggestions
+        : (remote.contextSuggestions?.length ? remote.contextSuggestions : local.contextSuggestions || []),
+      buildPlanId: remote.buildPlanId || local.buildPlanId || null,
+      buildJobId: remote.buildJobId || local.buildJobId || null,
+      buildRequiresRequestBoundExecution: Boolean(
+        remote.buildRequiresRequestBoundExecution || local.buildRequiresRequestBoundExecution
+      ),
+      imagePreview: remote.imagePreview || local.imagePreview || null,
+    });
+  });
+
+  localMessages.forEach((local) => {
+    if (!seen.has(local.id)) merged.push(local);
+  });
+  return merged.slice(-MAX_PROJECT_CHAT_MESSAGES);
+}
+
+export function hydrateRoutedChatMessages(
+  storedMessages: ChatMessage[],
+  inMemoryMessages: ChatMessage[],
+  options: { sameChat: boolean },
+): ChatMessage[] {
+  const overlapping = storedMessages.some((stored) =>
+    inMemoryMessages.some((message) => message.id === stored.id)
+  );
+  const keepInMemory = options.sameChat || overlapping;
+  if (!keepInMemory) return storedMessages;
+  if (!storedMessages.length) return inMemoryMessages;
+  return mergeFetchedChatMessages(storedMessages, inMemoryMessages);
+}
+
+export function chatIsWaiting(messages: ChatMessage[]) {
+  return messages.some((message) => message.status === "loading");
+}
+
+export function chatMessageIdentityKey(messages: ChatMessage[]) {
+  return messages.map((message) => message.id).join("|");
+}
+
+export function initialProjectChatMessages(projectId: string, title: string, sourcePrompt?: string | null): ChatMessage[] {
+  const messages: ChatMessage[] = [];
+  if (sourcePrompt?.trim()) {
+    messages.push({
+      id: newChatMessageId(),
+      role: "user",
+      content: sourcePrompt.trim(),
+      status: "idle",
+      timestamp: chatTimestamp(),
+      projectId,
+    });
+  }
+  messages.push({
+    id: newChatMessageId(),
+    role: "assistant",
+    content: `${title || "Project"} is the active project for this chat.`,
+    status: "success",
+    timestamp: chatTimestamp(),
+    projectId,
+  });
+  return messages;
+}
+
+export function missingProjectNotice(projectId: string) {
+  return `This chat pointed at project ${projectId}, but that project is no longer available in the project database. The chat history is still here; generate again to create a new project.`;
+}
+
+export function messagesWithoutMissingProject(messages: ChatMessage[], projectId: string): ChatMessage[] {
+  const notice = missingProjectNotice(projectId);
+  const normalizedMessages = messages.map((message) =>
+    message.projectId === projectId ? { ...message, projectId: null } : message
+  );
+  if (normalizedMessages.some((message) => message.role === "assistant" && message.content === notice)) {
+    return normalizedMessages;
+  }
+  const noticeMessage: ChatMessage = {
+    id: newChatMessageId(),
+    role: "assistant",
+    content: notice,
+    status: "error",
+    timestamp: chatTimestamp(),
+    projectId: null,
+  };
+  return [...normalizedMessages, noticeMessage].slice(-MAX_PROJECT_CHAT_MESSAGES);
+}

--- a/apps/web/app/forma-workspace/lib/chat-storage.ts
+++ b/apps/web/app/forma-workspace/lib/chat-storage.ts
@@ -1,0 +1,123 @@
+import type { ChatListItem } from "../sidebar";
+import type { ChatMessage } from "../types";
+import {
+  CHAT_INDEX_STORAGE_KEY,
+  CHAT_THREAD_STORAGE_PREFIX,
+  LEGACY_PROJECT_CHAT_STORAGE_PREFIX,
+  MAX_CHAT_INDEX_ITEMS,
+  MAX_PROJECT_CHAT_MESSAGES,
+  NEW_PROJECT_TITLE,
+  PINNED_CHATS_STORAGE_KEY,
+} from "../workspace-constants";
+import { chatTimestamp } from "./chat-ids";
+import { normalizeChatMessage } from "./chat-normalize";
+
+export function chatThreadStorageKey(chatId: string, scope = "local") {
+  return scope === "local"
+    ? `${CHAT_THREAD_STORAGE_PREFIX}${chatId}`
+    : `${CHAT_THREAD_STORAGE_PREFIX}${encodeURIComponent(scope)}.${chatId}`;
+}
+
+export function legacyProjectChatStorageKey(projectId: string) {
+  return `${LEGACY_PROJECT_CHAT_STORAGE_PREFIX}${projectId}`;
+}
+
+export function readStoredChatThread(chatId: string, legacyProjectId?: string | null, scope = "local"): ChatMessage[] {
+  if (typeof window === "undefined" || !chatId) return [];
+  try {
+    const raw = window.localStorage.getItem(chatThreadStorageKey(chatId, scope))
+      || (scope === "local" && legacyProjectId ? window.localStorage.getItem(legacyProjectChatStorageKey(legacyProjectId)) : null);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.map(normalizeChatMessage).filter(Boolean) as ChatMessage[] : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeStoredChatThread(chatId: string, messages: ChatMessage[], scope = "local") {
+  if (typeof window === "undefined" || !chatId) return;
+  try {
+    window.localStorage.setItem(chatThreadStorageKey(chatId, scope), JSON.stringify(messages.slice(-MAX_PROJECT_CHAT_MESSAGES)));
+  } catch {
+    // Local chat history is best-effort.
+  }
+}
+
+export function normalizeChatListItem(value: any): ChatListItem | null {
+  if (!value || typeof value !== "object") return null;
+  const chatId = typeof value.chatId === "string" ? value.chatId.trim() : "";
+  if (!chatId) return null;
+  return {
+    chatId,
+    title: typeof value.title === "string" && value.title.trim() ? value.title.trim() : NEW_PROJECT_TITLE,
+    projectId: typeof value.projectId === "string" ? value.projectId : "",
+    createdAt: typeof value.createdAt === "string" && value.createdAt ? value.createdAt : chatTimestamp(),
+    projectCount: Math.max(0, Number(value.projectCount || 0)),
+  };
+}
+
+export function chatIndexStorageKey(scope = "local") {
+  return scope === "local"
+    ? CHAT_INDEX_STORAGE_KEY
+    : `${CHAT_INDEX_STORAGE_KEY}.${encodeURIComponent(scope)}`;
+}
+
+export function readStoredChatIndex(scope = "local"): ChatListItem[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(chatIndexStorageKey(scope));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.map(normalizeChatListItem).filter(Boolean) as ChatListItem[] : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeStoredChatIndex(items: ChatListItem[], scope = "local") {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(chatIndexStorageKey(scope), JSON.stringify(items.slice(0, MAX_CHAT_INDEX_ITEMS)));
+  } catch {
+    // Local chat index is best-effort.
+  }
+}
+
+export function pinnedChatsStorageKey(scope = "local") {
+  return scope === "local"
+    ? PINNED_CHATS_STORAGE_KEY
+    : `${PINNED_CHATS_STORAGE_KEY}.${encodeURIComponent(scope)}`;
+}
+
+export function readPinnedChatIds(scope = "local"): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(pinnedChatsStorageKey(scope));
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed)
+      ? parsed.filter((value: unknown): value is string => typeof value === "string" && Boolean(value.trim()))
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writePinnedChatIds(ids: Iterable<string>, scope = "local") {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(pinnedChatsStorageKey(scope), JSON.stringify(Array.from(ids)));
+  } catch {
+    // Pinned chat ids are best-effort.
+  }
+}
+
+export function removeStoredChatThread(chatId: string, scope = "local") {
+  if (typeof window === "undefined" || !chatId) return;
+  try {
+    window.localStorage.removeItem(chatThreadStorageKey(chatId, scope));
+  } catch {
+    // Local chat history is best-effort.
+  }
+}

--- a/apps/web/app/forma-workspace/lib/context-build.ts
+++ b/apps/web/app/forma-workspace/lib/context-build.ts
@@ -1,0 +1,20 @@
+export const CONTEXT_BUILD_POLL_MS = 2000;
+export const CONTEXT_BUILD_FIRST_POLL_MS = 750;
+export const CONTEXT_BUILD_MAX_ATTEMPTS = 600;
+export const CONTEXT_BUILD_TIMEOUT_MESSAGE =
+  "Build progress timed out. Retry to resume from the latest saved stage.";
+
+export function contextBuildWatchKey(projectId: string, planId: string) {
+  return `${projectId}:${planId}`;
+}
+
+export function isActiveBuildStatus(status: string | null | undefined) {
+  return status === "planned" || status === "running";
+}
+
+export function shouldResumeDetachedBuild(options: {
+  requestBoundExecution: boolean;
+  alreadyWatching: boolean;
+}) {
+  return !options.requestBoundExecution && !options.alreadyWatching;
+}

--- a/apps/web/app/forma-workspace/lib/generation-input.ts
+++ b/apps/web/app/forma-workspace/lib/generation-input.ts
@@ -1,0 +1,14 @@
+export function validateGenerationInput(value: string, hasImage: boolean) {
+  const promptText = value.trim();
+  if (!promptText) {
+    return {
+      isValid: hasImage,
+      message: hasImage ? null : "Provide a prompt or reference image.",
+    };
+  }
+
+  return {
+    isValid: true,
+    message: null,
+  };
+}

--- a/apps/web/app/forma-workspace/lib/project-metadata.ts
+++ b/apps/web/app/forma-workspace/lib/project-metadata.ts
@@ -1,0 +1,70 @@
+import type { A2AJob } from "../use-admin-data";
+
+export function withProjectResponseMetadata(ir: any, response: any) {
+  if (!ir) return ir;
+  const timingMetadata = generationTimingMetadataFromJob(response?.job);
+  return {
+    ...ir,
+    assembly_metadata: {
+      ...(ir.assembly_metadata || {}),
+      project_id: ir.assembly_metadata?.project_id || response?.project_id,
+      chat_id: ir.assembly_metadata?.chat_id || response?.chat_id,
+      can_chat: Boolean(response?.can_chat ?? response?.canChat ?? ir.assembly_metadata?.can_chat ?? ir.assembly_metadata?.canChat),
+      frontend_job_id: ir.assembly_metadata?.frontend_job_id || response?.job_id,
+      source_prompt: ir.assembly_metadata?.source_prompt || response?.prompt,
+      ...timingMetadata,
+    },
+  };
+}
+
+export function timestampMs(value: any): number | null {
+  if (typeof value !== "string" || !value.trim()) return null;
+  const ms = new Date(value).getTime();
+  return Number.isNaN(ms) ? null : ms;
+}
+
+export function durationSecondsBetween(startValue: any, endValue: any): number | null {
+  const start = timestampMs(startValue);
+  const end = timestampMs(endValue);
+  if (start === null || end === null || end < start) return null;
+  return Math.max(1, Math.round((end - start) / 1000));
+}
+
+export function generationTimingMetadataFromJob(job: A2AJob | null | undefined): Record<string, any> {
+  const seconds = durationSecondsBetween(job?.started_at, job?.completed_at);
+  if (seconds === null) return {};
+  return {
+    total_generation_time_seconds: seconds,
+    total_generation_started_at: job?.started_at || null,
+    total_generation_completed_at: job?.completed_at || null,
+  };
+}
+
+export function formatDurationSeconds(value: any) {
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds) || seconds <= 0) return "-";
+  const totalSeconds = Math.max(1, Math.round(seconds));
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const remainingSeconds = totalSeconds % 60;
+  if (hours) return `${hours}h ${minutes}m ${remainingSeconds}s`;
+  if (minutes) return `${minutes}m ${remainingSeconds}s`;
+  return `${remainingSeconds}s`;
+}
+
+export function projectIdFromIR(ir: any) {
+  return ir?.assembly_metadata?.project_id || null;
+}
+
+export function chatIdFromIR(ir: any) {
+  return ir?.assembly_metadata?.chat_id || null;
+}
+
+export function canChatWithProjectIR(ir: any) {
+  return Boolean(ir?.assembly_metadata?.can_chat ?? ir?.assembly_metadata?.canChat);
+}
+
+export function chatIdFromJob(job: A2AJob) {
+  const rawChatId = job.payload?.chat_id || job.result_summary?.chat_id;
+  return typeof rawChatId === "string" ? rawChatId.trim() : "";
+}

--- a/apps/web/app/forma-workspace/lib/workspace-routes.ts
+++ b/apps/web/app/forma-workspace/lib/workspace-routes.ts
@@ -1,0 +1,82 @@
+import {
+  BookOpen,
+  CircuitBoard,
+  Clapperboard,
+  ClipboardList,
+  Cuboid,
+  LayoutDashboard,
+} from "lucide-react";
+
+export const workspaceTabs = [
+  { id: "overview", label: "Overview", icon: LayoutDashboard },
+  { id: "bom", label: "Bill of Materials", icon: ClipboardList },
+  { id: "mechanical", label: "Mechanical", icon: Cuboid },
+  { id: "schematic", label: "Electrical", icon: CircuitBoard },
+  { id: "assembly", label: "Documentation", icon: BookOpen },
+  { id: "video", label: "Media", icon: Clapperboard },
+];
+
+export const workspaceTabNamespaces: Record<string, string> = {
+  overview: "product.overview",
+  bom: "product.bom",
+  mechanical: "product.mech",
+  schematic: "product.electrical",
+  assembly: "project.docs",
+  video: "product.visuals.video",
+  jobs: "project.history.jobs",
+  logs: "project.runtime.logs",
+};
+
+export function normalizeTab(tab: string | null) {
+  if (!tab) return null;
+  const aliases: Record<string, string> = {
+    chat: "overview",
+    concept: "overview",
+    info: "overview",
+    image: "overview",
+    mech: "mechanical",
+    wire: "schematic",
+    electrical: "schematic",
+    docs: "assembly",
+    documentation: "assembly",
+    billing: "bom",
+    materials: "bom",
+    media: "video",
+  };
+  const normalized = aliases[tab] || tab;
+  return workspaceTabs.some((item) => item.id === normalized) ? normalized : null;
+}
+
+export function workspaceTabMeta(tab: string | null) {
+  const normalized = normalizeTab(tab);
+  return workspaceTabs.find((item) => item.id === normalized) || workspaceTabs[0];
+}
+
+export function workspaceNamespaceForTab(tab: string | null) {
+  const meta = workspaceTabMeta(tab);
+  return workspaceTabNamespaces[meta.id] || meta.id;
+}
+
+export function projectRoute(projectId: string) {
+  return `/project/${encodeURIComponent(projectId)}`;
+}
+
+export function chatRoute(chatId: string) {
+  return `/chat/${encodeURIComponent(chatId)}`;
+}
+
+export function safeDecodeProjectId(projectId: string) {
+  try {
+    return decodeURIComponent(projectId);
+  } catch {
+    return projectId;
+  }
+}
+
+export function safeDecodeChatId(chatId: string) {
+  try {
+    return decodeURIComponent(chatId);
+  } catch {
+    return chatId;
+  }
+}

--- a/apps/web/app/forma-workspace/pipeline-progress-view.tsx
+++ b/apps/web/app/forma-workspace/pipeline-progress-view.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useState } from "react";
+import { AlertTriangle, CheckCircle, ChevronDown, Cpu, RefreshCw, Square } from "lucide-react";
+
+import type { AgentPipelineProgress, ChatMessage } from "./types";
+import {
+  activePipelineStep,
+  completedPipelineStepCount,
+  formatPipelineAge,
+  formatPipelineDetails,
+  isCompletedPipelineStatus,
+  isFailedPipelineStatus,
+  latestPipelineEvent,
+  normalizeAgentPipelineEvents,
+  pipelineEventTimestampMs,
+  pipelineStepStatus,
+} from "./lib/agent-pipeline";
+import { formatDurationSeconds, timestampMs } from "./lib/project-metadata";
+import { defaultAgentPipelineSteps, PIPELINE_STALE_AFTER_MS } from "./workspace-constants";
+
+export function PipelineStepDot({ status }: { status: string }) {
+  const tone =
+    status === "completed"
+      ? "border-emerald-400 bg-emerald-400"
+      : status === "failed"
+        ? "border-rose-400 bg-rose-400"
+        : status === "skipped"
+          ? "border-slate-600 bg-slate-800"
+          : status === "active"
+            ? "border-cyan-300 bg-cyan-300"
+            : "border-slate-700 bg-black";
+  return <span className={`h-2.5 w-2.5 shrink-0 border ${tone}`} />;
+}
+
+export function AgentPipelineEventsDisclosure({
+  eventCount,
+  children,
+}: {
+  eventCount: number;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <details
+      className="group mt-3 border-t border-white/5 pt-3"
+      open={open}
+      onToggle={(event) => setOpen(event.currentTarget.open)}
+    >
+      <summary className="flex cursor-pointer list-none items-center justify-between gap-2 marker:content-none [&::-webkit-details-marker]:hidden">
+        <span className="inline-flex min-w-0 items-center gap-1.5">
+          <ChevronDown className="h-3 w-3 shrink-0 -rotate-90 text-zinc-600 transition-transform group-open:rotate-0" />
+          <span className="text-[10px] font-medium text-zinc-600">Recent events</span>
+        </span>
+        <span className="font-mono text-[10px] text-zinc-600">{eventCount}</span>
+      </summary>
+      <div className="mt-2">{children}</div>
+    </details>
+  );
+}
+
+export function AgentPipelineProgressView({
+  progress,
+  status,
+  compact = false,
+  onStop,
+  onReset,
+  resetting = false,
+}: {
+  progress?: AgentPipelineProgress | null;
+  status?: ChatMessage["status"];
+  compact?: boolean;
+  onStop?: () => void;
+  onReset?: () => void;
+  resetting?: boolean;
+}) {
+  if (!progress) return null;
+
+  const steps = progress.steps.length ? progress.steps : defaultAgentPipelineSteps;
+  const events = normalizeAgentPipelineEvents(progress.events);
+  const lastEvent = latestPipelineEvent(events);
+  const activeStep = activePipelineStep({ ...progress, steps });
+  const activeStepId = activeStep?.id || null;
+  const nowMs = Date.now();
+  const startedMs = timestampMs(progress.startedAt);
+  const elapsedSeconds = startedMs === null ? null : Math.max(1, Math.round((nowMs - startedMs) / 1000));
+  const lastEventMs = pipelineEventTimestampMs(lastEvent);
+  const quietMs = lastEventMs === null ? null : nowMs - lastEventMs;
+  const isLoading = status === "loading";
+  const isSuccess = status === "success";
+  const isCancelled = status === "cancelled";
+  // Progress events are an audit trail and may include a failed attempt that
+  // the backend subsequently retries. Only the terminal message state means
+  // the whole pipeline failed.
+  const isError = status === "error";
+  const waitingForFirstEvent = isLoading && !events.length && startedMs !== null && nowMs - startedMs >= PIPELINE_STALE_AFTER_MS;
+  const backendQuiet = isLoading && quietMs !== null && quietMs >= PIPELINE_STALE_AFTER_MS;
+  const completedCount = completedPipelineStepCount({ ...progress, steps });
+  const progressPercent = Math.min(100, Math.max(6, Math.round((completedCount / Math.max(steps.length, 1)) * 100)));
+  const visibleEvents = events.slice(compact ? -4 : -6);
+  const signalLabel = isError
+    ? "failed"
+    : isCancelled
+    ? "stopped"
+    : isSuccess
+    ? "completed"
+    : progress.synced
+    ? backendQuiet
+      ? "waiting on provider"
+      : "backend synced"
+    : waitingForFirstEvent
+      ? "starting"
+      : "estimated";
+  const signalTone = isError
+    ? "border-rose-400/35 bg-rose-950/25 text-rose-200"
+    : isCancelled
+    ? "border-amber-300/35 bg-amber-950/20 text-amber-100"
+    : isSuccess
+    ? "border-emerald-300/35 bg-emerald-950/20 text-emerald-100"
+    : backendQuiet || waitingForFirstEvent
+    ? "border-emerald-500/25 bg-emerald-950/25 text-emerald-100"
+    : progress.synced
+      ? "border-emerald-500/25 bg-emerald-950/25 text-emerald-100"
+      : "border-slate-500/25 bg-black/25 text-slate-400";
+
+  return (
+    <div className="mt-3 rounded-xl border border-white/5 bg-black/25 p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="text-[10px] font-medium text-zinc-500">Agent pipeline</span>
+            <span className={`inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] font-medium ${signalTone}`}>
+              {isError ? <AlertTriangle className="h-3 w-3" /> : isCancelled ? <Square className="h-3 w-3 fill-current" /> : isLoading ? <RefreshCw className="h-3 w-3 animate-spin" /> : <CheckCircle className="h-3 w-3" />}
+              {signalLabel}
+            </span>
+          </div>
+          {progress.jobId && (
+            <div className="mt-1 truncate font-mono text-[10px] text-zinc-600">{progress.jobId}</div>
+          )}
+        </div>
+        <div className="flex shrink-0 items-start gap-2">
+          {isLoading && onStop && (
+            <button
+              type="button"
+              onClick={onStop}
+              className="inline-flex h-7 items-center gap-1 rounded-lg border border-amber-300/40 px-2 text-[10px] font-medium text-amber-100 transition-colors hover:bg-amber-300/10"
+              aria-label="Stop agent pipeline"
+              title="Stop agent pipeline"
+            >
+              <Square className="h-3 w-3 fill-current" />
+              Stop
+            </button>
+          )}
+          {isError && onReset && (
+            <button
+              type="button"
+              onClick={onReset}
+              disabled={resetting}
+              className="inline-flex h-7 items-center gap-1 rounded-lg border border-emerald-500/30 bg-emerald-500/10 px-2 text-[10px] font-medium text-emerald-400 transition-colors hover:bg-emerald-500/20 disabled:cursor-wait disabled:opacity-60"
+              aria-label="Reset failed generation job"
+              title="Reset failed generation job and try again"
+            >
+              <RefreshCw className={`h-3 w-3 ${resetting ? "animate-spin" : ""}`} />
+              {resetting ? "Resetting" : "Reset job"}
+            </button>
+          )}
+          <div className="text-right">
+            <div className="font-mono text-[11px] font-semibold text-zinc-300">{completedCount}/{steps.length}</div>
+            <div className="text-[10px] text-zinc-600">{formatDurationSeconds(elapsedSeconds)}</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-3 h-1.5 overflow-hidden rounded-full bg-[#111216]">
+        <div
+          className={`h-full rounded-full ${isError ? "bg-rose-300" : isCancelled ? "bg-amber-300" : "bg-emerald-400"} ${isLoading ? "animate-pulse" : ""}`}
+          style={{ width: `${progressPercent}%` }}
+        />
+      </div>
+
+      <div className="mt-3 flex min-w-0 items-start gap-2 rounded-lg border border-white/5 bg-[#111216] p-3">
+        {isError ? <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-rose-300" /> : isCancelled ? <Square className="mt-0.5 h-4 w-4 shrink-0 fill-current text-amber-300" /> : isLoading ? <RefreshCw className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-emerald-400" /> : <Cpu className="mt-0.5 h-4 w-4 shrink-0 text-zinc-400" />}
+        <div className="min-w-0">
+          <div className="truncate text-xs font-semibold text-zinc-100">{activeStep?.label || "Preparing job"}</div>
+          <div className="mt-1 truncate text-[11px] font-medium text-emerald-400">{activeStep?.agent || "Forma runtime"}</div>
+          {activeStep?.description && !compact && (
+            <div className="mt-1 line-clamp-2 text-[11px] leading-4 text-zinc-500">{activeStep.description}</div>
+          )}
+          {lastEvent && (
+            <div className="mt-2 flex flex-wrap gap-2 text-[10px] text-zinc-500">
+              <span>Last: {lastEvent.label || lastEvent.step_id}</span>
+              <span>{String(lastEvent.status).replace(/_/g, " ")}</span>
+              <span>{formatPipelineAge(lastEvent.observed_at, nowMs)} ago</span>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {(backendQuiet || waitingForFirstEvent) && (
+        <div className="mt-2 flex gap-2 rounded-lg border border-emerald-500/20 bg-emerald-950/20 p-2 text-[11px] leading-4 text-emerald-100">
+          <RefreshCw className="mt-0.5 h-3.5 w-3.5 shrink-0 animate-spin" />
+          <span>
+            {events.length
+              ? `Still working. The active provider or backend call has been running for ${formatDurationSeconds(Math.round((quietMs || 0) / 1000))} since the last progress update.`
+              : "Still starting. The job poller is active and waiting for the first backend progress update."}
+          </span>
+        </div>
+      )}
+
+      <div className="mt-3 flex flex-wrap gap-1.5">
+        {steps.map((step) => (
+          <span
+            key={step.id}
+            className="inline-flex items-center gap-1.5 rounded-full border border-white/5 bg-[#111216] px-2 py-1 text-[10px] text-zinc-500"
+            title={`${step.agent}: ${step.label}`}
+          >
+            <PipelineStepDot status={pipelineStepStatus({ ...progress, steps }, step, activeStepId, isLoading)} />
+            <span className="max-w-[120px] truncate">{step.label}</span>
+          </span>
+        ))}
+      </div>
+
+      {!isLoading && (
+        <AgentPipelineEventsDisclosure eventCount={events.length}>
+          {visibleEvents.length ? (
+            <div className="space-y-1.5">
+              {visibleEvents.map((event, index) => {
+                const details = formatPipelineDetails(event.details);
+                return (
+                  <div key={`${event.step_id}-${event.status}-${event.observed_at || index}`} className="min-w-0 rounded-lg border border-white/5 bg-[#0f1014] px-2 py-1.5">
+                    <div className="flex min-w-0 flex-wrap items-center gap-2 text-[10px]">
+                      <span className="max-w-[160px] truncate font-medium text-zinc-300">{event.label || event.step_id}</span>
+                      <span className={`${isFailedPipelineStatus(event.status) ? "text-rose-300" : isCompletedPipelineStatus(event.status) ? "text-emerald-300" : "text-emerald-400"}`}>
+                        {String(event.status).replace(/_/g, " ")}
+                      </span>
+                      <span className="text-zinc-600">{formatPipelineAge(event.observed_at, nowMs)} ago</span>
+                    </div>
+                    {details && !compact && <div className="mt-1 line-clamp-2 text-[10px] leading-4 text-zinc-500">{details}</div>}
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="rounded-lg border border-white/5 bg-[#0f1014] px-2 py-2 text-[11px] leading-4 text-zinc-500">
+              Polling job metadata. Backend pipeline events will appear here as agents report progress.
+            </div>
+          )}
+        </AgentPipelineEventsDisclosure>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/forma-workspace/project-detail-panels.tsx
+++ b/apps/web/app/forma-workspace/project-detail-panels.tsx
@@ -89,6 +89,10 @@ export function OverviewPanel({
   const llmModel = metadata.runtime_model || metadata.actual_model || metadata.model_name || metadata.requested_model;
   const showProductImage = showImageSection || Boolean(activeImage);
   const showHardwareReference = productImages.length > 0 && referenceImages.length > 0;
+  const imageOutputRequested = metadata.image_output_requested !== false && metadata.image_output_enabled !== false;
+  const imageOutputFailed = imageOutputRequested && (
+    metadata.image_output_failed === true || metadata.image_output_status === "failed"
+  );
 
   return (
     <div className="h-full min-w-0 overflow-y-auto overflow-x-hidden bg-[var(--forma-page)] px-4 py-5 text-[var(--forma-text)] sm:px-5 sm:py-6">
@@ -103,7 +107,7 @@ export function OverviewPanel({
                 className="h-[280px] w-full object-cover object-center sm:h-[380px]"
               />
             ) : (
-              <ImageUnavailableState failed={metadata.image_output_failed === true || metadata.image_output_status === "failed"} />
+              <ImageUnavailableState failed={imageOutputFailed} requested={imageOutputRequested} />
             )}
             {activeImage && (
               <div className="absolute left-3 top-3 max-w-[calc(100%-1.5rem)] rounded-md border border-[var(--forma-border)] bg-[rgb(var(--forma-chrome-rgb)/0.92)] px-2.5 py-1.5 text-[11px] font-medium text-[var(--forma-text-strong)] shadow-sm backdrop-blur-sm">
@@ -744,19 +748,21 @@ export function PartsSidebar({ components, issues, isValid }: { components: any[
   );
 }
 
-export function ImageUnavailableState({ failed = false }: { failed?: boolean }) {
+export function ImageUnavailableState({ failed = false, requested = true }: { failed?: boolean; requested?: boolean }) {
   return (
     <div className="flex h-[280px] flex-col items-center justify-center bg-[var(--forma-surface-muted)] px-8 text-center sm:h-[380px]">
       <div className="flex h-16 w-16 items-center justify-center rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface)] text-[var(--forma-text-muted)]">
         {failed ? <AlertTriangle className="h-7 w-7" /> : <Box className="h-7 w-7" />}
       </div>
       <div className="mt-5 text-xs font-medium uppercase tracking-[0.16em] text-[var(--forma-text-strong)]">
-        {failed ? "Product image unavailable" : "Product image not generated"}
+        {failed ? "Product image unavailable" : requested ? "Product image not generated" : "Product image disabled"}
       </div>
       <p className="mt-2 max-w-md text-xs leading-5 text-[var(--forma-text-muted)]">
         {failed
           ? "Image generation failed for this revision. The project data and build artifacts are still available."
-          : "No generated product image is available for this revision."}
+          : requested
+            ? "No generated product image is available for this revision."
+            : "Image generation was not requested for this run. The project data and build artifacts are still available."}
       </p>
     </div>
   );

--- a/apps/web/app/forma-workspace/project-gallery.tsx
+++ b/apps/web/app/forma-workspace/project-gallery.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import {
   ArrowLeft,
   ArrowRight,
@@ -159,6 +160,8 @@ export function ProjectGallery({
   const pageMarkers = buildProjectGalleryPageMarkers(safePage, pageCount);
   const searchable = typeof searchValue === "string" && Boolean(onSearchValueChange);
   const hasSearch = Boolean(searchValue?.trim());
+  const [searchOpen, setSearchOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!serverPaginated) setLocalPage(0);
@@ -175,6 +178,20 @@ export function ProjectGallery({
     onVisibleProjectIdsChange?.(visibleProjectIds);
   }, [onVisibleProjectIdsChange, visibleProjectIds]);
 
+  useEffect(() => {
+    if (!searchOpen) return;
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    const closeOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setSearchOpen(false);
+    };
+    document.addEventListener("keydown", closeOnEscape);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", closeOnEscape);
+    };
+  }, [searchOpen]);
+
   const goToPage = (page: number) => {
     const nextPage = Math.min(Math.max(page, 0), pageCount - 1);
     if (serverPaginated) onPageChange?.(nextPage);
@@ -182,40 +199,127 @@ export function ProjectGallery({
   };
 
   return (
-    <section ref={sectionRef} id="all-projects" className={standalone ? "" : "mt-16 border-t border-white/5 pt-12"}>
-      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-        <div>
+    <section ref={sectionRef} id="all-projects" className={standalone ? "" : "mt-16 pt-12"}>
+      <div className="mb-6 flex items-center gap-3">
+        {searchable && (
+          <button
+            type="button"
+            onClick={() => setSearchOpen(true)}
+            className={`relative inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-md transition-colors hover:text-[var(--forma-text-strong)] ${
+              hasSearch ? "text-[var(--forma-text-strong)]" : "text-[var(--forma-text-muted)]"
+            }`}
+            aria-label={hasSearch ? `Search projects: ${searchValue}` : "Search projects"}
+            title={hasSearch ? searchValue : "Search projects"}
+          >
+            <Search className="h-4 w-4" />
+            {hasSearch && (
+              <span className="absolute right-1.5 top-1.5 h-1.5 w-1.5 rounded-full bg-[rgb(var(--forma-cyan-rgb))]" aria-hidden="true" />
+            )}
+          </button>
+        )}
+        <div className="min-w-0 flex-1">
           <h2 className="sr-only">{title}</h2>
-          <p className="text-sm leading-6 text-zinc-500">
+          <p className="truncate text-sm leading-6 text-[var(--forma-text-muted)]">
             {loading
               ? hasSearch ? "Searching projects..." : "Loading projects..."
               : hasSearch ? `${total} matching projects.` : `${total} saved projects.`}
           </p>
         </div>
-        {searchable && (
-          <label className="relative block w-full sm:max-w-sm">
-            <span className="sr-only">Search community projects</span>
-            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-500" />
-            <input
-              type="search"
-              value={searchValue}
-              onChange={(event) => onSearchValueChange?.(event.target.value)}
-              placeholder="Search projects"
-              className="h-9 w-full rounded-lg border border-white/5 bg-[#181b22] pl-10 pr-10 text-sm text-zinc-100 outline-none transition placeholder:text-zinc-500 focus:border-emerald-500"
-            />
-            {hasSearch && (
-              <button
-                type="button"
-                onClick={() => onSearchValueChange?.("")}
-                className="absolute right-0.5 top-1/2 inline-flex h-8 w-8 -translate-y-1/2 items-center justify-center rounded-lg text-zinc-500 transition-colors hover:text-zinc-100"
-                aria-label="Clear project search"
-              >
-                <X className="h-4 w-4" />
-              </button>
-            )}
-          </label>
-        )}
       </div>
+
+      {searchOpen && searchable && createPortal(
+        <div className="fixed inset-0 z-[80] flex items-start justify-center px-4 pt-[18vh] font-sans sm:pt-[22vh]">
+          <button
+            type="button"
+            className="absolute inset-0 bg-[rgb(var(--forma-scrim-rgb)/0.48)] backdrop-blur-md"
+            onClick={() => setSearchOpen(false)}
+            aria-label="Close search"
+          />
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="project-gallery-search-title"
+            className="relative z-10 w-full max-w-lg"
+          >
+            <h3 id="project-gallery-search-title" className="sr-only">Search projects</h3>
+            <div className="overflow-hidden rounded-xl bg-[var(--forma-surface)] shadow-[var(--forma-card-shadow)]">
+              <label className="flex items-center gap-3 px-4 py-3">
+                <Search className="h-4 w-4 shrink-0 text-[var(--forma-text-muted)]" aria-hidden="true" />
+                <input
+                  ref={searchInputRef}
+                  type="text"
+                  role="searchbox"
+                  value={searchValue}
+                  onChange={(event) => onSearchValueChange?.(event.target.value)}
+                  placeholder="Search projects"
+                  autoFocus
+                  autoComplete="off"
+                  spellCheck={false}
+                  className="min-w-0 flex-1 appearance-none bg-transparent text-sm leading-6 text-[var(--forma-text-strong)] outline-none placeholder:text-[var(--forma-text-muted)]"
+                />
+                {hasSearch && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onSearchValueChange?.("");
+                      searchInputRef.current?.focus();
+                    }}
+                    className="inline-flex h-7 w-7 shrink-0 items-center justify-center text-[var(--forma-text-muted)] transition-colors hover:text-[var(--forma-text-strong)]"
+                    aria-label="Clear project search"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                )}
+              </label>
+              {!hasSearch && (
+                <p className="px-4 pb-3 text-xs leading-5 text-[var(--forma-text-muted)]">
+                  {loading ? "Loading…" : "Type to match projects"}
+                </p>
+              )}
+              {hasSearch && (
+                <div className="border-t border-[var(--forma-border)]">
+                  <p className="px-4 py-2 text-xs leading-5 text-[var(--forma-text-muted)]">
+                    {loading
+                      ? "Searching…"
+                      : `${total} matching ${total === 1 ? "project" : "projects"}`}
+                  </p>
+                  {!loading && visibleItems.length > 0 && (
+                    <ul className="max-h-[min(48vh,22rem)] overflow-y-auto pb-1">
+                      {visibleItems.map((item) => (
+                        <li key={item.key}>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setSearchOpen(false);
+                              onOpenProjectPage(item.projectId);
+                            }}
+                            className="flex w-full items-center gap-3 px-4 py-2 text-left transition-colors hover:bg-[var(--forma-surface-muted)]"
+                          >
+                            <span className="min-w-0 flex-1 truncate text-sm text-[var(--forma-text-strong)]">
+                              {item.title}
+                            </span>
+                            {item.creatorDisplay && (
+                              <span className="shrink-0 text-xs text-[var(--forma-text-muted)]">
+                                {item.creatorDisplay}
+                              </span>
+                            )}
+                          </button>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                  {!loading && total === 0 && (
+                    <p className="px-4 pb-4 text-sm text-[var(--forma-text-muted)]">
+                      No projects match “{searchValue.trim()}”.
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>,
+        document.body,
+      )}
 
       {loading ? (
         <ProjectGallerySkeleton count={pageSize} />
@@ -234,7 +338,7 @@ export function ProjectGallery({
           </div>
 
           {pageCount > 1 && (
-            <div className="mt-5 flex flex-col gap-3 rounded-xl border border-white/5 bg-[#181b22] p-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="mt-5 flex flex-col gap-3 rounded-xl bg-[var(--forma-surface)] p-3 sm:flex-row sm:items-center sm:justify-between">
               <div className="text-xs font-medium text-zinc-500">
                 Showing {showingStart}-{showingEnd} of {total}
               </div>
@@ -295,7 +399,7 @@ export function ProjectGallery({
           )}
         </>
       ) : (
-        <div className="rounded-xl border border-white/5 bg-[#181b22] p-8 text-sm leading-6 text-zinc-500">
+        <div className="rounded-xl bg-[var(--forma-surface)] p-8 text-sm leading-6 text-zinc-500">
           {hasSearch ? `No projects match “${searchValue?.trim()}”.` : "No saved projects yet."}
         </div>
       )}
@@ -332,9 +436,9 @@ function ProjectGallerySkeleton({ count }: { count: number }) {
       {skeletonItems.map((item) => (
         <div
           key={item}
-          className="overflow-hidden rounded-xl border border-white/5 bg-[#181b22]"
+          className="overflow-hidden rounded-xl bg-[var(--forma-surface)]"
         >
-          <div className="aspect-square overflow-hidden border-b border-white/5 bg-[#0f1117] sm:aspect-[4/3]">
+          <div className="aspect-square overflow-hidden bg-[#0f1117] sm:aspect-[4/3]">
             <ProjectImageLoadingPanel />
           </div>
           <div className="flex min-h-[150px] flex-col justify-between gap-3 p-4">
@@ -496,10 +600,10 @@ function ProjectGalleryCard({
           onOpen();
         }
       }}
-      className="group cursor-pointer overflow-hidden rounded-xl border border-white/5 bg-[#181b22] outline-none transition-all hover:border-zinc-700/60 focus-visible:border-emerald-500"
+      className="group cursor-pointer overflow-hidden rounded-xl bg-[var(--forma-surface)] outline-none transition-shadow hover:shadow-[var(--forma-card-shadow)] focus-visible:ring-2 focus-visible:ring-emerald-500/50"
       aria-label={`View project ${item.title}`}
     >
-      <div className="aspect-square overflow-hidden border-b border-white/5 bg-[#0f1117] sm:aspect-[4/3]">
+      <div className="aspect-square overflow-hidden bg-[#0f1117] sm:aspect-[4/3]">
         {item.image ? (
           <img
             src={item.image.src}

--- a/apps/web/app/forma-workspace/project-tab-content.tsx
+++ b/apps/web/app/forma-workspace/project-tab-content.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { memo, type ReactNode } from "react";
+
+import { JobsPanel, LogsPanel } from "./admin-panels";
+import {
+  AssemblyPanel,
+  BomPanel,
+  MechanicalPanel,
+  OverviewPanel,
+} from "./project-detail-panels";
+import { JOB_POLL_INTERVAL_MS, LOG_POLL_INTERVAL_MS, generationLlmLabel } from "./workspace-constants";
+
+type ProjectTabContentProps = {
+  tabId: string;
+  title: string;
+  description: string;
+  imageCandidates: unknown[];
+  features: unknown[];
+  metrics: unknown;
+  metadata: Record<string, unknown>;
+  systemArchitecture: unknown;
+  showModelName: boolean;
+  showImageSection: boolean;
+  components: unknown[];
+  bomComponents: unknown[];
+  cadSources: unknown[];
+  fabricationCost: number;
+  canDownloadAssets: boolean;
+  mechToggles: unknown;
+  setMechToggles: (value: any) => void;
+  mechElectricalActive: boolean;
+  setMechElectricalActive: (value: boolean) => void;
+  mechanical: unknown;
+  schematic: ReactNode;
+  assembly: unknown;
+  issues: unknown[];
+  onDownloadJSON: () => void;
+  onDownloadMarkdown: () => void;
+  videoContent: ReactNode;
+  jobs: unknown[];
+  jobsLoading: boolean;
+  jobsError: string | null;
+  jobStatusFilter: string;
+  onStatusFilterChange: (value: string) => void;
+  onRefreshJobs: () => void;
+  onOpenProject: (job: any) => void;
+  findProjectForJob: (job: any) => unknown;
+  jobsLastUpdatedAt: string | null;
+  logs: unknown;
+  logsLoading: boolean;
+  logsError: string | null;
+  onRefreshLogs: () => void;
+  logsLastUpdatedAt: string | null;
+  canViewAdminTools?: boolean;
+};
+
+function ProjectTabContentView({
+  tabId,
+  title,
+  description,
+  imageCandidates,
+  features,
+  metrics,
+  metadata,
+  systemArchitecture,
+  showModelName,
+  showImageSection,
+  components,
+  bomComponents,
+  cadSources,
+  fabricationCost,
+  canDownloadAssets,
+  mechToggles,
+  setMechToggles,
+  mechElectricalActive,
+  setMechElectricalActive,
+  mechanical,
+  schematic,
+  assembly,
+  issues,
+  onDownloadJSON,
+  onDownloadMarkdown,
+  videoContent,
+  jobs,
+  jobsLoading,
+  jobsError,
+  jobStatusFilter,
+  onStatusFilterChange,
+  onRefreshJobs,
+  onOpenProject,
+  findProjectForJob,
+  jobsLastUpdatedAt,
+  logs,
+  logsLoading,
+  logsError,
+  onRefreshLogs,
+  logsLastUpdatedAt,
+  canViewAdminTools = false,
+}: ProjectTabContentProps) {
+  switch (tabId) {
+    case "overview":
+      return (
+        <OverviewPanel
+          title={title}
+          description={description}
+          imageCandidates={imageCandidates as any}
+          features={features as any}
+          metrics={metrics as any}
+          metadata={metadata}
+          systemArchitecture={systemArchitecture as any}
+          showModelName={showModelName}
+          showImageSection={showImageSection}
+        />
+      );
+    case "bom":
+      return (
+        <BomPanel
+          components={bomComponents as any}
+          metrics={metrics as any}
+          cadSources={cadSources as any}
+          fabricationCost={fabricationCost}
+          canDownloadAssets={canDownloadAssets}
+        />
+      );
+    case "mechanical":
+      return (
+        <MechanicalPanel
+          toggles={mechToggles as any}
+          setToggles={setMechToggles}
+          electricalActive={mechElectricalActive}
+          setElectricalActive={setMechElectricalActive}
+          components={components as any}
+          features={features as any}
+          metadata={metadata}
+          mechanical={mechanical as any}
+        />
+      );
+    case "schematic":
+      return schematic;
+    case "assembly":
+      return (
+        <AssemblyPanel
+          assembly={assembly as any}
+          issues={issues as any}
+          onDownloadJSON={onDownloadJSON}
+          onDownloadMarkdown={onDownloadMarkdown}
+          canDownloadAssets={canDownloadAssets}
+        />
+      );
+    case "video":
+      return videoContent;
+    case "jobs":
+      return (
+        <JobsPanel
+          jobs={jobs as any}
+          loading={jobsLoading}
+          error={jobsError}
+          statusFilter={jobStatusFilter}
+          onStatusFilterChange={onStatusFilterChange}
+          onRefresh={onRefreshJobs}
+          onOpenProject={onOpenProject as any}
+          findProjectForJob={findProjectForJob as any}
+          lastUpdatedAt={jobsLastUpdatedAt}
+          pollIntervalMs={JOB_POLL_INTERVAL_MS}
+          title="Project Jobs"
+          description="Only jobs tied to this project are shown here."
+          emptyMessage="No jobs recorded for this project and filter."
+          formatLlmLabel={generationLlmLabel}
+        />
+      );
+    case "logs":
+      return canViewAdminTools ? (
+        <LogsPanel
+          logs={logs as any}
+          loading={logsLoading}
+          error={logsError}
+          onRefresh={onRefreshLogs}
+          lastUpdatedAt={logsLastUpdatedAt}
+          pollIntervalMs={LOG_POLL_INTERVAL_MS}
+        />
+      ) : null;
+    default:
+      return null;
+  }
+}
+
+export const ProjectTabContent = memo(ProjectTabContentView);

--- a/apps/web/app/forma-workspace/project-workspace.tsx
+++ b/apps/web/app/forma-workspace/project-workspace.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
-import { ArrowRight, Eye, Layers, Maximize2, Minimize2, MessageSquare, RefreshCw, Square } from "lucide-react";
+import { ArrowRight, AlertTriangle, Eye, Layers, Maximize2, Minimize2, MessageSquare, RefreshCw, Square } from "lucide-react";
 
 import CopyButton from "../../components/copy-button";
 import { formatChatTimestamp } from "./lib/chat-ids";
@@ -81,6 +81,7 @@ export function ChatWorkspace({
   canStop,
   onStop,
   canChat,
+  notice = null,
   namespaceTabs,
   activeNamespace,
   activeNamespaceLabel,
@@ -101,6 +102,7 @@ export function ChatWorkspace({
   canStop: boolean;
   onStop: () => void;
   canChat: boolean;
+  notice?: string | null;
   namespaceTabs: typeof workspaceTabs;
   activeNamespace: string;
   activeNamespaceLabel: string;
@@ -138,11 +140,11 @@ export function ChatWorkspace({
 
       <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
         {canChat && (
-          <div className="flex h-full min-h-0 min-w-0 flex-col">
+          <div className="relative flex h-full min-h-0 min-w-0 flex-col">
             <div
               ref={containerRef}
               onScroll={onChatScroll}
-              className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-3 pb-5 pt-16 sm:px-5 sm:pb-6 sm:pt-16"
+              className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-3 pb-24 pt-16 sm:px-5 sm:pb-28 sm:pt-16"
             >
               <div className="mx-auto flex w-full min-w-0 max-w-6xl flex-col gap-3">
                 {messages.length ? (
@@ -152,16 +154,16 @@ export function ChatWorkspace({
                     return (
                       <div key={message.id} className={`mx-auto flex w-full min-w-0 max-w-3xl ${isUser ? "justify-end" : "justify-start"}`}>
                         <div
-                          className={`min-w-0 max-w-[92%] overflow-hidden rounded-xl border px-4 py-3 ${
+                          className={`min-w-0 max-w-[92%] overflow-hidden rounded-xl px-4 py-3 ${
                             isUser
-                              ? "border-emerald-500/20 bg-emerald-500/10 text-zinc-100"
+                              ? "bg-[var(--forma-surface-muted)] text-zinc-100"
                               : message.status === "error"
-                                ? "border-rose-400/30 bg-rose-950/25 text-rose-100"
+                                ? "border border-rose-400/30 bg-rose-950/25 text-rose-100"
                                 : message.status === "cancelled"
-                                  ? "border-amber-300/30 bg-amber-950/20 text-amber-50"
+                                  ? "border border-amber-300/30 bg-amber-950/20 text-amber-50"
                                 : isSystem
-                                  ? "border-white/5 bg-black/25 text-zinc-400"
-                                  : "border-white/5 bg-[#181b22] text-zinc-200"
+                                  ? "bg-[var(--forma-surface-muted)] text-zinc-400"
+                                  : "bg-[var(--forma-surface)] text-zinc-200"
                           }`}
                         >
                           <div className="mb-2 flex flex-wrap items-center gap-2 text-[10px] font-medium text-zinc-500">
@@ -203,33 +205,57 @@ export function ChatWorkspace({
               </div>
             </div>
 
-            <form onSubmit={onSubmit} className="shrink-0 border-t border-white/5 bg-[#0f1117]/95 p-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] backdrop-blur sm:p-4">
-              <div className="mx-auto max-w-3xl">
-                <div className="w-full rounded-2xl border border-white/5 bg-[#181b22] p-3 shadow-lg transition-all focus-within:border-emerald-500/50 focus-within:ring-1 focus-within:ring-emerald-500/20">
-                  <textarea
-                    value={input}
-                    onChange={(event) => setInput(event.target.value)}
-                    onKeyDown={(event) => {
-                      if (event.key === "Enter" && !event.shiftKey) {
-                        event.preventDefault();
-                        if (isLoading) return;
-                        event.currentTarget.form?.requestSubmit();
-                      }
-                    }}
-                    placeholder={`Describe a change to ${activeNamespaceLabel.toLowerCase()}...`}
-                    className="min-h-[72px] w-full resize-none border-none bg-transparent text-sm leading-6 text-zinc-100 outline-none placeholder:text-zinc-500"
-                  />
-                  <div className="mt-1 flex items-center justify-end gap-1.5">
+            <form
+              onSubmit={onSubmit}
+              className="pointer-events-none absolute inset-x-0 bottom-0 z-20 px-3 pb-[max(1.75rem,calc(env(safe-area-inset-bottom)+1rem))] pt-2 sm:px-5 sm:pb-8"
+            >
+              <div className="pointer-events-auto mx-auto max-w-3xl">
+                <div
+                  className={`prompt-composer w-full rounded-full bg-[var(--forma-surface)] px-2 py-1 ${
+                    canStop || isLoading ? "prompt-composer-illuminate" : "prompt-composer-idle"
+                  }`}
+                >
+                  {notice ? (
+                    <div id="project-chat-notice" role="status" className="px-2.5 pb-1 pt-1 text-[11px] leading-4 text-amber-200">
+                      <span className="inline-flex items-start gap-1.5">
+                        <AlertTriangle className="mt-px h-3 w-3 shrink-0 text-amber-300" />
+                        <span className="break-anywhere line-clamp-2 min-w-0">{notice}</span>
+                      </span>
+                    </div>
+                  ) : null}
+                  <div className="flex items-center gap-1">
+                    <textarea
+                      value={input}
+                      onChange={(event) => setInput(event.target.value)}
+                      onKeyDown={(event) => {
+                        if (event.key === "Enter" && !event.shiftKey) {
+                          event.preventDefault();
+                          if (isLoading) return;
+                          event.currentTarget.form?.requestSubmit();
+                        }
+                      }}
+                      rows={1}
+                      placeholder={`Describe a change to ${activeNamespaceLabel.toLowerCase()}...`}
+                      aria-label={`Describe a change to ${activeNamespaceLabel.toLowerCase()}`}
+                      aria-invalid={Boolean(notice)}
+                      aria-describedby={notice ? "project-chat-notice" : undefined}
+                      className="h-8 min-h-8 max-h-8 min-w-0 flex-1 resize-none overflow-y-auto border-none bg-transparent px-2.5 py-1.5 text-sm leading-5 text-zinc-100 outline-none placeholder:text-zinc-500"
+                    />
                     {!canStop && !isLoading && Boolean(input.trim()) && (
                       <span className="prompt-composer-enter-hint hidden sm:inline" aria-hidden="true">
                         Enter
+                      </span>
+                    )}
+                    {(canStop || isLoading) && (
+                      <span className="hidden text-[10px] font-medium text-[var(--forma-text-muted)] sm:inline">
+                        {canStop ? "Updating…" : "Waiting…"}
                       </span>
                     )}
                     <button
                       type={canStop ? "button" : "submit"}
                       onClick={canStop ? onStop : undefined}
                       disabled={!canStop && (isLoading || !projectId || !input.trim())}
-                      className={`prompt-composer-send inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed ${
+                      className={`prompt-composer-send inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full transition-colors disabled:cursor-not-allowed ${
                         !canStop && !isLoading && input.trim() ? "is-ready" : ""
                       }`}
                       aria-label={canStop ? "Stop project update" : "Apply change to project, or press Enter"}

--- a/apps/web/app/forma-workspace/project-workspace.tsx
+++ b/apps/web/app/forma-workspace/project-workspace.tsx
@@ -1,0 +1,469 @@
+"use client";
+
+import { useEffect, useLayoutEffect, useRef, useState, type ReactNode } from "react";
+import { ArrowRight, Eye, Layers, Maximize2, Minimize2, MessageSquare, RefreshCw, Square } from "lucide-react";
+
+import CopyButton from "../../components/copy-button";
+import { formatChatTimestamp } from "./lib/chat-ids";
+import { workspaceNamespaceForTab, workspaceTabs } from "./lib/workspace-routes";
+import { AgentPipelineProgressView } from "./pipeline-progress-view";
+import { EditableWorkspaceTitle, MobileSidebarButton } from "./sidebar";
+import type { ChatMessage } from "./types";
+import useChatAutoScroll from "./use-chat-auto-scroll";
+import useChromeHeaderScroll from "./use-chrome-header-scroll";
+
+export function ProjectDetailWorkspace({
+  onOpenSidebar,
+  projectId,
+  projectTitle,
+  owned,
+  onRenameTitle,
+  namespaceTabs,
+  activeNamespace,
+  onNamespaceChange,
+  projectContent,
+}: {
+  onOpenSidebar: () => void;
+  projectId: string | null;
+  projectTitle: string;
+  owned: boolean;
+  onRenameTitle?: (title: string) => void;
+  namespaceTabs: typeof workspaceTabs;
+  activeNamespace: string;
+  onNamespaceChange: (value: string) => void;
+  projectContent: React.ReactNode;
+}) {
+  return (
+    <div className="flex h-full min-h-0 min-w-0 flex-col bg-[var(--forma-page)]">
+      <header className="workspace-chrome-header flex min-h-14 min-w-0 items-center gap-3 overflow-hidden px-3 pb-5 pt-2 sm:px-4">
+        <MobileSidebarButton onClick={onOpenSidebar} />
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-[rgb(var(--forma-green-rgb)/0.12)] px-2 py-0.5 text-[10px] font-medium text-[rgb(var(--forma-green-rgb))]">
+              <Eye className="h-3 w-3" />
+              {owned ? "Your project" : "Public project"}
+            </span>
+            <EditableWorkspaceTitle
+              value={projectTitle}
+              canEdit={owned && Boolean(onRenameTitle)}
+              label="Project title"
+              onCommit={(title) => onRenameTitle?.(title)}
+            />
+          </div>
+        </div>
+      </header>
+
+      <section className="min-h-0 min-w-0 flex-1 overflow-hidden bg-[var(--forma-page)]" aria-label="Project workspace">
+        <ProjectWorkspacePanel
+          projectId={projectId}
+          namespaceTabs={namespaceTabs}
+          activeNamespace={activeNamespace}
+          onNamespaceChange={onNamespaceChange}
+        >
+          {projectContent}
+        </ProjectWorkspacePanel>
+      </section>
+    </div>
+  );
+}
+
+export function ChatWorkspace({
+  onOpenSidebar,
+  projectId,
+  chatId,
+  projectTitle,
+  onRenameTitle,
+  messages,
+  input,
+  setInput,
+  onSubmit,
+  isLoading,
+  canStop,
+  onStop,
+  canChat,
+  namespaceTabs,
+  activeNamespace,
+  activeNamespaceLabel,
+  activeNamespaceName,
+  onNamespaceChange,
+  projectContent,
+}: {
+  onOpenSidebar: () => void;
+  projectId: string | null;
+  chatId: string | null;
+  projectTitle: string;
+  onRenameTitle?: (title: string) => void;
+  messages: ChatMessage[];
+  input: string;
+  setInput: (value: string) => void;
+  onSubmit: (event: React.FormEvent) => void;
+  isLoading: boolean;
+  canStop: boolean;
+  onStop: () => void;
+  canChat: boolean;
+  namespaceTabs: typeof workspaceTabs;
+  activeNamespace: string;
+  activeNamespaceLabel: string;
+  activeNamespaceName: string;
+  onNamespaceChange: (value: string) => void;
+  projectContent: React.ReactNode;
+}) {
+  const { containerRef, endRef, handleScroll } = useChatAutoScroll(chatId || projectId || "project-chat", messages);
+  const { headerAway, updateFromContainer } = useChromeHeaderScroll(chatId || projectId || "project-chat");
+
+  const onChatScroll = () => {
+    handleScroll();
+    updateFromContainer(containerRef.current);
+  };
+
+  return (
+    <div className="relative flex h-full min-h-0 min-w-0 flex-col bg-[var(--forma-page)]">
+      <header className={`workspace-chrome-header absolute inset-x-0 top-0 z-20 flex min-h-14 min-w-0 items-center gap-3 px-3 pb-5 pt-2 sm:px-4 ${headerAway ? "is-away" : ""}`}>
+        <MobileSidebarButton onClick={onOpenSidebar} />
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-[rgb(var(--forma-green-rgb)/0.12)] px-2 py-0.5 text-[10px] font-medium text-[rgb(var(--forma-green-rgb))]">
+              {canChat ? <MessageSquare className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
+              {canChat ? "Project chat" : "Read-only project"}
+            </span>
+            <EditableWorkspaceTitle
+              value={projectTitle}
+              canEdit={canChat && Boolean(onRenameTitle)}
+              label="Project chat title"
+              onCommit={(title) => onRenameTitle?.(title)}
+            />
+          </div>
+        </div>
+      </header>
+
+      <div className="relative min-h-0 min-w-0 flex-1 overflow-hidden">
+        {canChat && (
+          <div className="flex h-full min-h-0 min-w-0 flex-col">
+            <div
+              ref={containerRef}
+              onScroll={onChatScroll}
+              className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-3 pb-5 pt-16 sm:px-5 sm:pb-6 sm:pt-16"
+            >
+              <div className="mx-auto flex w-full min-w-0 max-w-6xl flex-col gap-3">
+                {messages.length ? (
+                  messages.map((message) => {
+                    const isUser = message.role === "user";
+                    const isSystem = message.role === "system";
+                    return (
+                      <div key={message.id} className={`mx-auto flex w-full min-w-0 max-w-3xl ${isUser ? "justify-end" : "justify-start"}`}>
+                        <div
+                          className={`min-w-0 max-w-[92%] overflow-hidden rounded-xl border px-4 py-3 ${
+                            isUser
+                              ? "border-emerald-500/20 bg-emerald-500/10 text-zinc-100"
+                              : message.status === "error"
+                                ? "border-rose-400/30 bg-rose-950/25 text-rose-100"
+                                : message.status === "cancelled"
+                                  ? "border-amber-300/30 bg-amber-950/20 text-amber-50"
+                                : isSystem
+                                  ? "border-white/5 bg-black/25 text-zinc-400"
+                                  : "border-white/5 bg-[#181b22] text-zinc-200"
+                          }`}
+                        >
+                          <div className="mb-2 flex flex-wrap items-center gap-2 text-[10px] font-medium text-zinc-500">
+                            <span>{isUser ? "You" : isSystem ? "Context" : "Forma"}</span>
+                            <span className="text-zinc-700">·</span>
+                            <span suppressHydrationWarning>{formatChatTimestamp(message.timestamp)}</span>
+                            {message.status === "loading" && <RefreshCw className="h-3 w-3 animate-spin text-emerald-400" />}
+                            {message.status === "cancelled" && <Square className="h-3 w-3 fill-current text-amber-300" />}
+                            <CopyButton
+                              value={message.content}
+                              label={isUser ? "Copy your message" : isSystem ? "Copy context message" : "Copy Forma's message"}
+                              className="ml-auto"
+                            />
+                          </div>
+                          <p className="break-anywhere whitespace-pre-wrap text-sm leading-6">{message.content}</p>
+                          {!message.projectId && (
+                            <AgentPipelineProgressView progress={message.pipelineProgress} status={message.status} compact />
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })
+                ) : (
+                  <div className="mx-auto w-full max-w-3xl rounded-xl border border-white/5 bg-[#181b22] p-5 text-sm leading-6 text-zinc-500">
+                    This chat has no project messages yet.
+                  </div>
+                )}
+                <div ref={endRef} />
+                <ChatProjectArtifact
+                  projectId={projectId}
+                  projectTitle={projectTitle}
+                  canEdit={canChat && Boolean(onRenameTitle)}
+                  onRenameTitle={onRenameTitle}
+                  namespaceTabs={namespaceTabs}
+                  activeNamespace={activeNamespace}
+                  onNamespaceChange={onNamespaceChange}
+                  projectContent={projectContent}
+                />
+              </div>
+            </div>
+
+            <form onSubmit={onSubmit} className="shrink-0 border-t border-white/5 bg-[#0f1117]/95 p-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] backdrop-blur sm:p-4">
+              <div className="mx-auto max-w-3xl">
+                <div className="w-full rounded-2xl border border-white/5 bg-[#181b22] p-3 shadow-lg transition-all focus-within:border-emerald-500/50 focus-within:ring-1 focus-within:ring-emerald-500/20">
+                  <textarea
+                    value={input}
+                    onChange={(event) => setInput(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" && !event.shiftKey) {
+                        event.preventDefault();
+                        if (isLoading) return;
+                        event.currentTarget.form?.requestSubmit();
+                      }
+                    }}
+                    placeholder={`Describe a change to ${activeNamespaceLabel.toLowerCase()}...`}
+                    className="min-h-[72px] w-full resize-none border-none bg-transparent text-sm leading-6 text-zinc-100 outline-none placeholder:text-zinc-500"
+                  />
+                  <div className="mt-1 flex items-center justify-end gap-1.5">
+                    {!canStop && !isLoading && Boolean(input.trim()) && (
+                      <span className="prompt-composer-enter-hint hidden sm:inline" aria-hidden="true">
+                        Enter
+                      </span>
+                    )}
+                    <button
+                      type={canStop ? "button" : "submit"}
+                      onClick={canStop ? onStop : undefined}
+                      disabled={!canStop && (isLoading || !projectId || !input.trim())}
+                      className={`prompt-composer-send inline-flex h-7 w-7 items-center justify-center rounded-md transition-colors disabled:cursor-not-allowed ${
+                        !canStop && !isLoading && input.trim() ? "is-ready" : ""
+                      }`}
+                      aria-label={canStop ? "Stop project update" : "Apply change to project, or press Enter"}
+                      title={canStop ? "Stop project update" : `Apply change to ${activeNamespaceName} · Enter`}
+                    >
+                      {canStop ? <Square className="h-3.5 w-3.5 fill-current" /> : isLoading ? <RefreshCw className="h-3.5 w-3.5 animate-spin" /> : <ArrowRight className="h-4 w-4" />}
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
+        )}
+
+        {!canChat && (
+          <section className="absolute inset-0 min-h-0 min-w-0 overflow-hidden bg-[var(--forma-page)] pt-14" aria-label="Project workspace">
+            <ProjectWorkspacePanel
+              projectId={projectId}
+              namespaceTabs={namespaceTabs}
+              activeNamespace={activeNamespace}
+              onNamespaceChange={onNamespaceChange}
+            >
+              {projectContent}
+            </ProjectWorkspacePanel>
+          </section>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function scrollableVerticalParent(node: HTMLElement | null) {
+  let current = node?.parentElement || null;
+  while (current) {
+    const overflowY = window.getComputedStyle(current).overflowY;
+    if (/(auto|scroll)/.test(overflowY) && current.scrollHeight > current.clientHeight) return current;
+    current = current.parentElement;
+  }
+  return null;
+}
+
+export function ChatProjectArtifact({
+  projectId,
+  projectTitle,
+  canEdit = false,
+  onRenameTitle,
+  namespaceTabs,
+  activeNamespace,
+  onNamespaceChange,
+  projectContent,
+}: {
+  projectId: string | null;
+  projectTitle: string;
+  canEdit?: boolean;
+  onRenameTitle?: (title: string) => void;
+  namespaceTabs: typeof workspaceTabs;
+  activeNamespace: string;
+  onNamespaceChange: (namespaceId: string) => void;
+  projectContent: React.ReactNode;
+}) {
+  const [fullScreen, setFullScreen] = useState(false);
+  const artifactRef = useRef<HTMLElement>(null);
+  const chatScrollSnapshotRef = useRef<{
+    element: HTMLElement | null;
+    top: number;
+    left: number;
+    windowX: number;
+    windowY: number;
+  } | null>(null);
+  const restoreChatScrollRef = useRef(false);
+
+  const enterFullScreen = () => {
+    const element = scrollableVerticalParent(artifactRef.current);
+    chatScrollSnapshotRef.current = {
+      element,
+      top: element?.scrollTop || 0,
+      left: element?.scrollLeft || 0,
+      windowX: window.scrollX,
+      windowY: window.scrollY,
+    };
+    setFullScreen(true);
+  };
+
+  const exitFullScreen = () => {
+    restoreChatScrollRef.current = true;
+    setFullScreen(false);
+  };
+
+  useLayoutEffect(() => {
+    if (fullScreen || !restoreChatScrollRef.current) return;
+    restoreChatScrollRef.current = false;
+    const snapshot = chatScrollSnapshotRef.current;
+    if (!snapshot) return;
+
+    const restoreScroll = () => {
+      if (snapshot.element?.isConnected) {
+        snapshot.element.scrollTo({ top: snapshot.top, left: snapshot.left, behavior: "auto" });
+      } else {
+        window.scrollTo({ top: snapshot.windowY, left: snapshot.windowX, behavior: "auto" });
+      }
+    };
+
+    restoreScroll();
+    const frameId = window.requestAnimationFrame(restoreScroll);
+    return () => window.cancelAnimationFrame(frameId);
+  }, [fullScreen]);
+
+  useEffect(() => {
+    if (!fullScreen) return;
+    const previousOverflow = document.body.style.overflow;
+    const exitOnEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        restoreChatScrollRef.current = true;
+        setFullScreen(false);
+      }
+    };
+    document.body.style.overflow = "hidden";
+    window.addEventListener("keydown", exitOnEscape);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", exitOnEscape);
+    };
+  }, [fullScreen]);
+
+  return (
+    <section
+      ref={artifactRef}
+      className={`min-w-0 overflow-hidden bg-[var(--forma-page)] ${
+        fullScreen
+          ? "fixed inset-0 z-[80] flex h-[100dvh] w-screen flex-col"
+          : "mx-auto mt-3 w-full max-w-6xl rounded-xl border border-[var(--forma-border)]"
+      }`}
+      aria-labelledby="chat-project-title"
+    >
+      <header className="flex min-h-[56px] min-w-0 shrink-0 items-center justify-between gap-3 border-b border-[var(--forma-border)] bg-[var(--forma-surface)] px-4 py-2.5">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <Layers className="h-3.5 w-3.5 shrink-0 text-[rgb(var(--forma-green-rgb))]" />
+            <h3 id="chat-project-title" className="truncate text-[10px] font-medium text-[var(--forma-text-muted)]">
+              Project
+            </h3>
+          </div>
+          <EditableWorkspaceTitle
+            value={projectTitle}
+            canEdit={canEdit && Boolean(onRenameTitle)}
+            label="Project title"
+            element="div"
+            className="mt-0.5 truncate text-xs font-semibold text-[var(--forma-text-strong)]"
+            onCommit={(title) => onRenameTitle?.(title)}
+          />
+        </div>
+        <div className="flex min-w-0 items-center justify-end">
+          <button
+            type="button"
+            onClick={fullScreen ? exitFullScreen : enterFullScreen}
+            className="inline-flex h-8 shrink-0 items-center justify-center gap-1.5 rounded-lg border border-[var(--forma-border)] px-2.5 text-xs font-medium text-[var(--forma-text-body)] transition-colors hover:bg-[var(--forma-surface-muted)] hover:text-[var(--forma-text-strong)] sm:px-3"
+            aria-pressed={fullScreen}
+            aria-label={fullScreen ? "Exit project full screen" : "View project full screen"}
+            title={fullScreen ? "Exit full screen (Esc)" : "Full screen"}
+          >
+            {fullScreen ? <Minimize2 className="h-3.5 w-3.5" /> : <Maximize2 className="h-3.5 w-3.5" />}
+            <span className="hidden md:inline">{fullScreen ? "Exit full screen" : "Full screen"}</span>
+          </button>
+        </div>
+      </header>
+
+      <div className={fullScreen ? "min-h-0 min-w-0 flex-1 overflow-hidden" : "h-[70dvh] min-h-[540px] max-h-[820px] min-w-0 overflow-hidden"}>
+        <ProjectWorkspacePanel
+          projectId={projectId}
+          namespaceTabs={namespaceTabs}
+          activeNamespace={activeNamespace}
+          onNamespaceChange={onNamespaceChange}
+        >
+          {projectContent}
+        </ProjectWorkspacePanel>
+      </div>
+    </section>
+  );
+}
+
+export function ProjectWorkspacePanel({
+  projectId,
+  namespaceTabs,
+  activeNamespace,
+  onNamespaceChange,
+  children,
+}: {
+  projectId?: string | null;
+  namespaceTabs: typeof workspaceTabs;
+  activeNamespace: string;
+  onNamespaceChange: (value: string) => void;
+  children: React.ReactNode;
+}) {
+  const namespaceName = workspaceNamespaceForTab(activeNamespace);
+  return (
+    <div className="flex h-full min-h-0 min-w-0 flex-col">
+      <nav
+        className="flex min-h-[44px] min-w-0 shrink-0 items-center gap-1 overflow-x-auto border-b border-[var(--forma-border)] bg-[var(--forma-surface)] px-2"
+        aria-label="Project workspace"
+      >
+        {namespaceTabs.map((tab) => {
+          const Icon = tab.icon;
+          const active = activeNamespace === tab.id;
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => onNamespaceChange(tab.id)}
+              className={`inline-flex h-8 shrink-0 items-center justify-center gap-1.5 whitespace-nowrap rounded-lg px-2.5 text-xs font-medium transition-colors ${
+                active
+                  ? "bg-[rgb(var(--forma-green-rgb)/0.12)] text-[rgb(var(--forma-green-rgb))]"
+                  : "text-[var(--forma-text-muted)] hover:bg-[var(--forma-surface-muted)] hover:text-[var(--forma-text-strong)]"
+              }`}
+              aria-pressed={active}
+              title={`${tab.label} / ${workspaceNamespaceForTab(tab.id)}`}
+            >
+              <Icon className="h-3.5 w-3.5 shrink-0" strokeWidth={1.75} />
+              <span className={active ? "inline" : "hidden sm:inline"}>{tab.label}</span>
+            </button>
+          );
+        })}
+      </nav>
+      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">{children}</div>
+      <div className="flex shrink-0 items-center justify-end gap-2 border-t border-[var(--forma-border)] bg-[var(--forma-surface)] px-3 py-1.5 font-mono text-[9px] text-[var(--forma-text-muted)]">
+        {projectId && (
+          <span className="max-w-[min(100%,14rem)] truncate" title={projectId}>
+            {projectId}
+          </span>
+        )}
+        {projectId && <span aria-hidden="true">·</span>}
+        <span className="max-w-48 truncate" title={namespaceName}>
+          {namespaceName}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/forma-workspace/route-shell-ui.tsx
+++ b/apps/web/app/forma-workspace/route-shell-ui.tsx
@@ -1,0 +1,309 @@
+"use client";
+
+import type { ElementType, ReactNode } from "react";
+import { AlertTriangle, ArrowLeft, KeyRound, RefreshCw, Trash2 } from "lucide-react";
+
+import { useFormaAuth } from "../../lib/forma-auth";
+import { MobileSidebarButton } from "./sidebar";
+import type { ChatRouteTransition, PendingProjectDeletion } from "./types";
+
+export function ProjectDeletionDialog({
+  project,
+  acknowledged,
+  contribute,
+  busy,
+  error,
+  onAcknowledgedChange,
+  onContributeChange,
+  onCancel,
+  onConfirm,
+}: {
+  project: PendingProjectDeletion | null;
+  acknowledged: boolean;
+  contribute: boolean;
+  busy: boolean;
+  error: string | null;
+  onAcknowledgedChange: (value: boolean) => void;
+  onContributeChange: (value: boolean) => void;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  if (!project) return null;
+  return (
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm" role="presentation">
+      <section
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="delete-project-title"
+        className="w-full max-w-xl rounded-2xl border border-white/5 bg-[#181b22] p-6 text-zinc-100 shadow-2xl"
+      >
+        <div className="flex items-start gap-3">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-red-500/10 text-red-300">
+            <Trash2 className="h-5 w-5" />
+          </span>
+          <div className="min-w-0">
+            <h2 id="delete-project-title" className="text-lg font-semibold tracking-tight text-zinc-100">
+              Delete this project?
+            </h2>
+            <p className="mt-1 break-words text-sm text-zinc-400">{project.title}</p>
+          </div>
+        </div>
+        <p className="mt-5 text-sm leading-6 text-zinc-300">
+          Removed from your workspace now. Permanently deleted after 30 days.
+        </p>
+        <label className="mt-5 flex cursor-pointer items-start gap-3 rounded-lg border border-white/10 bg-[#0f1117] p-4 text-sm leading-5 text-zinc-300">
+          <input
+            type="checkbox"
+            checked={acknowledged}
+            onChange={(event) => onAcknowledgedChange(event.target.checked)}
+            disabled={busy}
+            className="mt-0.5 h-4 w-4 accent-red-400"
+          />
+          <span>I understand I will lose access to this project.</span>
+        </label>
+        <div className="mt-4 rounded-lg border border-emerald-500/20 bg-emerald-500/[0.06] p-4">
+          <label className="flex cursor-pointer items-start gap-3 text-sm font-medium leading-5 text-zinc-200">
+            <input
+              type="checkbox"
+              checked={contribute}
+              onChange={(event) => onContributeChange(event.target.checked)}
+              disabled={busy}
+              className="mt-0.5 h-4 w-4 accent-emerald-400"
+            />
+            <span>Keep a sanitized copy for product research.</span>
+          </label>
+          <p className="mt-3 text-xs leading-5 text-zinc-500">
+            Personal details are removed. You can withdraw until the copy is anonymized.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-4 text-xs font-medium">
+            <a href="/legal/privacy-policy" target="_blank" rel="noreferrer" className="text-emerald-400 transition-colors hover:text-emerald-300">Privacy policy</a>
+            <a href="/legal/data-contribution-terms" target="_blank" rel="noreferrer" className="text-emerald-400 transition-colors hover:text-emerald-300">Data contribution terms</a>
+          </div>
+        </div>
+        {error && <p className="mt-4 rounded-lg border border-red-400/30 bg-red-400/10 p-3 text-sm text-red-200">{error}</p>}
+        <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            className="inline-flex h-9 items-center justify-center rounded-lg border border-white/10 px-4 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-800/40 hover:text-zinc-100 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={!acknowledged || busy}
+            className="inline-flex h-9 items-center justify-center rounded-lg bg-red-500 px-4 text-xs font-medium text-white transition-colors hover:bg-red-400 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            {busy ? "Deleting..." : "Delete project"}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}
+
+
+export function WorkspaceChromeIdentity({
+  icon: Icon,
+  badge,
+  title,
+}: {
+  icon: ElementType<{ className?: string }>;
+  badge: string;
+  title: React.ReactNode;
+}) {
+  return (
+    <div className="min-w-0 flex-1">
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-400">
+          <Icon className="h-3 w-3" />
+          {badge}
+        </span>
+        {typeof title === "string" ? (
+          <h2 className="truncate text-sm font-semibold tracking-tight text-zinc-100">{title}</h2>
+        ) : title}
+      </div>
+    </div>
+  );
+}
+
+export function WorkspacePageHeading({
+  icon: Icon,
+  title,
+  description,
+}: {
+  icon: ElementType<{ className?: string }>;
+  title: string;
+  description: string;
+}) {
+  return (
+    <section className="mb-6 border-b border-white/5 pb-5">
+      <div className="hidden min-w-0 items-center gap-3 md:flex">
+        <div className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-emerald-500/10 text-emerald-400">
+          <Icon className="h-5 w-5" />
+        </div>
+        <div className="min-w-0">
+          <h1 className="truncate text-xl font-semibold tracking-tight text-zinc-100">{title}</h1>
+          <p className="mt-1 max-w-2xl text-sm leading-6 text-zinc-500">{description}</p>
+        </div>
+      </div>
+      <p className="max-w-2xl text-sm leading-6 text-zinc-500 md:hidden">{description}</p>
+    </section>
+  );
+}
+
+export function ProjectRouteFallbackPanel({
+  projectId,
+  error,
+  onHome,
+  onOpenSidebar,
+}: {
+  projectId: string;
+  error: string | null;
+  onHome: () => void;
+  onOpenSidebar: () => void;
+}) {
+  return (
+    <main className="flex min-h-0 min-w-0 flex-col">
+      <header className="flex h-12 items-center gap-3 border-b border-white/5 bg-[#0f1117]/80 px-4 backdrop-blur-md">
+        <MobileSidebarButton onClick={onOpenSidebar} />
+        <div className="flex min-w-0 flex-1 items-baseline gap-2">
+          <div className="truncate text-sm font-semibold tracking-tight text-zinc-100">
+            {error ? "Project unavailable" : "Opening project"}
+          </div>
+          <div className="truncate font-mono text-[10px] text-zinc-600">{projectId}</div>
+        </div>
+      </header>
+
+      <section className="flex min-h-0 flex-1 items-center justify-center p-5">
+        <div className="w-full max-w-md rounded-2xl border border-white/5 bg-[#181b22] p-6 text-center shadow-2xl shadow-black/30">
+          <div className="mx-auto flex h-11 w-11 items-center justify-center rounded-lg bg-emerald-500/10">
+            {error ? <AlertTriangle className="h-5 w-5 text-amber-300" /> : <RefreshCw className="h-5 w-5 animate-spin text-emerald-400" />}
+          </div>
+          <h1 className="mt-5 text-lg font-semibold tracking-tight text-zinc-100">
+            {error ? "Project unavailable" : "Opening project"}
+          </h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-500">
+            {error || "Loading the saved hardware plan."}
+          </p>
+          {error && (
+            <button
+              type="button"
+              onClick={onHome}
+              className="mt-5 inline-flex h-9 items-center gap-2 rounded-lg border border-white/10 px-4 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-800/40 hover:text-zinc-100"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back home
+            </button>
+          )}
+        </div>
+      </section>
+    </main>
+  );
+}
+
+export function AuthRequiredRouteScreen({
+  loading,
+  title,
+  message,
+  onHome,
+}: {
+  loading: boolean;
+  title: string;
+  message: string;
+  onHome: () => void;
+}) {
+  const { openSignIn } = useFormaAuth();
+  return (
+    <div className="flex min-h-screen w-full items-center justify-center bg-[#0f1117] px-5 font-sans text-zinc-100">
+      <div className="w-full max-w-md rounded-2xl border border-white/5 bg-[#181b22] p-6 shadow-2xl">
+        <div className="flex items-center gap-3">
+          <span className="flex h-10 w-10 items-center justify-center rounded-lg bg-emerald-500/10 text-emerald-400">
+            <KeyRound className="h-5 w-5" />
+          </span>
+          <div className="min-w-0">
+            <h1 className="truncate text-lg font-semibold tracking-tight text-zinc-100">{title}</h1>
+            <p className="mt-1 text-sm text-zinc-500">{loading ? "Checking session..." : message}</p>
+          </div>
+        </div>
+        <div className="mt-6 grid grid-cols-2 gap-2">
+          <button
+            type="button"
+            onClick={onHome}
+            className="inline-flex h-9 items-center justify-center rounded-lg border border-white/10 px-3 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-800/40 hover:text-zinc-100"
+          >
+            Home
+          </button>
+          <button
+            type="button"
+            disabled={loading}
+            onClick={() => openSignIn({ redirectUrl: typeof window !== "undefined" ? window.location.href : "/" })}
+            className="inline-flex h-9 items-center justify-center rounded-lg bg-emerald-500 px-3 text-xs font-semibold text-zinc-950 transition-colors hover:bg-emerald-400 disabled:cursor-wait disabled:opacity-50"
+          >
+            Sign in
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ChatRouteFallbackPanel({
+  transition,
+  onHome,
+  onOpenSidebar,
+}: {
+  transition: ChatRouteTransition;
+  onHome: () => void;
+  onOpenSidebar: () => void;
+}) {
+  const hasProjectTarget = Boolean(transition.projectId);
+  return (
+    <main className="flex min-h-0 min-w-0 flex-col">
+      <header className="flex h-12 min-w-0 items-center gap-2 overflow-hidden border-b border-white/5 bg-[#0f1117]/80 px-3 backdrop-blur-md sm:gap-3 sm:px-4">
+        <MobileSidebarButton onClick={onOpenSidebar} />
+        <div className="flex min-w-0 flex-1 items-baseline gap-2">
+          <div className="truncate text-sm font-semibold tracking-tight text-zinc-100">{transition.title || "Opening chat"}</div>
+          <span className="truncate font-mono text-[10px] text-zinc-600">{transition.projectId || transition.chatId}</span>
+        </div>
+      </header>
+
+      <section className="flex min-h-0 flex-1 items-center justify-center p-5">
+        <div className="w-full max-w-md rounded-2xl border border-white/5 bg-[#181b22] p-6 text-center shadow-2xl shadow-black/30">
+          <div className="mx-auto flex h-11 w-11 items-center justify-center rounded-lg bg-emerald-500/10">
+            {transition.error ? <AlertTriangle className="h-5 w-5 text-amber-300" /> : <RefreshCw className="h-5 w-5 animate-spin text-emerald-400" />}
+          </div>
+          <h1 className="mt-5 text-lg font-semibold tracking-tight text-zinc-100">
+            {transition.error ? "Chat unavailable" : hasProjectTarget ? "Opening project chat" : "Opening chat"}
+          </h1>
+          <p className="mt-3 text-sm leading-6 text-zinc-500">
+            {transition.error || (hasProjectTarget ? "Loading the active project for this chat." : "Preparing the chat workspace.")}
+          </p>
+          <div className="mt-4 space-y-2">
+            <div className="truncate rounded-lg border border-white/5 bg-[#0f1117] px-3 py-2 font-mono text-xs text-zinc-500">
+              {transition.chatId}
+            </div>
+            {transition.projectId && (
+              <div className="truncate rounded-lg border border-emerald-500/20 bg-emerald-500/[0.06] px-3 py-2 font-mono text-xs text-emerald-100">
+                {transition.projectId}
+              </div>
+            )}
+          </div>
+          {transition.error && (
+            <button
+              type="button"
+              onClick={onHome}
+              className="mt-5 inline-flex h-9 items-center gap-2 rounded-lg border border-white/10 px-4 text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-800/40 hover:text-zinc-100"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back home
+            </button>
+          )}
+        </div>
+      </section>
+    </main>
+  );
+}
+

--- a/apps/web/app/forma-workspace/sidebar.tsx
+++ b/apps/web/app/forma-workspace/sidebar.tsx
@@ -13,6 +13,7 @@ import {
   MoreHorizontal,
   PanelLeftClose,
   PanelLeftOpen,
+  Pencil,
   Pin,
   Plus,
   RefreshCw,
@@ -64,30 +65,33 @@ export function EditableWorkspaceTitle({
 
   if (editing) {
     return (
-      <input
-        value={draft}
-        onChange={(event) => setDraft(event.target.value)}
-        onBlur={() => {
-          const next = draft.trim() || value.trim() || "Untitled Hardware Project";
-          setEditing(false);
-          if (next !== value) onCommit(next);
-          else setDraft(value);
-        }}
-        onKeyDown={(event) => {
-          if (event.key === "Enter") {
-            event.preventDefault();
-            event.currentTarget.blur();
-          }
-          if (event.key === "Escape") {
-            event.preventDefault();
-            setDraft(value);
+      <div className="inline-flex min-w-0 max-w-full items-center gap-1.5">
+        <input
+          value={draft}
+          onChange={(event) => setDraft(event.target.value)}
+          onBlur={() => {
+            const next = draft.trim() || value.trim() || "Untitled Hardware Project";
             setEditing(false);
-          }
-        }}
-        autoFocus
-        aria-label={label}
-        className={`min-w-0 flex-1 bg-transparent ${className} outline-none`}
-      />
+            if (next !== value) onCommit(next);
+            else setDraft(value);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") {
+              event.preventDefault();
+              event.currentTarget.blur();
+            }
+            if (event.key === "Escape") {
+              event.preventDefault();
+              setDraft(value);
+              setEditing(false);
+            }
+          }}
+          autoFocus
+          aria-label={label}
+          className={`min-w-0 bg-transparent ${className} outline-none`}
+        />
+        <Pencil className="h-3 w-3 shrink-0 text-[var(--forma-text-muted)]" aria-hidden="true" />
+      </div>
     );
   }
 
@@ -97,9 +101,13 @@ export function EditableWorkspaceTitle({
       onClick={() => setEditing(true)}
       title={`Rename ${label.toLowerCase()}`}
       aria-label={`Rename ${label.toLowerCase()}`}
-      className={`min-w-0 flex-1 truncate text-left ${className} hover:text-white`}
+      className="group inline-flex min-w-0 max-w-full items-center gap-1.5 text-left"
     >
-      {value}
+      <span className={`min-w-0 truncate ${className}`}>{value}</span>
+      <Pencil
+        className="h-3 w-3 shrink-0 text-[var(--forma-text-muted)] opacity-70 transition-opacity group-hover:opacity-100 group-hover:text-[var(--forma-text-strong)]"
+        aria-hidden="true"
+      />
     </button>
   );
 }
@@ -120,7 +128,6 @@ function ApiConnectionStatus({ status }: { status: WorkspaceStatusPresentation }
       aria-label={status.label}
       title={status.label}
     >
-      <span className="status-badge-ping" aria-hidden="true" />
       <span className="status-badge-dot" aria-hidden="true" />
     </span>
   );
@@ -245,7 +252,7 @@ export function MobileSidebarDrawer({
     <div className="fixed inset-0 z-50 md:hidden" role="dialog" aria-modal="true" aria-label="Sidebar">
       <button
         type="button"
-        className="absolute inset-0 h-full w-full bg-black/60 backdrop-blur-sm"
+        className="absolute inset-0 h-full w-full bg-[rgb(var(--forma-scrim-rgb)/0.48)] backdrop-blur-md"
         onClick={onClose}
         aria-label="Close sidebar"
       />
@@ -497,7 +504,7 @@ function SidebarSectionLabel({ compact, children }: { compact: boolean; children
 function SidebarAccountDock({ compact }: { compact: boolean }) {
   const { isSignedIn } = useFormaAuth();
   return (
-    <div className={`mt-3 flex items-center gap-2.5 border-t border-white/5 pt-3 ${compact ? "justify-center" : "px-3"}`}>
+    <div className={`mt-3 flex items-center gap-2.5 pt-3 ${compact ? "justify-center" : "px-3"}`}>
       <AuthStatusControl authRequired compact={compact || isSignedIn} />
       {!compact && isSignedIn && <span className="truncate text-xs font-medium text-zinc-500">Account</span>}
     </div>
@@ -591,8 +598,8 @@ export function ChatSidebar({
     <aside
       className={
         isDrawer
-          ? "flex h-full min-h-0 w-[min(320px,calc(100vw-2rem))] flex-col overflow-hidden rounded-r-2xl border-r border-white/5 bg-[#181b22] text-zinc-100 shadow-2xl shadow-black/50"
-          : "hidden h-full min-h-0 flex-col border-r border-white/5 bg-[#181b22] text-zinc-100 md:flex"
+          ? "flex h-full min-h-0 w-[min(320px,calc(100vw-2rem))] flex-col overflow-hidden rounded-r-2xl bg-[var(--forma-surface)] text-zinc-100 shadow-[var(--forma-card-shadow)]"
+          : "hidden h-full min-h-0 flex-col bg-[var(--forma-surface)] text-zinc-100 md:flex"
       }
     >
       <div className="flex min-h-0 flex-1 flex-col">
@@ -706,7 +713,7 @@ export function ChatSidebar({
         </div>
       </div>
 
-      <div className="border-t border-white/5 px-3 py-3">
+      <div className="px-3 py-3">
         <SidebarSectionLabel compact={compact}>Workspace</SidebarSectionLabel>
         <div className="space-y-0.5">
           <SidebarNavLink href="/my-projects" icon={Database} label="My projects" compact={compact} onNavigate={onNavigate} />

--- a/apps/web/app/forma-workspace/sidebar.tsx
+++ b/apps/web/app/forma-workspace/sidebar.tsx
@@ -114,9 +114,7 @@ function formatSidebarDate(value: string | null) {
 function ApiConnectionStatus({ status }: { status: WorkspaceStatusPresentation }) {
   return (
     <span
-      className={`status-badge ${status.tone === "error" ? "status-badge-error" : "status-badge-ok"} ${
-        status.pulse ? "status-badge-pulse" : "status-badge-idle"
-      }`}
+      className={`status-badge ${status.tone === "error" ? "status-badge-error" : "status-badge-ok"}`}
       role="status"
       aria-live="polite"
       aria-label={status.label}
@@ -440,7 +438,7 @@ function ChatSidebarRow({
               event.stopPropagation();
               onToggleMenu();
             }}
-            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-zinc-500 opacity-0 transition-opacity hover:bg-zinc-800 hover:text-zinc-200 group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 aria-expanded:opacity-100"
+            className="inline-flex h-7 w-7 items-center justify-center rounded-md text-[var(--forma-text-muted)] opacity-0 transition-opacity hover:bg-[var(--forma-surface-muted)] hover:text-[var(--forma-text-strong)] group-hover:opacity-100 group-focus-within:opacity-100 focus-visible:opacity-100 aria-expanded:opacity-100"
             aria-label={`More options for ${chat.title}`}
             aria-haspopup="menu"
             aria-expanded={menuOpen}
@@ -450,7 +448,7 @@ function ChatSidebarRow({
           {menuOpen && (
             <div
               role="menu"
-              className="fixed z-50 w-36 overflow-hidden rounded-lg border border-white/10 bg-[#1f232c] py-1 shadow-xl shadow-black/50"
+              className="fixed z-50 w-36 overflow-hidden rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface)] py-1 shadow-[var(--forma-card-shadow)]"
               style={menuPos ? { top: menuPos.top, right: menuPos.right } : { visibility: "hidden" }}
             >
               {onPin && (
@@ -462,7 +460,7 @@ function ChatSidebarRow({
                     onCloseMenu();
                     onPin();
                   }}
-                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium text-zinc-300 transition-colors hover:bg-zinc-800 hover:text-zinc-100"
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium text-[var(--forma-text-body)] transition-colors hover:bg-[var(--forma-surface-muted)] hover:text-[var(--forma-text-strong)]"
                 >
                   <Pin className="h-3.5 w-3.5" />
                   {chat.pinned ? "Unpin" : "Pin"}
@@ -477,7 +475,7 @@ function ChatSidebarRow({
                     onCloseMenu();
                     onDelete();
                   }}
-                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium text-red-300 transition-colors hover:bg-red-500/10 hover:text-red-200"
+                  className="flex w-full items-center gap-2 px-3 py-2 text-left text-xs font-medium text-[rgb(var(--forma-red-rgb))] transition-colors hover:bg-[rgb(var(--forma-red-rgb)/0.1)] hover:text-[rgb(var(--forma-red-rgb))]"
                 >
                   <Trash2 className="h-3.5 w-3.5" />
                   Delete

--- a/apps/web/app/forma-workspace/types.ts
+++ b/apps/web/app/forma-workspace/types.ts
@@ -1,0 +1,133 @@
+import type { A2AJob } from "./use-admin-data";
+
+export type GenerationWorkflowOption = {
+  id: string;
+  label: string;
+  description?: string;
+  uses_catalog?: boolean;
+  uses_web_research?: boolean;
+  uses_firecrawl_mcp?: boolean;
+  uses_external_sources?: boolean;
+};
+
+export type AgentPipelineStep = {
+  id: string;
+  agent: string;
+  label: string;
+  description: string;
+  duration_ms?: number;
+  optional?: boolean;
+};
+
+export type AgentPipelineEvent = {
+  workflow?: string;
+  step_id: string;
+  status: "started" | "completed" | "failed" | "skipped" | string;
+  agent?: string;
+  label?: string;
+  description?: string;
+  observed_at?: string;
+  details?: Record<string, any>;
+};
+
+export type AgentPipelineProgress = {
+  startedAt: string;
+  steps: AgentPipelineStep[];
+  currentStepIndex: number;
+  estimated: boolean;
+  synced?: boolean;
+  jobId?: string | null;
+  events?: AgentPipelineEvent[];
+  uiUpdatedAt?: string;
+};
+
+export type ChatMessage = {
+  id: string;
+  role: "assistant" | "user" | "system";
+  content: string;
+  status?: "idle" | "loading" | "success" | "error" | "cancelled";
+  timestamp: string;
+  projectId?: string | null;
+  pipelineProgress?: AgentPipelineProgress | null;
+  imagePreview?: string | null;
+  contextProjectId?: string | null;
+  workflowState?: string | null;
+  contextQuestions?: string[];
+  contextSuggestions?: string[];
+  buildPlanId?: string | null;
+  buildJobId?: string | null;
+  buildRequiresRequestBoundExecution?: boolean;
+};
+
+export type ActiveGenerationRun = {
+  kind: "chat" | "project-chat" | "context-build";
+  controller: AbortController;
+  jobId: string | null;
+  planId?: string | null;
+  projectId?: string | null;
+  chatId: string;
+  assistantMessageId: string | null;
+  cancelled: boolean;
+};
+
+export type ActiveGenerationState = Pick<ActiveGenerationRun, "kind" | "jobId">;
+
+export type HumanContextQuestion = {
+  id: string;
+  label: string;
+  question: string;
+  placeholder: string;
+  suggestions: string[];
+};
+
+export type PendingHumanContext = {
+  basePrompt: string;
+  questions: HumanContextQuestion[];
+  answers: Record<string, string>;
+};
+
+export type PendingProjectDeletion = {
+  projectId: string;
+  title: string;
+};
+
+export type ApiErrorDetails = {
+  message: string;
+  code?: string;
+  reason?: string;
+  provider?: string;
+  model?: string;
+  job_id?: string;
+  debug?: Record<string, any>;
+};
+
+export type ChatRouteTransition = {
+  chatId: string;
+  title: string;
+  projectId: string;
+  error?: string | null;
+};
+
+export type VideoGenerationConfig = {
+  configured: boolean | null;
+  reason: string | null;
+};
+
+export type ImageGenerationConfig = {
+  configured: boolean | null;
+  requestCapable: boolean | null;
+  provider: string | null;
+  reason: string | null;
+};
+
+export type ProviderSetupState = {
+  llmRequired: boolean;
+  imageRequired: boolean;
+};
+
+export type HomeProps = {
+  routeProjectId?: string | null;
+  routeChatId?: string | null;
+  showDeveloperTools?: boolean;
+  homeView?: "chat" | "projects" | "my-projects" | "jobs" | "logs" | "settings" | "about";
+};

--- a/apps/web/app/forma-workspace/use-context-build-controller.ts
+++ b/apps/web/app/forma-workspace/use-context-build-controller.ts
@@ -1,0 +1,828 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { normalizeContextSuggestions } from "../../lib/context-suggestions";
+import type { A2AJob } from "./use-admin-data";
+import {
+  CONTEXT_BUILD_FIRST_POLL_MS,
+  CONTEXT_BUILD_MAX_ATTEMPTS,
+  CONTEXT_BUILD_POLL_MS,
+  CONTEXT_BUILD_TIMEOUT_MESSAGE,
+  contextBuildWatchKey,
+} from "./lib/context-build";
+import { chatMessageIdentityKey } from "./lib/chat-normalize";
+import { chatTimestamp, newBuildChatId, newChatMessageId } from "./lib/chat-ids";
+import { validateGenerationInput } from "./lib/generation-input";
+import {
+  createAgentPipelineProgress,
+  pipelineEventsFromWorkerTask,
+  progressFromJobEvents,
+  progressIncludesImageStep,
+} from "./lib/agent-pipeline";
+import { readApiErrorMessage } from "./lib/api-errors";
+import { withProjectResponseMetadata } from "./lib/project-metadata";
+import type { ActiveGenerationRun, AgentPipelineProgress, ChatMessage } from "./types";
+import { defaultAgentPipelineSteps } from "./workspace-constants";
+import { API_URL } from "./workspace-api";
+
+export type ContextBuildControllerOptions = {
+  activeChatId: string;
+  setActiveChatId: (chatId: string) => void;
+  chatMessages: ChatMessage[];
+  chatThreads: Record<string, ChatMessage[]>;
+  prompt: string;
+  setPrompt: (value: string) => void;
+  selectedImage: string | null;
+  setSelectedImage: (value: string | null) => void;
+  selectedImageSource: "upload" | "clipboard";
+  setSelectedImageSource: (value: "upload" | "clipboard") => void;
+  generateProductImage: boolean;
+  authRequired: boolean;
+  isSignedIn: boolean | null | undefined;
+  userImageUrl: string | null | undefined;
+  generationRequestHeaders: () => Promise<HeadersInit> | HeadersInit;
+  optionalAuthHeaders: () => Promise<HeadersInit> | HeadersInit;
+  requireSignedInForGeneration: () => Promise<boolean>;
+  noteAuthResponseStatus: (status: number) => void;
+  appendChatMessage: (message: Omit<ChatMessage, "id" | "timestamp"> & { id?: string }) => void;
+  updateChatMessage: (id: string, patch: Partial<Omit<ChatMessage, "id">>) => void;
+  appendThreadMessage: (chatId: string, message: Omit<ChatMessage, "id" | "timestamp"> & { id?: string }) => void;
+  updateThreadMessage: (chatId: string, id: string, patch: Partial<Omit<ChatMessage, "id">>) => void;
+  applyChatPipelineProgressFromJob: (...args: any[]) => void;
+  applyThreadPipelineProgressFromJob: (...args: any[]) => void;
+  rememberChatItem: (item: any) => void;
+  rememberProjectRecord: (record: any) => void;
+  setProjectIR: (ir: any) => void;
+  setGenerationInputNotice: (value: string | null) => void;
+  setIsLoading: (value: boolean) => void;
+  activeGenerationRef: { current: ActiveGenerationRun | null };
+  beginGenerationRun: (kind: ActiveGenerationRun["kind"], chatId: string) => ActiveGenerationRun;
+  finishGenerationRun: (run: ActiveGenerationRun) => void;
+  setGenerationRunJob: (run: ActiveGenerationRun, jobId: string, assistantMessageId: string) => void;
+  stopActiveGeneration: () => void;
+  syncChatRoute: (chatId: string) => void;
+  fetchProjectHistory: () => void;
+  fetchMyProjectHistory: () => void;
+};
+
+export function useContextBuildController(options: ContextBuildControllerOptions) {
+  const {
+    activeChatId,
+    setActiveChatId,
+    chatMessages,
+    chatThreads,
+    prompt,
+    setPrompt,
+    selectedImage,
+    setSelectedImage,
+    selectedImageSource,
+    setSelectedImageSource,
+    generateProductImage,
+    authRequired,
+    isSignedIn,
+    userImageUrl,
+    generationRequestHeaders,
+    optionalAuthHeaders,
+    requireSignedInForGeneration,
+    noteAuthResponseStatus,
+    appendChatMessage,
+    updateChatMessage,
+    appendThreadMessage,
+    updateThreadMessage,
+    applyChatPipelineProgressFromJob,
+    applyThreadPipelineProgressFromJob,
+    rememberChatItem,
+    rememberProjectRecord,
+    setProjectIR,
+    setGenerationInputNotice,
+    setIsLoading,
+    activeGenerationRef,
+    beginGenerationRun,
+    finishGenerationRun,
+    setGenerationRunJob,
+    stopActiveGeneration,
+    syncChatRoute,
+    fetchProjectHistory,
+    fetchMyProjectHistory,
+  } = options;
+
+  const contextProjectIdsRef = useRef<Record<string, string>>({});
+  const contextBuildWatchersRef = useRef(new Map<string, { stop: () => void }>());
+  const [contextWorkflowStates, setContextWorkflowStates] = useState<Record<string, string>>({});
+  const [contextBuildStarting, setContextBuildStarting] = useState(false);
+  const [resettingBuildMessageId, setResettingBuildMessageId] = useState<string | null>(null);
+  const [contextSubmitting, setContextSubmitting] = useState(false);
+
+  const pendingContextBuildMessage = useMemo(
+    () => [...chatMessages].reverse().find((message) => (
+      message.status === "loading"
+      && Boolean(message.buildPlanId)
+      && Boolean(message.contextProjectId)
+    )) || null,
+    [chatMessages],
+  );
+  const retryableContextBuildMessage = useMemo(() => {
+    const latestBuildMessage = [...chatMessages].reverse().find((message) => (
+      Boolean(message.buildPlanId)
+      && Boolean(message.buildJobId)
+      && Boolean(message.contextProjectId)
+    ));
+    return latestBuildMessage?.status === "error" ? latestBuildMessage : null;
+  }, [chatMessages]);
+
+  const beginContextBuildRun = (
+    projectId: string,
+    planId: string,
+    jobId: string,
+    chatId: string,
+    assistantMessageId: string,
+  ) => {
+    const active = activeGenerationRef.current;
+    if (active?.kind === "context-build" && active.planId === planId) return active;
+    const run = beginGenerationRun("context-build", chatId);
+    run.projectId = projectId;
+    run.planId = planId;
+    setGenerationRunJob(run, jobId, assistantMessageId);
+    return run;
+  };
+
+  const cancelContextBuild = async (projectId: string, planId: string) => {
+    try {
+      const response = await fetch(
+        `${API_URL}/projects/${encodeURIComponent(projectId)}/build/plans/${encodeURIComponent(planId)}/cancel`,
+        { method: "POST", headers: await generationRequestHeaders() },
+      );
+      if (!response.ok) throw new Error(await readApiErrorMessage(response));
+    } catch (error) {
+      console.warn("Could not notify the backend that the build was stopped.", error);
+      setGenerationInputNotice(error instanceof Error ? error.message : "Could not stop the build.");
+    }
+  };
+
+  const executeContextBuild = async (
+    projectId: string,
+    planId: string,
+    run?: ActiveGenerationRun,
+  ) => {
+    for (let attempt = 1; attempt <= 4; attempt += 1) {
+      try {
+        const response = await fetch(
+          `${API_URL}/projects/${encodeURIComponent(projectId)}/build/plans/${encodeURIComponent(planId)}/execute`,
+          {
+            method: "POST",
+            headers: await generationRequestHeaders(),
+            signal: run?.controller.signal,
+          },
+        );
+        if (!response.ok) throw new Error(await readApiErrorMessage(response));
+        return;
+      } catch (error) {
+        if (run?.cancelled || run?.controller.signal.aborted) return;
+        console.warn("The build execution request ended before the plan reached a terminal state.", error);
+        if (attempt === 4) {
+          setGenerationInputNotice(
+            error instanceof Error ? error.message : "The build execution request ended unexpectedly.",
+          );
+          return;
+        }
+        setGenerationInputNotice("Build connection interrupted. Resuming from the latest saved stage…");
+        await new Promise((resolve) => window.setTimeout(resolve, 1500));
+      }
+    }
+  };
+
+  const stopContextBuildMessage = (message: ChatMessage) => {
+    const projectId = message.contextProjectId;
+    const planId = message.buildPlanId;
+    if (!projectId || !planId) return;
+    const active = activeGenerationRef.current;
+    if (active?.kind === "context-build" && active.planId === planId) {
+      stopActiveGeneration();
+      return;
+    }
+    const stoppedMessage = "Build stopped by you. Your project brief is preserved.";
+    updateChatMessage(message.id, { content: stoppedMessage, status: "cancelled" });
+    updateThreadMessage(activeChatId, message.id, { content: stoppedMessage, status: "cancelled" });
+    setGenerationInputNotice("Build stopped. Your project brief is preserved.");
+    setIsLoading(false);
+    void cancelContextBuild(projectId, planId);
+  };
+
+  const resumeContextBuild = async (
+    projectId: string,
+    planId: string,
+    run?: ActiveGenerationRun,
+  ) => {
+    try {
+      const response = await fetch(
+        `${API_URL}/projects/${encodeURIComponent(projectId)}/build/plans/${encodeURIComponent(planId)}/resume`,
+        {
+          method: "POST",
+          headers: await generationRequestHeaders(),
+          signal: run?.controller.signal,
+        },
+      );
+      if (!response.ok) throw new Error(await readApiErrorMessage(response));
+    } catch (error) {
+      if (run?.cancelled || run?.controller.signal.aborted) return;
+      console.warn("Could not resume the detached build.", error);
+    }
+  };
+
+  const watchContextBuild = (
+    projectId: string,
+    planId: string,
+    jobId: string,
+    chatId: string,
+    assistantMessageId: string,
+    run?: ActiveGenerationRun,
+    requestBoundExecution = true,
+  ) => {
+    const watcherKey = contextBuildWatchKey(projectId, planId);
+    if (contextBuildWatchersRef.current.has(watcherKey)) return;
+    let cancelled = false;
+    let timeoutId: number | null = null;
+    const stop = () => {
+      cancelled = true;
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+        timeoutId = null;
+      }
+      contextBuildWatchersRef.current.delete(watcherKey);
+    };
+    contextBuildWatchersRef.current.set(watcherKey, { stop });
+    if (requestBoundExecution) {
+      void executeContextBuild(projectId, planId, run);
+    } else {
+      void resumeContextBuild(projectId, planId, run);
+    }
+    let attempts = 0;
+    let consecutiveErrors = 0;
+    const poll = async () => {
+      if (cancelled || run?.cancelled || run?.controller.signal.aborted) {
+          stop();
+        return;
+      }
+      attempts += 1;
+      try {
+        const response = await fetch(
+          `${API_URL}/projects/${encodeURIComponent(projectId)}/build/plans/${encodeURIComponent(planId)}`,
+          { headers: await generationRequestHeaders(), signal: run?.controller.signal },
+        );
+        if (!response.ok) throw new Error(await readApiErrorMessage(response));
+        consecutiveErrors = 0;
+        const plan = await response.json();
+        const planStatus = typeof plan?.status === "string" ? plan.status : "";
+        const task = plan?.jobs?.[jobId];
+        const progressEvents = pipelineEventsFromWorkerTask(task);
+        let synchronizedProgress: AgentPipelineProgress | null = null;
+        if (progressEvents.length) {
+          const seedProgress = createAgentPipelineProgress(
+            defaultAgentPipelineSteps,
+            false,
+            typeof task?.started_at === "string" ? task.started_at : chatTimestamp(),
+            jobId,
+          );
+          const progressJob: A2AJob = {
+            job_id: jobId,
+            action: "forma.generate_project",
+            sender: "worker-orchestrator",
+            recipient: "forma",
+            status: "running",
+            started_at: typeof task?.started_at === "string" ? task.started_at : null,
+            progress_events: progressEvents,
+          };
+          synchronizedProgress = progressFromJobEvents(progressJob, seedProgress, false);
+          applyChatPipelineProgressFromJob(assistantMessageId, progressJob, seedProgress, false);
+          applyThreadPipelineProgressFromJob(chatId, assistantMessageId, progressJob, seedProgress, false);
+        }
+        if (planStatus === "succeeded") {
+          const projectResponse = await fetch(`${API_URL}/projects/${encodeURIComponent(projectId)}`, {
+            headers: await optionalAuthHeaders(),
+          });
+          if (!projectResponse.ok) throw new Error(await readApiErrorMessage(projectResponse));
+          const projectData = await projectResponse.json();
+          const ir = withProjectResponseMetadata(projectData.project_ir, projectData);
+          const title = ir?.overview?.title || "Project";
+          setProjectIR(ir);
+          setContextWorkflowStates((current) => ({ ...current, [chatId]: "awaiting_feedback" }));
+          rememberProjectRecord({
+            project_id: projectId,
+            chat_id: chatId,
+            title,
+            prompt: projectData.prompt || title,
+            created_at: projectData.created_at || chatTimestamp(),
+            can_chat: true,
+            creator_display: "you",
+            creator_image_url: userImageUrl,
+            parts_count: Array.isArray(ir?.components) ? ir.components.length : 0,
+            save_count: 0,
+            remix_count: 0,
+            saved: false,
+          });
+          rememberChatItem({
+            chatId,
+            title,
+            projectId,
+            createdAt: chatTimestamp(),
+            projectCount: 1,
+          });
+          const readyMessage = `${title} is ready. The first structured design revision is available for review.`;
+          updateChatMessage(assistantMessageId, {
+            content: readyMessage,
+            status: "success",
+            pipelineProgress: synchronizedProgress,
+            projectId,
+            contextProjectId: projectId,
+            workflowState: "awaiting_feedback",
+          });
+          updateThreadMessage(chatId, assistantMessageId, {
+            content: readyMessage,
+            status: "success",
+            pipelineProgress: synchronizedProgress,
+            projectId,
+            contextProjectId: projectId,
+            workflowState: "awaiting_feedback",
+          });
+          setGenerationInputNotice("Design ready for review.");
+          void fetchProjectHistory();
+          if (!authRequired || isSignedIn) void fetchMyProjectHistory();
+          stop();
+          if (run) finishGenerationRun(run);
+          return;
+        }
+        if (planStatus === "cancelled" || planStatus === "canceled") {
+          const stoppedMessage = "Build stopped by you. Your project brief is preserved.";
+          updateChatMessage(assistantMessageId, { content: stoppedMessage, status: "cancelled" });
+          updateThreadMessage(chatId, assistantMessageId, { content: stoppedMessage, status: "cancelled" });
+          setGenerationInputNotice("Build stopped. Your project brief is preserved.");
+          stop();
+          if (run) finishGenerationRun(run);
+          return;
+        }
+        if (planStatus === "partial") {
+          try {
+            const projectResponse = await fetch(`${API_URL}/projects/${encodeURIComponent(projectId)}`, {
+              headers: await optionalAuthHeaders(),
+            });
+            if (projectResponse.ok) {
+              const projectData = await projectResponse.json();
+              setProjectIR(withProjectResponseMetadata(projectData.project_ir, projectData));
+            }
+          } catch (error) {
+            console.warn("Could not load the preserved partial project.", error);
+          }
+          const failedStage = task?.result?.metadata?.generation_retry?.retry_stage;
+          const partialMessage = typeof failedStage === "string" && failedStage
+            ? `The ${failedStage.replaceAll("_", " ")} stage failed. Earlier and independent work was preserved.`
+            : "One build stage failed. Earlier and independent work was preserved.";
+          updateChatMessage(assistantMessageId, {
+            content: partialMessage,
+            status: "error",
+            pipelineProgress: synchronizedProgress,
+            projectId,
+            workflowState: "awaiting_feedback",
+          });
+          updateThreadMessage(chatId, assistantMessageId, {
+            content: partialMessage,
+            status: "error",
+            pipelineProgress: synchronizedProgress,
+            projectId,
+            workflowState: "awaiting_feedback",
+          });
+          setGenerationInputNotice("Partial design saved. Retry will resume from the failed stage.");
+          stop();
+          if (run) finishGenerationRun(run);
+          return;
+        }
+        if (planStatus === "failed") {
+          const failureMessage = typeof task?.error?.message === "string"
+            ? task.error.message
+            : "The design build stopped after an agent failure.";
+          updateChatMessage(assistantMessageId, { content: failureMessage, status: "error", workflowState: "awaiting_feedback" });
+          updateThreadMessage(chatId, assistantMessageId, { content: failureMessage, status: "error", workflowState: "awaiting_feedback" });
+          setGenerationInputNotice(failureMessage);
+          stop();
+          if (run) finishGenerationRun(run);
+          return;
+        }
+      } catch (error) {
+        if (cancelled || run?.controller.signal.aborted) {
+          stop();
+          return;
+        }
+        consecutiveErrors += 1;
+        if (consecutiveErrors % 3 === 0) {
+          if (requestBoundExecution) void executeContextBuild(projectId, planId, run);
+          else void resumeContextBuild(projectId, planId, run);
+        }
+        if (attempts >= CONTEXT_BUILD_MAX_ATTEMPTS) {
+          const timeoutPatch: Partial<Omit<ChatMessage, "id">> = {
+            content: CONTEXT_BUILD_TIMEOUT_MESSAGE,
+            status: "error",
+          };
+          updateChatMessage(assistantMessageId, timeoutPatch);
+          updateThreadMessage(chatId, assistantMessageId, timeoutPatch);
+          setGenerationInputNotice(CONTEXT_BUILD_TIMEOUT_MESSAGE);
+          stop();
+          if (run) finishGenerationRun(run);
+          return;
+        }
+      }
+      if (cancelled) return;
+      if (attempts < CONTEXT_BUILD_MAX_ATTEMPTS) {
+        timeoutId = window.setTimeout(poll, CONTEXT_BUILD_POLL_MS);
+        return;
+      }
+      const timeoutPatch: Partial<Omit<ChatMessage, "id">> = {
+        content: CONTEXT_BUILD_TIMEOUT_MESSAGE,
+        status: "error",
+      };
+      updateChatMessage(assistantMessageId, timeoutPatch);
+      updateThreadMessage(chatId, assistantMessageId, timeoutPatch);
+      setGenerationInputNotice(CONTEXT_BUILD_TIMEOUT_MESSAGE);
+      stop();
+      if (run) finishGenerationRun(run);
+    };
+    timeoutId = window.setTimeout(poll, CONTEXT_BUILD_FIRST_POLL_MS);
+  };
+
+  const resetFailedContextBuild = async (message: ChatMessage) => {
+    const projectId = message.contextProjectId;
+    const planId = message.buildPlanId;
+    const jobId = message.buildJobId;
+    const chatId = activeChatId;
+    if (!projectId || !planId || !jobId || !chatId || activeGenerationRef.current) return;
+
+    setResettingBuildMessageId(message.id);
+    setGenerationInputNotice(null);
+    try {
+      const response = await fetch(
+        `${API_URL}/projects/${encodeURIComponent(projectId)}/build/plans/${encodeURIComponent(planId)}/reset`,
+        { method: "POST", headers: await generationRequestHeaders() },
+      );
+      if (!response.ok) throw new Error(await readApiErrorMessage(response));
+
+      const resetPlan = await response.json();
+      const resetJobId = typeof resetPlan?.jobs?.[jobId]?.request?.job_id === "string"
+        ? resetPlan.jobs[jobId].request.job_id
+        : jobId;
+      const previousProgress = message.pipelineProgress;
+      const resetTask = resetPlan?.jobs?.[jobId];
+      const resetEvents = pipelineEventsFromWorkerTask(resetTask);
+      const seedProgress = createAgentPipelineProgress(
+        previousProgress?.steps || defaultAgentPipelineSteps,
+        progressIncludesImageStep(previousProgress),
+        chatTimestamp(),
+        resetJobId,
+      );
+      const progress = resetEvents.length
+        ? progressFromJobEvents({
+            job_id: resetJobId,
+            action: "forma.generate_project",
+            sender: "worker-orchestrator",
+            recipient: "forma",
+            status: "running",
+            progress_events: resetEvents,
+          }, seedProgress, false)
+        : seedProgress;
+      const patch: Partial<Omit<ChatMessage, "id">> = {
+        content: "Trying the design build again with the preserved project brief.",
+        status: "loading",
+        pipelineProgress: progress,
+        workflowState: "building",
+      };
+      updateChatMessage(message.id, patch);
+      updateThreadMessage(chatId, message.id, patch);
+      setContextWorkflowStates((current) => ({ ...current, [chatId]: "building" }));
+      setGenerationInputNotice("Job reset. The build agents are trying again.");
+
+      const run = beginContextBuildRun(projectId, planId, resetJobId, chatId, message.id);
+      watchContextBuild(
+        projectId,
+        planId,
+        resetJobId,
+        chatId,
+        message.id,
+        run,
+        message.buildRequiresRequestBoundExecution !== false,
+      );
+    } catch (error) {
+      setGenerationInputNotice(error instanceof Error ? error.message : "Could not reset the failed job.");
+    } finally {
+      setResettingBuildMessageId(null);
+    }
+  };
+
+  useEffect(() => {
+    const pending = [...chatMessages].reverse().find((message) => (
+      message.status === "loading"
+      && Boolean(message.buildPlanId)
+      && Boolean(message.buildJobId)
+      && Boolean(message.contextProjectId)
+      && !message.projectId
+    ));
+    if (!pending?.buildPlanId || !pending.buildJobId || !pending.contextProjectId || !activeChatId) return;
+    if (!pending.pipelineProgress) {
+      const progress = createAgentPipelineProgress(
+        defaultAgentPipelineSteps,
+        generateProductImage,
+        chatTimestamp(),
+        pending.buildJobId,
+      );
+      updateChatMessage(pending.id, { pipelineProgress: progress, status: "loading" });
+      updateThreadMessage(activeChatId, pending.id, { pipelineProgress: progress, status: "loading" });
+    }
+    const run = beginContextBuildRun(
+      pending.contextProjectId,
+      pending.buildPlanId,
+      pending.buildJobId,
+      activeChatId,
+      pending.id,
+    );
+    watchContextBuild(
+      pending.contextProjectId,
+      pending.buildPlanId,
+      pending.buildJobId,
+      activeChatId,
+      pending.id,
+      run,
+      pending.buildRequiresRequestBoundExecution !== false,
+    );
+    // The watcher registry makes this restart-safe without duplicating poll loops.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeChatId, chatMessageIdentityKey(chatMessages)]);
+
+  useEffect(() => () => {
+    contextBuildWatchersRef.current.forEach((watcher) => watcher.stop());
+    contextBuildWatchersRef.current.clear();
+  }, []);
+
+  const submitGatherContext = async (answer?: string) => {
+    if (contextSubmitting || activeGenerationRef.current) return;
+    if (!(await requireSignedInForGeneration())) return;
+
+    const submittedPrompt = answer ?? prompt;
+    const validation = validateGenerationInput(submittedPrompt, Boolean(selectedImage));
+    if (!validation.isValid) {
+      setGenerationInputNotice(validation.message);
+      return;
+    }
+
+    const requestChatId = activeChatId || newBuildChatId();
+    const requestProjectId = contextProjectIdsRef.current[requestChatId] || (
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(requestChatId)
+        ? requestChatId
+        : newBuildChatId()
+    );
+    contextProjectIdsRef.current[requestChatId] = requestProjectId;
+    const text = submittedPrompt.trim();
+    const imageData = selectedImage;
+    const userMessageId = newChatMessageId();
+    const assistantMessageId = newChatMessageId();
+    const userContent = text || "Shared a hardware reference image.";
+
+    setActiveChatId(requestChatId);
+    rememberChatItem({
+      chatId: requestChatId,
+      title: text || "Hardware reference",
+      projectId: "",
+      createdAt: chatTimestamp(),
+      projectCount: 0,
+    });
+    syncChatRoute(requestChatId);
+    appendChatMessage({ id: userMessageId, role: "user", content: userContent, imagePreview: imageData, status: "idle" });
+    appendThreadMessage(requestChatId, { id: userMessageId, role: "user", content: userContent, imagePreview: imageData, status: "idle" });
+    appendChatMessage({ id: assistantMessageId, role: "assistant", content: "Thinking…", status: "loading" });
+    appendThreadMessage(requestChatId, { id: assistantMessageId, role: "assistant", content: "Thinking…", status: "loading" });
+    setPrompt("");
+    setSelectedImage(null);
+    setSelectedImageSource("upload");
+    setGenerationInputNotice(null);
+    setContextSubmitting(true);
+
+    try {
+      const res = await fetch(`${API_URL}/projects/${encodeURIComponent(requestProjectId)}/context/messages`, {
+        method: "POST",
+        headers: await generationRequestHeaders(),
+        body: JSON.stringify({
+          conversation_id: requestChatId,
+          text,
+          attachments: imageData ? [{
+            attachment_id: `context-image-${userMessageId}`,
+            kind: "image",
+            name: "hardware-reference.png",
+            media_type: imageData.match(/^data:([^;,]+)/)?.[1] || "image/png",
+            data_url: imageData,
+            source: selectedImageSource,
+          }] : [],
+        }),
+      });
+      if (!res.ok) {
+        noteAuthResponseStatus(res.status);
+        throw new Error(await readApiErrorMessage(res));
+      }
+      const data = await res.json();
+      const turnKind = typeof data?.turn_kind === "string" ? data.turn_kind : "context";
+      const persistedProjectId = typeof data?.design_brief?.project_id === "string"
+        ? data.design_brief.project_id
+        : typeof data?.workflow?.project_id === "string"
+          ? data.workflow.project_id
+          : "";
+      const workflowState = typeof data?.workflow?.state === "string" ? data.workflow.state : "";
+      const buildPlanId = typeof data?.build_execution?.plan_id === "string"
+        ? data.build_execution.plan_id
+        : "";
+      const buildJobId = typeof data?.build_execution?.job_id === "string"
+        ? data.build_execution.job_id
+        : "";
+      const buildExecutionStatus = typeof data?.build_execution?.status === "string"
+        ? data.build_execution.status
+        : "";
+      const buildRequiresRequestBoundExecution = data?.build_execution?.request_bound_execution !== false;
+      const buildIsActive = buildExecutionStatus === "planned" || buildExecutionStatus === "running";
+      const buildPipelineProgress = buildPlanId
+        ? createAgentPipelineProgress(defaultAgentPipelineSteps, generateProductImage, chatTimestamp(), buildJobId || null)
+        : null;
+      if (persistedProjectId) contextProjectIdsRef.current[requestChatId] = persistedProjectId;
+      if (workflowState) {
+        setContextWorkflowStates((current) => ({ ...current, [requestChatId]: workflowState }));
+      }
+      const assistantContent = typeof data?.assistant_message === "string"
+        ? data.assistant_message
+        : "How can I help with your hardware idea?";
+      updateChatMessage(assistantMessageId, {
+        content: assistantContent,
+        status: buildIsActive ? "loading" : buildExecutionStatus === "failed" ? "error" : "success",
+        pipelineProgress: buildPipelineProgress,
+        contextProjectId: persistedProjectId || null,
+        workflowState: workflowState || null,
+        contextQuestions: Array.isArray(data?.questions) ? data.questions : [],
+        contextSuggestions: normalizeContextSuggestions(data?.suggestions),
+        buildPlanId: buildPlanId || null,
+        buildJobId: buildJobId || null,
+        buildRequiresRequestBoundExecution,
+      });
+      updateThreadMessage(requestChatId, assistantMessageId, {
+        content: assistantContent,
+        status: buildIsActive ? "loading" : buildExecutionStatus === "failed" ? "error" : "success",
+        pipelineProgress: buildPipelineProgress,
+        contextProjectId: persistedProjectId || null,
+        workflowState: workflowState || null,
+        contextQuestions: Array.isArray(data?.questions) ? data.questions : [],
+        contextSuggestions: normalizeContextSuggestions(data?.suggestions),
+        buildPlanId: buildPlanId || null,
+        buildJobId: buildJobId || null,
+        buildRequiresRequestBoundExecution,
+      });
+      setGenerationInputNotice(
+        buildPlanId
+          ? "Build started. Live agent progress is shown above."
+          : turnKind === "context"
+          ? "Project context updated."
+          : turnKind === "proceed"
+            ? "Project handed to the next agent stage."
+            : null,
+      );
+      if (buildPlanId && buildJobId && persistedProjectId) {
+        const run = beginContextBuildRun(
+          persistedProjectId,
+          buildPlanId,
+          buildJobId,
+          requestChatId,
+          assistantMessageId,
+        );
+        watchContextBuild(
+          persistedProjectId,
+          buildPlanId,
+          buildJobId,
+          requestChatId,
+          assistantMessageId,
+          run,
+          buildRequiresRequestBoundExecution,
+        );
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Could not save project context.";
+      updateChatMessage(assistantMessageId, { content: message, status: "error" });
+      updateThreadMessage(requestChatId, assistantMessageId, { content: message, status: "error" });
+      setGenerationInputNotice(message);
+    } finally {
+      setContextSubmitting(false);
+    }
+  };
+
+  const handleGatherContext = (event: React.FormEvent) => {
+    event.preventDefault();
+    void submitGatherContext();
+  };
+
+  const handleBuildNow = async () => {
+    if (contextBuildStarting || contextSubmitting || activeGenerationRef.current) return;
+    const requestChatId = activeChatId;
+    const availableMessages = requestChatId
+      ? chatThreads[requestChatId] || chatMessages
+      : chatMessages;
+    const persistedContextMessage = [...availableMessages]
+      .reverse()
+      .find((message) => Boolean(message.contextProjectId));
+    const projectId = requestChatId
+      ? contextProjectIdsRef.current[requestChatId] || persistedContextMessage?.contextProjectId || ""
+      : "";
+    if (!requestChatId || !projectId) {
+      setGenerationInputNotice("Share the initial project context before starting the build.");
+      return;
+    }
+
+    setContextBuildStarting(true);
+    setGenerationInputNotice(null);
+    try {
+      const response = await fetch(`${API_URL}/projects/${encodeURIComponent(projectId)}/context/messages`, {
+        method: "POST",
+        headers: await generationRequestHeaders(),
+        body: JSON.stringify({
+          conversation_id: requestChatId,
+          requested_tool: "build_project",
+        }),
+      });
+      if (!response.ok) {
+        noteAuthResponseStatus(response.status);
+        throw new Error(await readApiErrorMessage(response));
+      }
+      const outcome = await response.json();
+      const workflowState = typeof outcome?.workflow?.state === "string"
+        ? outcome.workflow.state
+        : "building";
+      const buildPlanId = typeof outcome?.build_execution?.plan_id === "string"
+        ? outcome.build_execution.plan_id
+        : "";
+      const buildJobId = typeof outcome?.build_execution?.job_id === "string"
+        ? outcome.build_execution.job_id
+        : "";
+      const buildStatus = typeof outcome?.build_execution?.status === "string"
+        ? outcome.build_execution.status
+        : "planned";
+      const buildRequiresRequestBoundExecution = outcome?.build_execution?.request_bound_execution !== false;
+      const buildIsActive = buildStatus === "planned" || buildStatus === "running";
+      const pipelineProgress = buildPlanId
+        ? createAgentPipelineProgress(defaultAgentPipelineSteps, generateProductImage, chatTimestamp(), buildJobId || null)
+        : null;
+      contextProjectIdsRef.current[requestChatId] = projectId;
+      setContextWorkflowStates((current) => ({ ...current, [requestChatId]: workflowState }));
+      const message: ChatMessage = {
+        id: newChatMessageId(),
+        role: "assistant",
+        content: typeof outcome?.assistant_message === "string"
+          ? outcome.assistant_message
+          : buildIsActive
+            ? "I’ve started the design build."
+            : "The first design revision is ready for review.",
+        status: buildIsActive ? "loading" : buildStatus === "failed" ? "error" : "success",
+        timestamp: chatTimestamp(),
+        contextProjectId: projectId,
+        workflowState,
+        pipelineProgress,
+        buildPlanId: buildPlanId || null,
+        buildJobId: buildJobId || null,
+        buildRequiresRequestBoundExecution,
+      };
+      appendChatMessage(message);
+      appendThreadMessage(requestChatId, message);
+      setGenerationInputNotice(
+        buildIsActive ? "Build started. Live agent progress is shown above." : "Design ready for review.",
+      );
+      if (buildPlanId && buildJobId) {
+        const run = beginContextBuildRun(projectId, buildPlanId, buildJobId, requestChatId, message.id);
+        watchContextBuild(
+          projectId,
+          buildPlanId,
+          buildJobId,
+          requestChatId,
+          message.id,
+          run,
+          buildRequiresRequestBoundExecution,
+        );
+      }
+    } catch (error) {
+      setGenerationInputNotice(error instanceof Error ? error.message : "Could not start the build.");
+    } finally {
+      setContextBuildStarting(false);
+    }
+  };
+  return {
+    contextWorkflowStates,
+    contextBuildStarting,
+    contextSubmitting,
+    resettingBuildMessageId,
+    pendingContextBuildMessage,
+    retryableContextBuildMessage,
+    submitGatherContext,
+    handleGatherContext,
+    handleBuildNow,
+    resetFailedContextBuild,
+    stopContextBuildMessage,
+    cancelContextBuild,
+    contextProjectIdsRef,
+  };
+}

--- a/apps/web/app/forma-workspace/video-panel.tsx
+++ b/apps/web/app/forma-workspace/video-panel.tsx
@@ -1,0 +1,846 @@
+"use client";
+
+import {
+  AlertTriangle,
+  CheckCircle,
+  ExternalLink,
+  Eye,
+  Film,
+  Layers,
+  Paperclip,
+  RefreshCw,
+  ShieldCheck,
+  Sparkles,
+} from "lucide-react";
+
+import CopyButton from "../../components/copy-button";
+import { isFinalVideoStatus, formatBytes } from "./admin-panels";
+import { previewableImageSrc } from "./project-gallery";
+import type { ProjectImageCandidate } from "../../lib/project-images";
+import {
+  VIDEO_PROMPT_MAX_CHARS,
+  videoIdentity,
+  videoLabel,
+  videoPromptText,
+  videoSourceUrl,
+  type StoredVideoInfo,
+} from "./use-project-video";
+import type { VideoGenerationMode, VideoModelOption } from "./use-video-models";
+
+export function videoStatusTone(status: string) {
+  const normalized = status.toLowerCase();
+  if (normalized === "succeeded" || normalized === "success") {
+    return "border-[rgb(var(--forma-green-rgb)/0.35)] bg-[rgb(var(--forma-green-rgb)/0.1)] text-[rgb(var(--forma-green-rgb))]";
+  }
+  if (normalized === "failed" || normalized === "failure" || normalized === "error") {
+    return "border-[rgb(var(--forma-red-rgb)/0.35)] bg-[rgb(var(--forma-red-rgb)/0.1)] text-[rgb(var(--forma-red-rgb))]";
+  }
+  if (normalized === "running" || normalized === "loading" || normalized === "reviewing") {
+    return "border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] text-[rgb(var(--forma-cyan-rgb))]";
+  }
+  if (normalized === "queued") {
+    return "border-[rgb(var(--forma-yellow-rgb)/0.35)] bg-[rgb(var(--forma-yellow-rgb)/0.1)] text-[rgb(var(--forma-yellow-rgb))]";
+  }
+  return "border-[var(--forma-border)] bg-[var(--forma-surface-muted)] text-[var(--forma-text-muted)]";
+}
+
+export function VideoPanel({
+  projectId,
+  readOnly,
+  models,
+  modelsLoading,
+  modelsError,
+  selectedModel,
+  setSelectedModel,
+  mode,
+  setMode,
+  imageInput,
+  setImageInput,
+  imageOptions,
+  selectedImageSources,
+  setSelectedImageSources,
+  defaultImage,
+  sourceVideoUrl,
+  setSourceVideoUrl,
+  prompt,
+  setPrompt,
+  duration,
+  setDuration,
+  aspectRatio,
+  setAspectRatio,
+  aspectRatios,
+  status,
+  statusMessage,
+  requestId,
+  storedVideo,
+  gallery,
+  galleryLoading,
+  galleryError,
+  generationAvailable,
+  generationUnavailableReason,
+  reviewStatus,
+  reviewMessage,
+  reviewAvailable,
+  reviewUnavailableReason,
+  selectedReviewVideoKey,
+  setSelectedReviewVideoKey,
+  makeNewVideo,
+  setMakeNewVideo,
+  promptGenerating,
+  promptMessage,
+  onGenerate,
+  onGeneratePrompt,
+  onReview,
+  onReviewVideo,
+  onUploadImage,
+  onUseProjectImage,
+  onRefreshGallery,
+  canGenerate,
+  canReview,
+  canMakeNewVideo,
+  canGeneratePrompt,
+}: {
+  projectId: string | null;
+  readOnly: boolean;
+  models: VideoModelOption[];
+  modelsLoading: boolean;
+  modelsError: string | null;
+  selectedModel: string;
+  setSelectedModel: (value: string) => void;
+  mode: VideoGenerationMode;
+  setMode: (value: VideoGenerationMode) => void;
+  imageInput: string;
+  setImageInput: (value: string) => void;
+  imageOptions: ProjectImageCandidate[];
+  selectedImageSources: string[];
+  setSelectedImageSources: (value: string[]) => void;
+  defaultImage: string;
+  sourceVideoUrl: string;
+  setSourceVideoUrl: (value: string) => void;
+  prompt: string;
+  setPrompt: (value: string) => void;
+  duration: string;
+  setDuration: (value: string) => void;
+  aspectRatio: string;
+  setAspectRatio: (value: string) => void;
+  aspectRatios: string[];
+  status: string;
+  statusMessage: string | null;
+  requestId: string | null;
+  storedVideo: StoredVideoInfo | null;
+  gallery: StoredVideoInfo[];
+  galleryLoading: boolean;
+  galleryError: string | null;
+  generationAvailable: boolean;
+  generationUnavailableReason: string | null;
+  reviewStatus: string;
+  reviewMessage: string | null;
+  reviewAvailable: boolean;
+  reviewUnavailableReason: string | null;
+  selectedReviewVideoKey: string | null;
+  setSelectedReviewVideoKey: (value: string | null) => void;
+  makeNewVideo: boolean;
+  setMakeNewVideo: (value: boolean) => void;
+  promptGenerating: boolean;
+  promptMessage: string | null;
+  onGenerate: () => void;
+  onGeneratePrompt: () => void;
+  onReview: () => void;
+  onReviewVideo: (video: StoredVideoInfo) => void;
+  onUploadImage: () => void;
+  onUseProjectImage: () => void;
+  onRefreshGallery: () => void;
+  canGenerate: boolean;
+  canReview: boolean;
+  canMakeNewVideo: boolean;
+  canGeneratePrompt: boolean;
+}) {
+  const modeModels = models.filter((model) => model.mode === mode);
+  const sourceVideos = gallery
+    .map((video, index) => ({
+      video,
+      url: videoSourceUrl(video),
+      label: videoLabel(video, `Video ${index + 1}`),
+    }))
+    .filter((item) => item.url);
+  const videoToVideoAvailable = sourceVideos.length > 0;
+  const selectedImagePreviewSource = selectedImageSources[0] || imageInput;
+  const imagePreview = mode === "image-to-video" ? previewableImageSrc(selectedImagePreviewSource) : null;
+  const sourceVideoPreview = mode === "video-to-video" ? sourceVideoUrl : "";
+  const isGenerating = status === "loading" || Boolean(requestId && !storedVideo && !isFinalVideoStatus(status));
+  const isReviewing = reviewStatus === "loading";
+  const generateDisabled = !canGenerate || isGenerating || !modeModels.length;
+  const reviewDisabled = !canReview || isReviewing;
+  const savedHref = readOnly ? null : storedVideo?.publicUrl || null;
+  const allProjectImagesSelected = imageOptions.length > 0 && imageOptions.every((candidate) => selectedImageSources.includes(candidate.src));
+  const toggleImageSource = (source: string) => {
+    setSelectedImageSources(
+      selectedImageSources.includes(source)
+        ? selectedImageSources.filter((item) => item !== source)
+        : [...selectedImageSources, source]
+    );
+  };
+
+  if (!generationAvailable) {
+    return (
+      <div className="h-full min-w-0 overflow-y-auto overflow-x-hidden bg-[var(--forma-page)] px-4 py-5 text-[var(--forma-text)] sm:px-5 sm:py-6">
+        <div className="mx-auto min-w-0 max-w-[890px]">
+          <section className="rounded-xl border border-[var(--forma-border)] bg-[var(--forma-surface)] p-4 sm:p-5">
+            <div className="flex flex-col gap-4 border-b border-[var(--forma-border)] pb-4 sm:flex-row sm:items-start sm:justify-between">
+              <div className="flex min-w-0 items-start gap-3">
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] text-[rgb(var(--forma-cyan-rgb))]">
+                  <Film className="h-4 w-4" />
+                </span>
+                <div className="min-w-0">
+                  <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Media</div>
+                  <h2 className="mt-1 text-sm font-semibold tracking-tight text-[var(--forma-text-strong)]">Video</h2>
+                  <div className="mt-1.5 truncate font-mono text-[10px] text-[var(--forma-text-muted)]">{projectId || "No project id"}</div>
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={onReview}
+                disabled={reviewDisabled}
+                className="inline-flex h-9 shrink-0 items-center justify-center gap-2 rounded-md border border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] px-3 text-xs font-medium text-[rgb(var(--forma-cyan-rgb))] transition-colors hover:border-[rgb(var(--forma-cyan-rgb)/0.55)] disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {isReviewing ? <RefreshCw className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
+                Review
+              </button>
+            </div>
+
+            {readOnly && (
+              <div className="mt-5 rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-3 text-xs leading-5 text-[var(--forma-text-secondary)]">
+                Read-only project. Video actions are available only to the owner.
+              </div>
+            )}
+
+            <div className="mt-5 rounded-lg border border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] p-4">
+              <div className="flex items-start gap-3">
+                <Sparkles className="mt-0.5 h-4 w-4 shrink-0 text-[rgb(var(--forma-cyan-rgb))]" />
+                <div className="min-w-0">
+                  <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-[rgb(var(--forma-cyan-rgb))]">Alpha</div>
+                  <p className="mt-2 text-sm leading-6 text-[var(--forma-text-body)]">
+                    We are in alpha and video generation is coming soon.
+                  </p>
+                  {generationUnavailableReason && (
+                    <p className="mt-2 break-words text-xs leading-5 text-[var(--forma-text-secondary)]">{generationUnavailableReason}</p>
+                  )}
+                </div>
+              </div>
+            </div>
+
+            <VideoReviewStatus
+              status={reviewStatus}
+              message={reviewMessage}
+              available={reviewAvailable}
+              unavailableReason={reviewUnavailableReason}
+              isReviewing={isReviewing}
+              makeNewVideo={makeNewVideo}
+              setMakeNewVideo={setMakeNewVideo}
+              canMakeNewVideo={canMakeNewVideo}
+            />
+
+            <VideoGallery
+              videos={gallery}
+              loading={galleryLoading}
+              error={galleryError}
+              onRefresh={onRefreshGallery}
+              selectedKey={selectedReviewVideoKey}
+              onSelect={setSelectedReviewVideoKey}
+              onReview={onReviewVideo}
+              canReview={canReview}
+              canOpenAssets={!readOnly}
+              reviewing={isReviewing}
+            />
+          </section>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full min-w-0 overflow-y-auto overflow-x-hidden bg-[var(--forma-page)] px-4 py-5 text-[var(--forma-text)] sm:px-5 sm:py-6">
+      <div className="mx-auto flex min-w-0 max-w-[890px] flex-col gap-4">
+        <section className="min-w-0 rounded-xl border border-[var(--forma-border)] bg-[var(--forma-surface)] p-4 sm:p-5">
+          <div className="mb-5 flex flex-col gap-4 border-b border-[var(--forma-border)] pb-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex min-w-0 items-start gap-3">
+              <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] text-[rgb(var(--forma-cyan-rgb))]">
+                <Film className="h-4 w-4" />
+              </span>
+              <div className="min-w-0">
+                <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Media</div>
+                <h2 className="mt-1 text-sm font-semibold tracking-tight text-[var(--forma-text-strong)]">Video</h2>
+                <div className="mt-1.5 truncate font-mono text-[10px] text-[var(--forma-text-muted)]">{projectId || "No project id"}</div>
+              </div>
+            </div>
+            <div className="flex shrink-0 flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={onReview}
+                disabled={reviewDisabled}
+                className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] px-3 text-xs font-medium text-[rgb(var(--forma-cyan-rgb))] transition-colors hover:border-[rgb(var(--forma-cyan-rgb)/0.55)] disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {isReviewing ? <RefreshCw className="h-4 w-4 animate-spin" /> : <ShieldCheck className="h-4 w-4" />}
+                Review
+              </button>
+              <button
+                type="button"
+                onClick={onGenerate}
+                disabled={generateDisabled}
+                className="inline-flex h-9 items-center justify-center gap-2 rounded-md border border-[var(--forma-text-strong)] bg-[var(--forma-text-strong)] px-3 text-xs font-medium text-[var(--forma-page)] transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                {isGenerating ? <RefreshCw className="h-4 w-4 animate-spin" /> : <Film className="h-4 w-4" />}
+                Generate
+              </button>
+            </div>
+          </div>
+
+          {readOnly && (
+            <div className="mb-5 rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-3 text-xs leading-5 text-[var(--forma-text-secondary)]">
+              Read-only project. Video actions are available only to the owner.
+            </div>
+          )}
+
+          <div className="mb-4 grid grid-cols-2 overflow-hidden rounded-lg border border-[var(--forma-border)]">
+            {([
+              { value: "image-to-video" as VideoGenerationMode, label: "Image" },
+              { value: "video-to-video" as VideoGenerationMode, label: "Video", disabled: !videoToVideoAvailable },
+            ]).map((item) => (
+              <button
+                key={item.value}
+                type="button"
+                onClick={() => {
+                  if (!item.disabled) setMode(item.value);
+                }}
+                disabled={item.disabled}
+                className={`flex h-10 items-center justify-center gap-2 border-r border-[var(--forma-border)] text-xs font-medium last:border-r-0 ${
+                  mode === item.value
+                    ? "bg-[var(--forma-surface)] text-[var(--forma-text-strong)]"
+                    : "bg-[var(--forma-surface-muted)] text-[var(--forma-text-muted)] hover:text-[var(--forma-text-strong)]"
+                } disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:text-[var(--forma-text-muted)]`}
+              >
+                {item.value === "video-to-video" ? <Film className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                {item.label}
+              </button>
+            ))}
+          </div>
+
+          <div className="grid gap-4 2xl:grid-cols-[minmax(0,1fr)_170px_180px]">
+            <label className="block text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">
+              Model
+              <select
+                value={selectedModel}
+                onChange={(event) => setSelectedModel(event.target.value)}
+                disabled={modelsLoading || !modeModels.length}
+                className="mt-2 h-10 w-full rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] px-3 text-sm font-normal tracking-normal text-[var(--forma-text-body)] outline-none focus:border-[rgb(var(--forma-cyan-rgb))] disabled:opacity-50"
+              >
+                {!modeModels.length && <option value="">No models</option>}
+                {modeModels.map((model) => (
+                  <option key={model.id} value={model.id}>
+                    {model.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="block text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">
+              Aspect ratio
+              <select
+                value={aspectRatio}
+                onChange={(event) => setAspectRatio(event.target.value)}
+                className="mt-2 h-10 w-full rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] px-3 text-sm font-normal tracking-normal text-[var(--forma-text-body)] outline-none focus:border-[rgb(var(--forma-cyan-rgb))]"
+              >
+                {aspectRatios.map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <div>
+              <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Duration</div>
+              <div className="mt-2 grid grid-cols-2 overflow-hidden rounded-lg border border-[var(--forma-border)]">
+                {["5", "10"].map((value) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setDuration(value)}
+                    className={`h-10 border-r border-[var(--forma-border)] text-xs font-medium last:border-r-0 ${
+                      duration === value
+                        ? "bg-[var(--forma-surface)] text-[var(--forma-text-strong)]"
+                        : "bg-[var(--forma-surface-muted)] text-[var(--forma-text-muted)] hover:text-[var(--forma-text-strong)]"
+                    }`}
+                  >
+                    {value}s
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-5">
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <label htmlFor="video-prompt" className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">
+                Prompt
+              </label>
+              <button
+                type="button"
+                onClick={onGeneratePrompt}
+                disabled={!canGeneratePrompt}
+                className="inline-flex h-9 items-center gap-2 rounded-md border border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] px-3 text-[11px] font-medium text-[rgb(var(--forma-cyan-rgb))] transition-colors hover:border-[rgb(var(--forma-cyan-rgb)/0.55)] disabled:cursor-not-allowed disabled:opacity-40"
+                title="Generate an image-to-video prompt from project namespaces"
+              >
+                {promptGenerating ? <RefreshCw className="h-3.5 w-3.5 animate-spin" /> : <Sparkles className="h-3.5 w-3.5" />}
+                Generate prompt
+              </button>
+            </div>
+            <textarea
+              id="video-prompt"
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              maxLength={VIDEO_PROMPT_MAX_CHARS}
+              placeholder="Slow orbit, reveal ports, show display glow."
+              className="mt-2 min-h-[132px] w-full resize-none rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] px-3 py-3 text-sm font-normal leading-6 tracking-normal text-[var(--forma-text-body)] outline-none placeholder:text-[var(--forma-text-muted)] focus:border-[rgb(var(--forma-cyan-rgb))]"
+            />
+            <div className="mt-2 flex flex-wrap items-center justify-between gap-2">
+              {promptMessage ? (
+                <p className="break-words text-[11px] leading-5 text-[var(--forma-text-secondary)]">{promptMessage}</p>
+              ) : (
+                <span />
+              )}
+              <span className={`font-mono text-[10px] ${prompt.length > VIDEO_PROMPT_MAX_CHARS - 120 ? "text-[rgb(var(--forma-yellow-rgb))]" : "text-[var(--forma-text-muted)]"}`}>
+                {prompt.length}/{VIDEO_PROMPT_MAX_CHARS}
+              </span>
+            </div>
+          </div>
+
+          {mode === "image-to-video" ? (
+            <div className="mt-5 rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-3">
+              <div className="mb-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Image source</div>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={onUploadImage}
+                    className="inline-flex h-9 items-center gap-2 rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] px-3 text-xs font-medium text-[var(--forma-text-body)] transition-colors hover:bg-[var(--forma-page)] hover:text-[var(--forma-text-strong)]"
+                  >
+                    <Paperclip className="h-4 w-4" />
+                    Upload
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setSelectedImageSources(allProjectImagesSelected ? [] : imageOptions.map((candidate) => candidate.src))}
+                    disabled={!imageOptions.length}
+                    className="inline-flex h-9 items-center gap-2 rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] px-3 text-xs font-medium text-[var(--forma-text-body)] transition-colors hover:bg-[var(--forma-page)] hover:text-[var(--forma-text-strong)] disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    <Layers className="h-4 w-4" />
+                    {allProjectImagesSelected ? "Clear" : "All"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onUseProjectImage}
+                    disabled={!defaultImage}
+                    className="inline-flex h-9 items-center gap-2 rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] px-3 text-xs font-medium text-[var(--forma-text-body)] transition-colors hover:bg-[var(--forma-page)] hover:text-[var(--forma-text-strong)] disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    <Eye className="h-4 w-4" />
+                    First
+                  </button>
+                </div>
+              </div>
+
+              {imageOptions.length > 0 && (
+                <div className="mb-3 grid gap-2 sm:grid-cols-3">
+                  {imageOptions.map((candidate) => {
+                    const selected = selectedImageSources.includes(candidate.src);
+                    return (
+                      <button
+                        key={candidate.src}
+                        type="button"
+                        onClick={() => toggleImageSource(candidate.src)}
+                        className={`min-w-0 rounded-lg border p-2 text-left transition ${
+                          selected
+                            ? "border-[rgb(var(--forma-cyan-rgb)/0.55)] bg-[var(--forma-surface)] text-[rgb(var(--forma-cyan-rgb))]"
+                            : "border-[var(--forma-border)] bg-[var(--forma-surface)] text-[var(--forma-text-muted)] hover:border-[var(--forma-text-muted)] hover:text-[var(--forma-text-strong)]"
+                        }`}
+                        aria-pressed={selected}
+                      >
+                        <div className="relative h-20 overflow-hidden rounded-md bg-[var(--forma-surface-muted)]">
+                          <img src={candidate.src} alt={candidate.label} className="h-full w-full object-cover" />
+                          <span className={`absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-md border text-[10px] font-medium ${
+                            selected
+                              ? "border-[rgb(var(--forma-cyan-rgb))] bg-[rgb(var(--forma-cyan-rgb))] text-[var(--forma-page)]"
+                              : "border-[var(--forma-border)] bg-[rgb(var(--forma-chrome-rgb)/0.8)] text-[var(--forma-text-strong)]"
+                          }`}>
+                            {selected ? <CheckCircle className="h-3.5 w-3.5" /> : null}
+                          </span>
+                        </div>
+                        <div className="mt-2 truncate text-[10px] font-medium">{candidate.label}</div>
+                      </button>
+                    );
+                  })}
+                </div>
+              )}
+
+              <input
+                value={imageInput}
+                onChange={(event) => {
+                  setImageInput(event.target.value);
+                  setSelectedImageSources([]);
+                }}
+                placeholder="https://... or data:image/..."
+                className="h-10 w-full rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] px-3 font-mono text-xs text-[var(--forma-text-body)] outline-none placeholder:text-[var(--forma-text-muted)] focus:border-[rgb(var(--forma-cyan-rgb))]"
+              />
+              <div className="mt-2 text-[11px] leading-5 text-[var(--forma-text-secondary)]">
+                {selectedImageSources.length
+                  ? `${selectedImageSources.length} project image${selectedImageSources.length === 1 ? "" : "s"} selected.`
+                  : "No project images selected; the manual image field will be used."}
+              </div>
+            </div>
+          ) : (
+            <label className="mt-5 block text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">
+              Source video
+              <select
+                value={sourceVideoUrl}
+                onChange={(event) => setSourceVideoUrl(event.target.value)}
+                disabled={!sourceVideos.length}
+                className="mt-2 h-10 w-full rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] px-3 text-sm font-normal tracking-normal text-[var(--forma-text-body)] outline-none focus:border-[rgb(var(--forma-cyan-rgb))] disabled:opacity-50"
+              >
+                {!sourceVideos.length && <option value="">No saved videos</option>}
+                {sourceVideos.map((item) => (
+                  <option key={item.url} value={item.url}>
+                    {item.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          )}
+
+          <VideoGallery
+            videos={gallery}
+            loading={galleryLoading}
+            error={galleryError}
+            onRefresh={onRefreshGallery}
+            selectedKey={selectedReviewVideoKey}
+            onSelect={setSelectedReviewVideoKey}
+            onReview={onReviewVideo}
+            canReview={canReview}
+            canOpenAssets={!readOnly}
+            reviewing={isReviewing}
+          />
+        </section>
+
+        <aside className="min-w-0 rounded-xl border border-[var(--forma-border)] bg-[var(--forma-surface)] p-4 sm:p-5">
+          <div className="aspect-video overflow-hidden rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)]">
+            {mode === "video-to-video" && sourceVideoPreview ? (
+              <video src={sourceVideoPreview} controls preload="metadata" className="h-full w-full object-contain" />
+            ) : imagePreview ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={imagePreview} alt="Video source preview" className="h-full w-full object-contain" />
+            ) : (
+              <div className="flex h-full items-center justify-center text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">
+                No source
+              </div>
+            )}
+          </div>
+          {mode === "image-to-video" && selectedImageSources.length > 0 && (
+            <div className="mt-2 rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] px-3 py-2 text-[11px] leading-5 text-[var(--forma-text-secondary)]">
+              Previewing the first selected image. Generate will queue {selectedImageSources.length} image source{selectedImageSources.length === 1 ? "" : "s"}.
+            </div>
+          )}
+
+          <div className="mt-4 rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-4">
+            <div className="flex items-center justify-between gap-3">
+              <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Status</span>
+              <span className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[11px] font-medium uppercase tracking-[0.12em] ${videoStatusTone(status)}`}>
+                {status === "failed" ? <AlertTriangle className="h-3.5 w-3.5" /> : status === "succeeded" ? <CheckCircle className="h-3.5 w-3.5" /> : <RefreshCw className={`h-3.5 w-3.5 ${isGenerating ? "animate-spin" : ""}`} />}
+                {status}
+              </span>
+            </div>
+            {requestId && <div className="mt-3 truncate font-mono text-[10px] text-[var(--forma-text-muted)]">{requestId}</div>}
+            {statusMessage && <p className="mt-3 break-words text-xs leading-5 text-[var(--forma-text-secondary)]">{statusMessage}</p>}
+            {modelsError && <p className="mt-3 break-words text-xs leading-5 text-[rgb(var(--forma-yellow-rgb))]">{modelsError}</p>}
+          </div>
+
+          <VideoReviewStatus
+            status={reviewStatus}
+            message={reviewMessage}
+            available={reviewAvailable}
+            unavailableReason={reviewUnavailableReason}
+            isReviewing={isReviewing}
+            makeNewVideo={makeNewVideo}
+            setMakeNewVideo={setMakeNewVideo}
+            canMakeNewVideo={canMakeNewVideo}
+          />
+
+          {storedVideo && (
+            <div className="mt-4 rounded-lg border border-[rgb(var(--forma-green-rgb)/0.35)] bg-[rgb(var(--forma-green-rgb)/0.1)] p-4">
+              <div className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.14em] text-[rgb(var(--forma-green-rgb))]">
+                <CheckCircle className="h-4 w-4" />
+                Saved
+              </div>
+              {savedHref ? (
+                <a
+                  href={savedHref}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="mt-3 inline-flex max-w-full items-center gap-2 rounded-md border border-[rgb(var(--forma-green-rgb)/0.4)] px-3 py-2 text-xs font-medium text-[rgb(var(--forma-green-rgb))] transition-colors hover:border-[rgb(var(--forma-green-rgb)/0.6)]"
+                >
+                  <ExternalLink className="h-4 w-4 shrink-0" />
+                  Open saved video
+                </a>
+              ) : (
+                <div className="mt-3 break-all font-mono text-xs leading-5 text-[var(--forma-text-body)]">{storedVideo.s3Uri || storedVideo.key}</div>
+              )}
+              {storedVideo.key && <div className="mt-3 break-all font-mono text-[10px] leading-5 text-[var(--forma-text-muted)]">{storedVideo.key}</div>}
+            </div>
+          )}
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+export function VideoReviewStatus({
+  status,
+  message,
+  available,
+  unavailableReason,
+  isReviewing,
+  makeNewVideo,
+  setMakeNewVideo,
+  canMakeNewVideo,
+}: {
+  status: string;
+  message: string | null;
+  available: boolean;
+  unavailableReason: string | null;
+  isReviewing: boolean;
+  makeNewVideo: boolean;
+  setMakeNewVideo: (value: boolean) => void;
+  canMakeNewVideo: boolean;
+}) {
+  return (
+    <div className="mt-4 rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-4">
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Review</span>
+        <span className={`inline-flex items-center gap-1.5 rounded-md border px-2 py-1 text-[11px] font-medium uppercase tracking-[0.12em] ${videoStatusTone(status)}`}>
+          {status === "failed" ? (
+            <AlertTriangle className="h-3.5 w-3.5" />
+          ) : status === "succeeded" ? (
+            <CheckCircle className="h-3.5 w-3.5" />
+          ) : isReviewing ? (
+            <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+          ) : (
+            <ShieldCheck className="h-3.5 w-3.5" />
+          )}
+          {status}
+        </span>
+      </div>
+      <label className={`mt-3 flex min-h-10 items-center gap-3 rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] px-3 py-2 text-xs font-medium ${
+        canMakeNewVideo ? "text-[var(--forma-text-body)]" : "text-[var(--forma-text-muted)]"
+      }`}>
+        <input
+          type="checkbox"
+          checked={makeNewVideo}
+          onChange={(event) => setMakeNewVideo(event.target.checked)}
+          disabled={!canMakeNewVideo || isReviewing}
+          className="h-4 w-4 accent-[rgb(var(--forma-cyan-rgb))] disabled:cursor-not-allowed"
+        />
+        <span>Make new video</span>
+      </label>
+      {message && <p className="mt-3 break-words text-xs leading-5 text-[var(--forma-text-secondary)]">{message}</p>}
+      {!available && unavailableReason && <p className="mt-3 break-words text-xs leading-5 text-[rgb(var(--forma-yellow-rgb))]">{unavailableReason}</p>}
+    </div>
+  );
+}
+
+export function VideoGallery({
+  videos,
+  loading,
+  error,
+  onRefresh,
+  selectedKey,
+  onSelect,
+  onReview,
+  canReview,
+  canOpenAssets,
+  reviewing,
+}: {
+  videos: StoredVideoInfo[];
+  loading: boolean;
+  error: string | null;
+  onRefresh: () => void;
+  selectedKey: string | null;
+  onSelect: (value: string | null) => void;
+  onReview: (video: StoredVideoInfo) => void;
+  canReview: boolean;
+  canOpenAssets: boolean;
+  reviewing: boolean;
+}) {
+  return (
+    <div className="mt-5 rounded-lg border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-3">
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Film className="h-4 w-4 text-[rgb(var(--forma-cyan-rgb))]" />
+          <div className="text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Gallery</div>
+        </div>
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={!canOpenAssets}
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] text-[var(--forma-text-muted)] transition-colors hover:bg-[var(--forma-page)] hover:text-[var(--forma-text-strong)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-[var(--forma-surface)] disabled:hover:text-[var(--forma-text-muted)]"
+          title={canOpenAssets ? "Refresh gallery" : "Videos are available only on projects you generated."}
+          aria-label="Refresh gallery"
+        >
+          <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-3 break-words rounded-md border border-[rgb(var(--forma-yellow-rgb)/0.35)] bg-[rgb(var(--forma-yellow-rgb)/0.1)] p-3 text-xs leading-5 text-[rgb(var(--forma-yellow-rgb))]">
+          {error}
+        </div>
+      )}
+
+      {loading && !videos.length ? (
+        <div className="rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] p-4 text-xs leading-5 text-[var(--forma-text-secondary)]">
+          Loading gallery…
+        </div>
+      ) : videos.length ? (
+        <div className="grid gap-3 md:grid-cols-2">
+          {videos.map((video, index) => {
+            const key = videoIdentity(video, `video-${index}`);
+            const reviewable = Boolean(videoSourceUrl(video));
+            return (
+              <VideoGalleryItem
+                key={key}
+                video={video}
+                identity={key}
+                selected={selectedKey === key}
+                onSelect={() => onSelect(key)}
+                onReview={() => onReview(video)}
+                canReview={canReview && reviewable}
+                canOpenAssets={canOpenAssets}
+                reviewing={reviewable && reviewing && selectedKey === key}
+                reviewable={reviewable}
+              />
+            );
+          })}
+        </div>
+      ) : (
+        <div className="rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface)] p-4 text-xs leading-5 text-[var(--forma-text-secondary)]">
+          No videos yet.
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function VideoGalleryItem({
+  video,
+  identity,
+  selected,
+  onSelect,
+  onReview,
+  canReview,
+  canOpenAssets,
+  reviewing,
+  reviewable,
+}: {
+  video: StoredVideoInfo;
+  identity: string;
+  selected: boolean;
+  onSelect: () => void;
+  onReview: () => void;
+  canReview: boolean;
+  canOpenAssets: boolean;
+  reviewing: boolean;
+  reviewable: boolean;
+}) {
+  const playableUrl = canOpenAssets ? videoSourceUrl(video) || null : null;
+  const openUrl = canOpenAssets ? playableUrl || null : null;
+  const label = videoLabel(video);
+  const prompt = videoPromptText(video);
+
+  return (
+    <article className={`min-w-0 overflow-hidden rounded-lg border bg-[var(--forma-surface)] transition ${
+      selected
+        ? "border-[rgb(var(--forma-cyan-rgb)/0.55)]"
+        : "border-[var(--forma-border)]"
+    }`}>
+      <div className="aspect-video bg-[var(--forma-surface-muted)]">
+        {playableUrl ? (
+          <video src={playableUrl} controls preload="metadata" className="h-full w-full object-contain" />
+        ) : (
+          <div className="flex h-full items-center justify-center px-3 text-center text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">
+            Video saved
+          </div>
+        )}
+      </div>
+      <div className="border-t border-[var(--forma-border)] p-3">
+        <div className="flex min-w-0 items-start justify-between gap-2">
+          <div className="min-w-0">
+            <div className="truncate font-mono text-[11px] text-[var(--forma-text-secondary)]">{label}</div>
+            <div className="mt-1 truncate font-mono text-[10px] text-[var(--forma-text-muted)]">{identity}</div>
+          </div>
+          <span className={`shrink-0 rounded-md border px-2 py-1 text-[10px] font-medium uppercase tracking-[0.12em] ${
+            selected
+              ? "border-[rgb(var(--forma-cyan-rgb)/0.45)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] text-[rgb(var(--forma-cyan-rgb))]"
+              : "border-[var(--forma-border)] text-[var(--forma-text-muted)]"
+          }`}>
+            {selected ? "Selected" : reviewable ? "Reviewable" : "No URL"}
+          </span>
+        </div>
+        <div className="mt-3 rounded-md border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-3">
+          <div className="text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">Prompt</div>
+          <p className="mt-2 max-h-28 overflow-y-auto break-words text-xs leading-5 text-[var(--forma-text-secondary)]">
+            {prompt || "No prompt saved for this video."}
+          </p>
+        </div>
+        {video.key && <div className="mt-2 break-all font-mono text-[10px] leading-4 text-[var(--forma-text-muted)]">{video.key}</div>}
+        <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
+          <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">{formatBytes(video.sizeBytes || 0)}</span>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={onSelect}
+              disabled={!reviewable || !canOpenAssets}
+              className="inline-flex h-8 items-center gap-1.5 rounded-md border border-[var(--forma-border)] px-2 text-[10px] font-medium text-[var(--forma-text-body)] transition-colors hover:bg-[var(--forma-surface-muted)] hover:text-[var(--forma-text-strong)] disabled:cursor-not-allowed disabled:opacity-40"
+              title={canOpenAssets ? (reviewable ? "Select video for review" : "This saved video needs an HTTP(S) URL before review") : "Videos are available only on projects you generated."}
+            >
+              {selected ? <CheckCircle className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+              Select
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                onSelect();
+                onReview();
+              }}
+              disabled={!canReview || reviewing}
+              className="inline-flex h-8 items-center gap-1.5 rounded-md border border-[rgb(var(--forma-cyan-rgb)/0.35)] bg-[rgb(var(--forma-cyan-rgb)/0.1)] px-2 text-[10px] font-medium text-[rgb(var(--forma-cyan-rgb))] transition-colors hover:border-[rgb(var(--forma-cyan-rgb)/0.55)] disabled:cursor-not-allowed disabled:opacity-40"
+              title={reviewable ? "Review selected video" : "This saved video needs an HTTP(S) URL before review"}
+            >
+              {reviewing ? <RefreshCw className="h-3.5 w-3.5 animate-spin" /> : <ShieldCheck className="h-3.5 w-3.5" />}
+              Review
+            </button>
+            {openUrl ? (
+              <a
+                href={openUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex h-8 items-center gap-1.5 rounded-md border border-[var(--forma-border)] px-2 text-[10px] font-medium text-[var(--forma-text-body)] transition-colors hover:bg-[var(--forma-surface-muted)] hover:text-[var(--forma-text-strong)]"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+                Open
+              </a>
+            ) : (
+              <span className="truncate font-mono text-[10px] text-[var(--forma-text-muted)]">{video.s3Uri || "-"}</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/apps/web/app/forma-workspace/workspace-api.ts
+++ b/apps/web/app/forma-workspace/workspace-api.ts
@@ -1,0 +1,22 @@
+import { webConfig } from "../../lib/config";
+
+export function normalizeApiUrl(value: string) {
+  const trimmed = value.trim().replace(/\/+$/, "");
+  if (!trimmed) return "/api";
+  return trimmed.endsWith("/api") ? trimmed : `${trimmed}/api`;
+}
+
+export const API_URL = normalizeApiUrl(webConfig.apiBaseUrl);
+export const DEFAULT_SHOW_DEVELOPER_TOOLS = webConfig.publicDeveloperTools;
+
+export function downloadBrowserFile(contents: string, filename: string, mimeType: string) {
+  const blob = new Blob([contents], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}

--- a/apps/web/app/forma-workspace/workspace-constants.ts
+++ b/apps/web/app/forma-workspace/workspace-constants.ts
@@ -1,0 +1,158 @@
+import { WORKSPACE_STATUS_STALE_AFTER_MS } from "../../lib/connection-status";
+import type { AgentPipelineStep, GenerationWorkflowOption } from "./types";
+
+export const DEFAULT_WORKFLOW_ID = "default";
+export const WEB_RESEARCH_WORKFLOW_ID = "web_research";
+export const JOB_POLL_INTERVAL_MS = 5000;
+export const ACTIVE_JOB_PROGRESS_POLL_INTERVAL_MS = 1200;
+export const PIPELINE_UI_HEARTBEAT_MS = 5000;
+export const PIPELINE_STALE_AFTER_MS = WORKSPACE_STATUS_STALE_AFTER_MS;
+export const RECOVERY_JOB_BATCH_SIZE = 3;
+export const RECOVERY_JOB_MAX_BACKOFF_MS = 60000;
+export const LOG_POLL_INTERVAL_MS = 5000;
+export const CHAT_THREAD_STORAGE_PREFIX = "forma.chat.";
+export const CHAT_INDEX_STORAGE_KEY = "forma.chatIndex";
+export const PINNED_CHATS_STORAGE_KEY = "forma.pinnedChats";
+export const LEGACY_PROJECT_CHAT_STORAGE_PREFIX = "forma.projectChat.";
+export const MAX_PROJECT_CHAT_MESSAGES = 80;
+export const MAX_CHAT_INDEX_ITEMS = 200;
+export const INITIAL_CHAT_TIMESTAMP = "2000-01-01T00:00:00.000Z";
+export const NEW_PROJECT_TITLE = "New project";
+export const CHAT_DIAGNOSTIC_CHARACTER_LIMIT = 420;
+
+export const defaultGenerationWorkflows: GenerationWorkflowOption[] = [
+  { id: DEFAULT_WORKFLOW_ID, label: "Catalog", description: "Catalog workflow", uses_catalog: true },
+  { id: WEB_RESEARCH_WORKFLOW_ID, label: "Web Research", description: "Live web research workflow", uses_web_research: true, uses_firecrawl_mcp: true, uses_external_sources: true },
+];
+
+export const RUNPOD_PARTI_BASE_MODEL = "caid-technologies/parti-base";
+export const BASETEN_GLM_MODEL = "zai-org/GLM-5.2";
+export const BASETEN_DEEPSEEK_MODEL = "deepseek-ai/DeepSeek-V4-Pro";
+export const ANTHROPIC_OPUS_MODEL = "claude-opus-5";
+export const ANTHROPIC_SONNET_MODEL = "claude-sonnet-5";
+export const GEMINI_FLASH_MODEL = "gemini-3.7-flash";
+export const CLOUDFLARE_GEMMA_MODEL = "@cf/google/gemma-4-26b-a4b-it";
+export const NVIDIA_GLM_MODEL = "nvidia/z-ai/glm-5.2";
+export const NVIDIA_QWEN_CODER_32B_MODEL = "qwen/qwen2.5-coder-32b-instruct";
+export const NVIDIA_LLAMA_8B_MODEL = "meta/llama-3.1-8b-instruct";
+
+export const defaultAgentPipelineSteps: AgentPipelineStep[] = [
+  {
+    id: "safety_guardrail",
+    agent: "Safety Guardrail",
+    label: "Checking safe build scope",
+    description: "Screening the request for low-voltage maker hardware constraints.",
+    duration_ms: 3500,
+  },
+  {
+    id: "context_clarifier",
+    agent: "Context Clarifier Agent",
+    label: "Clarifying build context",
+    description: "Checking whether user-provided answers should be folded into generation.",
+    duration_ms: 2500,
+  },
+  {
+    id: "intent_parser",
+    agent: "Intent Parser Agent",
+    label: "Parsing the hardware idea",
+    description: "Converting the prompt into project intent and category.",
+    duration_ms: 5500,
+  },
+  {
+    id: "requirements",
+    agent: "Requirements Agent",
+    label: "Extracting requirements",
+    description: "Capturing functions, voltage, constraints, and safety notes.",
+    duration_ms: 5500,
+  },
+  {
+    id: "system_architecture",
+    agent: "System Architecture Agent",
+    label: "Decomposing the complete system",
+    description: "Building a purpose-driven tree of electrical, mechanical, firmware, and nested subsystems.",
+    duration_ms: 5500,
+  },
+  {
+    id: "component_selection",
+    agent: "Component Selection Agent",
+    label: "Selecting compatible parts",
+    description: "Choosing parts by system role before exact catalog pins are hydrated.",
+    duration_ms: 6500,
+  },
+  {
+    id: "wiring_netlist",
+    agent: "Wiring/Netlist Agent",
+    label: "Drafting nets and pin mappings",
+    description: "Connecting power, ground, buses, controller pins, and peripherals.",
+    duration_ms: 6500,
+  },
+  {
+    id: "validation_repair",
+    agent: "Validation + Auto-Correction Agent",
+    label: "Validating and repairing wiring",
+    description: "Checking shorts, voltage mismatches, unpowered parts, and pin conflicts.",
+    duration_ms: 5500,
+  },
+  {
+    id: "bom",
+    agent: "BOM Agent",
+    label: "Calculating BOM and cost",
+    description: "Summing selected components and updating the project estimate.",
+    duration_ms: 3000,
+  },
+  {
+    id: "mechanical_fabrication",
+    agent: "Mechanical/Fabrication Agent",
+    label: "Designing enclosure and placement",
+    description: "Generating mounting, fabrication, CAD, and 3D placement details.",
+    duration_ms: 6500,
+  },
+  {
+    id: "assembly",
+    agent: "Assembly Instruction Agent",
+    label: "Writing build steps",
+    description: "Producing sequential assembly instructions and safety flags.",
+    duration_ms: 5500,
+  },
+  {
+    id: "package_project",
+    agent: "Project Packager",
+    label: "Packaging project artifacts",
+    description: "Building the HardwareIR, diagrams, validation summary, and saved record.",
+    duration_ms: 3500,
+  },
+];
+
+export const optionalImagePipelineStep: AgentPipelineStep = {
+  id: "image_generation",
+  agent: "Product Image Agent",
+  label: "Generating product visuals",
+  description: "Creating optional concept images from the completed HardwareIR visual spec.",
+  duration_ms: 8000,
+  optional: true,
+};
+
+export const samplePrompts = [
+  "Compact handheld device with display, controls, USB-C power, and enclosure",
+  "Environmental monitor with sensor feedback, display, and battery power",
+  "Small controller for a low-voltage actuator or relay",
+];
+
+export function generationLlmLabel(provider: string, model: string) {
+  if (provider === "runpod-serverless" && model === RUNPOD_PARTI_BASE_MODEL) return RUNPOD_PARTI_BASE_MODEL;
+  if (provider === "runpod" && model === RUNPOD_PARTI_BASE_MODEL) return "Runpod Parti Base";
+  if (provider === "baseten" && model === BASETEN_GLM_MODEL) return "GLM 5.2";
+  if (provider === "baseten" && model === BASETEN_DEEPSEEK_MODEL) return "Baseten DeepSeek V4 Pro";
+  if (provider === "anthropic" && model === ANTHROPIC_OPUS_MODEL) return "Claude Opus 5";
+  if (provider === "anthropic" && model === ANTHROPIC_SONNET_MODEL) return "Claude Sonnet 5";
+  if (provider === "gemini" && model === GEMINI_FLASH_MODEL) return "Gemini 3.7 Flash";
+  if (provider === "vertex" && model === GEMINI_FLASH_MODEL) return "Vertex Gemini 3.7 Flash";
+  if (provider === "huggingface") return `Hugging Face ${model}`;
+  if (provider === "gmi" && model === "anthropic/claude-fable-5") return "GMI Claude Fable 5";
+  if (provider === "cloudflare" && model === CLOUDFLARE_GEMMA_MODEL) return "Cloudflare Gemma 4 26B A4B";
+  if (provider === "nvidia" && model === NVIDIA_GLM_MODEL) return "NVIDIA GLM 5.2";
+  if (provider === "nvidia" && model === NVIDIA_QWEN_CODER_32B_MODEL) return "NVIDIA Qwen2.5 Coder 32B";
+  if (provider === "nvidia" && model === NVIDIA_LLAMA_8B_MODEL) return "NVIDIA Llama 3.1 8B";
+  if (provider === "simulation") return "Local Simulation";
+  return `${provider} ${model}`.trim();
+}

--- a/apps/web/app/forma-workspace/workspace-sidebar-shell.tsx
+++ b/apps/web/app/forma-workspace/workspace-sidebar-shell.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import type { ReactNode } from "react";
+
+import type { WorkspaceStatusPresentation } from "../../lib/connection-status";
+import { ChatSidebar, MobileSidebarDrawer, type ChatListItem } from "./sidebar";
+import WorkspaceFrame from "./workspace-frame";
+
+export type WorkspaceSidebarShellProps = {
+  collapsed: boolean;
+  mobileSidebarOpen: boolean;
+  onMobileSidebarClose: () => void;
+  onToggleCollapsed: () => void;
+  onHome: () => void;
+  chats: ChatListItem[];
+  activeChatId: string | null;
+  onNewChat: () => void;
+  newChatDisabled: boolean;
+  onOpenChat: (item: ChatListItem) => void;
+  onRenameChat?: (item: ChatListItem, title: string) => void;
+  onPinChat?: (item: ChatListItem) => void;
+  onDeleteChat?: (item: ChatListItem) => void;
+  waitingChatIds: Set<string>;
+  chatsLoading?: boolean;
+  showJobs: boolean;
+  jobsPending?: boolean;
+  showDeveloperTools: boolean;
+  authRequired: boolean;
+  workspaceStatus: WorkspaceStatusPresentation;
+  homeMobileTopPadding?: boolean;
+  children: ReactNode;
+};
+
+export function WorkspaceSidebarShell({
+  collapsed,
+  mobileSidebarOpen,
+  onMobileSidebarClose,
+  onToggleCollapsed,
+  onHome,
+  chats,
+  activeChatId,
+  onNewChat,
+  newChatDisabled,
+  onOpenChat,
+  onRenameChat,
+  onPinChat,
+  onDeleteChat,
+  waitingChatIds,
+  chatsLoading,
+  showJobs,
+  jobsPending,
+  showDeveloperTools,
+  authRequired,
+  workspaceStatus,
+  homeMobileTopPadding = false,
+  children,
+}: WorkspaceSidebarShellProps) {
+  const shared = {
+    collapsed,
+    onToggle: onToggleCollapsed,
+    onHome,
+    chats,
+    activeChatId,
+    onNewChat,
+    newChatDisabled,
+    onOpenChat,
+    onRenameChat,
+    onPinChat,
+    onDeleteChat,
+    waitingChatIds,
+    chatsLoading,
+    showJobs,
+    jobsPending,
+    showDeveloperTools,
+    authRequired,
+  };
+
+  return (
+    <WorkspaceFrame
+      collapsed={collapsed}
+      workspaceStatus={workspaceStatus}
+      homeMobileTopPadding={homeMobileTopPadding}
+      mobileSidebar={(
+        <MobileSidebarDrawer
+          open={mobileSidebarOpen}
+          onClose={onMobileSidebarClose}
+          {...shared}
+        />
+      )}
+      desktopSidebar={<ChatSidebar {...shared} />}
+    >
+      {children}
+    </WorkspaceFrame>
+  );
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -928,14 +928,6 @@ html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark
   border-color: var(--forma-page);
 }
 
-html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark"]) .status-badge-ok {
-  color: rgb(var(--forma-green-rgb));
-}
-
-html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark"]) .status-badge-error {
-  color: rgb(var(--forma-red-rgb));
-}
-
 .workspace-chrome-header {
   border-bottom: 0;
   background: linear-gradient(
@@ -1017,13 +1009,11 @@ html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark
 }
 
 .prompt-composer {
-  border: 1px solid var(--forma-border);
   box-shadow: var(--forma-composer-shadow);
-  transition: box-shadow 220ms ease, border-color 220ms ease;
+  transition: box-shadow 220ms ease;
 }
 
 .prompt-composer-idle:focus-within {
-  border-color: rgb(var(--forma-cyan-rgb) / 0.45);
   box-shadow:
     var(--forma-composer-shadow),
     0 0 0 1px rgb(var(--forma-cyan-rgb) / 0.28),
@@ -1105,52 +1095,33 @@ html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark
 }
 
 .status-badge {
-  position: relative;
   display: inline-flex;
-  width: 12px;
-  height: 12px;
+  width: 8px;
+  height: 8px;
   flex-shrink: 0;
   align-items: center;
   justify-content: center;
 }
 
 .status-badge-dot {
-  position: relative;
-  z-index: 1;
   width: 8px;
   height: 8px;
   border-radius: 9999px;
-  background: radial-gradient(
-    circle at 32% 28%,
-    color-mix(in srgb, white 78%, currentColor) 0 16%,
-    currentColor 48%,
-    color-mix(in srgb, currentColor 68%, black) 100%
-  );
-  box-shadow:
-    0 0 0 1.5px color-mix(in srgb, currentColor 58%, transparent),
-    0 0 7px 1px color-mix(in srgb, currentColor 36%, transparent),
-    0 1px 2px color-mix(in srgb, currentColor 38%, transparent);
-}
-
-.status-badge-ping {
-  position: absolute;
-  inset: -8px;
-  border-radius: 9999px;
-  background:
-    radial-gradient(
-      circle,
-      color-mix(in srgb, currentColor 46%, transparent) 0 16%,
-      color-mix(in srgb, currentColor 18%, transparent) 34%,
-      color-mix(in srgb, currentColor 7%, transparent) 54%,
-      transparent 72%
-    );
-  pointer-events: none;
+  background: currentColor;
 }
 
 .status-badge-ok {
-  color: #34d399;
+  color: rgb(var(--forma-green-rgb));
+}
+
+.status-badge-ok .status-badge-dot {
+  box-shadow: 0 0 0 4px rgb(var(--forma-green-rgb) / 0.18);
 }
 
 .status-badge-error {
-  color: #f87171;
+  color: rgb(var(--forma-red-rgb));
+}
+
+.status-badge-error .status-badge-dot {
+  box-shadow: 0 0 0 4px rgb(var(--forma-red-rgb) / 0.18);
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -553,6 +553,7 @@ html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark
  * in either light theme. Keep the text on the theme's strong foreground.
  */
 html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark"]) [class~='hover:bg-[#17181d]']:hover,
+html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark"]) [class~='hover:bg-zinc-800']:hover,
 html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark"]) [class~='hover:bg-zinc-800/40']:hover,
 html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark"]) [class~='hover:bg-zinc-800/50']:hover {
   background-color: var(--forma-surface-muted);
@@ -1119,19 +1120,31 @@ html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark
   width: 8px;
   height: 8px;
   border-radius: 9999px;
-  background: currentColor;
+  background: radial-gradient(
+    circle at 32% 28%,
+    color-mix(in srgb, white 78%, currentColor) 0 16%,
+    currentColor 48%,
+    color-mix(in srgb, currentColor 68%, black) 100%
+  );
   box-shadow:
-    0 0 0 3px color-mix(in srgb, currentColor 28%, transparent),
-    0 0 12px currentColor;
+    0 0 0 1.5px color-mix(in srgb, currentColor 58%, transparent),
+    0 0 7px 1px color-mix(in srgb, currentColor 36%, transparent),
+    0 1px 2px color-mix(in srgb, currentColor 38%, transparent);
 }
 
 .status-badge-ping {
   position: absolute;
-  inset: 0;
+  inset: -8px;
   border-radius: 9999px;
-  background: currentColor;
-  opacity: 0.55;
-  transform-origin: center;
+  background:
+    radial-gradient(
+      circle,
+      color-mix(in srgb, currentColor 46%, transparent) 0 16%,
+      color-mix(in srgb, currentColor 18%, transparent) 34%,
+      color-mix(in srgb, currentColor 7%, transparent) 54%,
+      transparent 72%
+    );
+  pointer-events: none;
 }
 
 .status-badge-ok {
@@ -1140,50 +1153,4 @@ html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark
 
 .status-badge-error {
   color: #f87171;
-}
-
-.status-badge-pulse .status-badge-ping,
-.status-badge-idle .status-badge-ping {
-  animation: status-badge-ping 2.4s cubic-bezier(0, 0, 0.2, 1) infinite;
-}
-
-.status-badge-pulse .status-badge-ping {
-  animation-duration: 1.6s;
-}
-
-.status-badge-idle .status-badge-dot {
-  animation: status-badge-glow 2.8s ease-in-out infinite;
-}
-
-.status-badge-pulse .status-badge-dot {
-  animation: status-badge-glow 1.6s ease-in-out infinite;
-}
-
-@keyframes status-badge-ping {
-  0% {
-    transform: scale(1);
-    opacity: 0.55;
-  }
-  75%,
-  100% {
-    transform: scale(2.6);
-    opacity: 0;
-  }
-}
-
-@keyframes status-badge-glow {
-  0%,
-  100% {
-    box-shadow: 0 0 0 1px rgb(255 255 255 / 0.08), 0 0 8px currentColor;
-  }
-  50% {
-    box-shadow: 0 0 0 1px rgb(255 255 255 / 0.14), 0 0 16px currentColor;
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .status-badge-ping,
-  .status-badge-dot {
-    animation: none !important;
-  }
 }

--- a/apps/web/app/user/user-integrations-page.tsx
+++ b/apps/web/app/user/user-integrations-page.tsx
@@ -47,7 +47,8 @@ const BUTTON_OUTLINE_CLASS =
   "inline-flex h-8 items-center gap-1.5 rounded-lg border border-[#2c2f37] px-3 text-xs font-medium text-slate-300 transition hover:bg-white/5 hover:text-white disabled:cursor-wait disabled:opacity-50";
 const BUTTON_DANGER_CLASS =
   "inline-flex h-8 items-center gap-1.5 rounded-lg border border-rose-400/30 px-3 text-xs font-medium text-rose-200 transition hover:bg-rose-500/15 disabled:cursor-wait disabled:opacity-50";
-const CARD_SURFACE_CLASS = "rounded-xl border border-[#2c2f37] bg-[#181b22]";
+const CARD_SURFACE_CLASS = "rounded-xl bg-[var(--forma-surface)]";
+const NESTED_SURFACE_CLASS = "rounded-xl bg-[var(--forma-surface-muted)]";
 const STATUS_PILL_CLASS = "inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium";
 
 type IntegrationFieldStatus = {
@@ -615,12 +616,12 @@ function SettingsCollapsible({
   children: React.ReactNode;
 }) {
   return (
-    <details className="group rounded-xl border border-[#2c2f37] bg-[#101115]/70">
+    <details className={`group ${NESTED_SURFACE_CLASS}`}>
       <summary className="flex cursor-pointer list-none items-center gap-3 px-4 py-3 marker:content-none [&::-webkit-details-marker]:hidden">
         <ChevronDown className="h-4 w-4 shrink-0 -rotate-90 text-slate-500 transition-transform group-open:rotate-0" />
         <span className="text-sm font-medium text-white">{title}</span>
       </summary>
-      <div className="space-y-2 border-t border-[#2c2f37] px-4 py-3 text-xs leading-5 text-slate-500">{children}</div>
+      <div className="space-y-2 px-4 py-3 text-xs leading-5 text-slate-500">{children}</div>
     </details>
   );
 }
@@ -639,7 +640,7 @@ function SettingsAdvancedDisclosure({
   children: React.ReactNode;
 }) {
   return (
-    <section className="rounded-xl border border-[#2c2f37] bg-[#101115]/70">
+    <section className={NESTED_SURFACE_CLASS}>
       <button type="button" onClick={onToggle} aria-expanded={open} className="flex w-full items-center gap-3 px-4 py-3 text-left">
         <ChevronDown className={`h-4 w-4 shrink-0 text-slate-500 transition-transform ${open ? "" : "-rotate-90"}`} />
         <div className="min-w-0 flex-1">
@@ -652,7 +653,7 @@ function SettingsAdvancedDisclosure({
           <p className="mt-0.5 text-xs leading-5 text-slate-500">{description}</p>
         </div>
       </button>
-      {open ? <div className="space-y-8 border-t border-[#2c2f37] px-4 py-4">{children}</div> : null}
+      {open ? <div className="space-y-8 px-4 py-4">{children}</div> : null}
     </section>
   );
 }
@@ -988,12 +989,12 @@ function ModelCombobox({
       </div>
 
       {open && !disabled && (
-        <div id={listId} role="listbox" className="absolute z-30 mt-1 max-h-72 w-full overflow-y-auto rounded-lg border border-[#2c2f37] bg-[#181b22] shadow-2xl">
+        <div id={listId} role="listbox" className="absolute z-30 mt-1 max-h-72 w-full overflow-y-auto rounded-lg bg-[var(--forma-surface)] shadow-[var(--forma-card-shadow)]">
           {filteredOptions.length ? (
             filteredOptions.map((option, index) => (
               <React.Fragment key={option.value}>
                 {option.group && option.group !== filteredOptions[index - 1]?.group && (
-                  <div className="sticky top-0 border-b border-[#2c2f37] bg-[#181b22] px-3 py-2 text-xs font-medium text-slate-400">
+                  <div className="sticky top-0 bg-[var(--forma-surface)] px-3 py-2 text-xs font-medium text-slate-400">
                     {option.group}
                   </div>
                 )}
@@ -1018,7 +1019,7 @@ function ModelCombobox({
           ) : (
             <div className="px-3 py-3 text-xs leading-5 text-slate-400">No matching suggestion. Keep your custom model ID and save it.</div>
           )}
-          <div className="sticky bottom-0 border-t border-[#2c2f37] bg-[#181b22] px-3 py-2 text-[11px] text-slate-500">
+          <div className="sticky bottom-0 bg-[var(--forma-surface)] px-3 py-2 text-[11px] text-slate-500">
             {suggestionType === "model"
               ? `${options.length} suggestions · any model ID is allowed`
               : "Suggestions only · custom values are allowed"}
@@ -1560,7 +1561,7 @@ function ImageModelTestPanel({
 
         {result && (
           <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
-            <div className="flex min-h-72 items-center justify-center rounded-lg border border-[#2c2f37] bg-[#101115] p-3">
+            <div className="flex min-h-72 items-center justify-center rounded-lg bg-[var(--forma-surface-muted)] p-3">
               {/* Provider results can be data URLs or short-lived remote URLs, so Next image optimization is not appropriate here. */}
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img src={result.image_data_url} alt="Direct image model test result" className="max-h-[640px] w-full object-contain" />
@@ -1570,7 +1571,7 @@ function ImageModelTestPanel({
                 <div className="text-xs font-medium">Request succeeded</div>
                 <div className="mt-2 font-mono text-sm">{result.elapsed_ms.toLocaleString()} ms</div>
               </div>
-              <div className="rounded-lg border border-[#2c2f37] p-3 font-mono text-xs leading-5 text-slate-400">
+              <div className="rounded-lg bg-[var(--forma-surface-muted)] p-3 font-mono text-xs leading-5 text-slate-400">
                 <div><span className="text-slate-600">Provider:</span> {result.provider}</div>
                 <div><span className="text-slate-600">Model:</span> {result.model}</div>
                 <div><span className="text-slate-600">Size:</span> {result.size || "Provider default"}</div>
@@ -1581,11 +1582,11 @@ function ImageModelTestPanel({
         )}
 
         {diagnostics != null && (
-          <details className="rounded-lg border border-[#2c2f37] bg-[#101115]">
+          <details className="rounded-lg bg-[var(--forma-surface-muted)]">
             <summary className="cursor-pointer px-3 py-2.5 text-xs font-medium text-slate-400">
               Raw diagnostics
             </summary>
-            <pre className="max-h-96 overflow-auto border-t border-[#2c2f37] p-3 text-[11px] leading-5 text-slate-400">
+            <pre className="max-h-96 overflow-auto p-3 text-[11px] leading-5 text-slate-400">
               {JSON.stringify(diagnostics, null, 2)}
             </pre>
           </details>
@@ -1609,16 +1610,14 @@ function ThemeSettingsPanel() {
   const themeCards: Array<{
     id: FormaTheme;
     label: string;
-    badge?: string;
     description: string;
     icon: typeof Sun;
     previewStyle: React.CSSProperties;
   }> = [
     {
       id: "light",
-      label: "Solarized Light+",
-      badge: "Day default",
-      description: "Warm low-glare #fdf6e3 surfaces with classic Solarized palette.",
+      label: "Solarized Light",
+      description: "Warm cream surfaces.",
       icon: Sun,
       previewStyle: {
         backgroundColor: solarizedLight.base3,
@@ -1628,9 +1627,8 @@ function ThemeSettingsPanel() {
     },
     {
       id: "solarized-dark",
-      label: "Solarized Dark+",
-      badge: "Night default",
-      description: "Deep cyan #002b36 base & #001f26 panels with rich syntax colors.",
+      label: "Solarized Dark",
+      description: "Deep cyan night theme.",
       icon: Moon,
       previewStyle: {
         backgroundColor: solarizedDark.base03,
@@ -1641,8 +1639,7 @@ function ThemeSettingsPanel() {
     {
       id: "arctic",
       label: "Arctic",
-      badge: "Slate Light",
-      description: "Cool white panels on a slate #eef2f7 page for higher contrast.",
+      description: "Cool white, higher contrast.",
       icon: Snowflake,
       previewStyle: {
         backgroundColor: arcticLight.surface,
@@ -1671,7 +1668,7 @@ function ThemeSettingsPanel() {
 
       <div className="space-y-6 p-5">
         {/* Compact Auto Day/Night Banner & Switch */}
-        <div className="flex flex-col gap-3 rounded-xl border border-[#2c2f37] bg-[#101115] p-3.5 sm:flex-row sm:items-center sm:justify-between">
+        <div className={`flex flex-col gap-3 p-3.5 sm:flex-row sm:items-center sm:justify-between ${NESTED_SURFACE_CLASS}`}>
           <div className="flex items-center gap-3">
             <Sparkles
               className={`h-4 w-4 shrink-0 ${
@@ -1689,8 +1686,8 @@ function ThemeSettingsPanel() {
               </div>
               <p className="mt-0.5 text-xs text-slate-400">
                 {themeMode === "auto" && solarInfo
-                  ? `Switches to ${solarInfo.nextEvent === "sunset" ? "Solarized Dark+" : "Solarized Light+"} automatically at ${formatTime(solarInfo.nextTime)}.`
-                  : "Automatically switches between Solarized Light+ by day and Solarized Dark+ at night based on your local sunrise & sunset."}
+                  ? `Switches to ${solarInfo.nextEvent === "sunset" ? "Solarized Dark" : "Solarized Light"} automatically at ${formatTime(solarInfo.nextTime)}.`
+                  : "Automatically switches between Solarized Light by day and Solarized Dark at night based on your local sunrise & sunset."}
               </p>
             </div>
           </div>
@@ -1729,14 +1726,14 @@ function ThemeSettingsPanel() {
                   role="radio"
                   aria-checked={selected}
                   onClick={() => setTheme(card.id)}
-                  className={`min-w-0 rounded-xl border p-3 text-left transition ${
+                  className={`min-w-0 rounded-xl p-3 text-left transition ${
                     selected
-                      ? "border-emerald-500/50 bg-emerald-500/10 shadow-md ring-1 ring-emerald-500/30"
-                      : "border-zinc-700/40 bg-[#0f1117] hover:border-zinc-600"
+                      ? "bg-emerald-500/10 shadow-md"
+                      : "bg-[var(--forma-surface-muted)] hover:bg-[var(--forma-surface-muted)]"
                   }`}
                 >
                   <span
-                    className="relative flex h-16 items-center justify-center overflow-hidden rounded-lg border border-zinc-700/40 shadow-inner"
+                    className="relative flex h-16 items-center justify-center overflow-hidden rounded-lg shadow-inner"
                     style={card.previewStyle}
                     aria-hidden="true"
                   >
@@ -1749,13 +1746,8 @@ function ThemeSettingsPanel() {
                       {selected ? <Check className="h-3 w-3" /> : null}
                     </span>
                   </span>
-                  <div className="mt-3 flex items-center justify-between">
+                  <div className="mt-3">
                     <span className="block text-sm font-medium text-white">{card.label}</span>
-                    {card.badge && (
-                      <span className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-slate-400">
-                        {card.badge}
-                      </span>
-                    )}
                   </div>
                   <span className="mt-1 block text-xs leading-5 text-slate-400">{card.description}</span>
                 </button>
@@ -1857,7 +1849,7 @@ function SettingsNavBrandGroup({
         <span className="min-w-0 flex-1 truncate text-[13px] font-medium">{label}</span>
         {badge}
       </div>
-      <div className="ml-3 space-y-0.5 border-l border-[#2c2f37] pl-1.5">{children}</div>
+      <div className="ml-3 space-y-0.5 pl-1.5">{children}</div>
     </div>
   );
 }
@@ -2441,7 +2433,7 @@ export default function UserIntegrationsPage({ embedded = false }: { embedded?: 
         </section>
       ) : (
         <section className={signedInGrid}>
-        <aside className={`h-fit min-h-0 max-h-[calc(100vh-180px)] overflow-y-auto ${CARD_SURFACE_CLASS} md:sticky md:top-4`}>
+        <aside className="h-fit min-h-0 max-h-[calc(100vh-180px)] overflow-y-auto rounded-xl bg-[var(--forma-surface)] md:sticky md:top-4">
           <div className="px-3 py-3">
             <div className="text-sm font-semibold text-white">Settings</div>
             <p className="mt-1 text-[11px] leading-4 text-slate-400">Account, models, and workspace defaults.</p>
@@ -2474,7 +2466,7 @@ export default function UserIntegrationsPage({ embedded = false }: { embedded?: 
               {loading && !payload ? (
                 <div className="px-2 py-2 text-[11px] leading-5 text-slate-500">Loading integrations...</div>
               ) : !navigationGroups.length ? (
-                <div className="rounded-lg border border-[#2c2f37] p-3">
+                <div className="rounded-lg bg-[var(--forma-surface-muted)] p-3">
                   <p className="text-[11px] leading-5 text-slate-400">
                     {error ? "Could not load integrations." : "No integrations are available for this workspace."}
                   </p>

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -13,7 +13,6 @@
         "@opennextjs/cloudflare": "1.20.2",
         "@react-three/drei": "10.7.7",
         "@react-three/fiber": "9.7.0",
-        "framer-motion": "^11.2.6",
         "lucide-react": "1.28.0",
         "next": "15.5.21",
         "react": "19.2.8",
@@ -23,6 +22,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "3.3.6",
+        "@playwright/test": "^1.62.1",
         "@types/node": "25.9.1",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.4",
@@ -31,6 +31,7 @@
         "eslint-config-next": "15.5.21",
         "postcss": "^8",
         "tailwindcss": "^3.4",
+        "tsx": "^4.20.5",
         "typescript": "^5",
         "wrangler": "4.118.0"
       }
@@ -3670,6 +3671,22 @@
         "rclone.js": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -8061,33 +8078,6 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
-    "node_modules/framer-motion": {
-      "version": "11.18.2",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
-      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-dom": "^11.18.1",
-        "motion-utils": "^11.18.1",
-        "tslib": "^2.4.0"
-      },
-      "peerDependencies": {
-        "@emotion/is-prop-valid": "*",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@emotion/is-prop-valid": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -9611,21 +9601,6 @@
         "obliterator": "^1.6.1"
       }
     },
-    "node_modules/motion-dom": {
-      "version": "11.18.1",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
-      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
-      "license": "MIT",
-      "dependencies": {
-        "motion-utils": "^11.18.1"
-      }
-    },
-    "node_modules/motion-utils": {
-      "version": "11.18.1",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
-      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
-      "license": "MIT"
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -10759,6 +10734,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {
@@ -12351,6 +12373,25 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tunnel-rat": {
       "version": "0.1.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,8 @@
     "build": "rm -rf .next && next build",
     "start": "next start",
     "lint": "eslint .",
+    "test:unit": "tsx --test test/*.test.ts",
+    "test:e2e": "../../scripts/development/e2e-web.sh",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
@@ -18,7 +20,6 @@
     "@opennextjs/cloudflare": "1.20.2",
     "@react-three/drei": "10.7.7",
     "@react-three/fiber": "9.7.0",
-    "framer-motion": "^11.2.6",
     "lucide-react": "1.28.0",
     "next": "15.5.21",
     "react": "19.2.8",
@@ -28,6 +29,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "3.3.6",
+    "@playwright/test": "^1.62.1",
     "@types/node": "25.9.1",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
@@ -37,6 +39,7 @@
     "postcss": "^8",
     "tailwindcss": "^3.4",
     "typescript": "^5",
+    "tsx": "^4.20.5",
     "wrangler": "4.118.0"
   },
   "overrides": {

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,46 @@
+import { defineConfig, devices } from "@playwright/test";
+
+const frontendPort = Number(process.env.FRONTEND_PORT || 3010);
+const backendPort = Number(process.env.BACKEND_PORT || 8010);
+const baseURL = process.env.PLAYWRIGHT_BASE_URL || `http://127.0.0.1:${frontendPort}`;
+const webServer = process.env.PLAYWRIGHT_REUSE_EXISTING === "1"
+  ? undefined
+  : {
+      command: [
+        "cd ../.. &&",
+        "FORMA_AUTH_MODE=local",
+        "FORMA_USER_SECRETS_KEY=${FORMA_USER_SECRETS_KEY:-playwright-local-secret-not-for-production}",
+        "FORMA_DEV_MODE=true",
+        "DATABASE_BACKEND=sqlite",
+        "SQLITE_DATABASE_URL=${SQLITE_DATABASE_URL:-sqlite:///$PWD/tmp/playwright/forma-e2e.db}",
+        "LLM_PROVIDER=simulation",
+        "IMAGE_OUTPUT_ENABLED=false",
+        "IMAGE_PROVIDER=none",
+        `NEXT_PUBLIC_API_URL=http://127.0.0.1:${backendPort}`,
+        `BACKEND_PORT=${backendPort}`,
+        `FRONTEND_PORT=${frontendPort}`,
+        "./scripts/development/dev.sh",
+      ].join(" "),
+      url: baseURL,
+      reuseExistingServer: false,
+      timeout: 120_000,
+    };
+
+export default defineConfig({
+  testDir: "./test/e2e",
+  timeout: 90_000,
+  expect: {
+    timeout: 20_000,
+  },
+  use: {
+    baseURL,
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  ...(webServer ? { webServer } : {}),
+});

--- a/apps/web/test/admin-job-sort.test.mjs
+++ b/apps/web/test/admin-job-sort.test.mjs
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import {
   adminJobLastOccurredAt,
   sortAdminJobs,
-} from "../lib/admin-job-sort.ts";
+} from "../lib/admin-job-sort";
 
 const jobs = [
   {

--- a/apps/web/test/agent-pipeline.test.ts
+++ b/apps/web/test/agent-pipeline.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  createAgentPipelineProgress,
+  mergeMessagePipelineProgressFromJob,
+} from "../app/forma-workspace/lib/agent-pipeline";
+import { defaultAgentPipelineSteps } from "../app/forma-workspace/workspace-constants";
+import type { ChatMessage } from "../app/forma-workspace/types";
+
+test("pipeline merge advances a loading chat message from worker events", () => {
+  const seed = createAgentPipelineProgress(defaultAgentPipelineSteps, false, "2026-01-01T00:00:00.000Z", "job-1");
+  const message: ChatMessage = {
+    id: "msg-1",
+    role: "assistant",
+    content: "Thinking…",
+    status: "loading",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    pipelineProgress: seed,
+  };
+  const next = mergeMessagePipelineProgressFromJob(message, {
+    job_id: "job-1",
+    action: "forma.generate_project",
+    sender: "worker-orchestrator",
+    recipient: "forma",
+    status: "running",
+    started_at: "2026-01-01T00:00:00.000Z",
+    progress_events: [
+      { step_id: "safety_guardrail", status: "completed", observed_at: "2026-01-01T00:00:01.000Z" },
+      { step_id: "intent_parser", status: "started", observed_at: "2026-01-01T00:00:02.000Z" },
+    ],
+  }, seed, false);
+
+  assert.equal(next.status, "loading");
+  assert.equal(next.pipelineProgress?.synced, true);
+  assert.ok((next.pipelineProgress?.currentStepIndex || 0) >= 1);
+});

--- a/apps/web/test/chat-list.test.ts
+++ b/apps/web/test/chat-list.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  mergeChatListItems,
+  sortChatListItems,
+  upsertChatListItem,
+} from "../app/forma-workspace/lib/chat-list";
+import type { ChatListItem } from "../app/forma-workspace/sidebar";
+
+const older: ChatListItem = {
+  chatId: "chat-a",
+  title: "New project",
+  projectId: "",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  projectCount: 0,
+};
+
+const newer: ChatListItem = {
+  chatId: "chat-a",
+  title: "Plant monitor",
+  projectId: "proj-1",
+  createdAt: "2026-01-02T00:00:00.000Z",
+  projectCount: 1,
+};
+
+test("upsert keeps a real title when a later New project placeholder arrives", () => {
+  const merged = upsertChatListItem([newer], { ...older, title: "New project" });
+  assert.equal(merged[0].title, "Plant monitor");
+  assert.equal(merged[0].projectId, "proj-1");
+});
+
+test("mergeChatListItems prefers primary fields, the later timestamp, and pinned order", () => {
+  const pinned: ChatListItem = {
+    chatId: "chat-b",
+    title: "Pinned",
+    projectId: "proj-2",
+    createdAt: "2025-01-01T00:00:00.000Z",
+    projectCount: 1,
+    pinned: true,
+  };
+  const merged = mergeChatListItems([older], [newer, pinned]);
+  const chatA = merged.find((item) => item.chatId === "chat-a");
+  assert.equal(chatA?.title, "New project");
+  assert.equal(chatA?.createdAt, "2026-01-02T00:00:00.000Z");
+  assert.equal(chatA?.projectCount, 1);
+  assert.deepEqual(merged.map((item) => item.chatId), ["chat-b", "chat-a"]);
+});

--- a/apps/web/test/chat-normalize.test.ts
+++ b/apps/web/test/chat-normalize.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { ChatMessage } from "../app/forma-workspace/types";
+import {
+  hydrateRoutedChatMessages,
+  mergeFetchedChatMessages,
+} from "../app/forma-workspace/lib/chat-normalize";
+
+function message(partial: Partial<ChatMessage> & Pick<ChatMessage, "id" | "content">): ChatMessage {
+  return {
+    role: "assistant",
+    status: "idle",
+    timestamp: "2026-01-01T00:00:00.000Z",
+    projectId: null,
+    pipelineProgress: null,
+    imagePreview: null,
+    contextProjectId: null,
+    workflowState: null,
+    contextQuestions: [],
+    contextSuggestions: [],
+    buildPlanId: null,
+    buildJobId: null,
+    buildRequiresRequestBoundExecution: false,
+    ...partial,
+  };
+}
+
+test("merge keeps a completed gather result when stored thread still says Thinking", () => {
+  const local = message({
+    id: "assistant-1",
+    content: "I started the design brief. Proceed with defaults?",
+    status: "success",
+    contextProjectId: "proj-1",
+    workflowState: "gathering_context",
+    contextQuestions: ["What enclosure material?"],
+    contextSuggestions: ["Use safe prototype defaults"],
+  });
+  const remote = message({
+    id: "assistant-1",
+    content: "Thinking…",
+    status: "loading",
+  });
+
+  const merged = mergeFetchedChatMessages([remote], [local]);
+  assert.equal(merged[0]?.content, local.content);
+  assert.equal(merged[0]?.status, "success");
+  assert.equal(merged[0]?.workflowState, "gathering_context");
+  assert.equal(merged[0]?.contextProjectId, "proj-1");
+  assert.deepEqual(merged[0]?.contextQuestions, ["What enclosure material?"]);
+  assert.deepEqual(merged[0]?.contextSuggestions, ["Use safe prototype defaults"]);
+});
+
+test("hydrate keeps in-flight messages for the same chat when storage is empty", () => {
+  const inMemory = [
+    message({ id: "user-1", role: "user", content: "Build a plant monitor" }),
+    message({ id: "assistant-1", content: "Thinking…", status: "loading" }),
+  ];
+  const hydrated = hydrateRoutedChatMessages([], inMemory, { sameChat: true });
+  assert.equal(hydrated, inMemory);
+});
+
+test("hydrate replaces in-memory messages when opening a different chat", () => {
+  const otherChat = [message({ id: "user-a", role: "user", content: "Other chat" })];
+  const stored = [message({ id: "user-b", role: "user", content: "Opened chat" })];
+  const hydrated = hydrateRoutedChatMessages(stored, otherChat, { sameChat: false });
+  assert.equal(hydrated[0]?.id, "user-b");
+  assert.equal(hydrateRoutedChatMessages([], otherChat, { sameChat: false }).length, 0);
+});
+
+test("hydrate merges when stored ids belong to the in-memory thread even if sameChat is false", () => {
+  const local = message({
+    id: "assistant-1",
+    content: "I started the design brief.",
+    status: "success",
+    contextProjectId: "proj-1",
+    workflowState: "gathering_context",
+  });
+  const stored = [message({ id: "assistant-1", content: "Thinking…", status: "loading" })];
+  const hydrated = hydrateRoutedChatMessages(stored, [local], { sameChat: false });
+  assert.equal(hydrated[0]?.content, "I started the design brief.");
+  assert.equal(hydrated[0]?.workflowState, "gathering_context");
+});

--- a/apps/web/test/context-build.test.ts
+++ b/apps/web/test/context-build.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  contextBuildWatchKey,
+  isActiveBuildStatus,
+  shouldResumeDetachedBuild,
+} from "../app/forma-workspace/lib/context-build";
+
+test("detached resume is skipped when this client is already watching", () => {
+  assert.equal(
+    shouldResumeDetachedBuild({ requestBoundExecution: false, alreadyWatching: true }),
+    false,
+  );
+  assert.equal(
+    shouldResumeDetachedBuild({ requestBoundExecution: false, alreadyWatching: false }),
+    true,
+  );
+});
+
+test("request-bound runtimes never resume via detached launch", () => {
+  assert.equal(
+    shouldResumeDetachedBuild({ requestBoundExecution: true, alreadyWatching: false }),
+    false,
+  );
+  assert.equal(isActiveBuildStatus("planned"), true);
+  assert.equal(isActiveBuildStatus("succeeded"), false);
+  assert.equal(contextBuildWatchKey("proj", "plan"), "proj:plan");
+});

--- a/apps/web/test/context-suggestions.test.ts
+++ b/apps/web/test/context-suggestions.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { normalizeContextSuggestions } from "../lib/context-suggestions.ts";
+import { normalizeContextSuggestions } from "../lib/context-suggestions";
 
 test("context suggestions are trimmed, deduplicated, and bounded", () => {
   assert.deepEqual(

--- a/apps/web/test/e2e/simulation.spec.ts
+++ b/apps/web/test/e2e/simulation.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+
+test("simulation flow generates, inspects, and reloads a project without duplicate local execute", async ({ page }) => {
+  const executeRequests: string[] = [];
+  page.on("request", (request) => {
+    const url = request.url();
+    if (url.includes("/build/plans/") && url.endsWith("/execute")) {
+      executeRequests.push(url);
+    }
+  });
+
+  await page.goto("/");
+
+  await page.getByRole("textbox", { name: /describe the hardware idea/i }).fill(
+    "Build a battery powered plant watering monitor with soil moisture sensing, OLED status, USB-C charging, and a compact 3D printed enclosure.",
+  );
+  await page.getByRole("button", { name: /check hardware idea/i }).click();
+
+  await expect(page.getByRole("button", { name: /safe prototype defaults/i })).toBeVisible({ timeout: 30_000 });
+  await page.getByRole("button", { name: /safe prototype defaults/i }).click();
+
+  await expect(page.getByText(/structured design revision is available for review/i)).toBeVisible();
+  await expect(page.getByRole("button", { name: "Overview" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Bill of Materials" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Bill of Materials" }).click();
+  await expect(page.getByText(/total estimated cost/i)).toBeVisible();
+
+  await page.getByRole("button", { name: "Mechanical" }).click();
+  await expect(page.getByRole("button", { name: "Mechanical" })).toHaveAttribute("aria-pressed", "true");
+
+  await page.getByRole("button", { name: "Electrical" }).click();
+  await expect(page.getByRole("button", { name: "Electrical" })).toHaveAttribute("aria-pressed", "true");
+
+  await page.getByRole("button", { name: "Documentation" }).click();
+  await expect(page.getByRole("heading", { name: "Build Instructions" })).toBeVisible();
+
+  expect(executeRequests).toEqual([]);
+
+  const chatUrl = new URL(page.url());
+  const projectId = chatUrl.pathname.split("/").filter(Boolean).at(-1);
+  expect(projectId).toBeTruthy();
+
+  await page.goto(`/project/${projectId}?tab=overview`);
+  await expect(page.getByRole("heading", { level: 1, name: /Plant Moisture Monitor|Watering System/i })).toBeVisible();
+  await expect(page.getByText("Product image disabled")).toBeVisible();
+});
+
+test("reload during an active build completes without local execute", async ({ page }) => {
+  const executeRequests: string[] = [];
+  page.on("request", (request) => {
+    const url = request.url();
+    if (url.includes("/build/plans/") && url.endsWith("/execute")) {
+      executeRequests.push(url);
+    }
+  });
+
+  await page.goto("/");
+  await page.getByRole("textbox", { name: /describe the hardware idea/i }).fill(
+    "Build a battery powered plant watering monitor with soil moisture sensing, OLED status, USB-C charging, and a compact 3D printed enclosure.",
+  );
+  await page.getByRole("button", { name: /check hardware idea/i }).click();
+  await expect(page.getByRole("button", { name: /safe prototype defaults/i })).toBeVisible({ timeout: 30_000 });
+  await page.getByRole("button", { name: /safe prototype defaults/i }).click();
+  await page.reload();
+  await expect(page.getByText(/structured design revision is available for review/i)).toBeVisible({ timeout: 60_000 });
+  expect(executeRequests).toEqual([]);
+});

--- a/apps/web/test/project-cost-metrics.test.ts
+++ b/apps/web/test/project-cost-metrics.test.ts
@@ -4,7 +4,7 @@ import { test } from "node:test";
 import {
   calculateProjectCostMetrics,
   resolveProjectComponentInstances,
-} from "../lib/project-cost-metrics.ts";
+} from "../lib/project-cost-metrics";
 
 const project = {
   part_definitions: [{

--- a/apps/web/test/settings-nav-status.test.ts
+++ b/apps/web/test/settings-nav-status.test.ts
@@ -5,7 +5,7 @@ import {
   imageOutputIsEnabled,
   parsePreferredLlmProvider,
   settingsNavBadge,
-} from "../lib/settings-nav-status.ts";
+} from "../lib/settings-nav-status";
 
 test("parsePreferredLlmProvider reads anthropic from a Claude selector", () => {
   assert.equal(parsePreferredLlmProvider("anthropic/claude-opus-5"), "anthropic");

--- a/forma_core/workspaces/context/models.py
+++ b/forma_core/workspaces/context/models.py
@@ -78,6 +78,7 @@ class ContextBuildExecution(BaseModel):
     plan_id: NonEmptyString
     job_id: NonEmptyString
     status: NonEmptyString
+    request_bound_execution: bool = False
 
 
 class ContextGatheringResponse(BaseModel):

--- a/scripts/development/dev-core-logs.sh
+++ b/scripts/development/dev-core-logs.sh
@@ -31,7 +31,7 @@ is_truthy() {
 
 is_port_open() {
   local port="$1"
-  ss -ltn 2>/dev/null | awk '{print $4}' | grep -Eq "[:.]${port}$"
+  dev_is_port_open "$BACKEND_HOST" "$port" || dev_is_port_open "$FRONTEND_HOST" "$port"
 }
 
 wait_for_url() {
@@ -42,7 +42,7 @@ wait_for_url() {
   local failure_log="${5:-}"
 
   for _ in $(seq 1 "$attempts"); do
-    if curl -fsS "$url" >/dev/null 2>&1; then
+    if curl -fsS --max-time 2 "$url" >/dev/null 2>&1; then
       log "$label is ready at $url"
       return 0
     fi
@@ -98,6 +98,7 @@ trap cleanup EXIT INT TERM HUP
 
 cd "$ROOT_DIR"
 
+dev_ensure_local_simulation_env
 dev_cleanup_previous_session
 
 if [ ! -x "$VENV_DIR/bin/python" ]; then
@@ -116,7 +117,7 @@ if [ ! -d "$ROOT_DIR/apps/web/node_modules" ]; then
 fi
 
 if is_port_open "$BACKEND_PORT"; then
-  if curl -fsS "http://$BACKEND_HOST:$BACKEND_PORT/api" >/dev/null 2>&1; then
+  if curl -fsS --max-time 2 "http://$BACKEND_HOST:$BACKEND_PORT/api" >/dev/null 2>&1; then
     log "Backend already appears to be running at http://$BACKEND_HOST:$BACKEND_PORT"
     log "Core-only logs require the backend to be started by this script."
   else

--- a/scripts/development/dev-processes.sh
+++ b/scripts/development/dev-processes.sh
@@ -3,23 +3,74 @@
 # Shared lifecycle helpers for the local development launchers.
 # The caller must define ROOT_DIR and may override DEV_RUNTIME_DIR.
 
-DEV_RUNTIME_DIR="${DEV_RUNTIME_DIR:-$ROOT_DIR/.tmp/development}"
+DEV_RUNTIME_DIR="${DEV_RUNTIME_DIR:-$ROOT_DIR/tmp/development}"
 DEV_BACKEND_PID_FILE="${DEV_BACKEND_PID_FILE:-$DEV_RUNTIME_DIR/backend.pgid}"
 DEV_FRONTEND_PID_FILE="${DEV_FRONTEND_PID_FILE:-$DEV_RUNTIME_DIR/frontend.pgid}"
+DEV_PROCESS_PYTHON="${DEV_PROCESS_PYTHON:-${PYTHON_BIN:-python3}}"
+
+dev_is_port_open() {
+  local host="$1"
+  local port="$2"
+
+  "$DEV_PROCESS_PYTHON" - "$host" "$port" <<'PY'
+import socket
+import sys
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+    sock.settimeout(0.25)
+    raise SystemExit(0 if sock.connect_ex((host, port)) == 0 else 1)
+PY
+}
 
 dev_group_is_running() {
   local pgid="$1"
+  if ps -p "$pgid" -o stat= 2>/dev/null | awk '$1 !~ /^Z/ { found=1 } END { exit !found }'; then
+    return 0
+  fi
   ps -eo pgid=,stat= | awk -v target="$pgid" \
     '$1 == target && $2 !~ /^Z/ { found=1 } END { exit !found }'
 }
 
 dev_group_belongs_to_repo() {
   local pgid="$1"
+  local recorded_root="${2:-}"
   local pid cwd
+
+  if [ -n "$recorded_root" ] && [ "$recorded_root" = "$ROOT_DIR" ]; then
+    return 0
+  fi
 
   while read -r pid; do
     [ -n "$pid" ] || continue
-    cwd="$(readlink -f "/proc/$pid/cwd" 2>/dev/null || true)"
+    cwd="$(
+      "$DEV_PROCESS_PYTHON" - "$pid" 2>/dev/null <<'PY' || true
+import os
+import subprocess
+import sys
+
+pid = sys.argv[1]
+proc_cwd = f"/proc/{pid}/cwd"
+if os.path.exists(proc_cwd):
+    print(os.path.realpath(proc_cwd))
+    raise SystemExit(0)
+
+try:
+    output = subprocess.check_output(
+        ["lsof", "-a", "-p", pid, "-d", "cwd", "-Fn"],
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+except Exception:
+    raise SystemExit(0)
+
+for line in output.splitlines():
+    if line.startswith("n"):
+        print(os.path.realpath(line[1:]))
+        break
+PY
+    )"
     case "$cwd" in
       "$ROOT_DIR"|"$ROOT_DIR"/*) return 0 ;;
     esac
@@ -32,9 +83,10 @@ dev_remove_pid_file() {
   local pid_file="$1"
   local expected_pgid="$2"
   local recorded_pgid=""
+  local recorded_root=""
 
   if [ -f "$pid_file" ]; then
-    read -r recorded_pgid <"$pid_file" || true
+    read -r recorded_pgid recorded_root <"$pid_file" || true
     if [ "$recorded_pgid" = "$expected_pgid" ]; then
       rm -f -- "$pid_file"
     fi
@@ -45,6 +97,7 @@ dev_stop_process_group() {
   local pgid="$1"
   local label="$2"
   local pid_file="${3:-}"
+  local recorded_root="${4:-}"
   local attempt
 
   if ! [[ "$pgid" =~ ^[0-9]+$ ]] || [ "$pgid" -le 1 ]; then
@@ -54,7 +107,7 @@ dev_stop_process_group() {
     [ -n "$pid_file" ] && dev_remove_pid_file "$pid_file" "$pgid"
     return 0
   fi
-  if ! dev_group_belongs_to_repo "$pgid"; then
+  if ! dev_group_belongs_to_repo "$pgid" "$recorded_root"; then
     printf '[forma-dev] Refusing to stop %s process group %s; it is not owned by %s.\n' \
       "$label" "$pgid" "$ROOT_DIR" >&2
     [ -n "$pid_file" ] && dev_remove_pid_file "$pid_file" "$pgid"
@@ -80,10 +133,11 @@ dev_stop_recorded_process() {
   local pid_file="$1"
   local label="$2"
   local pgid=""
+  local recorded_root=""
 
   [ -f "$pid_file" ] || return 0
-  read -r pgid <"$pid_file" || true
-  dev_stop_process_group "$pgid" "$label" "$pid_file"
+  read -r pgid recorded_root <"$pid_file" || true
+  dev_stop_process_group "$pgid" "$label" "$pid_file" "$recorded_root"
 }
 
 dev_cleanup_previous_session() {
@@ -100,12 +154,82 @@ dev_start_process_group() {
   local child_pid
 
   mkdir -p "$DEV_RUNTIME_DIR"
-  if [ -n "$log_file" ]; then
-    setsid "$@" >"$log_file" 2>&1 &
-  else
-    setsid "$@" &
-  fi
+  "$DEV_PROCESS_PYTHON" - "$log_file" "$@" <<'PY' &
+import os
+import subprocess
+import sys
+
+log_file = sys.argv[1]
+command = sys.argv[2:]
+
+os.setsid()
+stdout = stderr = None
+log_handle = None
+if log_file:
+    log_handle = open(log_file, "ab", buffering=0)
+    stdout = stderr = log_handle
+
+try:
+    process = subprocess.Popen(command, stdout=stdout, stderr=stderr)
+    raise SystemExit(process.wait())
+finally:
+    if log_handle is not None:
+        log_handle.close()
+PY
   child_pid="$!"
-  printf '%s\n' "$child_pid" >"$pid_file"
+  printf '%s %s\n' "$child_pid" "$ROOT_DIR" >"$pid_file"
   printf -v "$output_variable" '%s' "$child_pid"
+}
+
+dev_ensure_local_simulation_env() {
+  if [ -f "$ROOT_DIR/.env" ] || [ -n "${FORMA_USER_SECRETS_KEY:-}" ]; then
+    dev_ensure_sqlite_parent
+    return
+  fi
+
+  local secret_file="$DEV_RUNTIME_DIR/forma-user-secrets.key"
+  mkdir -p "$DEV_RUNTIME_DIR"
+  if [ ! -s "$secret_file" ]; then
+    "$DEV_PROCESS_PYTHON" - "$secret_file" <<'PY'
+import base64
+import os
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+path.write_text(base64.b64encode(os.urandom(48)).decode("ascii"), encoding="utf-8")
+path.chmod(0o600)
+PY
+  fi
+
+  export FORMA_AUTH_MODE="${FORMA_AUTH_MODE:-local}"
+  export FORMA_USER_SECRETS_KEY
+  FORMA_USER_SECRETS_KEY="$(tr -d '\n\r' <"$secret_file")"
+  export FORMA_DEV_MODE="${FORMA_DEV_MODE:-true}"
+  export DATABASE_BACKEND="${DATABASE_BACKEND:-sqlite}"
+  export SQLITE_DATABASE_URL="${SQLITE_DATABASE_URL:-sqlite:///$DEV_RUNTIME_DIR/forma-dev.db}"
+  export LLM_PROVIDER="${LLM_PROVIDER:-simulation}"
+  export IMAGE_OUTPUT_ENABLED="${IMAGE_OUTPUT_ENABLED:-false}"
+  export IMAGE_PROVIDER="${IMAGE_PROVIDER:-none}"
+  export NEXT_PUBLIC_API_URL="${NEXT_PUBLIC_API_URL:-http://$BACKEND_HOST:$BACKEND_PORT}"
+  export NEXT_PUBLIC_FORMA_DEV_MODE="${NEXT_PUBLIC_FORMA_DEV_MODE:-true}"
+  dev_ensure_sqlite_parent
+}
+
+dev_ensure_sqlite_parent() {
+  "$DEV_PROCESS_PYTHON" - "${SQLITE_DATABASE_URL:-}" <<'PY'
+import pathlib
+import sys
+from urllib.parse import unquote, urlparse
+
+url = sys.argv[1].strip()
+if not url.startswith("sqlite:///") or url in {"sqlite://", "sqlite:///:memory:", "sqlite://"}:
+    raise SystemExit(0)
+
+parsed = urlparse(url)
+path = unquote(parsed.path)
+if not path:
+    raise SystemExit(0)
+pathlib.Path(path).parent.mkdir(parents=True, exist_ok=True)
+PY
 }

--- a/scripts/development/dev.sh
+++ b/scripts/development/dev.sh
@@ -23,7 +23,7 @@ log() {
 
 is_port_open() {
   local port="$1"
-  ss -ltn 2>/dev/null | awk '{print $4}' | grep -Eq "[:.]${port}$"
+  dev_is_port_open "$BACKEND_HOST" "$port" || dev_is_port_open "$FRONTEND_HOST" "$port"
 }
 
 wait_for_url() {
@@ -33,7 +33,7 @@ wait_for_url() {
   local process_pid="${4:-}"
 
   for _ in $(seq 1 "$attempts"); do
-    if curl -fsS "$url" >/dev/null 2>&1; then
+    if curl -fsS --max-time 2 "$url" >/dev/null 2>&1; then
       log "$label is ready at $url"
       return 0
     fi
@@ -86,6 +86,7 @@ trap cleanup EXIT INT TERM HUP
 
 cd "$ROOT_DIR"
 
+dev_ensure_local_simulation_env
 dev_cleanup_previous_session
 
 if [ ! -x "$VENV_DIR/bin/python" ]; then
@@ -104,7 +105,7 @@ if [ ! -d "$ROOT_DIR/apps/web/node_modules" ]; then
 fi
 
 if is_port_open "$BACKEND_PORT"; then
-  if curl -fsS "http://$BACKEND_HOST:$BACKEND_PORT/api" >/dev/null 2>&1; then
+  if curl -fsS --max-time 2 "http://$BACKEND_HOST:$BACKEND_PORT/api" >/dev/null 2>&1; then
     log "Backend already appears to be running at http://$BACKEND_HOST:$BACKEND_PORT"
     log "Backend logs are controlled by the existing backend process."
   else
@@ -127,7 +128,7 @@ dev_start_process_group frontend_pid "$DEV_FRONTEND_PID_FILE" "" \
   bash -c 'cd "$1" && shift && exec "$@"' bash "$ROOT_DIR/apps/web" \
   npm run dev -- --hostname "$FRONTEND_HOST" --port "$FRONTEND_PORT"
 
-wait_for_url "http://$FRONTEND_HOST:$FRONTEND_PORT/" "Frontend"
+wait_for_url "http://$FRONTEND_HOST:$FRONTEND_PORT/" "Frontend" 120
 
 cat <<EOF
 

--- a/scripts/development/e2e-web.sh
+++ b/scripts/development/e2e-web.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BACKEND_HOST="${BACKEND_HOST:-127.0.0.1}"
+BACKEND_PORT="${BACKEND_PORT:-8010}"
+FRONTEND_HOST="${FRONTEND_HOST:-127.0.0.1}"
+FRONTEND_PORT="${FRONTEND_PORT:-3010}"
+FRONTEND_URL="http://$FRONTEND_HOST:$FRONTEND_PORT"
+BACKEND_URL="http://$BACKEND_HOST:$BACKEND_PORT/api"
+DEV_PID=""
+
+cleanup() {
+  local status=$?
+  if [ -n "$DEV_PID" ]; then
+    kill -TERM "$DEV_PID" >/dev/null 2>&1 || true
+    wait "$DEV_PID" >/dev/null 2>&1 || true
+  fi
+  exit "$status"
+}
+
+wait_for_url() {
+  local url="$1"
+  local label="$2"
+  local attempt
+
+  for attempt in $(seq 1 120); do
+    if curl -fsS --max-time 2 "$url" >/dev/null 2>&1; then
+      printf '[forma-e2e] %s ready at %s\n' "$label" "$url"
+      return 0
+    fi
+    if [ -n "$DEV_PID" ] && ! kill -0 "$DEV_PID" >/dev/null 2>&1; then
+      wait "$DEV_PID" || true
+      printf '[forma-e2e] dev stack exited before %s became ready.\n' "$label" >&2
+      return 1
+    fi
+    sleep 1
+  done
+
+  printf '[forma-e2e] %s did not become ready at %s\n' "$label" "$url" >&2
+  return 1
+}
+
+trap cleanup EXIT INT TERM HUP
+
+cd "$ROOT_DIR"
+
+FORMA_AUTH_MODE="${FORMA_AUTH_MODE:-local}" \
+FORMA_USER_SECRETS_KEY="${FORMA_USER_SECRETS_KEY:-playwright-local-secret-not-for-production}" \
+FORMA_DEV_MODE="${FORMA_DEV_MODE:-true}" \
+DATABASE_BACKEND="${DATABASE_BACKEND:-sqlite}" \
+SQLITE_DATABASE_URL="${SQLITE_DATABASE_URL:-sqlite:///$ROOT_DIR/tmp/playwright/forma-e2e.db}" \
+LLM_PROVIDER="${LLM_PROVIDER:-simulation}" \
+IMAGE_OUTPUT_ENABLED="${IMAGE_OUTPUT_ENABLED:-false}" \
+IMAGE_PROVIDER="${IMAGE_PROVIDER:-none}" \
+NEXT_PUBLIC_API_URL="${NEXT_PUBLIC_API_URL:-http://$BACKEND_HOST:$BACKEND_PORT}" \
+BACKEND_HOST="$BACKEND_HOST" \
+BACKEND_PORT="$BACKEND_PORT" \
+FRONTEND_HOST="$FRONTEND_HOST" \
+FRONTEND_PORT="$FRONTEND_PORT" \
+./scripts/development/dev.sh &
+DEV_PID="$!"
+
+wait_for_url "$BACKEND_URL" "Backend"
+wait_for_url "$FRONTEND_URL" "Frontend"
+
+cd "$ROOT_DIR/apps/web"
+PLAYWRIGHT_REUSE_EXISTING=1 \
+PLAYWRIGHT_BASE_URL="$FRONTEND_URL" \
+PLAYWRIGHT_BACKEND_URL="$BACKEND_URL" \
+npx playwright test "$@"

--- a/tests/api/test_project_access.py
+++ b/tests/api/test_project_access.py
@@ -634,6 +634,46 @@ class ProjectGenerationAccessTests(unittest.TestCase):
         self.assertEqual("generated-project", response["project_id"])
         self.assertEqual("generated-chat", response["chat_id"])
 
+    def test_failed_generation_status_returns_api_error(self) -> None:
+        job_store = MagicMock()
+        job_store.is_cancelled.return_value = False
+        job_store.get_job.return_value = {"status": "failed"}
+        generated_response = {
+            "generation_status": "failed",
+            "generation_stages": {"system_architecture": {"status": "failed"}},
+            "project_ir": {
+                "assembly_metadata": {
+                    "project_id": "failed-project",
+                    "chat_id": "failed-chat",
+                    "generation_status": "failed",
+                    "generation_error": {"message": "architecture timed out"},
+                }
+            },
+        }
+
+        with (
+            patch.object(main, "_apply_user_integrations"),
+            patch.object(main, "get_workflow_debug_config", return_value={}),
+            patch.object(main, "_deployment_runtime_config", return_value={"alpha_generation_gate_active": False}),
+            patch.object(main, "JOB_STORE", job_store),
+            patch.object(main, "observe_agent_pipeline", return_value=nullcontext()),
+            patch.object(main, "build_generation_response", return_value=generated_response),
+            patch.object(main, "_attach_generation_timing_metadata", side_effect=lambda response, _job: response),
+            patch.object(main, "update_generated_project_hardware_ir"),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                asyncio.run(
+                    main.generate_project_endpoint(
+                        GenerateProjectRequest(prompt="Build a sensor", chat_id="failed-chat"),
+                        _user_context("user-a"),
+                    )
+                )
+
+        self.assertEqual(424, raised.exception.status_code)
+        self.assertEqual("generation_stage_failed", raised.exception.detail["code"])
+        self.assertEqual("architecture timed out", raised.exception.detail["message"])
+        job_store.mark_failed.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/projects/test_context_gathering.py
+++ b/tests/projects/test_context_gathering.py
@@ -3,13 +3,14 @@ from __future__ import annotations
 import asyncio
 import os
 import tempfile
+import time
 import unittest
 import uuid
 from contextlib import contextmanager
 from pathlib import Path
 from threading import Event
 from typing import Iterator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi import FastAPI, HTTPException
 from fastapi.testclient import TestClient
@@ -300,6 +301,7 @@ class ContextGatheringIntegrationTests(unittest.TestCase):
         self.assertEqual(201, started.status_code, started.text)
         self.assertEqual("building", started.json()["workflow"]["state"])
         self.assertEqual("build-plan-test", started.json()["build_execution"]["plan_id"])
+        self.assertFalse(started.json()["build_execution"]["request_bound_execution"])
         self.assertIn("started the design", started.json()["assistant_message"])
         self.assertEqual(1, dispatcher.calls)
 
@@ -331,6 +333,7 @@ class ContextGatheringIntegrationTests(unittest.TestCase):
         self.assertEqual("building", started.json()["workflow"]["state"])
         self.assertNotIn("critical choice", started.json()["assistant_message"])
         self.assertEqual("planned", execution["status"])
+        self.assertFalse(execution["request_bound_execution"])
         self.assertEqual(str(frozen.build_id), execution["build_id"])
         self.assertEqual([execution["job_id"]], list(plan.jobs))
         launch_plan.assert_called_once_with(execution["plan_id"], OWNER)
@@ -353,6 +356,7 @@ class ContextGatheringIntegrationTests(unittest.TestCase):
 
         self.assertEqual(201, started.status_code, started.text)
         self.assertEqual("planned", started.json()["build_execution"]["status"])
+        self.assertTrue(started.json()["build_execution"]["request_bound_execution"])
         launch_plan.assert_not_called()
 
     def test_detached_build_worker_inherits_request_vertex_oidc_token(self) -> None:
@@ -459,6 +463,111 @@ class ContextGatheringIntegrationTests(unittest.TestCase):
         self.assertEqual("planned", response.json()["status"])
         self.assertEqual(2, response.json()["attempt"])
         reset.assert_awaited_once_with(execution["plan_id"], OWNER)
+
+    def test_launch_once_does_not_start_a_second_owner_for_the_same_plan(self) -> None:
+        started = Event()
+        hold = Event()
+        launches: list[tuple[str, str]] = []
+
+        async def execute_plan(plan_id, owner, **_kwargs):
+            launches.append((plan_id, owner))
+            started.set()
+            hold.wait(timeout=2)
+
+        with patch("apps.api.context_builds.execute_project_generation_plan", side_effect=execute_plan):
+            first = ContextBuildDispatcher.launch_once("plan-owned", OWNER)
+            second = ContextBuildDispatcher.launch_once("plan-owned", OWNER)
+            self.assertTrue(started.wait(timeout=2), "Detached worker did not start.")
+            self.assertTrue(first)
+            self.assertFalse(second)
+            self.assertTrue(ContextBuildDispatcher.owns_plan("plan-owned"))
+            hold.set()
+            deadline = time.time() + 2
+            while ContextBuildDispatcher.owns_plan("plan-owned") and time.time() < deadline:
+                time.sleep(0.05)
+
+        self.assertEqual([("plan-owned", OWNER)], launches)
+        self.assertFalse(ContextBuildDispatcher.owns_plan("plan-owned"))
+
+    def test_resume_skips_terminal_and_request_bound_plans(self) -> None:
+        plan = MagicMock()
+        plan.status = WorkerPlanStatus.SUCCEEDED
+        with (
+            patch("apps.api.context_builds.get_project_generation_plan", return_value=plan),
+            patch.object(ContextBuildDispatcher, "launch_once") as launch,
+        ):
+            result = ContextBuildDispatcher.resume("plan-terminal", OWNER)
+
+        self.assertIs(plan, result)
+        launch.assert_not_called()
+
+        plan.status = WorkerPlanStatus.PLANNED
+        with (
+            patch("apps.api.context_builds.get_project_generation_plan", return_value=plan),
+            patch.object(ContextBuildDispatcher, "requires_request_bound_execution", return_value=True),
+            patch.object(ContextBuildDispatcher, "launch_once") as launch,
+        ):
+            ContextBuildDispatcher.resume("plan-vercel", OWNER)
+
+        launch.assert_not_called()
+
+    def test_resume_endpoint_relaunches_unowned_nonterminal_plan(self) -> None:
+        project_id = str(uuid.uuid4())
+        conversation_id = "conversation-resume-build"
+        self.app.dependency_overrides.pop(context_build_dispatcher)
+        with sqlite_repository(), patch(
+            "apps.api.context_builds.ContextBuildDispatcher._launch",
+        ):
+            self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={"conversation_id": conversation_id, "text": "Build a relay controller."},
+            )
+            started = self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={"conversation_id": conversation_id, "text": "start"},
+            )
+            execution = started.json()["build_execution"]
+            with patch.object(ContextBuildDispatcher, "launch_once", return_value=True) as launch:
+                response = self.client.post(
+                    f"/projects/{project_id}/build/plans/{execution['plan_id']}/resume",
+                )
+
+        self.assertEqual(200, response.status_code, response.text)
+        self.assertEqual(execution["plan_id"], response.json()["plan_id"])
+        launch.assert_called_once_with(execution["plan_id"], OWNER)
+
+    def test_resume_endpoint_rejects_another_users_plan(self) -> None:
+        project_id = str(uuid.uuid4())
+        conversation_id = "conversation-resume-owner"
+        other = UserContext(
+            provider="test",
+            subject="other-user",
+            owner_user_id="other-user",
+            is_authenticated=True,
+            is_admin=False,
+        )
+        self.app.dependency_overrides.pop(context_build_dispatcher)
+        with sqlite_repository(), patch(
+            "apps.api.context_builds.ContextBuildDispatcher._launch",
+        ):
+            self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={"conversation_id": conversation_id, "text": "Build a relay controller."},
+            )
+            started = self.client.post(
+                f"/projects/{project_id}/context/messages",
+                json={"conversation_id": conversation_id, "text": "start"},
+            )
+            execution = started.json()["build_execution"]
+            self.app.dependency_overrides[require_user_context] = lambda: other
+            try:
+                response = self.client.post(
+                    f"/projects/{project_id}/build/plans/{execution['plan_id']}/resume",
+                )
+            finally:
+                self.app.dependency_overrides[require_user_context] = lambda: USER
+
+        self.assertEqual(404, response.status_code, response.text)
 
     def test_text_image_and_document_append_brief_versions_without_enqueuing_jobs(self) -> None:
         project_id = str(uuid.uuid4())

--- a/tests/tooling/test_development_scripts.py
+++ b/tests/tooling/test_development_scripts.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+DEV_PROCESSES = ROOT_DIR / "scripts" / "development" / "dev-processes.sh"
+
+
+def run_bash(script: str, root: Path) -> subprocess.CompletedProcess[str]:
+    inherited_env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in {
+            "DATABASE_BACKEND",
+            "FORMA_AUTH_MODE",
+            "FORMA_DEV_MODE",
+            "FORMA_USER_SECRETS_KEY",
+            "IMAGE_OUTPUT_ENABLED",
+            "IMAGE_PROVIDER",
+            "LLM_PROVIDER",
+            "NEXT_PUBLIC_API_URL",
+            "NEXT_PUBLIC_FORMA_DEV_MODE",
+            "SQLITE_DATABASE_URL",
+        }
+    }
+    env = {
+        **inherited_env,
+        "ROOT_DIR": str(root),
+        "PYTHON_BIN": sys.executable,
+        "BACKEND_HOST": "127.0.0.1",
+        "BACKEND_PORT": "8123",
+        "FRONTEND_HOST": "127.0.0.1",
+        "FRONTEND_PORT": "3123",
+    }
+    return subprocess.run(
+        ["bash", "-lc", script],
+        cwd=root,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+class DevelopmentScriptTests(unittest.TestCase):
+    def test_zero_config_defaults_to_local_simulation(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            result = run_bash(
+                textwrap.dedent(
+                    f"""
+                    set -euo pipefail
+                    source {shlex.quote(str(DEV_PROCESSES))}
+                    dev_ensure_local_simulation_env
+                    test -s "$DEV_RUNTIME_DIR/forma-user-secrets.key"
+                    printf '%s\\n' "$FORMA_AUTH_MODE|$FORMA_DEV_MODE|$DATABASE_BACKEND|$LLM_PROVIDER|$IMAGE_PROVIDER|$NEXT_PUBLIC_FORMA_DEV_MODE"
+                    printf '%s\\n' "$SQLITE_DATABASE_URL"
+                    """
+                ),
+                root,
+            )
+
+        lines = result.stdout.strip().splitlines()
+        self.assertEqual("local|true|sqlite|simulation|none|true", lines[0])
+        self.assertIn("/tmp/development/forma-dev.db", lines[1])
+
+    def test_existing_env_file_keeps_environment_explicit(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / ".env").write_text("FORMA_AUTH_MODE=local\n", encoding="utf-8")
+            result = run_bash(
+                textwrap.dedent(
+                    f"""
+                    set -euo pipefail
+                    source {shlex.quote(str(DEV_PROCESSES))}
+                    dev_ensure_local_simulation_env
+                    test ! -e "$DEV_RUNTIME_DIR/forma-user-secrets.key"
+                    printf '%s\\n' "${{FORMA_USER_SECRETS_KEY-unset}}|${{LLM_PROVIDER-unset}}"
+                    """
+                ),
+                root,
+            )
+
+        self.assertEqual("unset|unset", result.stdout.strip())
+
+    def test_explicit_sqlite_url_parent_is_created(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            result = run_bash(
+                textwrap.dedent(
+                    f"""
+                    set -euo pipefail
+                    export FORMA_USER_SECRETS_KEY=explicit-test-secret
+                    export SQLITE_DATABASE_URL="sqlite:///$ROOT_DIR/custom/db/forma.db"
+                    source {shlex.quote(str(DEV_PROCESSES))}
+                    dev_ensure_local_simulation_env
+                    test -d "$ROOT_DIR/custom/db"
+                    printf 'created\\n'
+                    """
+                ),
+                root,
+            )
+
+        self.assertEqual("created", result.stdout.strip())
+
+    def test_process_group_lifecycle_uses_recorded_repo_root(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            result = run_bash(
+                textwrap.dedent(
+                    f"""
+                    set -euo pipefail
+                    source {shlex.quote(str(DEV_PROCESSES))}
+                    mkdir -p "$DEV_RUNTIME_DIR"
+                    dev_start_process_group child "$DEV_RUNTIME_DIR/test.pgid" "$DEV_RUNTIME_DIR/test.log" "$PYTHON_BIN" -c 'import time; time.sleep(30)'
+                    read -r recorded_pid recorded_root <"$DEV_RUNTIME_DIR/test.pgid"
+                    test "$recorded_pid" = "$child"
+                    test "$recorded_root" = "$ROOT_DIR"
+                    dev_group_is_running "$child"
+                    dev_stop_process_group "$child" "test" "$DEV_RUNTIME_DIR/test.pgid" "$recorded_root"
+                    test ! -e "$DEV_RUNTIME_DIR/test.pgid"
+                    if dev_group_is_running "$child"; then exit 7; fi
+                    printf 'stopped\\n'
+                    """
+                ),
+                root,
+            )
+
+        self.assertEqual("stopped", result.stdout.strip().splitlines()[-1])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Resume detached context builds with lock-protected `launch_once` and owner-checked `POST .../resume`. Local/Docker UI polls GET and must not POST `/execute`; Vercel stays request-bound.
- Extract the generation controller and split `forma-workspace.tsx` into focused modules so the orchestrator stays under the size cap, while keeping gather results across `/chat` hydration.
- Show hardware references in Overview and keep project tabs theme-aware from the earlier commit on this branch.
- Soften Settings, About, Community, and sidebar surfaces (tone panels, no hard card borders).
- Keep the original new-project composer; use a compact floating one-liner when iterating on an existing project.
- Persist a renamed title on the chat when `PATCH /projects` 404s because no generated project exists yet.
- Add unit coverage for recovery/hydration plus Playwright for generate → inspect and reload-during-build without duplicate local execute.

## Test plan
- [ ] `python -m unittest tests.projects.test_context_gathering`
- [ ] `npm run test:unit` in `apps/web`
- [ ] `npm run test:e2e` (both simulation specs, `executeRequests === []`)
- [ ] Reload mid-build on local simulation and confirm `/resume` is used, not `/execute`
- [ ] Open a generated project Overview and confirm the hardware reference still appears
- [ ] Rename a started chat before a generated project exists and confirm no “Project not found” console error
- [ ] Confirm Settings/About/Community/sidebar use surface panels without hard borders
- [ ] Confirm new-project prompt is tall; existing project prompt is a compact one-liner