### PR TITLE
feat: use shared workspace for hardware projects

### DIFF
--- a/.agents/skills/forma-hardware/SKILL.md
+++ b/.agents/skills/forma-hardware/SKILL.md
@@ -7,6 +7,14 @@ description: Compile, validate, inspect, or generate safe low-voltage maker-elec
 
 Use the host agent to author the design and Forma to normalize Hardware IR, apply deterministic electrical checks, and render diagrams. Never replace a failed live generation with simulated output unless the user explicitly requests simulation.
 
+## Workspace
+
+At the start of every project run, create a fresh project directory with `scripts/create_project.py` and use the returned path as `PROJECT_DIR`. The helper creates a UUID-named directory under `~/forma-workspace/`; never derive the project ID from the request. Keep every source file and generated artifact inside `PROJECT_DIR`.
+
+```bash
+PROJECT_DIR=$(python <skill-directory>/scripts/create_project.py)
+```
+
 ## Connect
 
 Prefer the native `forma.*` MCP tools when available. Otherwise run the bundled standard-library client:
@@ -21,13 +29,13 @@ It reads `FORMA_MCP_URL`, defaulting to `http://127.0.0.1:8000/mcp`, and optiona
 
 1. Keep the project within safe low-voltage educational or maker scope. Decline weapons, critical medical or life-support devices, mains AC, automotive control, and unsafe high-power battery requests.
 2. Read [references/hardware-ir.md](references/hardware-ir.md), then author complete Hardware IR from the brief. Preserve stated power, dimensions, budget, environment, interfaces, and part preferences. Do not invent verified supplier availability or physical clearances.
-3. Save the IR as `forma-project.json`.
+3. Save the IR as `$PROJECT_DIR/forma-project.json`.
 4. Call `forma.compile_project` with `project_ir` and the correct `authoring_agent` (`openclaw`, `nemoclaw`, `opencode`, `claude`, or `codex`). With the bundled client:
 
 ```bash
-python <skill-directory>/scripts/forma.py compile forma-project.json --authoring-agent openclaw --output compiled-project.json
-python <skill-directory>/scripts/forma.py compile forma-project.json --authoring-agent nemoclaw --output compiled-project.json
-python <skill-directory>/scripts/forma.py compile forma-project.json --authoring-agent opencode --output compiled-project.json
+python <skill-directory>/scripts/forma.py compile "$PROJECT_DIR/forma-project.json" --authoring-agent openclaw --output "$PROJECT_DIR/compiled-project.json"
+python <skill-directory>/scripts/forma.py compile "$PROJECT_DIR/forma-project.json" --authoring-agent nemoclaw --output "$PROJECT_DIR/compiled-project.json"
+python <skill-directory>/scripts/forma.py compile "$PROJECT_DIR/forma-project.json" --authoring-agent opencode --output "$PROJECT_DIR/compiled-project.json"
 ```
 
 5. Fix practical agent-authored errors and compile again. Treat every `CRITICAL` finding as blocking.
@@ -38,7 +46,7 @@ python <skill-directory>/scripts/forma.py compile forma-project.json --authoring
 Call `forma.validate_circuit`, or use:
 
 ```bash
-python <skill-directory>/scripts/forma.py validate forma-project.json --output validation.json
+python <skill-directory>/scripts/forma.py validate "$PROJECT_DIR/forma-project.json" --output "$PROJECT_DIR/validation.json"
 ```
 
 ## Optional server-side generation
@@ -46,9 +54,9 @@ python <skill-directory>/scripts/forma.py validate forma-project.json --output v
 Use `forma.generate_project` only when the user wants Forma's separately configured server-side LLM. Prefer host-authored IR plus `forma.compile_project` for normal OpenClaw, NemoClaw, and OpenCode work.
 
 ```bash
-python <skill-directory>/scripts/forma.py generate "ESP32 plant monitor with an OLED" --output forma-project.json
+python <skill-directory>/scripts/forma.py generate "ESP32 plant monitor with an OLED" --output "$PROJECT_DIR/forma-project.json"
 ```
 
 ## Output integrity
 
-Keep compiled JSON intact. Do not expose credentials. Do not claim that diagrams, prices, availability, compatibility, or clearances were physically verified unless returned evidence establishes that.
+Keep compiled JSON intact inside `PROJECT_DIR`. Do not expose credentials. Do not claim that diagrams, prices, availability, compatibility, or clearances were physically verified unless returned evidence establishes that.

--- a/.agents/skills/forma-hardware/agents/openai.yaml
+++ b/.agents/skills/forma-hardware/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Forma Hardware"
   short_description: "Compile and validate hardware with Forma"
-  default_prompt: "Use $forma-hardware to compile and validate a safe low-voltage hardware prototype."
+  default_prompt: "Use $forma-hardware to create a fresh UUID project directory under ~/forma-workspace/<generated-uuid>/, then compile and validate a safe low-voltage hardware prototype entirely inside that directory."

--- a/.agents/skills/forma-hardware/scripts/create_project.py
+++ b/.agents/skills/forma-hardware/scripts/create_project.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Create a unique project directory in the shared Forma workspace."""
+
+from __future__ import annotations
+
+import argparse
+import uuid
+from pathlib import Path
+
+
+WORKSPACE_NAME = "forma-workspace"
+
+
+def create_project_directory(workspace: str | Path | None = None) -> Path:
+    """Create and return a UUID-named project directory."""
+    workspace_path = (
+        Path(workspace).expanduser()
+        if workspace is not None
+        else Path.home() / WORKSPACE_NAME
+    )
+    workspace_path.mkdir(parents=True, exist_ok=True)
+
+    while True:
+        project_path = workspace_path / str(uuid.uuid4())
+        try:
+            project_path.mkdir()
+        except FileExistsError:
+            continue
+        return project_path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Create a Forma workspace project directory")
+    parser.add_argument(
+        "--workspace",
+        help="Workspace root override for tests or isolated environments",
+    )
+    args = parser.parse_args(argv)
+    print(create_project_directory(args.workspace))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tooling/test_agent_skill_compatibility.py
+++ b/tests/tooling/test_agent_skill_compatibility.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import importlib.util
 import unittest
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from uuid import UUID
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -39,6 +41,20 @@ class AgentSkillCompatibilityTests(unittest.TestCase):
 
         self.assertEqual("nemoclaw", args.authoring_agent)
         self.assertEqual("compiled.json", args.output)
+
+    def test_project_allocator_uses_a_generated_uuid_under_the_workspace(self) -> None:
+        script = SKILL_ROOT / "scripts" / "create_project.py"
+        spec = importlib.util.spec_from_file_location("forma_skill_project", script)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+
+        with TemporaryDirectory() as temporary_directory:
+            workspace = Path(temporary_directory) / "forma-workspace"
+            project_path = module.create_project_directory(workspace)
+            self.assertEqual(workspace, project_path.parent)
+            UUID(project_path.name)
+            self.assertTrue(project_path.is_dir())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add a UUID-based project directory allocator under `~/forma-workspace/<uuid>/`
- require the `forma-hardware` workflow to keep source and generated artifacts inside that directory
- update the OpenAI skill prompt and add allocator coverage

Fixes #321

## Tests
- `python -m unittest tests.tooling.test_agent_skill_compatibility` (3 passed)
- `python -m compileall` passed for the helper and test
- isolated shared-workspace allocator smoke test passed
