### PR TITLE
feat: persist MCP compiled projects

### DIFF
--- a/apps/api/a2a.py
+++ b/apps/api/a2a.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from fastapi import WebSocket, WebSocketDisconnect
 from pydantic import BaseModel, Field
 
+from apps.api.auth import UserContext
 from forma_core.agents.workflows import (
     generate_project_with_workflow,
     get_workflow_debug_config,
@@ -22,6 +23,7 @@ from forma_core.database import (
     ensure_project_action_allowed,
     get_generated_project,
     save_generated_project,
+    update_generated_project_metadata,
     update_generated_project_hardware_ir,
 )
 from forma_core.images import build_image_provider, build_project_visual_spec, get_image_output_debug_config
@@ -1307,7 +1309,7 @@ def _mcp_tools() -> List[Dict[str, Any]]:
             "name": "forma.compile_project",
             "description": (
                 "Normalize, electrically validate, and render host-agent-authored Forma Hardware IR "
-                "without invoking a server-side LLM."
+                "without invoking a server-side LLM, then persist the result for gallery/workspace use."
             ),
             "inputSchema": {
                 "type": "object",
@@ -1316,10 +1318,24 @@ def _mcp_tools() -> List[Dict[str, Any]]:
                         "type": "object",
                         "description": "Forma Hardware IR authored by the calling agent.",
                     },
+                    "project_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "Optional existing project UUID to update when owned by the caller.",
+                    },
                     "authoring_agent": {
                         "type": "string",
                         "enum": ["openclaw", "opencode", "nemoclaw", "claude", "codex", "other"],
                         "default": "other",
+                    },
+                    "prompt": {
+                        "type": "string",
+                        "description": "Optional source prompt stored with the project.",
+                    },
+                    "visibility": {
+                        "type": "string",
+                        "enum": ["public", "private"],
+                        "default": "public",
                     },
                 },
                 "required": ["project_ir"],
@@ -1448,17 +1464,20 @@ def _mcp_tools() -> List[Dict[str, Any]]:
     ]
 
 
-async def handle_mcp_json_rpc(payload: Any) -> Any:
+async def handle_mcp_json_rpc(payload: Any, user_context: Optional[UserContext] = None) -> Any:
     if isinstance(payload, list):
         if not payload:
             return _jsonrpc_error(None, -32600, "Invalid empty JSON-RPC batch.")
-        responses = [await _handle_mcp_request(item) for item in payload]
+        responses = [await _handle_mcp_request(item, user_context) for item in payload]
         filtered = [response for response in responses if response is not None]
         return filtered or None
