### PR TITLE
feat: add Windows development launcher

### DIFF
--- a/.agents/skills/forma-hardware/references/configuration.md
+++ b/.agents/skills/forma-hardware/references/configuration.md
@@ -20,6 +20,12 @@ LLM, creates an encrypted local key under `.forma/`, and starts both services:
 ./scripts/development/dev.sh
 ```
 
+On Windows PowerShell, run the native equivalent:
+
+```powershell
+.\scripts\development\dev.ps1
+```
+
 The launcher honors explicit environment overrides. OpenCode (or another host
 agent) supplies the model that authors Hardware IR; `forma.compile_project`
 then performs deterministic validation, rendering, and persistence. The
@@ -86,7 +92,7 @@ Then run `opencode mcp list`. For a protected server, add `"Authorization": "Bea
 
 ## Troubleshooting
 
-- Connection refused: run `./scripts/development/dev.sh` from a Forma checkout, or set `FORMA_MCP_URL` to a hosted `/api/mcp` endpoint.
+- Connection refused: run `./scripts/development/dev.sh` (or `.\scripts\development\dev.ps1` on Windows) from a Forma checkout, or set `FORMA_MCP_URL` to a hosted `/api/mcp` endpoint.
 - HTTP 401/403: supply either a Clerk admin bearer token or the dedicated `FORMA_MCP_API_KEY`.
 - NemoClaw rejects the URL: use a stable HTTPS endpoint, not host loopback; declare an exact private hostname when needed.
 - Method not found: update the Forma server and inspect `python scripts/forma.py tools`.

