### PR TITLE
feat: manage OpenCAD dependency in Forma skill

### DIFF
--- a/.agents/skills/forma-hardware/SKILL.md
+++ b/.agents/skills/forma-hardware/SKILL.md
@@ -5,7 +5,21 @@ description: Compile, validate, inspect, or generate safe low-voltage maker-elec
 
 # Forma Hardware
 
-Use the host agent to author the design and Forma to normalize Hardware IR, apply deterministic electrical checks, and render diagrams. Never replace a failed live generation with simulated output unless the user explicitly requests simulation.
+Use the host agent to author the design and Forma to normalize Hardware IR, apply deterministic electrical checks, and render diagrams. For CAD-capable workflows, use the Forma-owned OpenCAD adapter described in [references/cad.md](references/cad.md). Never replace a failed live generation with simulated output unless the user explicitly requests simulation.
+
+## CAD dependency
+
+When the user asks for a CAD model or STEP/STL export, prepare the managed
+runtime before writing or running the model:
+
+```bash
+python <skill-directory>/scripts/cad.py setup
+```
+
+The setup command reuses compatible OpenCAD `0.2.3` installations and installs
+`opencad[occt]==0.2.3` when needed. It verifies native OCCT before a generation
+job begins. Do not import OpenCAD from Forma's core package; use the adapter's
+`build` command for model execution and export.
 
 ## Workspace
 

--- a/.agents/skills/forma-hardware/references/cad.md
+++ b/.agents/skills/forma-hardware/references/cad.md
@@ -1,0 +1,64 @@
+# Forma CAD
+
+The Forma hardware skill manages OpenCAD for CAD-capable workflows. The base
+`caid-forma-core` package does not install OpenCAD.
+
+## Supported runtime
+
+- OpenCAD: `0.2.3`
+- Required extra: `occt`
+- Exact managed requirement: `opencad[occt]==0.2.3`
+- Python: `3.11+` for the Forma skill environment
+
+The OCCT extra is required for real STEP and STL exchange files. The analytic
+OpenCAD backend is not a substitute for an exported CAD artifact.
+
+## Setup and verification
+
+Run setup once when installing the skill, before starting a CAD generation
+workflow:
+
+```bash
+python <skill-directory>/scripts/cad.py setup
+```
+
+Setup first reuses an installed OpenCAD `0.2.3` runtime when its native OCCT
+backend is available. Otherwise it installs the exact managed requirement and
+verifies the backend before returning. To verify without changing the active
+Python environment:
+
+```bash
+python <skill-directory>/scripts/cad.py check
+```
+
+If setup fails, the command reports one exact recovery command. Keep the
+command's Python interpreter and environment consistent with the interpreter
+used to invoke `cad.py`.
+
+## Build an artifact
+
+Have the agent write a readable OpenCAD model and use the adapter for export:
+
+```bash
+python <skill-directory>/scripts/cad.py build PROJECT/assembly.py PROJECT/outputs/assembly.step --tree-output PROJECT/outputs/assembly.tree.json
+python <skill-directory>/scripts/cad.py build PROJECT/assembly.py PROJECT/outputs/assembly.stl
+```
+
+The adapter creates an OCCT runtime, runs the model, validates the exchange
+file structure, and publishes the output atomically. Existing outputs are not
+replaced unless `--force` is supplied. Keep the model source and feature tree
+with the artifact so the result can be rebuilt.
+
+## OpenCAD source overrides
+
+An existing compatible installation is always preferred. For a private wheel,
+mirror, or local package that still reports the supported `0.2.3` version, set
+`FORMA_OPENCAD_REQUIREMENT` for setup and build:
+
+```bash
+FORMA_OPENCAD_REQUIREMENT='opencad[occt] @ file:///path/to/opencad-0.2.3-py3-none-any.whl' python <skill-directory>/scripts/cad.py setup
+```
+
+The override changes only the package source/installer requirement. The
+adapter still rejects any runtime whose reported OpenCAD version is not
+`0.2.3` or whose OCCT backend cannot be constructed.