-    return await _handle_mcp_request(payload)
+    return await _handle_mcp_request(payload, user_context)
 
 
-async def _handle_mcp_request(request: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+async def _handle_mcp_request(
+    request: Dict[str, Any],
+    user_context: Optional[UserContext] = None,
+) -> Optional[Dict[str, Any]]:
     if (
         not isinstance(request, dict)
         or request.get("jsonrpc") != "2.0"
@@ -1508,7 +1527,7 @@ async def _handle_mcp_request(request: Dict[str, Any]) -> Optional[Dict[str, Any
         if method == "tools/call":
             tool_name = params.get("name")
             arguments = params.get("arguments") or {}
-            result = await _call_mcp_tool(tool_name, arguments)
+            result = await _call_mcp_tool(tool_name, arguments, user_context)
             return _jsonrpc_result(request_id, _mcp_tool_result(result))
 
         return _jsonrpc_error(request_id, -32601, f"Unknown MCP method: {method}")
@@ -1516,18 +1535,115 @@ async def _handle_mcp_request(request: Dict[str, Any]) -> Optional[Dict[str, Any
         return _jsonrpc_error(request_id, -32000, str(exc))
 
 
-async def _call_mcp_tool(tool_name: str, arguments: Dict[str, Any]) -> Dict[str, Any]:
+def _persist_mcp_compile(
+    project: HardwareIR,
+    arguments: Dict[str, Any],
+    user_context: Optional[UserContext],
+) -> Dict[str, Any]:
+    """Persist a host-authored compilation without trusting caller ownership."""
+    metadata = dict(project.assembly_metadata or {})
+    requested_project_id = arguments.get("project_id") or metadata.get("project_id")
+    try:
+        project_id = (
+            str(uuid.UUID(str(requested_project_id).strip()))
+            if requested_project_id
+            else str(uuid.uuid4())
+        )
+    except (TypeError, ValueError, AttributeError) as exc:
+        raise ValueError("project_id must be a UUID when supplied.") from exc
+
+    owner_user_id = (
+        str(user_context.owner_user_id).strip()
+        if user_context is not None and user_context.owner_user_id
+        else None
+    )
+    existing = get_generated_project(project_id, include_deleted=True)
+    if existing is not None:
+        if getattr(existing, "status", "active") != "active":
+            raise ValueError("A deleted compiled project cannot be restored by recompiling.")
+        existing_owner = str(getattr(existing, "owner_user_id", "") or "").strip()
+        if not owner_user_id or existing_owner != owner_user_id:
+            raise ValueError("An existing compiled project can only be updated by its owner.")
+        chat_id = str(getattr(existing, "chat_id", "") or "").strip() or None
+        existing_ir = getattr(existing, "hardware_ir", {})
+        existing_metadata = existing_ir.get("assembly_metadata", {}) if isinstance(existing_ir, dict) else {}
+        revision = int(existing_metadata.get("compile_revision") or 1) + 1
+        created_at = str(getattr(existing, "created_at", "") or _utc_now())
+    else:
+        chat_id = str(uuid.uuid4()) if owner_user_id else None
+        revision = 1
+        created_at = _utc_now()
+
+    title = str((project.overview.title if project.overview else "") or "").strip() or "Untitled Forma Project"
+    prompt = str(arguments.get("prompt") or metadata.get("source_prompt") or title).strip()
+    visibility = str(
+        arguments.get("visibility")
+        or (getattr(existing, "visibility", None) if existing is not None else None)
+        or "public"
+    ).strip().lower()
+    if visibility not in {"public", "private"}:
+        raise ValueError("visibility must be public or private.")
+    if not owner_user_id:
+        visibility = "public"
+
+    project.assembly_metadata = {
+        **metadata,
+        "project_id": project_id,
+        "chat_id": chat_id,
+        "authoring_agent": arguments.get("authoring_agent", "other"),
+        "compiled_by": "forma.compile_project",
+        "compile_revision": revision,
+        "created_at": created_at,
+        "source_prompt": prompt,
+    }
+    hardware_ir = project.model_dump(mode="json")
+    if existing is not None:
+        if not update_generated_project_hardware_ir(
+            project_id,
+            hardware_ir,
+            owner_user_id=owner_user_id,
+        ):
+            raise RuntimeError("Could not update the persisted compiled project.")
+        if not update_generated_project_metadata(
+            project_id,
+            owner_user_id=owner_user_id,
+            title=title,
+            prompt=prompt,
+            visibility=visibility,
+        ):
+            raise RuntimeError("Could not update the compiled project metadata.")
+    else:
+        save_generated_project(
+            project_id=project_id,
+            title=title,
+            prompt=prompt,
+            hardware_ir=hardware_ir,
+            created_at=created_at,
+            chat_id=chat_id,
+            owner_user_id=owner_user_id,
+            visibility=visibility,
+        )
+    return {
+        "project_id": project_id,
+        "chat_id": chat_id,
+        "persisted": True,
+        "visibility": visibility,
+    }
+
+
+async def _call_mcp_tool(
+    tool_name: str,
+    arguments: Dict[str, Any],
+    user_context: Optional[UserContext] = None,
+) -> Dict[str, Any]:
     if tool_name == "forma.compile_project":
         project = HardwareIR.model_validate(arguments.get("project_ir"))
         issues = validate_circuit(project.components, project.nets, project.requirements)
         project.validation = build_validation_summary(issues)
         project.is_valid = not project.validation.critical
-        project.assembly_metadata = {
-            **(project.assembly_metadata or {}),
-            "authoring_agent": arguments.get("authoring_agent", "other"),
-            "compiled_by": "forma.compile_project",
-        }
+        persistence = _persist_mcp_compile(project, arguments, user_context)
         return {
+            **persistence,
             "project_ir": project.model_dump(mode="json"),
             "is_valid": project.is_valid,
             "validation": project.validation.model_dump(mode="json"),

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1571,7 +1571,7 @@ async def a2a_websocket_endpoint(websocket: WebSocket, agent_id: str):
 @app.post("/mcp")
 async def mcp_endpoint(payload: Any = Body(...), _user: UserContext = Depends(require_mcp_user_context)):
     """MCP Streamable HTTP endpoint exposing Forma tools."""
-    response = await handle_mcp_json_rpc(payload)
+    response = await handle_mcp_json_rpc(payload, _user)
     if response is None:
         return Response(status_code=202)
     return response
@@ -1580,7 +1580,7 @@ async def mcp_endpoint(payload: Any = Body(...), _user: UserContext = Depends(re
 @app.post("/a2a/mcp")
 async def a2a_mcp_endpoint(payload: Any = Body(...), _user: UserContext = Depends(require_mcp_user_context)):
     """Alias for agents that discover MCP under the A2A route prefix."""
-    response = await handle_mcp_json_rpc(payload)
+    response = await handle_mcp_json_rpc(payload, _user)
     if response is None:
         return Response(status_code=202)
     return response

--- a/tests/api/test_mcp_agent_compatibility.py
+++ b/tests/api/test_mcp_agent_compatibility.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import os
 import unittest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
 from apps.api.a2a import MCP_DEFAULT_PROTOCOL_VERSION, handle_mcp_json_rpc
+from apps.api.auth import UserContext
 from apps.api.main import app
 
 
@@ -82,27 +84,131 @@ class McpAgentCompatibilityTests(unittest.IsolatedAsyncioTestCase):
         authoring_agents = compiler["inputSchema"]["properties"]["authoring_agent"]["enum"]
         self.assertIn("nemoclaw", authoring_agents)
 
-    async def test_compile_project_validates_without_generation(self) -> None:
-        response = await handle_mcp_json_rpc(
-            {
-                "jsonrpc": "2.0",
-                "id": 4,
-                "method": "tools/call",
-                "params": {
-                    "name": "forma.compile_project",
-                    "arguments": {
-                        "project_ir": {"components": [], "nets": []},
-                        "authoring_agent": "nemoclaw",
+    async def test_compile_project_persists_public_project_and_returns_identity(self) -> None:
+        with patch("apps.api.a2a.get_generated_project", return_value=None), patch(
+            "apps.api.a2a.save_generated_project"
+        ) as save_project:
+            response = await handle_mcp_json_rpc(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 4,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "forma.compile_project",
+                        "arguments": {
+                            "project_ir": {"components": [], "nets": []},
+                            "authoring_agent": "nemoclaw",
+                        },
+                    },
+                }
+            )
+
+        compiled = response["result"]["structuredContent"]
+        self.assertTrue(compiled["persisted"])
+        self.assertIsNone(compiled["chat_id"])
+        self.assertEqual("public", compiled["visibility"])
+        self.assertRegex(compiled["project_id"], r"^[0-9a-f-]{36}$")
+        save_project.assert_called_once()
+        self.assertEqual(compiled["project_id"], save_project.call_args.kwargs["project_id"])
+        self.assertEqual("public", save_project.call_args.kwargs["visibility"])
+
+    async def test_compile_project_persists_authenticated_private_project(self) -> None:
+        user = UserContext(
+            provider="test",
+            subject="agent-user",
+            owner_user_id="agent-user",
+            is_authenticated=True,
+            is_admin=False,
+        )
+        with patch("apps.api.a2a.get_generated_project", return_value=None), patch(
+            "apps.api.a2a.save_generated_project"
+        ) as save_project:
+            response = await handle_mcp_json_rpc(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 5,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "forma.compile_project",
+                        "arguments": {
+                            "project_ir": {"components": [], "nets": []},
+                            "prompt": "Build a private sensor enclosure",
+                            "visibility": "private",
+                        },
                     },
                 },
-            }
-        )
+                user,
+            )
+
+        compiled = response["result"]["structuredContent"]
+        self.assertEqual("private", compiled["visibility"])
+        self.assertIsNotNone(compiled["chat_id"])
+        self.assertEqual("agent-user", save_project.call_args.kwargs["owner_user_id"])
+        self.assertEqual("Build a private sensor enclosure", save_project.call_args.kwargs["prompt"])
+
+    async def test_compile_project_persists_and_validates(self) -> None:
+        with patch("apps.api.a2a.get_generated_project", return_value=None), patch(
+            "apps.api.a2a.save_generated_project"
+        ):
+            response = await handle_mcp_json_rpc(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 6,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "forma.compile_project",
+                        "arguments": {
+                            "project_ir": {"components": [], "nets": []},
+                            "authoring_agent": "nemoclaw",
+                        },
+                    },
+                }
+            )
 
         compiled = response["result"]["structuredContent"]
         self.assertTrue(compiled["is_valid"])
         self.assertEqual("nemoclaw", compiled["project_ir"]["assembly_metadata"]["authoring_agent"])
         self.assertIn("mermaid_code", compiled)
         self.assertIn("svg_schematic", compiled)
+
+    async def test_compile_project_cannot_update_another_owner(self) -> None:
+        project_id = "12345678-1234-4234-8234-123456789012"
+        with patch(
+            "apps.api.a2a.get_generated_project",
+            return_value=SimpleNamespace(
+                owner_user_id="different-user",
+                status="active",
+                hardware_ir={},
+                chat_id=None,
+                created_at="2026-01-01T00:00:00Z",
+                visibility="private",
+            ),
+        ), patch("apps.api.a2a.update_generated_project_hardware_ir") as update_project:
+            response = await handle_mcp_json_rpc(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 7,
+                    "method": "tools/call",
+                    "params": {
+                        "name": "forma.compile_project",
+                        "arguments": {
+                            "project_id": project_id,
+                            "project_ir": {"components": [], "nets": []},
+                        },
+                    },
+                },
+                UserContext(
+                    provider="test",
+                    subject="agent-user",
+                    owner_user_id="agent-user",
+                    is_authenticated=True,
+                    is_admin=False,
+                ),
+            )
+
+        self.assertEqual(-32000, response["error"]["code"])
+        self.assertIn("only be updated by its owner", response["error"]["message"])
+        update_project.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Close the MCP persistence gap: forma.compile_project now publishes every compilation through the existing generated-project repository instead of returning a transient JSON-only artifact. New records are available to gallery/workspace retrieval, and authenticated callers receive an owned chat record for discussion.

The operation accepts an optional project_id for owner-checked recompilation, preserves compile revision metadata, stores the source prompt, and rejects cross-owner updates or deleted-project resurrection. Dedicated service API-key requests are stored as public gallery projects because they have no user owner; authenticated MCP requests can choose public or private visibility.

## Related issue

This PR addresses the persistence/lineage requirement from the agent interoperability work.

## Change type

- [x] Feature
- [x] Test

## Verification

- python -m compileall -q apps/api/a2a.py apps/api/main.py tests/api/test_mcp_agent_compatibility.py -> passed.
- git diff --check -> passed.
- python -m unittest tests.api.test_mcp_agent_compatibility -v -> blocked because fastapi is not installed in this environment.

## Configuration or migration requirements

No schema migration is required. The existing generated-project, chat, gallery, and workspace persistence interfaces are reused.

## Visual changes

Not applicable.

## Safety and compatibility

Ownership is taken from the authenticated UserContext and is never accepted from tool arguments. Existing project updates require the authenticated owner, and deleted project IDs cannot be restored through this tool. Existing direct callers remain compatible because the new request context parameter is optional.

## AI assistance

Implementation and tests were prepared with AI assistance.