--- a/.agents/skills/forma-hardware/scripts/forma.py
+++ b/.agents/skills/forma-hardware/scripts/forma.py
@@ -69,8 +69,8 @@ def request(method: str, params: dict[str, Any] | None = None, *, url: str | Non
     except URLError as exc:
         raise FormaClientError(
             f"Could not reach Forma at {target_url}: {exc.reason}. "
-            "Run ./scripts/development/dev.sh from a Forma checkout, "
-            "or set FORMA_MCP_URL to a hosted /api/mcp endpoint."
+            "Run ./scripts/development/dev.sh (or .\\scripts\\development\\dev.ps1 on Windows) "
+            "from a Forma checkout, or set FORMA_MCP_URL to a hosted /api/mcp endpoint."
         ) from exc
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise FormaClientError("Forma returned invalid JSON.") from exc

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -195,6 +195,12 @@ From the repository root:
 ./scripts/development/dev.sh
 ```
 
+On Windows PowerShell:
+
+```powershell
+.\scripts\development\dev.ps1
+```
+
 This starts the FastAPI backend and Next.js frontend together.
 
 ### Docker

--- a/README.md
+++ b/README.md
@@ -40,10 +40,16 @@ It blocks or warns on high-risk domains (mains AC, medical, automotive control, 
 Detailed instructions live in [docs/setup.md](docs/setup.md). The short version:
 
 ### Run Everything
-From the repo root:
+From the repo root, use the launcher for your platform:
 
 ```bash
 ./scripts/development/dev.sh
+```
+
+On Windows PowerShell:
+
+```powershell
+.\scripts\development\dev.ps1
 ```
 
 This starts the FastAPI backend and Next.js frontend together. It installs

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -52,7 +52,7 @@ LLM configuration behavior:
 
 - Runtime precedence is fixed in one backend resolver: explicit request override, saved integration, environment, then provider default. `/api/runtime/config` is the client authority; clients must not reconstruct readiness or defaults from environment variables or integration form fields.
 - `LOG_LEVEL`: backend logging level, for example `INFO` or `DEBUG`
-- `BACKEND_LOG_FILE`: optional log file for backend and uvicorn logs, for example `./forma-backend.log`. `./scripts/development/dev.sh` defaults this to `.logs/backend-dev.log` so the frontend LOGS tab can tail local backend output.
+- `BACKEND_LOG_FILE`: optional log file for backend and uvicorn logs, for example `./forma-backend.log`. The development launchers default this to `.logs/backend-dev.log` so the frontend LOGS tab can tail local backend output.
 - `FORMA_DEBUG=true`: include redacted traceback/context debug payloads in API errors and failed job metadata; this also defaults backend logging to `DEBUG` when `LOG_LEVEL` is unset
 - `FORMA_DEV_MODE=true`: selects SQLite for the complete application database even when remote Supabase env vars are present; Supabase Storage writes are disabled and image data stays inline in the SQLite project record
 - `FORMA_DEPLOYMENT=true`: requires a configured deployment provider or signed-in user's BYOK provider for `/api/generate`; the frontend keeps the composer visible and directs users without an active provider to Settings

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,6 +21,12 @@ The combined dev launcher starts the backend and frontend together and writes ba
 ./scripts/development/dev.sh
 ```
 
+On Windows PowerShell, use the native launcher instead:
+
+```powershell
+.\scripts\development\dev.ps1
+```
+
 On first run it installs missing dependencies, defaults to local auth with
 SQLite without selecting an LLM, and stores a generated encryption key in
 `.forma/local-secrets.env`. The connected host agent authors the Hardware IR;
@@ -32,6 +38,13 @@ If you run uvicorn directly and want the frontend LOGS tab to show backend outpu
 Tests:
 ```bash
 ./scripts/quality/test.sh
+```
+
+Windows PowerShell equivalent:
+
+```powershell
+.\.venv\Scripts\python.exe -m compileall -q apps/api forma_core evals scripts tests
+.\.venv\Scripts\python.exe -m unittest discover -s tests -t . -v
 ```
 
 Frontend:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -62,6 +62,20 @@ source .venv/bin/activate
 pip install -r apps/api/requirements.txt
 ```
 
+To start the backend and frontend together on Windows PowerShell, run the
+native development launcher from the repository root:
+
+```powershell
+.\scripts\development\dev.ps1
+```
+
+If local PowerShell execution policy blocks scripts, invoke it with a
+process-scoped bypass:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\scripts\development\dev.ps1
+```
+
 Both `requirements.txt` and `apps/api/requirements.txt` list only third-party
 runtime dependencies. Do not add local package paths such as `.[backend]` or
 `../..`; Vercel may resolve dependency files from a service subdirectory and

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,4 +18,17 @@ Common entrypoints:
 ./scripts/quality/benchmark.sh
 ```
 
+Windows PowerShell development launcher:
+
+```powershell
+.\scripts\development\dev.ps1
+```
+
+Windows PowerShell test equivalent:
+
+```powershell
+.\.venv\Scripts\python.exe -m compileall -q apps/api forma_core evals scripts tests
+.\.venv\Scripts\python.exe -m unittest discover -s tests -t . -v
+```
+
 Scripts should stay thin and call reusable implementations from `forma_core` or `evals` instead of accumulating application logic.

--- a/scripts/development/dev.ps1
+++ b/scripts/development/dev.ps1
@@ -1,0 +1,303 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+function Get-ConfiguredValue {
+    param(
+        [Parameter(Mandatory = $true)][string]$Name,
+        [Parameter(Mandatory = $true)][string]$Default
+    )
+
+    $value = [Environment]::GetEnvironmentVariable($Name)
+    if ([string]::IsNullOrWhiteSpace($value)) {
+        return $Default
+    }
+    return $value
+}
+
+function Invoke-Checked {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $false)][string[]]$ArgumentList = @()
+    )
+
+    & $FilePath @ArgumentList
+    if ($LASTEXITCODE -ne 0) {
+        throw "Command failed with exit code $LASTEXITCODE`: $FilePath $($ArgumentList -join ' ')"
+    }
+}
+
+function Test-PortOpen {
+    param([Parameter(Mandatory = $true)][int]$Port)
+
+    try {
+        $connection = Get-NetTCPConnection -LocalPort $Port -State Listen -ErrorAction Stop
+        return $null -ne $connection
+    } catch {
+        return $false
+    }
+}
+
+function Test-ProcessRunning {
+    param([Parameter(Mandatory = $true)][int]$ProcessId)
+
+    return $null -ne (Get-Process -Id $ProcessId -ErrorAction SilentlyContinue)
+}
+
+function Test-RepoProcess {
+    param([Parameter(Mandatory = $true)][int]$ProcessId)
+
+    $process = Get-CimInstance Win32_Process -Filter "ProcessId = $ProcessId" -ErrorAction SilentlyContinue
+    if ($null -eq $process) {
+        return $false
+    }
+
+    $command = "{0} {1}" -f $process.ExecutablePath, $process.CommandLine
+    return $command.IndexOf($RootDir, [StringComparison]::OrdinalIgnoreCase) -ge 0
+}
+
+function Stop-RecordedProcess {
+    param(
+        [Parameter(Mandatory = $true)][string]$PidFile,
+        [Parameter(Mandatory = $true)][string]$Label
+    )
+
+    if (-not (Test-Path -LiteralPath $PidFile)) {
+        return
+    }
+
+    $rawPid = (Get-Content -LiteralPath $PidFile -Raw).Trim()
+    $processId = 0
+    if ([int]::TryParse($rawPid, [ref]$processId) -and (Test-ProcessRunning $processId)) {
+        if (Test-RepoProcess $processId) {
+            Write-Host "[forma-dev] Stopping prior $Label process $processId..."
+            & taskkill.exe /PID $processId /T /F *> $null
+        } else {
+            Write-Warning "Refusing to stop $Label process $processId because it is not associated with this checkout."
+        }
+    }
+
+    Remove-Item -LiteralPath $PidFile -Force -ErrorAction SilentlyContinue
+}
+
+function Wait-ForUrl {
+    param(
+        [Parameter(Mandatory = $true)][string]$Url,
+        [Parameter(Mandatory = $true)][string]$Label,
+        [Parameter(Mandatory = $false)][int]$Attempts = 60,
+        [Parameter(Mandatory = $false)][Nullable[int]]$ProcessId = $null
+    )
+
+    for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+        try {
+            $response = Invoke-WebRequest -Uri $Url -UseBasicParsing -TimeoutSec 2
+            if ($response.StatusCode -ge 200 -and $response.StatusCode -lt 500) {
+                Write-Host "[forma-dev] $Label is ready at $Url"
+                return
+            }
+        } catch {
+            # The service may still be starting.
+        }
+
+        if ($null -ne $ProcessId -and -not (Test-ProcessRunning $ProcessId.Value)) {
+            throw "$Label process exited before becoming ready."
+        }
+        Start-Sleep -Seconds 1
+    }
+
+    throw "$Label did not become ready at $Url"
+}
+
+function Start-ManagedProcess {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [Parameter(Mandatory = $false)][string[]]$ArgumentList = @(),
+        [Parameter(Mandatory = $true)][string]$WorkingDirectory,
+        [Parameter(Mandatory = $true)][string]$PidFile,
+        [Parameter(Mandatory = $true)][string]$OutputFile,
+        [Parameter(Mandatory = $true)][string]$ErrorFile
+    )
+
+    $parent = Split-Path -Parent $PidFile
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    $outputParent = Split-Path -Parent $OutputFile
+    New-Item -ItemType Directory -Path $outputParent -Force | Out-Null
+
+    $process = Start-Process `
+        -FilePath $FilePath `
+        -ArgumentList $ArgumentList `
+        -WorkingDirectory $WorkingDirectory `
+        -RedirectStandardOutput $OutputFile `
+        -RedirectStandardError $ErrorFile `
+        -PassThru
+    Set-Content -LiteralPath $PidFile -Value $process.Id -Encoding ascii
+    return $process.Id
+}
+
+$RootDir = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+Set-Location -LiteralPath $RootDir
+
+$BackendHost = Get-ConfiguredValue "BACKEND_HOST" "127.0.0.1"
+$BackendPort = [int](Get-ConfiguredValue "BACKEND_PORT" "8000")
+$FrontendHost = Get-ConfiguredValue "FRONTEND_HOST" "127.0.0.1"
+$RequestedFrontendPort = [int](Get-ConfiguredValue "FRONTEND_PORT" "3000")
+$PythonBin = Get-ConfiguredValue "PYTHON_BIN" "python"
+$VenvDir = Get-ConfiguredValue "VENV_DIR" (Join-Path $RootDir ".venv")
+$BackendLogFile = Get-ConfiguredValue "BACKEND_LOG_FILE" (Join-Path $RootDir ".logs\backend-dev.log")
+$LocalSecretsFile = Get-ConfiguredValue "FORMA_LOCAL_SECRETS_FILE" (Join-Path $RootDir ".forma\local-secrets.env")
+$RuntimeDir = Get-ConfiguredValue "DEV_RUNTIME_DIR" (Join-Path $RootDir ".tmp\development")
+
+if (-not [IO.Path]::IsPathRooted($LocalSecretsFile)) {
+    $LocalSecretsFile = Join-Path $RootDir $LocalSecretsFile
+}
+if (-not [IO.Path]::IsPathRooted($BackendLogFile)) {
+    $BackendLogFile = Join-Path $RootDir $BackendLogFile
+}
+if (-not [IO.Path]::IsPathRooted($VenvDir)) {
+    $VenvDir = Join-Path $RootDir $VenvDir
+}
+if (-not [IO.Path]::IsPathRooted($RuntimeDir)) {
+    $RuntimeDir = Join-Path $RootDir $RuntimeDir
+}
+
+$VenvPython = Join-Path $VenvDir "Scripts\python.exe"
+$VenvPip = Join-Path $VenvDir "Scripts\pip.exe"
+$BackendPidFile = Join-Path $RuntimeDir "backend.pid"
+$FrontendPidFile = Join-Path $RuntimeDir "frontend.pid"
+$BackendErrorLogFile = "$BackendLogFile.err"
+$FrontendLogFile = Join-Path (Split-Path -Parent $BackendLogFile) "frontend-dev.log"
+$FrontendErrorLogFile = "$FrontendLogFile.err"
+
+$env:FORMA_AUTH_MODE = Get-ConfiguredValue "FORMA_AUTH_MODE" "local"
+$env:FORMA_DEV_MODE = Get-ConfiguredValue "FORMA_DEV_MODE" "true"
+$env:BACKEND_LOG_FILE = $BackendLogFile
+# Do not select an LLM here. The connected host agent authors the IR, while
+# Forma compiles it deterministically. Existing provider/model environment
+# values are inherited unchanged for explicit server-side generation.
+
+if ([string]::IsNullOrWhiteSpace($env:FORMA_USER_SECRETS_KEY) -and (Test-Path -LiteralPath $LocalSecretsFile)) {
+    foreach ($line in Get-Content -LiteralPath $LocalSecretsFile) {
+        if ($line -match '^FORMA_USER_SECRETS_KEY=(.*)$') {
+            $env:FORMA_USER_SECRETS_KEY = $Matches[1].Trim()
+            break
+        }
+    }
+}
+
+if ([string]::IsNullOrWhiteSpace($env:FORMA_USER_SECRETS_KEY)) {
+    $secretsDirectory = Split-Path -Parent $LocalSecretsFile
+    New-Item -ItemType Directory -Path $secretsDirectory -Force | Out-Null
+    $env:FORMA_USER_SECRETS_KEY = (& $PythonBin -c "import secrets; print(secrets.token_urlsafe(48))" | Out-String).Trim()
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($env:FORMA_USER_SECRETS_KEY)) {
+        throw "Could not generate FORMA_USER_SECRETS_KEY with $PythonBin."
+    }
+    Set-Content -LiteralPath $LocalSecretsFile -Value "FORMA_USER_SECRETS_KEY=$($env:FORMA_USER_SECRETS_KEY)" -Encoding ascii
+    Write-Host "[forma-dev] Generated a local encryption key at $LocalSecretsFile"
+}
+
+$backendProcessId = $null
+$frontendProcessId = $null
+$ownsBackend = $false
+$ownsFrontend = $false
+
+try {
+    Stop-RecordedProcess $FrontendPidFile "frontend"
+    Stop-RecordedProcess $BackendPidFile "backend"
+
+    if (-not (Test-Path -LiteralPath $VenvPython)) {
+        Write-Host "[forma-dev] Creating Python virtualenv at $VenvDir"
+        Invoke-Checked $PythonBin @("-m", "venv", $VenvDir)
+    }
+
+    & $VenvPython -m uvicorn --version *> $null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "[forma-dev] Installing backend dependencies"
+        Invoke-Checked $VenvPip @("install", "-r", (Join-Path $RootDir "apps\api\requirements.txt"))
+    }
+
+    $npmCommand = Get-Command npm.cmd -ErrorAction SilentlyContinue
+    if ($null -eq $npmCommand) {
+        $npmCommand = Get-Command npm -ErrorAction SilentlyContinue
+    }
+    if ($null -eq $npmCommand) {
+        throw "npm was not found on PATH. Install Node.js before starting Forma."
+    }
+
+    $frontendDirectory = Join-Path $RootDir "apps\web"
+    if (-not (Test-Path -LiteralPath (Join-Path $frontendDirectory "node_modules"))) {
+        Write-Host "[forma-dev] Installing frontend dependencies"
+        Push-Location -LiteralPath $frontendDirectory
+        try {
+            Invoke-Checked $npmCommand.Source @("install")
+        } finally {
+            Pop-Location
+        }
+    }
+
+    if (Test-PortOpen $BackendPort) {
+        Wait-ForUrl "http://$BackendHost`:$BackendPort/api" "Backend"
+        Write-Host "[forma-dev] Backend already appears to be running at http://$BackendHost`:$BackendPort"
+    } else {
+        Write-Host "[forma-dev] Starting backend at http://$BackendHost`:$BackendPort"
+        Write-Host "[forma-dev] Backend log file: $BackendLogFile"
+        $backendProcessId = Start-ManagedProcess `
+            -FilePath $VenvPython `
+            -ArgumentList @("-m", "uvicorn", "apps.api.main:app", "--host", $BackendHost, "--port", [string]$BackendPort) `
+            -WorkingDirectory $RootDir `
+            -PidFile $BackendPidFile `
+            -OutputFile $BackendLogFile `
+            -ErrorFile $BackendErrorLogFile
+        $ownsBackend = $true
+        Wait-ForUrl "http://$BackendHost`:$BackendPort/api" "Backend" 60 $backendProcessId
+    }
+
+    $frontendPort = $RequestedFrontendPort
+    while (Test-PortOpen $frontendPort) {
+        $frontendPort++
+        if ($frontendPort -gt ($RequestedFrontendPort + 20)) {
+            throw "No free frontend port found from $RequestedFrontendPort to $($RequestedFrontendPort + 20)."
+        }
+    }
+
+    Write-Host "[forma-dev] Starting frontend at http://$FrontendHost`:$frontendPort"
+    $frontendProcessId = Start-ManagedProcess `
+        -FilePath $npmCommand.Source `
+        -ArgumentList @("--prefix", "`"$frontendDirectory`"", "run", "dev", "--", "--hostname", $FrontendHost, "--port", [string]$frontendPort) `
+        -WorkingDirectory $frontendDirectory `
+        -PidFile $FrontendPidFile `
+        -OutputFile $FrontendLogFile `
+        -ErrorFile $FrontendErrorLogFile
+    $ownsFrontend = $true
+    Wait-ForUrl "http://$FrontendHost`:$frontendPort/" "Frontend" 60 $frontendProcessId
+
+    Write-Host ""
+    Write-Host "Forma is running:"
+    Write-Host "  Backend:  http://$BackendHost`:$BackendPort"
+    Write-Host "  Frontend: http://$FrontendHost`:$frontendPort"
+    Write-Host ""
+    Write-Host "Press Ctrl+C to stop both services."
+
+    while ($true) {
+        if ($ownsBackend -and -not (Test-ProcessRunning $backendProcessId)) {
+            throw "Backend process exited. See $BackendLogFile and $BackendErrorLogFile."
+        }
+        if ($ownsFrontend -and -not (Test-ProcessRunning $frontendProcessId)) {
+            throw "Frontend process exited. See $FrontendLogFile and $FrontendErrorLogFile."
+        }
+        Start-Sleep -Seconds 1
+    }
+} finally {
+    if ($ownsFrontend -and $null -ne $frontendProcessId -and (Test-ProcessRunning $frontendProcessId) -and (Test-RepoProcess $frontendProcessId)) {
+        & taskkill.exe /PID $frontendProcessId /T /F *> $null
+    }
+    if ($ownsBackend -and $null -ne $backendProcessId -and (Test-ProcessRunning $backendProcessId) -and (Test-RepoProcess $backendProcessId)) {
+        & taskkill.exe /PID $backendProcessId /T /F *> $null
+    }
+    if ($ownsFrontend -and (Test-Path -LiteralPath $FrontendPidFile)) {
+        Remove-Item -LiteralPath $FrontendPidFile -Force -ErrorAction SilentlyContinue
+    }
+    if ($ownsBackend -and (Test-Path -LiteralPath $BackendPidFile)) {
+        Remove-Item -LiteralPath $BackendPidFile -Force -ErrorAction SilentlyContinue
+    }
+}