--- a/.agents/skills/forma-hardware/scripts/cad.py
+++ b/.agents/skills/forma-hardware/scripts/cad.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""Managed OpenCAD adapter for the Forma hardware skill.
+
+The skill owns this boundary so callers do not need to know how OpenCAD selects
+its native geometry backend or exports an exchange file. OpenCAD is imported
+only after the dependency check succeeds.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import importlib.metadata
+import json
+import os
+import runpy
+import struct
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+SUPPORTED_OPENCAD_VERSION = "0.2.3"
+DEFAULT_OPENCAD_REQUIREMENT = f"opencad[occt]=={SUPPORTED_OPENCAD_VERSION}"
+OPENCAD_REQUIREMENT_ENV = "FORMA_OPENCAD_REQUIREMENT"
+SUPPORTED_OUTPUT_SUFFIXES = {".step", ".stp", ".stl"}
+
+
+class OpenCADError(RuntimeError):
+    """Raised when the Forma CAD runtime cannot be prepared or used."""
+
+
+@dataclass(frozen=True)
+class OpenCADRuntime:
+    """Validated OpenCAD runtime exposed by the Forma adapter."""
+
+    version: str
+    requirement: str
+
+    def build_model(self, model: Path, output: Path, tree_output: Path | None) -> int:
+        """Run a model with OCCT and export its final shape."""
+        try:
+            from opencad.kernel.core.backend_factory import create_backend
+            from opencad.kernel_adapter import registry_result_to_dict
+            from opencad.runtime import RuntimeContext, set_default_context
+        except ImportError as exc:
+            raise OpenCADError(_diagnostic("the OpenCAD export API could not be imported", self.requirement)) from exc
+
+        try:
+            context = RuntimeContext(backend=create_backend("occt", require_native=True))
+        except Exception as exc:
+            raise OpenCADError(_diagnostic(f"the OCCT backend is unavailable: {exc}", self.requirement)) from exc
+
+        set_default_context(context)
+        model_directory = str(model.parent)
+        added_model_directory = model_directory not in sys.path
+        if added_model_directory:
+            sys.path.insert(0, model_directory)
+        try:
+            runpy.run_path(str(model), run_name="__main__")
+        finally:
+            if added_model_directory:
+                sys.path.remove(model_directory)
+
+        if not context.last_shape_id:
+            raise OpenCADError("The OpenCAD model produced no shape to export.")
+
+        operation = "export_stl" if output.suffix.lower() == ".stl" else "export_step"
+        result = registry_result_to_dict(
+            context.registry,
+            operation,
+            {"shape_id": context.last_shape_id, "filepath": str(output)},
+        )
+        if not result.get("ok"):
+            raise OpenCADError(f"CAD export failed: {result.get('message', 'unknown error')}")
+        if tree_output is not None:
+            context.save_tree_json(str(tree_output))
+        return len(context.tree.nodes) - 1
+
+
+def _configured_requirement(requirement: str | None) -> str:
+    value = (requirement or os.environ.get(OPENCAD_REQUIREMENT_ENV) or DEFAULT_OPENCAD_REQUIREMENT).strip()
+    if not value:
+        value = DEFAULT_OPENCAD_REQUIREMENT
+    if any(character in value for character in ('"', "\r", "\n")):
+        raise OpenCADError(
+            f"{OPENCAD_REQUIREMENT_ENV} must be a single pip requirement without quotes or newlines. "
+            f"Recovery command: {_recovery_command(DEFAULT_OPENCAD_REQUIREMENT)}"
+        )
+    return value
+
+
+def _recovery_command(requirement: str) -> str:
+    return f'python -m pip install "{requirement}"'
+
+
+def _diagnostic(reason: str, requirement: str) -> str:
+    return (
+        f"OpenCAD {SUPPORTED_OPENCAD_VERSION} with the OCCT extra is unavailable: {reason}.\n"
+        f"Recovery command: {_recovery_command(requirement)}"
+    )
+
+
+def _runtime_version(module: Any) -> str | None:
+    module_version = str(getattr(module, "__version__", "")).strip()
+    if module_version:
+        return module_version
+    try:
+        return importlib.metadata.version("opencad")
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def _inspect_runtime(requirement: str) -> tuple[OpenCADRuntime | None, str]:
+    try:
+        module = importlib.import_module("opencad")
+    except Exception as exc:
+        return None, f"the package could not be imported: {exc}"
+
+    runtime_version = _runtime_version(module)
+    if runtime_version is None:
+        return None, "the installed package does not declare a version"
+    if runtime_version != SUPPORTED_OPENCAD_VERSION:
+        return None, f"installed version {runtime_version} is incompatible"
+
+    try:
+        distribution_version = importlib.metadata.version("opencad")
+    except importlib.metadata.PackageNotFoundError:
+        distribution_version = None
+    if distribution_version is not None and distribution_version != SUPPORTED_OPENCAD_VERSION:
+        return None, f"installed distribution version {distribution_version} is incompatible"
+
+    try:
+        from opencad.kernel.core.backend_factory import create_backend
+
+        create_backend("occt", require_native=True)
+    except Exception as exc:
+        return None, f"the native OCCT backend is unavailable: {exc}"
+
+    return OpenCADRuntime(version=runtime_version, requirement=requirement), ""
+
+
+def _clear_opencad_modules() -> None:
+    for name in list(sys.modules):
+        if name == "opencad" or name.startswith("opencad."):
+            del sys.modules[name]
+    importlib.invalidate_caches()
+
+
+def _install(requirement: str) -> None:
+    command = [sys.executable, "-m", "pip", "install", "--upgrade", requirement]
+    try:
+        completed = subprocess.run(command, check=False, capture_output=True, text=True)
+    except OSError as exc:
+        raise OpenCADError(_diagnostic(f"pip could not be started: {exc}", requirement)) from exc
+    if completed.returncode == 0:
+        return
+
+    detail = (completed.stderr or completed.stdout or "pip returned a non-zero exit code").strip()
+    if len(detail) > 1200:
+        detail = detail[-1200:]
+    raise OpenCADError(_diagnostic(f"managed installation failed: {detail}", requirement))
+
+
+def ensure_opencad(*, install: bool = True, requirement: str | None = None) -> OpenCADRuntime:
+    """Return a compatible native runtime, installing the skill dependency if needed."""
+    configured = _configured_requirement(requirement)
+    runtime, reason = _inspect_runtime(configured)
+    if runtime is not None:
+        return runtime
+    if not install:
+        raise OpenCADError(_diagnostic(reason, configured))
+
+    _install(configured)
+    _clear_opencad_modules()
+    runtime, reason = _inspect_runtime(configured)
+    if runtime is None:
+        raise OpenCADError(_diagnostic(f"managed installation completed but verification failed: {reason}", configured))
+    return runtime
+
+
+def _temporary_path(destination: Path) -> Path:
+    handle = tempfile.NamedTemporaryFile(
+        prefix=f".{destination.stem}-",
+        suffix=destination.suffix,
+        dir=destination.parent,
+        delete=False,
+    )
+    handle.close()
+    return Path(handle.name)
+
+
+def _binary_stl_triangle_count(data: bytes) -> int | None:
+    if len(data) < 84:
+        return None
+    triangle_count = struct.unpack_from("<I", data, 80)[0]
+    return triangle_count if 84 + triangle_count * 50 == len(data) else None
+
+
+def inspect_cad_file(filepath: str | Path) -> dict[str, Any]:
+    """Validate the basic exchange-file structure before publishing an output."""
+    path = Path(filepath)
+    if not path.is_file():
+        raise OpenCADError(f"CAD file does not exist: {path}")
+    data = path.read_bytes()
+    if not data:
+        raise OpenCADError(f"CAD file is empty: {path}")
+
+    suffix = path.suffix.lower()
+    if suffix in {".step", ".stp"}:
+        upper = data.upper()
+        if not upper.lstrip().startswith(b"ISO-10303-21;"):
+            raise OpenCADError("STEP validation failed: missing ISO-10303-21 header.")
+        if b"END-ISO-10303-21;" not in upper or b"DATA;" not in upper or b"ENDSEC;" not in upper:
+            raise OpenCADError("STEP validation failed: missing exchange data section or end marker.")
+        return {"format": "step", "path": str(path.resolve()), "bytes": len(data), "valid": True}
+
+    if suffix == ".stl":
+        triangle_count = _binary_stl_triangle_count(data)
+        encoding = "binary"
+        if triangle_count is None:
+            text = data.decode("utf-8", errors="replace").lower()
+            if not text.lstrip().startswith("solid") or "endsolid" not in text:
+                raise OpenCADError("STL validation failed: file is neither valid binary nor recognizable ASCII STL.")
+            triangle_count = text.count("facet normal")
+            encoding = "ascii"
+        if triangle_count < 1:
+            raise OpenCADError("STL validation failed: mesh contains no triangles.")
+        return {
+            "format": "stl",
+            "encoding": encoding,
+            "triangles": triangle_count,
+            "path": str(path.resolve()),
+            "bytes": len(data),
+            "valid": True,
+        }
+
+    raise OpenCADError("Unsupported CAD format. Use a .step, .stp, or .stl file.")
+
+
+def build_cad_file(
+    model: str | Path,
+    output: str | Path,
+    *,
+    tree_output: str | Path | None = None,
+    force: bool = False,
+    requirement: str | None = None,
+) -> dict[str, Any]:
+    """Build, validate, and atomically publish a CAD artifact."""
+    model_path = Path(model).resolve()
+    output_path = Path(output).resolve()
+    tree_path = Path(tree_output).resolve() if tree_output else None
+    if not model_path.is_file():
+        raise OpenCADError(f"Model script does not exist: {model_path}")
+    if model_path.suffix.lower() != ".py":
+        raise OpenCADError("The OpenCAD model must be a .py file.")
+    if output_path.suffix.lower() not in SUPPORTED_OUTPUT_SUFFIXES:
+        raise OpenCADError("Output must end in .step, .stp, or .stl.")
+    if tree_path == output_path:
+        raise OpenCADError("CAD output and feature-tree output must use different paths.")
+    for destination in (output_path, tree_path):
+        if destination is not None and destination.exists() and not force:
+            raise OpenCADError(f"Refusing to replace existing file without --force: {destination}")
+
+    runtime = ensure_opencad(requirement=requirement)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    if tree_path is not None:
+        tree_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_output = _temporary_path(output_path)
+    temporary_tree = _temporary_path(tree_path) if tree_path is not None else None
+
+    try:
+        feature_count = runtime.build_model(model_path, temporary_output, temporary_tree)
+        summary = inspect_cad_file(temporary_output)
+        summary["features"] = feature_count
+        os.replace(temporary_output, output_path)
+        summary["path"] = str(output_path)
+        if tree_path is not None and temporary_tree is not None:
+            os.replace(temporary_tree, tree_path)
+            summary["tree_path"] = str(tree_path)
+        summary["model_path"] = str(model_path)
+        summary["opencad_version"] = runtime.version
+        return summary
+    finally:
+        temporary_output.unlink(missing_ok=True)
+        if temporary_tree is not None:
+            temporary_tree.unlink(missing_ok=True)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prepare OpenCAD and build Forma CAD artifacts.")
+    commands = parser.add_subparsers(dest="command", required=True)
+    for name, help_text in (
+        ("setup", "Install and verify the managed OpenCAD runtime."),
+        ("check", "Verify OpenCAD without installing anything."),
+    ):
+        command = commands.add_parser(name, help=help_text)
+        command.add_argument("--requirement", help=f"Optional pip requirement override (also {OPENCAD_REQUIREMENT_ENV}).")
+
+    build = commands.add_parser("build", help="Build and validate a STEP or STL artifact from an OpenCAD model.")
+    build.add_argument("model", help="OpenCAD Python model")
+    build.add_argument("output", help="Destination ending in .step, .stp, or .stl")
+    build.add_argument("--tree-output", help="Optional feature-tree JSON destination")
+    build.add_argument("--force", action="store_true", help="Replace existing output files")
+    build.add_argument("--requirement", help=f"Optional pip requirement override (also {OPENCAD_REQUIREMENT_ENV}).")
+    return parser
+
+
+def run(args: argparse.Namespace) -> dict[str, Any]:
+    if args.command in {"setup", "check"}:
+        runtime = ensure_opencad(install=args.command == "setup", requirement=args.requirement)
+        return {
+            "opencad_version": runtime.version,
+            "requirement": runtime.requirement,
+            "occt": True,
+            "valid": True,
+        }
+    return build_cad_file(
+        args.model,
+        args.output,
+        tree_output=args.tree_output,
+        force=args.force,
+        requirement=args.requirement,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        print(json.dumps(run(args), indent=2, sort_keys=True))
+        return 0
+    except (OpenCADError, OSError, ValueError) as exc:
+        print(f"forma-cad: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/agent-clients.md
+++ b/docs/agent-clients.md
@@ -43,6 +43,22 @@ nemoclaw my-sandbox upload .agents/skills/forma-hardware /sandbox/.openclaw/work
 
 Repeat the upload for each agent workspace. For a stable private RFC1918 endpoint, add `--trusted-private-host forma.internal.example` when registering it and use a certificate valid for that exact hostname. NemoClaw intentionally rejects `http://127.0.0.1`, `localhost`, and `host.docker.internal` MCP URLs.
 
+## CAD skill dependency
+
+The shared skill manages the OpenCAD dependency for CAD-capable workflows;
+the base Forma SDK and MCP client do not install it. Run setup once after
+installing the skill, before asking an agent to create or export CAD:
+
+```bash
+python .agents/skills/forma-hardware/scripts/cad.py setup
+```
+
+The adapter pins OpenCAD `0.2.3` with the `occt` extra, reuses a compatible
+native installation, and verifies OCCT before a model runs. See the skill's
+[CAD reference](../.agents/skills/forma-hardware/references/cad.md) for build
+commands, exact recovery diagnostics, and `FORMA_OPENCAD_REQUIREMENT` source
+overrides.
+
 ## OpenCode
 
 OpenCode also discovers `.agents/skills/forma-hardware/SKILL.md`. Add Forma to `opencode.json`:

--- a/tests/tooling/test_agent_skill_compatibility.py
+++ b/tests/tooling/test_agent_skill_compatibility.py
@@ -56,6 +56,20 @@ class AgentSkillCompatibilityTests(unittest.TestCase):
             UUID(project_path.name)
             self.assertTrue(project_path.is_dir())
 
+    def test_cad_adapter_declares_managed_native_dependency(self) -> None:
+        script = SKILL_ROOT / "scripts" / "cad.py"
+        content = script.read_text(encoding="utf-8")
+        self.assertIn('SUPPORTED_OPENCAD_VERSION = "0.2.3"', content)
+        self.assertIn('DEFAULT_OPENCAD_REQUIREMENT = f"opencad[occt]=={SUPPORTED_OPENCAD_VERSION}"', content)
+        self.assertIn('create_backend("occt", require_native=True)', content)
+        self.assertIn("FORMA_OPENCAD_REQUIREMENT", content)
+
+    def test_base_core_dependencies_do_not_include_opencad(self) -> None:
+        pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+        requirements = (REPO_ROOT / "requirements.txt").read_text(encoding="utf-8")
+        self.assertNotIn("opencad", pyproject.lower())
+        self.assertNotIn("opencad", requirements.lower())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tooling/test_cad_skill.py
+++ b/tests/tooling/test_cad_skill.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_ROOT = REPO_ROOT / ".agents" / "skills" / "forma-hardware"
+CAD_SCRIPT = SKILL_ROOT / "scripts" / "cad.py"
+
+
+def load_cad_module():
+    spec = importlib.util.spec_from_file_location("forma_cad_skill", CAD_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Could not load the Forma CAD adapter")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class CadSkillTests(unittest.TestCase):
+    def test_compatible_runtime_is_reused_without_pip(self) -> None:
+        module = load_cad_module()
+        with patch.object(module, "_inspect_runtime") as inspect_runtime, patch.object(module, "_install") as install:
+            inspect_runtime.return_value = (
+                module.OpenCADRuntime("0.2.3", module.DEFAULT_OPENCAD_REQUIREMENT),
+                "",
+            )
+
+            runtime = module.ensure_opencad()
+
+        self.assertEqual("0.2.3", runtime.version)
+        install.assert_not_called()
+
+    def test_missing_runtime_is_installed_and_verified(self) -> None:
+        module = load_cad_module()
+        runtime = module.OpenCADRuntime("0.2.3", module.DEFAULT_OPENCAD_REQUIREMENT)
+        with patch.object(module, "_inspect_runtime", side_effect=[(None, "package is missing"), (runtime, "")]) as inspect_runtime, patch.object(module, "_install") as install, patch.object(module, "_clear_opencad_modules"):
+            result = module.ensure_opencad()
+
+        self.assertEqual(runtime, result)
+        install.assert_called_once_with(module.DEFAULT_OPENCAD_REQUIREMENT)
+        self.assertEqual(2, inspect_runtime.call_count)
+
+    def test_failed_setup_contains_one_exact_recovery_command(self) -> None:
+        module = load_cad_module()
+        with patch.object(module, "_inspect_runtime", return_value=(None, "OCCT is missing")), patch.object(
+            module.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="pip failed"
+            ),
+        ):
+            with self.assertRaises(module.OpenCADError) as raised:
+                module.ensure_opencad()
+
+        message = str(raised.exception)
+        command = 'python -m pip install "opencad[occt]==0.2.3"'
+        self.assertIn(command, message)
+        self.assertEqual(1, message.count(command))
+
+    def test_clean_skill_copy_exports_minimal_step_when_occt_is_available(self) -> None:
+        module = load_cad_module()
+        try:
+            module.ensure_opencad(install=False)
+        except module.OpenCADError as exc:
+            self.skipTest(f"OpenCAD OCCT integration dependency unavailable: {exc}")
+
+        with tempfile.TemporaryDirectory() as directory:
+            workspace = Path(directory)
+            installed_skill = workspace / ".agents" / "skills" / "forma-hardware"
+            shutil.copytree(SKILL_ROOT, installed_skill)
+            model = workspace / "assembly.py"
+            model.write_text(
+                "from opencad import Part\n\nresult = Part(name='Integration box').box(12, 10, 4)\n",
+                encoding="utf-8",
+            )
+            output = workspace / "outputs" / "assembly.step"
+            tree = workspace / "outputs" / "assembly.tree.json"
+            environment = os.environ.copy()
+            environment.pop("FORMA_OPENCAD_REQUIREMENT", None)
+
+            setup = subprocess.run(
+                [sys.executable, str(installed_skill / "scripts" / "cad.py"), "setup"],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            self.assertEqual(0, setup.returncode, setup.stderr)
+
+            build = subprocess.run(
+                [
+                    sys.executable,
+                    str(installed_skill / "scripts" / "cad.py"),
+                    "build",
+                    str(model),
+                    str(output),
+                    "--tree-output",
+                    str(tree),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=environment,
+            )
+            self.assertEqual(0, build.returncode, build.stderr)
+            summary = json.loads(build.stdout)
+            self.assertTrue(summary["valid"])
+            self.assertEqual("0.2.3", summary["opencad_version"])
+            self.assertTrue(output.is_file())
+            self.assertTrue(tree.is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add a Forma-owned CAD adapter that manages and verifies OpenCAD with native OCCT before model execution. Compatible OpenCAD installations are reused; missing or incompatible runtimes are installed with the pinned requirement and produce an exact recovery command when setup fails.

## Related issue

Closes #323

## Change type

- [x] Feature
- [x] Documentation
- [x] Test

## Verification

- python -m unittest tests.tooling.test_agent_skill_compatibility tests.tooling.test_cad_skill -v: 9 passed.
- python -m compileall -q apps/api forma_core evals scripts tests .agents/skills/forma-hardware/scripts: passed.
- python .agents/skills/forma-hardware/scripts/cad.py check and setup: OpenCAD 0.2.3 with OCCT verified.
- Integration test copied the skill into a clean temporary workspace and exported a valid minimal STEP file plus feature tree.
- Full repository discovery was not clean in this environment because backend dependencies are not installed (fastapi, python-dotenv, sqlalchemy, and others); it also reported one unrelated Hugging Face artifact-size assertion.

## Configuration or migration requirements

No base package or deployment dependency changes. CAD skill setup installs opencad[occt]==0.2.3 into the active Python environment. FORMA_OPENCAD_REQUIREMENT supports private wheel or mirror sources while the adapter still enforces OpenCAD 0.2.3 and native OCCT.

## Visual changes

Not applicable.

## Safety and compatibility

OpenCAD remains outside caid-forma-core and application requirements. CAD export requires the native OCCT backend; the analytic backend is never substituted for an exchange-file artifact.

## AI assistance

Implementation and tests were prepared with AI assistance.