### PR TITLE
feat: compile wiring intents deterministically

### DIFF
--- a/docs/hardware-ir.md
+++ b/docs/hardware-ir.md
@@ -53,6 +53,15 @@ The IR is produced in a loop:
 
 This makes the IR more than a snapshot—it’s a record of what was checked and why the design is considered safe within MVP scope.
 
+## Deterministic wiring compilation
+
+Wiring agents do not author canonical `ConnectionNet` objects or duplicate `pin_mappings`. They receive a compact
+endpoint catalog keyed by stable IDs such as `U1.GPIO21` and return `WiringIntent` objects containing endpoint IDs.
+Application code resolves those IDs, rejects unknown or conflicting endpoints, assigns canonical net IDs, and derives
+MCU `pin_mappings` from the compiled nets. A repair response may replace a named rejected net with `replace_net_id`;
+unrelated valid nets remain unchanged. Power rails with explicit source/input semantics are checked separately from
+signal connectivity, so equal nominal voltage alone does not establish a valid power source.
+
 ## Hardware IR 0.2 migration
 
 Hardware IR 0.2 separates physical design state from procurement aggregation. Repeated parts are represented as independently addressable instances (`M1`, `M2`, `M3`, `M4`), while the BOM can still contain one row with quantity four. Nets and mechanical placements always target a physical instance, and validation rejects duplicate or unknown references, unknown pins when a pinout is defined, mismatched BOM quantities, and non-deterministic extended prices.

--- a/forma_core/agents/orchestrator.py
+++ b/forma_core/agents/orchestrator.py
@@ -62,6 +62,14 @@ from forma_core.workspaces.projects.models import (
     expand_component_instances,
 )
 from forma_core.validation import validate_circuit, check_safety_violations, build_validation_summary
