### PR TITLE
fix: preserve UserContext through MCP and A2A actions

### DIFF
--- a/apps/api/a2a.py
+++ b/apps/api/a2a.py
@@ -723,7 +723,11 @@ def _persist_updated_project_ir(
 
     try:
         hardware_ir = ir.model_dump()
-        updated = update_generated_project_hardware_ir(project_id, hardware_ir)
+        updated = update_generated_project_hardware_ir(
+            project_id,
+            hardware_ir,
+            owner_user_id=owner_user_id,
+        )
         if updated:
             return
 
@@ -753,6 +757,26 @@ def _apply_owner_user_integrations(owner_user_id: Optional[str]) -> None:
         return
     if isinstance(owner_user_id, str) and owner_user_id.strip():
         apply_user_integrations_to_environment(UserIntegrationStore.for_user(owner_user_id.strip()))
+
+
+def _context_owner_user_id(user_context: Optional[UserContext]) -> Optional[str]:
+    if user_context is None or not user_context.is_authenticated:
+        return None
+    owner_user_id = str(user_context.owner_user_id or "").strip()
+    return owner_user_id or None
+
+
+def _message_for_user_context(message: A2AMessage, user_context: Optional[UserContext]) -> A2AMessage:
+    """Replace caller-supplied ownership metadata with authenticated identity."""
+    if not message.action.startswith("forma."):
+        return message
+
+    payload = dict(message.payload)
+    payload.pop("owner_user_id", None)
+    owner_user_id = _context_owner_user_id(user_context)
+    if owner_user_id:
+        payload["owner_user_id"] = owner_user_id
+    return message.model_copy(update={"payload": payload})
 
 
 def build_generation_response(
@@ -997,15 +1021,21 @@ def build_generation_response(
             return response
 
 
-async def call_forma_action(action: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+async def call_forma_action(
+    action: str,
+    payload: Dict[str, Any],
+    user_context: Optional[UserContext] = None,
+) -> Dict[str, Any]:
     normalized = action.removeprefix("forma.")
-    owner_user_id = payload.get("owner_user_id")
+    owner_user_id = _context_owner_user_id(user_context)
     project_id = payload.get("project_id")
 
-    if project_id and owner_user_id:
+    if project_id and not owner_user_id:
+        raise ValueError("An authenticated user context is required for project actions.")
+    if project_id:
         ensure_project_action_allowed(
             str(project_id),
-            str(owner_user_id),
+            owner_user_id,
             action,
             require_workflow=normalized == "generate_project",
         )
@@ -1034,7 +1064,7 @@ async def call_forma_action(action: str, payload: Dict[str, Any]) -> Dict[str, A
             payload.get("chat_id"),
             payload.get("source_project_id"),
             payload.get("client_job_id") or payload.get("frontend_job_id"),
-            payload.get("owner_user_id"),
+            owner_user_id,
             data_sources,
             past_job_context,
             payload.get("project_id"),
@@ -1077,15 +1107,21 @@ def _is_server_message(message: A2AMessage) -> bool:
     return message.recipient in SERVER_RECIPIENTS or message.action.startswith("forma.")
 
 
-async def submit_a2a_message(message: A2AMessage) -> A2AEvent:
+async def submit_a2a_message(
+    message: A2AMessage,
+    user_context: Optional[UserContext] = None,
+) -> A2AEvent:
+    message = _message_for_user_context(message, user_context)
     await A2A_HUB.register(message.sender)
     server_owned = _is_server_message(message)
     project_id = message.payload.get("project_id")
-    owner_user_id = message.payload.get("owner_user_id")
-    if server_owned and project_id and owner_user_id:
+    owner_user_id = _context_owner_user_id(user_context)
+    if server_owned and project_id and not owner_user_id:
+        raise ValueError("An authenticated user context is required for project actions.")
+    if server_owned and project_id:
         ensure_project_action_allowed(
             str(project_id),
-            str(owner_user_id),
+            owner_user_id,
             message.action,
             require_workflow=message.action.removeprefix("forma.") == "generate_project",
         )
@@ -1114,7 +1150,7 @@ async def submit_a2a_message(message: A2AMessage) -> A2AEvent:
     await A2A_HUB.publish(ack)
 
     if server_owned:
-        asyncio.create_task(_process_server_message(message))
+        asyncio.create_task(_process_server_message(message, user_context))
     else:
         JOB_STORE.mark_routed(message.job_id)
         await A2A_HUB.publish(
@@ -1133,14 +1169,17 @@ async def submit_a2a_message(message: A2AMessage) -> A2AEvent:
     return ack
 
 
-async def _process_server_message(message: A2AMessage) -> None:
+async def _process_server_message(
+    message: A2AMessage,
+    user_context: Optional[UserContext] = None,
+) -> None:
     JOB_STORE.mark_running(message.job_id)
     try:
         with observe_agent_pipeline(
             lambda event: JOB_STORE.append_progress_event(message.job_id, event.as_dict()),
             cancellation_check=lambda: JOB_STORE.is_cancelled(message.job_id),
         ):
-            result = await call_forma_action(message.action, message.payload)
+            result = await call_forma_action(message.action, message.payload, user_context)
         generation_status = str(result.get("generation_status") or "succeeded").lower()
         if generation_status == "partial":
             JOB_STORE.mark_partial(message.job_id, result)
@@ -1177,7 +1216,11 @@ async def _process_server_message(message: A2AMessage) -> None:
     await A2A_HUB.publish(event)
 
 
-async def handle_a2a_websocket(websocket: WebSocket, agent_id: str) -> None:
+async def handle_a2a_websocket(
+    websocket: WebSocket,
+    agent_id: str,
+    user_context: Optional[UserContext] = None,
+) -> None:
     await websocket.accept()
     await A2A_HUB.register(agent_id, {"transports": ["websocket"]})
 
@@ -1195,13 +1238,13 @@ async def handle_a2a_websocket(websocket: WebSocket, agent_id: str) -> None:
         while True:
             raw_message = await websocket.receive_json()
             if isinstance(raw_message, dict) and raw_message.get("jsonrpc") == "2.0":
-                response = await handle_mcp_json_rpc(raw_message)
+                response = await handle_mcp_json_rpc(raw_message, user_context)
                 if response is not None:
                     await websocket.send_json(response)
                 continue
 
             raw_message = {**raw_message, "sender": raw_message.get("sender") or agent_id}
-            await submit_a2a_message(A2AMessage.model_validate(raw_message))
+            await submit_a2a_message(A2AMessage.model_validate(raw_message), user_context)
     except WebSocketDisconnect:
         logger.info("A2A websocket disconnected: %s", agent_id)
     finally:
@@ -1552,11 +1595,7 @@ def _persist_mcp_compile(
     except (TypeError, ValueError, AttributeError) as exc:
         raise ValueError("project_id must be a UUID when supplied.") from exc
 
-    owner_user_id = (
-        str(user_context.owner_user_id).strip()
-        if user_context is not None and user_context.owner_user_id
-        else None
-    )
+    owner_user_id = _context_owner_user_id(user_context)
     existing = get_generated_project(project_id, include_deleted=True)
     if existing is not None:
         if getattr(existing, "status", "active") != "active":
@@ -1652,7 +1691,7 @@ async def _call_mcp_tool(
         }
 
     if tool_name == "forma.a2a.send_message":
-        ack = await submit_a2a_message(A2AMessage.model_validate(arguments))
+        ack = await submit_a2a_message(A2AMessage.model_validate(arguments), user_context)
         return ack.model_dump()
 
     if tool_name == "forma.a2a.poll_events":
@@ -1695,4 +1734,4 @@ async def _call_mcp_tool(
         registry = _lattice_registry()
         return {"agent": registry.get(arguments.get("agent_id", "fabricator")).model_dump(mode="json")}
 
-    return await call_forma_action(tool_name, arguments)
+    return await call_forma_action(tool_name, arguments, user_context)

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1295,10 +1295,7 @@ async def register_a2a_agent(agent_id: str, registration: A2AAgentRegistration):
 @app.post("/a2a/messages")
 async def send_a2a_message(message: A2AMessage, user: UserContext = Depends(require_user_context)):
     """Submits an A2A message and queues an async result for the sender."""
-    owner_user_id = user.owner_user_id
-    if owner_user_id and message.action.startswith("forma."):
-        message.payload = {**message.payload, "owner_user_id": owner_user_id}
-    ack = await submit_a2a_message(message)
+    ack = await submit_a2a_message(message, user)
     return ack.model_dump()
 
 

--- a/tests/api/test_a2a_user_integrations.py
+++ b/tests/api/test_a2a_user_integrations.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from apps.api import a2a
+from apps.api.auth import UserContext
 from forma_core import user_integrations
 from forma_core.image_providers import build_image_provider
 from forma_core.user_integrations import UserIntegrationStore
@@ -44,6 +45,7 @@ class A2AUserIntegrationTests(unittest.TestCase):
 
         update_project.assert_called_once()
         self.assertEqual(project_id, update_project.call_args.args[0])
+        self.assertEqual("user_123", update_project.call_args.kwargs["owner_user_id"])
         save_project.assert_called_once()
         save_kwargs = save_project.call_args.kwargs
         self.assertEqual(project_id, save_kwargs["project_id"])
@@ -229,7 +231,7 @@ class A2AUserIntegrationTests(unittest.TestCase):
                     "OPENAI_IMAGE_MODEL": "gpt-image-2",
                 },
                 clear=True,
-            ), patch.object(UserIntegrationStore, "for_user", return_value=store), patch.object(
+            ), patch.object(UserIntegrationStore, "for_user", return_value=store) as for_user, patch.object(
                 a2a, "build_generation_response", side_effect=fake_build_generation_response
             ), patch.object(
                 a2a.asyncio, "to_thread", side_effect=run_to_thread_inline
@@ -241,8 +243,15 @@ class A2AUserIntegrationTests(unittest.TestCase):
                             {
                                 "prompt": "test",
                                 "generate_image": True,
-                                "owner_user_id": "user_123",
+                                "owner_user_id": "attacker-user",
                             },
+                            UserContext(
+                                provider="test",
+                                subject="user_123",
+                                owner_user_id="user_123",
+                                is_authenticated=True,
+                                is_admin=False,
+                            ),
                         )
                     )
                 finally:
@@ -251,6 +260,7 @@ class A2AUserIntegrationTests(unittest.TestCase):
                     user_integrations._APPLIED_ENV_VALUES.clear()
                     user_integrations._ORIGINAL_ENV_VALUES.clear()
 
+        for_user.assert_called_once_with("user_123")
         self.assertEqual("huggingface", observed["provider"])
         self.assertEqual("black-forest-labs/FLUX.1-schnell", observed["model_name"])
         self.assertEqual("fal-ai", observed["inference_provider"])

--- a/tests/api/test_mcp_agent_compatibility.py
+++ b/tests/api/test_mcp_agent_compatibility.py
@@ -1,18 +1,30 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import unittest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from fastapi.testclient import TestClient
 
-from apps.api.a2a import MCP_DEFAULT_PROTOCOL_VERSION, handle_mcp_json_rpc
+from apps.api import a2a
+from apps.api.a2a import A2AMessage, MCP_DEFAULT_PROTOCOL_VERSION, handle_mcp_json_rpc
 from apps.api.auth import UserContext
 from apps.api.main import app
 
 
 class McpAgentCompatibilityTests(unittest.IsolatedAsyncioTestCase):
+    @staticmethod
+    def _user(owner_user_id: str = "agent-user") -> UserContext:
+        return UserContext(
+            provider="test",
+            subject=owner_user_id,
+            owner_user_id=owner_user_id,
+            is_authenticated=True,
+            is_admin=False,
+        )
+
     def test_mcp_route_accepts_a_dedicated_agent_api_key(self) -> None:
         api_key = "n" * 32
         with patch.dict(
@@ -209,6 +221,73 @@ class McpAgentCompatibilityTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(-32000, response["error"]["code"])
         self.assertIn("only be updated by its owner", response["error"]["message"])
         update_project.assert_not_called()
+
+    async def test_mcp_action_forwards_authenticated_context(self) -> None:
+        user = self._user()
+        with patch.object(a2a, "call_forma_action", new=AsyncMock(return_value={"ok": True})) as action:
+            response = await handle_mcp_json_rpc(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "context",
+                    "method": "tools/call",
+                    "params": {"name": "forma.debug_config", "arguments": {}},
+                },
+                user,
+            )
+
+        self.assertEqual({"ok": True}, response["result"]["structuredContent"])
+        action.assert_awaited_once()
+        self.assertIs(user, action.await_args.args[2])
+
+    async def test_queued_a2a_action_keeps_context_and_replaces_payload_owner(self) -> None:
+        user = self._user()
+        message = A2AMessage(
+            sender="test-agent",
+            action="forma.generate_project",
+            payload={"prompt": "Build it", "owner_user_id": "attacker-user"},
+        )
+        with patch.object(a2a.A2A_HUB, "register", new=AsyncMock()), patch.object(
+            a2a.A2A_HUB, "publish", new=AsyncMock()
+        ), patch.object(a2a.JOB_STORE, "create_job", return_value={"job_id": message.job_id}) as create_job, patch.object(
+            a2a, "_process_server_message", new=AsyncMock()
+        ) as process:
+            await a2a.submit_a2a_message(message, user)
+            await asyncio.sleep(0)
+
+        self.assertEqual("agent-user", create_job.call_args.kwargs["payload"]["owner_user_id"])
+        process.assert_awaited_once()
+        self.assertIs(user, process.await_args.args[1])
+
+    async def test_mcp_a2a_send_forwards_authenticated_context(self) -> None:
+        user = self._user()
+        ack = SimpleNamespace(model_dump=lambda: {"accepted": True})
+        with patch.object(a2a, "submit_a2a_message", new=AsyncMock(return_value=ack)) as submit:
+            response = await handle_mcp_json_rpc(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "send",
+                    "method": "tools/call",
+                    "params": {
+                        "name": "forma.a2a.send_message",
+                        "arguments": {"action": "forma.generate_project", "payload": {"prompt": "Build it"}},
+                    },
+                },
+                user,
+            )
+
+        self.assertEqual({"accepted": True}, response["result"]["structuredContent"])
+        submit.assert_awaited_once()
+        self.assertIs(user, submit.await_args.args[1])
+
+    async def test_project_action_cannot_use_payload_owner_without_context(self) -> None:
+        with self.assertRaisesRegex(ValueError, "authenticated user context"):
+            await a2a.call_forma_action(
+                "forma.generate_project",
+                {
+                    "project_id": "12345678-1234-4234-8234-123456789012",
+                    "owner_user_id": "victim-user",
+                },
+            )
 
 
 if __name__ == "__main__":

--- a/tests/projects/test_context_gathering.py
+++ b/tests/projects/test_context_gathering.py
@@ -657,7 +657,7 @@ class ContextGatheringIntegrationTests(unittest.TestCase):
         ) as create_job:
             database.initialize_project_workflow(project_id, OWNER)
             with self.assertRaises(WorkflowStateError):
-                asyncio.run(a2a.submit_a2a_message(message))
+                asyncio.run(a2a.submit_a2a_message(message, USER))
 
         create_job.assert_not_called()
 


### PR DESCRIPTION
## Summary
- propagate authenticated `UserContext` through MCP and server-owned A2A dispatch
- use authenticated identity instead of payload-supplied `owner_user_id`
- preserve owner scope through queued project persistence and add regression coverage

Closes #331

## Validation
- `python -m py_compile apps/api/a2a.py apps/api/main.py tests/api/test_mcp_agent_compatibility.py tests/api/test_a2a_user_integrations.py tests/projects/test_context_gathering.py`
- `git diff --check`
- Focused unit tests were attempted but could not start because `fastapi` and `pytest` are not installed in the active Python environment.