--- a/tests/tooling/test_agent_skill_compatibility.py
+++ b/tests/tooling/test_agent_skill_compatibility.py
@@ -88,6 +88,7 @@ class AgentSkillCompatibilityTests(unittest.TestCase):
 
         message = str(raised.exception)
         self.assertIn("./scripts/development/dev.sh", message)
+        self.assertIn(".\\scripts\\development\\dev.ps1", message)
         self.assertIn("FORMA_MCP_URL", message)
 
     def test_local_launcher_bootstraps_required_runtime_defaults(self) -> None:
@@ -102,6 +103,22 @@ class AgentSkillCompatibilityTests(unittest.TestCase):
         entrypoint = (REPO_ROOT / "apps" / "api" / "entrypoint.sh").read_text(encoding="utf-8")
         self.assertIn("/data/.forma_user_secrets_key", entrypoint)
         self.assertIn("exec uvicorn apps.api.main:app", entrypoint)
+
+    def test_windows_launcher_uses_native_process_and_path_handling(self) -> None:
+        launcher = REPO_ROOT / "scripts" / "development" / "dev.ps1"
+        content = launcher.read_text(encoding="utf-8")
+
+        self.assertTrue(launcher.is_file())
+        self.assertIn("Get-NetTCPConnection", content)
+        self.assertIn("Start-Process", content)
+        self.assertIn("Get-CimInstance Win32_Process", content)
+        self.assertIn("Scripts\\python.exe", content)
+        self.assertIn("taskkill.exe /PID", content)
+        self.assertIn("FORMA_USER_SECRETS_KEY", content)
+        self.assertIn("$env:BACKEND_LOG_FILE = $BackendLogFile", content)
+        self.assertNotIn(".venv/bin/", content)
+        self.assertNotIn("/proc", content)
+        self.assertNotRegex(content, r"(?m)^\s*(bash|setsid|chmod|ss)\b")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #328

## Summary
- Add a native PowerShell launcher for the FastAPI backend and Next.js frontend.
- Use Windows-native port, process, path, logging, readiness, and cleanup behavior.
- Preserve explicit host-agent LLM provider/model settings and local encrypted-secret bootstrap.
- Document Windows startup and test commands across contributor and agent guidance.
- Add compatibility coverage and a Windows launcher hint to the bundled client.

## Validation
- Focused compatibility suite: 8 passed.
- PowerShell parser validation: passed.
- Native Start-Process npm smoke tests: passed.
- Python compile check and git diff check: passed.
- Full suite attempted: 224 tests ran; 61 dependency import errors and 1 unrelated existing Hugging Face artifact-size failure remain in this environment.