+from forma_core.wiring import (
+    WiringIntent,
+    build_endpoint_catalog,
+    compile_wiring_intent,
+    derive_pin_mappings,
+    endpoint_catalog_prompt,
+    wiring_failure_category,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +82,7 @@ class DefaultComponentSelection(BaseModel):
 class DefaultWiringOutput(BaseModel):
     nets: List[ConnectionNet]
     pin_mappings: List[PinMappingEntry]
+    intent_issues: List[ValidationIssue] = Field(default_factory=list)
 
 
 class DefaultValidationOutput(BaseModel):
@@ -949,44 +958,62 @@ class HardwarePipelineOrchestrator:
             # 5. Wiring/Netlist Agent (With Auto-Correction Loop)
             logger.info("Invoking Wiring/Netlist Agent...")
             with agent_pipeline_step("default", "wiring_netlist"):
+                endpoint_catalog_json = json.dumps(
+                    endpoint_catalog_prompt(build_endpoint_catalog(components)),
+                    indent=2,
+                )
                 wiring_prompt = f"""
-            You are a Wiring/Netlist Agent. Your task is to connect the physical pins of the selected components to create a working circuit.
+            You are a Wiring Intent Agent. Describe the connections needed for the selected components.
+            Do not generate canonical net IDs or nested ref_des/pin_id objects.
             
-            Selected Components:
-            {components_json}
+            Endpoint catalog. Use only these exact endpoint IDs:
+            {endpoint_catalog_json}
             
             Requirements: {requirements.model_dump_json()}
             
             Rules for connecting:
-            1. Establish a Ground rail (GND) net and connect all Ground/GND pins to it (e.g., ESP32 'GND', SSD1306 'GND', sensor 'GND', battery 'NEG').
-            2. Establish a Power rail (VCC/3.3V/5V) net and connect VCC power pins to it. Make sure operating voltages match! Don't short 5V to 3.3V!
-            3. Wire signal pins: Connect communication pins together:
+            1. Establish a Ground rail (GND) net and connect all compatible ground endpoints to it.
+            2. Establish a Power rail (VCC/3.3V/5V) net only when the catalog identifies a source or regulated output.
+               Make sure operating voltages match. Do not short 5V to 3.3V or power to ground.
+            3. Wire signal endpoints: Connect communication pins together:
                - I2C SCL connects to the MCU's SCL (e.g., ESP32 pin 'D22' or Arduino pin 'A5')
                - I2C SDA connects to the MCU's SDA (e.g., ESP32 pin 'D21' or Arduino pin 'A4')
                - Digital sensor data pins connect to any Digital/GPIO pin on the MCU.
                - PWM actuators connect to a PWM-capable pin on the MCU.
-            4. Every physical pin should appear in only one net. Do not place the same signal pin in multiple nets.
-            5. Passive parts bridge nets by using one passive pin per net. For a pull-up resistor, put one resistor pin on the signal net and the other resistor pin on the power rail; do not create a separate pull-up signal net containing the sensor data pin.
+            4. Every non-power/non-ground endpoint should appear in only one net.
+            5. Passive parts bridge nets by using one passive endpoint per net.
             6. Do NOT leave critical pins unconnected.
             
-            Generate:
-            - nets: List of ConnectionNet. Each net has net_id, name, net_type (Power, Ground, I2C, SPI, Digital, PWM, Analog), voltage, and pins (list of PinReference: ref_des + pin_id).
-            - pin_mappings: List of PinMappingEntry mapping the MCU's pins to functional connections.
-            
-            Output a JSON representation of:
+            Return WiringIntent with nets containing name, net_type, voltage, and endpoint_ids.
             """
-                class WiringWrapper(BaseModel):
-                    nets: List[ConnectionNet]
-                    pin_mappings: List[PinMappingEntry]
-
-                wiring_data: WiringWrapper = self._call_llm_structured(wiring_prompt, WiringWrapper, image_bytes, image_mime_type)
-                nets = wiring_data.nets
-                pin_mappings = wiring_data.pin_mappings
+                wiring_intent: WiringIntent = self._call_llm_structured(
+                    wiring_prompt,
+                    WiringIntent,
+                    image_bytes,
+                    image_mime_type,
+                )
+                wiring_compilation = compile_wiring_intent(components, wiring_intent)
+                nets = list(wiring_compilation.nets)
+                pin_mappings = derive_pin_mappings(components, nets)
 
             # Self-healing loop: Run validation checks on wiring
             logger.info("Running circuit validation checks on generated netlist...")
             with agent_pipeline_step("default", "validation_repair"):
-                validation_issues = validate_circuit(components, nets, requirements, prompt=user_prompt)
+                validation_issues = [
+                    *wiring_compilation.issues,
+                    *validate_circuit(components, nets, requirements, prompt=user_prompt),
+                ]
+                if validation_issues:
+                    emit_agent_pipeline_event(
+                        "default",
+                        "validation_repair",
+                        "diagnostics",
+                        details={
+                            "failure_categories": sorted({
+                                wiring_failure_category(issue) for issue in validation_issues
+                            }),
+                        },
+                    )
                 is_valid = not any(issue.severity == "CRITICAL" for issue in validation_issues)
 
                 if not is_valid:
@@ -994,10 +1021,11 @@ class HardwarePipelineOrchestrator:
                     issues_json = json.dumps([issue.model_dump() for issue in validation_issues], indent=2)
                     
                     healing_prompt = f"""
-                You are a Wiring/Netlist Auto-Correction Agent. The previous wiring configuration contained critical electrical or logical errors.
+                You are a Wiring Intent Auto-Correction Agent. Correct only the rejected or invalid nets.
+                Return replacement intents for existing canonical nets using replace_net_id. Omit valid nets.
                 
-                Selected Components:
-                {components_json}
+                Endpoint catalog:
+                {endpoint_catalog_json}
                 
                 Previous Wiring Nets:
                 {json.dumps([n.model_dump() for n in nets], indent=2)}
@@ -1012,14 +1040,27 @@ class HardwarePipelineOrchestrator:
                 - If a pin is reused in multiple signal nets, fix the mapping to separate GPIO pins.
                 - A physical pin must appear in only one net. For pull-up or pull-down resistors, put one resistor pin on the signal net and the other resistor pin on the power/ground rail; never put the sensor/MCU signal pin in a separate resistor-only signal net.
                 
-                Generate a corrected list of ConnectionNet and PinMappingEntry.
+                Return WiringIntent. Use endpoint_ids from the catalog only. Keep valid existing nets unchanged.
                 """
-                    corrected_wiring: WiringWrapper = self._call_llm_structured(healing_prompt, WiringWrapper, image_bytes, image_mime_type)
-                    nets = corrected_wiring.nets
-                    pin_mappings = corrected_wiring.pin_mappings
+                    corrected_intent: WiringIntent = self._call_llm_structured(
+                        healing_prompt,
+                        WiringIntent,
+                        image_bytes,
+                        image_mime_type,
+                    )
+                    repaired = compile_wiring_intent(
+                        components,
+                        corrected_intent,
+                        existing_nets=nets,
+                    )
+                    nets = repaired.all_nets
+                    pin_mappings = derive_pin_mappings(components, nets)
                     
                     # Re-validate
-                    validation_issues = validate_circuit(components, nets, requirements, prompt=user_prompt)
+                    validation_issues = [
+                        *repaired.issues,
+                        *validate_circuit(components, nets, requirements, prompt=user_prompt),
+                    ]
                     is_valid = not any(issue.severity == "CRITICAL" for issue in validation_issues)
                     logger.info(f"Self-healing completed. Is valid: {is_valid}")
 
@@ -1838,19 +1879,28 @@ class HardwarePipelineOrchestrator:
         image_bytes: Optional[bytes],
         image_mime_type: Optional[str],
     ) -> DefaultWiringOutput:
-        return self._call_llm_structured(
+        endpoint_catalog = endpoint_catalog_prompt(build_endpoint_catalog(components))
+        wiring_intent: WiringIntent = self._call_llm_structured(
             f"""
-            You are a Wiring/Netlist Agent. Connect the selected component pins into a safe low-voltage circuit.
-            Components: {json.dumps([component_detail_payload(item) for item in components], indent=2)}
+            You are a Wiring Intent Agent. Describe the connections needed for the selected components.
+            Use only exact endpoint IDs from this catalog; do not generate nested ref_des/pin_id objects
+            or canonical net IDs.
+            Endpoint catalog: {json.dumps(endpoint_catalog, indent=2)}
             Requirements: {requirements.model_dump_json()}
             Establish compatible ground and power rails, connect required communication and control signals,
-            and do not mix incompatible logic voltages. Every physical pin may appear in only one net. Passive
-            parts bridge nets using one passive pin per net. Do not leave critical power or ground pins
-            unconnected. Return DefaultWiringOutput with complete nets and controller pin mappings.
+            and do not mix incompatible logic voltages. Every non-power/non-ground endpoint may appear in only
+            one net. Passive parts bridge nets using one passive endpoint per net. Do not leave critical power
+            or ground endpoints unconnected. Return WiringIntent.
             """,
-            DefaultWiringOutput,
+            WiringIntent,
             image_bytes,
             image_mime_type,
+        )
+        compilation = compile_wiring_intent(components, wiring_intent)
+        return DefaultWiringOutput(
+            nets=compilation.nets,
+            pin_mappings=derive_pin_mappings(components, compilation.nets),
+            intent_issues=compilation.issues,
         )
 
     def _generate_default_validation(
@@ -1864,24 +1914,43 @@ class HardwarePipelineOrchestrator:
     ) -> DefaultValidationOutput:
         nets = list(wiring.nets)
         pin_mappings = list(wiring.pin_mappings)
-        issues = validate_circuit(components, nets, requirements, prompt=user_prompt)
+        issues = [
+            *wiring.intent_issues,
+            *validate_circuit(components, nets, requirements, prompt=user_prompt),
+        ]
+        if issues:
+            emit_agent_pipeline_event(
+                "default",
+                "validation_repair",
+                "diagnostics",
+                details={
+                    "failure_categories": sorted({
+                        wiring_failure_category(issue) for issue in issues
+                    }),
+                },
+            )
         is_valid = not any(issue.severity.upper() == "CRITICAL" for issue in issues)
         if not is_valid:
             corrected = self._call_llm_structured(
                 f"""
-                You are a Wiring/Netlist Auto-Correction Agent. Correct this netlist using the validation report.
-                Components: {json.dumps([component_detail_payload(item) for item in components], indent=2)}
+                You are a Wiring Intent Auto-Correction Agent. Correct only the rejected or invalid nets.
+                Return replacement intents for existing canonical nets using replace_net_id. Omit valid nets.
+                Endpoint catalog: {json.dumps(endpoint_catalog_prompt(build_endpoint_catalog(components)), indent=2)}
                 Previous nets: {json.dumps([item.model_dump(mode='json') for item in nets], indent=2)}
                 Validation issues: {json.dumps([item.model_dump(mode='json') for item in issues], indent=2)}
-                Return DefaultWiringOutput.
+                Use endpoint_ids from the catalog only. Keep valid existing nets unchanged. Return WiringIntent.
                 """,
-                DefaultWiringOutput,
+                WiringIntent,
                 image_bytes,
                 image_mime_type,
             )
-            nets = corrected.nets
-            pin_mappings = corrected.pin_mappings
-            issues = validate_circuit(components, nets, requirements, prompt=user_prompt)
+            repaired = compile_wiring_intent(components, corrected, existing_nets=nets)
+            nets = repaired.all_nets
+            pin_mappings = derive_pin_mappings(components, nets)
+            issues = [
+                *repaired.issues,
+                *validate_circuit(components, nets, requirements, prompt=user_prompt),
+            ]
             is_valid = not any(issue.severity.upper() == "CRITICAL" for issue in issues)
         return DefaultValidationOutput(
             nets=nets,
@@ -1960,11 +2029,7 @@ class HardwarePipelineOrchestrator:
         assembly_output = stage_run.output("assembly", DefaultAssemblyOutput)
         components = list(selection.components) if selection is not None else []
         nets = list(validation.nets if validation is not None else (wiring.nets if wiring is not None else []))
-        pin_mappings = list(
-            validation.pin_mappings
-            if validation is not None
-            else (wiring.pin_mappings if wiring is not None else [])
-        )
+        pin_mappings = derive_pin_mappings(components, nets)
         if overview is not None and bom is not None:
             overview.estimated_cost = bom.estimated_cost
         constraints = []

--- a/forma_core/agents/web_research_workflow.py
+++ b/forma_core/agents/web_research_workflow.py
@@ -65,6 +65,14 @@ from forma_core.validation import (
     check_safety_violations,
     validate_circuit,
 )
+from forma_core.wiring import (
+    WiringIntent,
+    build_endpoint_catalog,
+    compile_wiring_intent,
+    derive_pin_mappings,
+    endpoint_catalog_prompt,
+    wiring_failure_category,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -88,6 +96,7 @@ class WebComponentSelection(BaseModel):
 class WiringWrapper(BaseModel):
     nets: List[ConnectionNet]
     pin_mappings: List[PinMappingEntry]
+    intent_issues: List[ValidationIssue] = Field(default_factory=list)
 
 
 class AssemblyWrapper(BaseModel):
@@ -352,14 +361,31 @@ class WebResearchHardwarePipeline:
 
         logger.info("Running circuit validation checks on web-researched netlist...")
         with agent_pipeline_step(self.workflow_id, "validation_repair"):
-            validation_issues = validate_circuit(components, nets, plan.requirements, prompt=user_prompt)
+            validation_issues = [
+                *wiring.intent_issues,
+                *validate_circuit(components, nets, plan.requirements, prompt=user_prompt),
+            ]
+            if validation_issues:
+                emit_agent_pipeline_event(
+                    self.workflow_id,
+                    "validation_repair",
+                    "diagnostics",
+                    details={
+                        "failure_categories": sorted({
+                            wiring_failure_category(issue) for issue in validation_issues
+                        }),
+                    },
+                )
             is_valid = not any(issue.severity.upper() == "CRITICAL" for issue in validation_issues)
             if not is_valid:
                 logger.info("Invoking Validation + Auto-Correction Agent...")
                 corrected = self._repair_wiring(plan, components_json, nets, validation_issues)
                 nets = corrected.nets
                 pin_mappings = corrected.pin_mappings
-                validation_issues = validate_circuit(components, nets, plan.requirements, prompt=user_prompt)
+                validation_issues = [
+                    *corrected.intent_issues,
+                    *validate_circuit(components, nets, plan.requirements, prompt=user_prompt),
+                ]
                 is_valid = not any(issue.severity.upper() == "CRITICAL" for issue in validation_issues)
 
         total_cost = sum(
@@ -520,13 +546,30 @@ class WebResearchHardwarePipeline:
         def validate_and_repair() -> ValidationStageOutput:
             nets = list(wiring.nets)
             pin_mappings = list(wiring.pin_mappings)
-            issues = validate_circuit(components, nets, plan.requirements, prompt=user_prompt)
+            issues = [
+                *wiring.intent_issues,
+                *validate_circuit(components, nets, plan.requirements, prompt=user_prompt),
+            ]
+            if issues:
+                emit_agent_pipeline_event(
+                    self.workflow_id,
+                    "validation_repair",
+                    "diagnostics",
+                    details={
+                        "failure_categories": sorted({
+                            wiring_failure_category(issue) for issue in issues
+                        }),
+                    },
+                )
             is_valid = not any(issue.severity.upper() == "CRITICAL" for issue in issues)
             if not is_valid:
                 corrected = self._repair_wiring(plan, components_json, nets, issues)
                 nets = corrected.nets
                 pin_mappings = corrected.pin_mappings
-                issues = validate_circuit(components, nets, plan.requirements, prompt=user_prompt)
+                issues = [
+                    *corrected.intent_issues,
+                    *validate_circuit(components, nets, plan.requirements, prompt=user_prompt),
+                ]
                 is_valid = not any(issue.severity.upper() == "CRITICAL" for issue in issues)
             return ValidationStageOutput(
                 nets=nets,
@@ -600,11 +643,7 @@ class WebResearchHardwarePipeline:
         research = stage_run.output("external_research", ExternalSourceLibrary)
 
         nets = list(validation.nets if validation is not None else (wiring.nets if wiring is not None else []))
-        pin_mappings = list(
-            validation.pin_mappings
-            if validation is not None
-            else (wiring.pin_mappings if wiring is not None else [])
-        )
+        pin_mappings = derive_pin_mappings(components, nets)
         validation_issues = list(validation.issues if validation is not None else [])
         all_issues = [*validation_issues, *(self._audit_to_validation_issues(audit) if audit is not None else [])]
         assembly = list(assembly_wrapper.steps if assembly_wrapper is not None else [])
@@ -817,9 +856,12 @@ class WebResearchHardwarePipeline:
         plan: WebProjectPlan,
         components_json: str,
     ) -> WiringWrapper:
+        components = [ComponentInstance.model_validate(item) for item in json.loads(components_json)]
+        endpoint_catalog = endpoint_catalog_prompt(build_endpoint_catalog(components))
         prompt = f"""
-        You are a Wiring/Netlist Agent for sourced web components.
-        Create safe low-voltage nets and MCU pin mappings.
+        You are a Wiring Intent Agent for sourced web components.
+        Describe safe low-voltage connections using only exact endpoint IDs from the catalog.
+        Do not create canonical net IDs, nested ref_des/pin_id objects, or pin mappings.
 
         User request:
         {user_prompt}
@@ -827,21 +869,30 @@ class WebResearchHardwarePipeline:
         Requirements:
         {plan.requirements.model_dump_json()}
 
-        Components:
-        {components_json}
+        Endpoint catalog:
+        {json.dumps(endpoint_catalog, indent=2)}
 
         Rules:
-        - Every power pin must connect to a compatible power rail.
-        - Every ground pin must connect to a ground net.
+        - Every power endpoint must connect to a compatible source or regulated-output rail.
+        - Every ground endpoint must connect to a ground net.
         - Do not short power to ground or mix incompatible logic voltages.
         - Use level shifting or voltage-compatible parts when needed.
-        - A physical pin must appear in only one net.
-        - Passive components bridge nets with one passive pin per net.
-        - Keep pin_mappings focused on controller pins and human-readable functions.
+        - A non-power/non-ground endpoint must appear in only one net.
+        - Passive components bridge nets with one passive endpoint per net.
 
-        Return WiringWrapper.
+        Return WiringIntent with name, net_type, voltage, and endpoint_ids for each net.
         """
-        return self._call_llm_structured(prompt, WiringWrapper, pipeline_step_id="wiring_netlist")
+        wiring_intent: WiringIntent = self._call_llm_structured(
+            prompt,
+            WiringIntent,
+            pipeline_step_id="wiring_netlist",
+        )
+        compilation = compile_wiring_intent(components, wiring_intent)
+        return WiringWrapper(
+            nets=compilation.nets,
+            pin_mappings=derive_pin_mappings(components, compilation.nets),
+            intent_issues=compilation.issues,
+        )
 
     def _repair_wiring(
         self,
@@ -850,15 +901,17 @@ class WebResearchHardwarePipeline:
         nets: List[ConnectionNet],
         issues: List[ValidationIssue],
     ) -> WiringWrapper:
+        components = [ComponentInstance.model_validate(item) for item in json.loads(components_json)]
         prompt = f"""
-        You are a Wiring/Netlist Auto-Correction Agent.
-        Correct the netlist using the validation report.
+        You are a Wiring Intent Auto-Correction Agent.
+        Correct only the rejected or invalid nets using the validation report.
+        Return replacement intents for existing canonical nets using replace_net_id. Omit valid nets.
 
         Requirements:
         {plan.requirements.model_dump_json()}
 
-        Components:
-        {components_json}
+        Endpoint catalog:
+        {json.dumps(endpoint_catalog_prompt(build_endpoint_catalog(components)), indent=2)}
 
         Previous nets:
         {json.dumps([net.model_dump() for net in nets], indent=2)}
@@ -866,9 +919,20 @@ class WebResearchHardwarePipeline:
         Validation issues:
         {json.dumps([issue.model_dump() for issue in issues], indent=2)}
 
-        Return corrected WiringWrapper.
+        Use endpoint_ids from the catalog only. Keep valid existing nets unchanged. Return WiringIntent.
         """
-        return self._call_llm_structured(prompt, WiringWrapper, pipeline_step_id="validation_repair")
+        repair_intent: WiringIntent = self._call_llm_structured(
+            prompt,
+            WiringIntent,
+            pipeline_step_id="validation_repair",
+        )
+        compilation = compile_wiring_intent(components, repair_intent, existing_nets=nets)
+        merged_nets = compilation.all_nets
+        return WiringWrapper(
+            nets=merged_nets,
+            pin_mappings=derive_pin_mappings(components, merged_nets),
+            intent_issues=compilation.issues,
+        )
 
     def _generate_mechanical(
         self,

--- a/forma_core/wiring.py
+++ b/forma_core/wiring.py
@@ -38,6 +38,7 @@ class NetIntent(BaseModel):
     net_type: str
     voltage: Optional[float] = None
     endpoint_ids: List[str] = Field(default_factory=list)
+    replace_net_id: Optional[str] = None
 
 
 class WiringIntent(BaseModel):
@@ -52,7 +53,13 @@ class RejectedNetIntent(BaseModel):
 
 class WiringCompilationResult(BaseModel):
     nets: List[ConnectionNet] = Field(default_factory=list)
+    preserved_nets: List[ConnectionNet] = Field(default_factory=list)
     rejected: List[RejectedNetIntent] = Field(default_factory=list)
+
+    @property
+    def all_nets(self) -> List[ConnectionNet]:
+        """Return preserved nets followed by newly compiled or replaced nets."""
+        return [*self.preserved_nets, *self.nets]
 
     @property
     def issues(self) -> List[ValidationIssue]:
@@ -168,16 +175,38 @@ def compile_wiring_intent(
     """Compile model intent into canonical nets while rejecting only invalid intents."""
     catalog = build_endpoint_catalog(components)
     component_refs = {component.ref_des for component in components}
-    reserved_ids = {net.net_id for net in existing_nets}
+    existing_by_id = {net.net_id: net for net in existing_nets}
+    reserved_ids = set(existing_by_id)
     endpoint_to_net: Dict[str, str] = {}
     for net in existing_nets:
         for pin in net.pins:
             endpoint_to_net[make_endpoint_id(pin.ref_des, pin.pin_id)] = net.net_id
 
     compiled: List[ConnectionNet] = []
+    preserved = list(existing_nets)
+    replaced_net_ids: set[str] = set()
     rejected: List[RejectedNetIntent] = []
     for index, intent in enumerate(wiring.nets):
         intent_issues: List[ValidationIssue] = []
+        replacement_id = str(intent.replace_net_id or "").strip() or None
+        replacement_net = existing_by_id.get(replacement_id) if replacement_id else None
+        if replacement_id and replacement_net is None:
+            intent_issues.append(_validation_issue(
+                "Unknown Replacement Net",
+                f"Wiring intent '{intent.name}' targets unknown net '{replacement_id}'.",
+                "Set replace_net_id to an existing canonical net ID or omit it for a new net.",
+            ))
+        elif replacement_id in replaced_net_ids:
+            intent_issues.append(_validation_issue(
+                "Duplicate Replacement Net",
+                f"Wiring intent '{intent.name}' attempts to replace net '{replacement_id}' more than once.",
+                "Return one replacement intent per canonical net.",
+            ))
+        elif replacement_net is not None:
+            for pin in replacement_net.pins:
+                endpoint_to_net.pop(make_endpoint_id(pin.ref_des, pin.pin_id), None)
+            reserved_ids.discard(replacement_id)
+
         if not intent.endpoint_ids:
             intent_issues.append(_validation_issue(
                 "Empty Net",
@@ -240,21 +269,28 @@ def compile_wiring_intent(
                 ))
 
         if intent_issues:
+            if replacement_net is not None:
+                for pin in replacement_net.pins:
+                    endpoint_to_net[make_endpoint_id(pin.ref_des, pin.pin_id)] = replacement_net.net_id
             rejected.append(RejectedNetIntent(intent_index=index, intent=intent, issues=intent_issues))
             continue
 
         net = ConnectionNet(
-            net_id=_canonical_net_id(intent.name, intent.net_type, reserved_ids),
+            net_id=replacement_id or _canonical_net_id(intent.name, intent.net_type, reserved_ids),
             name=intent.name,
             net_type=intent.net_type,
             voltage=intent.voltage,
             pins=[PinReference(ref_des=entry.ref_des, pin_id=entry.pin_id) for entry in entries],
         )
         compiled.append(net)
+        reserved_ids.add(net.net_id)
+        if replacement_id:
+            preserved = [item for item in preserved if item.net_id != replacement_id]
+            replaced_net_ids.add(replacement_id)
         for endpoint_id in unique_endpoint_ids:
             endpoint_to_net[endpoint_id] = net.net_id
 
-    return WiringCompilationResult(nets=compiled, rejected=rejected)
+    return WiringCompilationResult(nets=compiled, preserved_nets=preserved, rejected=rejected)
 
 
 def derive_pin_mappings(
@@ -302,6 +338,8 @@ _FAILURE_CATEGORIES = {
     "short circuit": "short_circuit",
     "missing power source": "missing_power_net",
     "power source conflict": "intent_compilation_failure",
+    "unknown replacement net": "intent_compilation_failure",
+    "duplicate replacement net": "intent_compilation_failure",
     "repair exhausted": "repair_exhausted",
 }
 

--- a/tests/projects/test_wiring_compiler.py
+++ b/tests/projects/test_wiring_compiler.py
@@ -128,6 +128,36 @@ class WiringCompilerTests(unittest.TestCase):
         self.assertEqual(preserved_dump, initial.nets[0].model_dump())
         self.assertEqual("NET_I2C_CLOCK", repaired.nets[0].net_id)
 
+    def test_targeted_replacement_preserves_unrelated_nets(self) -> None:
+        components = _components()
+        initial = compile_wiring_intent(
+            components,
+            WiringIntent(nets=[
+                NetIntent(name="I2C Data", net_type="I2C", endpoint_ids=["U1.SDA", "SEN1.SDA"]),
+                NetIntent(name="I2C Clock", net_type="I2C", endpoint_ids=["U1.SCL", "SEN1.SCL"]),
+            ]),
+        )
+
+        repaired = compile_wiring_intent(
+            components,
+            WiringIntent(nets=[NetIntent(
+                name="I2C Data Repaired",
+                net_type="I2C",
+                endpoint_ids=["U1.SDA", "SEN1.SDA", "SEN2.SDA"],
+                replace_net_id="NET_I2C_DATA",
+            )]),
+            existing_nets=initial.nets,
+        )
+
+        self.assertEqual(
+            ["NET_I2C_CLOCK", "NET_I2C_DATA"],
+            [net.net_id for net in repaired.all_nets],
+        )
+        self.assertEqual(
+            ["SEN2"],
+            [pin.ref_des for pin in repaired.all_nets[1].pins if pin.ref_des == "SEN2"],
+        )
+
     def test_compiler_rejects_signal_reuse_across_nets(self) -> None:
         result = compile_wiring_intent(
             _components(),


### PR DESCRIPTION
## Summary

Complete the first implementation slice for #290. Wiring agents now return endpoint-based intent instead of independently generating canonical nets and pin mappings. Forma resolves the endpoint catalog, compiles canonical ConnectionNet objects, derives controller mappings, rejects bad intents without dropping valid nets, and supports targeted replacement during repair.

Both the default and web-research generation paths use the compiler. Wiring diagnostics are emitted as categorized pipeline events, and the Hardware IR documentation describes the contract.

## Related issue

Closes #290

## Change type

- [x] Feature
- [x] Test
- [x] Documentation

## Verification

- python -m unittest tests.projects.test_wiring_compiler -v -> 10 passed.
- python -m compileall -q forma_core/wiring.py forma_core/agents/orchestrator.py forma_core/agents/web_research_workflow.py tests/projects/test_wiring_compiler.py -> passed.
- git diff --check -> passed.
- Full generation-stage tests could not run because python-dotenv is not installed in this environment.

## Configuration or migration requirements

No database migration is required. Existing persisted WiringWrapper stage records remain readable because the canonical wrapper fields are retained and intent_issues defaults empty.

## Visual changes

Not applicable.

## Safety and compatibility

The model-facing wiring contract no longer accepts arbitrary canonical net endpoints in the integrated paths. Exact endpoint IDs are resolved against selected component pins. Signal reuse, unknown endpoints, empty nets, direct power/ground shorts, missing power sources, and conflicting replacement targets are rejected deterministically. Pin mappings are generated only from validated canonical nets.

## AI assistance

Implementation and tests were prepared with AI assistance.