### PR TITLE
fix: sanitize MCP and A2A errors

### DIFF
--- a/apps/api/a2a.py
+++ b/apps/api/a2a.py
@@ -52,6 +52,14 @@ from forma_core.observability import (
     update_observation,
 )
 from forma_core.agents.pipeline import emit_agent_pipeline_event, ensure_agent_pipeline_active, observe_agent_pipeline
+from forma_core.debug import (
+    api_error_detail,
+    exception_debug_payload,
+    log_exception,
+    new_error_correlation_id,
+    public_error_message,
+    redact_error_value,
+)
 from forma_core.runtime import (
     AlphaGenerationUnavailableError,
     deployment_runtime_config,
@@ -200,7 +208,21 @@ def get_a2a_capabilities() -> Dict[str, Any]:
     try:
         llm_runtime = get_llm_runtime_debug_config()
     except Exception as exc:
-        llm_runtime = {"error": str(exc)}
+        correlation_id = new_error_correlation_id()
+        log_exception(
+            logger,
+            "A2A capability runtime lookup failed",
+            exc,
+            correlation_id=correlation_id,
+        )
+        llm_runtime = {
+            "error": api_error_detail(
+                code="runtime_config_failed",
+                message="Runtime configuration could not be resolved.",
+                correlation_id=correlation_id,
+                public=True,
+            )
+        }
 
     return {
         "agent_id": FORMA_AGENT_ID,
@@ -294,9 +316,18 @@ def _attach_stored_image_metadata(
             allow_remote_url=allow_remote_url,
         )
     except Exception as exc:
-        logger.warning("Image upload to Supabase Storage failed for %s: %s", metadata_prefix, exc)
+        correlation_id = new_error_correlation_id()
+        log_exception(
+            logger,
+            "Image upload to Supabase Storage failed",
+            exc,
+            correlation_id=correlation_id,
+            context={"metadata_prefix": metadata_prefix, "project_id": project_id},
+        )
         return {
-            f"{metadata_prefix}_storage_error": str(exc)[:500],
+            f"{metadata_prefix}_storage_error": public_error_message("storage_failed"),
+            f"{metadata_prefix}_storage_error_code": "storage_failed",
+            f"{metadata_prefix}_storage_error_correlation_id": correlation_id,
             f"{metadata_prefix}_storage_bucket": get_image_storage_config().get("bucket"),
         }
 
@@ -435,22 +466,28 @@ def _attach_product_image(prompt_text: str, ir: Any, generate_image: bool = Fals
         return
 
     if not image_config.get("configured", False):
-        error_message = image_config.get("reason") or "Image output was requested, but the image provider is not configured."
+        error_detail = api_error_detail(
+            code="image_generation_failed",
+            message="Image output is not configured.",
+            correlation_id=new_error_correlation_id(),
+            public=True,
+        )
         logger.warning(
-            "Image generation operation failed before request: provider=%s model=%s reason=%s debug=%s",
+            "Image generation operation failed before request: provider=%s model=%s code=%s",
             image_config.get("provider"),
             image_config.get("model_name"),
-            error_message,
-            json.dumps(image_config, default=str, sort_keys=True),
+            error_detail["code"],
         )
         ir.assembly_metadata = {
             **(ir.assembly_metadata or {}),
             "image_output_status": "failed",
             "image_output_failed": True,
-            "image_output_error": str(error_message)[:500],
+            "image_output_error": error_detail["message"],
+            "image_output_error_code": error_detail["code"],
+            "image_output_error_correlation_id": error_detail["correlation_id"],
             "image_output_error_type": "configuration",
             "image_output_debug": image_config,
-            "product_image_error": str(error_message)[:500],
+            "product_image_error": error_detail["message"],
         }
         _set_operation_status(
             ir,
@@ -463,7 +500,7 @@ def _attach_product_image(prompt_text: str, ir: Any, generate_image: bool = Fals
             enabled=image_config.get("enabled", False),
             configured=False,
             reason=image_config.get("reason"),
-            error=str(error_message)[:500],
+            error=error_detail["message"],
             error_type="configuration",
             details={"image_output_debug": image_config},
         )
@@ -480,20 +517,32 @@ def _attach_product_image(prompt_text: str, ir: Any, generate_image: bool = Fals
     try:
         generated_images = image_provider.generate_project_image_sequence(prompt_text, ir)
     except Exception as exc:
-        logger.exception(
-            "Image generation operation failed: provider=%s model=%s error_type=%s error=%s",
-            image_config.get("provider"),
-            image_config.get("model_name"),
-            exc.__class__.__name__,
+        correlation_id = new_error_correlation_id()
+        log_exception(
+            logger,
+            "Image generation operation failed",
             exc,
+            correlation_id=correlation_id,
+            context={
+                "provider": image_config.get("provider"),
+                "model": image_config.get("model_name"),
+            },
         )
-        error_message = str(exc)[:500]
+        error_detail = api_error_detail(
+            code="image_generation_failed",
+            message="Image generation could not be completed.",
+            correlation_id=correlation_id,
+            public=True,
+        )
+        error_message = error_detail["message"]
         ir.assembly_metadata = {
             **(ir.assembly_metadata or {}),
             "image_output_status": "failed",
             "image_output_failed": True,
             "image_output_error": error_message,
-            "image_output_error_type": exc.__class__.__name__,
+            "image_output_error_code": error_detail["code"],
+            "image_output_error_correlation_id": correlation_id,
+            "image_output_error_type": "provider",
             "image_output_debug": image_config,
             "product_image_error": error_message,
         }
@@ -508,7 +557,7 @@ def _attach_product_image(prompt_text: str, ir: Any, generate_image: bool = Fals
             enabled=image_config.get("enabled", False),
             configured=image_config.get("configured", False),
             error=error_message,
-            error_type=exc.__class__.__name__,
+            error_type="provider",
             details={"image_output_debug": image_config},
         )
         return
@@ -520,7 +569,13 @@ def _attach_product_image(prompt_text: str, ir: Any, generate_image: bool = Fals
         len(generated_images),
     )
     if not generated_images:
-        error_message = "Image output was requested, but the image provider returned no images."
+        error_detail = api_error_detail(
+            code="image_generation_failed",
+            message="Image output was requested, but no images were returned.",
+            correlation_id=new_error_correlation_id(),
+            public=True,
+        )
+        error_message = error_detail["message"]
         logger.warning(
             "Image generation operation failed: provider=%s model=%s error_type=empty_response error=%s",
             image_config.get("provider"),
@@ -532,6 +587,8 @@ def _attach_product_image(prompt_text: str, ir: Any, generate_image: bool = Fals
             "image_output_status": "failed",
             "image_output_failed": True,
             "image_output_error": error_message,
+            "image_output_error_code": error_detail["code"],
+            "image_output_error_correlation_id": error_detail["correlation_id"],
             "image_output_error_type": "empty_response",
             "image_output_debug": image_config,
             "product_image_error": error_message,
@@ -1112,6 +1169,7 @@ async def submit_a2a_message(
     user_context: Optional[UserContext] = None,
 ) -> A2AEvent:
     message = _message_for_user_context(message, user_context)
+    message = message.model_copy(update={"correlation_id": message.correlation_id or new_error_correlation_id()})
     await A2A_HUB.register(message.sender)
     server_owned = _is_server_message(message)
     project_id = message.payload.get("project_id")
@@ -1184,33 +1242,71 @@ async def _process_server_message(
         if generation_status == "partial":
             JOB_STORE.mark_partial(message.job_id, result)
         elif generation_status == "failed":
+            correlation_id = new_error_correlation_id()
+            error_detail = api_error_detail(
+                code="generation_root_failed",
+                message="A required root generation stage failed.",
+                job_id=message.job_id,
+                correlation_id=correlation_id,
+                public=True,
+            )
             JOB_STORE.mark_failed(
                 message.job_id,
-                "A required root generation stage failed; partial diagnostics were preserved.",
+                error_detail["message"],
+                error_code=error_detail["code"],
+                correlation_id=correlation_id,
             )
         else:
             JOB_STORE.mark_succeeded(message.job_id, result)
+        transport_result = redact_error_value(result) if generation_status in {"partial", "failed"} else result
+        event_type = "error" if generation_status == "failed" else "result"
+        event_payload = (
+            {"error": error_detail, "result": transport_result}
+            if generation_status == "failed"
+            else transport_result
+        )
         event = A2AEvent(
             job_id=message.job_id,
             message_id=message.message_id,
-            correlation_id=message.correlation_id,
-            type="result",
+            correlation_id=error_detail["correlation_id"] if generation_status == "failed" else message.correlation_id,
+            type=event_type,
             action=message.action,
             sender=FORMA_AGENT_ID,
             recipient=message.sender,
-            payload=result,
+            payload=event_payload,
         )
     except Exception as exc:
-        JOB_STORE.mark_failed(message.job_id, str(exc))
+        correlation_id = new_error_correlation_id()
+        error_detail = api_error_detail(
+            code="a2a_action_failed",
+            message="A2A action failed.",
+            job_id=message.job_id,
+            correlation_id=correlation_id,
+            public=True,
+        )
+        log_exception(
+            logger,
+            "A2A action failed",
+            exc,
+            correlation_id=correlation_id,
+            context={"action": message.action, "job_id": message.job_id, "payload": message.payload},
+        )
+        JOB_STORE.mark_failed(
+            message.job_id,
+            error_detail["message"],
+            exception_debug_payload(exc, correlation_id=correlation_id),
+            error_code=error_detail["code"],
+            correlation_id=correlation_id,
+        )
         event = A2AEvent(
             job_id=message.job_id,
             message_id=message.message_id,
-            correlation_id=message.correlation_id,
+            correlation_id=correlation_id,
             type="error",
             action=message.action,
             sender=FORMA_AGENT_ID,
             recipient=message.sender,
-            payload={"error": str(exc)},
+            payload={"error": error_detail},
         )
 
     await A2A_HUB.publish(event)
@@ -1247,6 +1343,22 @@ async def handle_a2a_websocket(
             await submit_a2a_message(A2AMessage.model_validate(raw_message), user_context)
     except WebSocketDisconnect:
         logger.info("A2A websocket disconnected: %s", agent_id)
+    except Exception as exc:
+        correlation_id = new_error_correlation_id()
+        error_detail = api_error_detail(
+            code="a2a_protocol_error",
+            message="The A2A message could not be processed.",
+            correlation_id=correlation_id,
+            public=True,
+        )
+        log_exception(
+            logger,
+            "A2A WebSocket message failed",
+            exc,
+            correlation_id=correlation_id,
+            context={"agent_id": agent_id},
+        )
+        await websocket.send_json({"type": "error", "error": error_detail})
     finally:
         sender_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
@@ -1310,7 +1422,21 @@ async def _handle_tcp_client(reader: asyncio.StreamReader, writer: asyncio.Strea
                 raw_message = {**raw_message, "sender": raw_message.get("sender") or agent_id}
                 await submit_a2a_message(A2AMessage.model_validate(raw_message))
             except Exception as exc:
-                writer.write(json.dumps({"type": "error", "error": str(exc)}).encode("utf-8") + b"\n")
+                correlation_id = new_error_correlation_id()
+                error_detail = api_error_detail(
+                    code="a2a_protocol_error",
+                    message="The A2A message could not be processed.",
+                    correlation_id=correlation_id,
+                    public=True,
+                )
+                log_exception(
+                    logger,
+                    "A2A TCP message failed",
+                    exc,
+                    correlation_id=correlation_id,
+                    context={"agent_id": agent_id},
+                )
+                writer.write(json.dumps({"type": "error", "error": error_detail}).encode("utf-8") + b"\n")
                 await writer.drain()
     finally:
         sender_task.cancel()
@@ -1332,10 +1458,29 @@ def _jsonrpc_result(request_id: Any, result: Any) -> Dict[str, Any]:
     return {"jsonrpc": "2.0", "id": request_id, "result": result}
 
 
-def _jsonrpc_error(request_id: Any, code: int, message: str, data: Optional[Any] = None) -> Dict[str, Any]:
-    error: Dict[str, Any] = {"code": code, "message": message}
+def _jsonrpc_error(
+    request_id: Any,
+    code: int,
+    message: str,
+    data: Optional[Any] = None,
+    *,
+    error_code: str = "mcp_request_failed",
+    correlation_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    detail = api_error_detail(
+        code=error_code,
+        message=message,
+        correlation_id=correlation_id or new_error_correlation_id(),
+        public=True,
+    )
+    error: Dict[str, Any] = {"code": code, "message": detail["message"]}
+    error_data: Dict[str, Any] = {
+        "code": detail["code"],
+        "correlation_id": detail["correlation_id"],
+    }
     if data is not None:
-        error["data"] = data
+        error_data["details"] = redact_error_value(data)
+    error["data"] = error_data
     return {"jsonrpc": "2.0", "id": request_id, "error": error}
 
 
@@ -1510,7 +1655,12 @@ def _mcp_tools() -> List[Dict[str, Any]]:
 async def handle_mcp_json_rpc(payload: Any, user_context: Optional[UserContext] = None) -> Any:
     if isinstance(payload, list):
         if not payload:
-            return _jsonrpc_error(None, -32600, "Invalid empty JSON-RPC batch.")
+            return _jsonrpc_error(
+                None,
+                -32600,
+                "Invalid empty JSON-RPC batch.",
+                error_code="mcp_invalid_request",
+            )
         responses = [await _handle_mcp_request(item, user_context) for item in payload]
         filtered = [response for response in responses if response is not None]
         return filtered or None
@@ -1526,17 +1676,29 @@ async def _handle_mcp_request(
         or request.get("jsonrpc") != "2.0"
         or not isinstance(request.get("method"), str)
     ):
-        return _jsonrpc_error(None, -32600, "Invalid JSON-RPC request.")
+        return _jsonrpc_error(None, -32600, "Invalid JSON-RPC request.", error_code="mcp_invalid_request")
 
     is_notification = "id" not in request
     request_id = request.get("id")
     method = request.get("method")
-    params = request.get("params") or {}
+    params = request.get("params")
+    if params is None:
+        params = {}
+    correlation_id = new_error_correlation_id()
 
     # JSON-RPC notifications never receive a response. Forma currently has no
     # notification methods with server-side work beyond initialization.
     if is_notification:
         return None
+
+    if not isinstance(params, dict):
+        return _jsonrpc_error(
+            request_id,
+            -32602,
+            "Request parameters are invalid.",
+            error_code="mcp_invalid_params",
+            correlation_id=correlation_id,
+        )
 
     try:
         if method == "initialize":
@@ -1569,13 +1731,50 @@ async def _handle_mcp_request(
 
         if method == "tools/call":
             tool_name = params.get("name")
-            arguments = params.get("arguments") or {}
+            if not isinstance(tool_name, str) or not tool_name.strip():
+                raise TypeError("tools/call requires a tool name.")
+            arguments = params.get("arguments")
+            if arguments is None:
+                arguments = {}
+            if not isinstance(arguments, dict):
+                raise TypeError("tools/call arguments must be an object.")
             result = await _call_mcp_tool(tool_name, arguments, user_context)
             return _jsonrpc_result(request_id, _mcp_tool_result(result))
 
-        return _jsonrpc_error(request_id, -32601, f"Unknown MCP method: {method}")
+        return _jsonrpc_error(
+            request_id,
+            -32601,
+            "The requested MCP method was not found.",
+            error_code="mcp_method_not_found",
+            correlation_id=correlation_id,
+        )
     except Exception as exc:
-        return _jsonrpc_error(request_id, -32000, str(exc))
+        log_exception(
+            logger,
+            "MCP request failed",
+            exc,
+            correlation_id=correlation_id,
+            context={"method": method, "params": params},
+        )
+        if isinstance(exc, PermissionError):
+            error_code = "authorization_required"
+            rpc_code = -32003
+            public_message = "You are not authorized to use this MCP tool."
+        elif isinstance(exc, (TypeError, KeyError)):
+            error_code = "mcp_invalid_params"
+            rpc_code = -32602
+            public_message = "Request parameters are invalid."
+        else:
+            error_code = "mcp_tool_failed"
+            rpc_code = -32000
+            public_message = "The MCP request could not be completed."
+        return _jsonrpc_error(
+            request_id,
+            rpc_code,
+            public_message,
+            error_code=error_code,
+            correlation_id=correlation_id,
+        )
 
 
 def _persist_mcp_compile(

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -50,10 +50,12 @@ from forma_core.debug import (
     get_debug_mode_config,
     runtime_safe_error_message,
 )
-from fastapi import Body, Depends, FastAPI, HTTPException, Query, WebSocket, status
+from fastapi import Body, Depends, FastAPI, HTTPException, Query, Request, WebSocket, status
 from fastapi.encoders import jsonable_encoder
+from fastapi.exception_handlers import request_validation_exception_handler
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import Response
+from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel, ValidationError
 from dotenv import load_dotenv
 
@@ -136,6 +138,7 @@ from forma_core.config.contract import resolve_runtime_contract
 from forma_core.workspaces.projects.iteration import ProjectIterator
 from forma_core.llm import LLMProviderConfigError
 from forma_core.llm import LLMProviderOutputError
+from forma_core.debug import api_error_detail, log_exception, new_error_correlation_id
 from forma_core.workspaces.projects.objects import build_project_object, list_project_namespaces
 from forma_core.agents.pipeline import PipelineCancelledError, list_agent_pipeline_steps, observe_agent_pipeline, pipeline_workflow_id
 from forma_core.video_prompts import generate_image_to_video_prompt_from_namespaces
@@ -260,6 +263,36 @@ app = FastAPI(
     openapi_url="/openapi.json",
     swagger_ui_oauth2_redirect_url="/docs/oauth2-redirect",
 )
+
+
+@app.exception_handler(RequestValidationError)
+async def transport_validation_exception_handler(request: Request, exc: RequestValidationError):
+    if request.url.path not in {
+        "/a2a/messages",
+        "/mcp",
+        "/a2a/mcp",
+        "/api/a2a/messages",
+        "/api/mcp",
+        "/api/a2a/mcp",
+    }:
+        return await request_validation_exception_handler(request, exc)
+    correlation_id = new_error_correlation_id()
+    logger.warning(
+        "Transport request validation failed: path=%s correlation_id=%s",
+        request.url.path,
+        correlation_id,
+    )
+    return JSONResponse(
+        status_code=422,
+        content={
+            "detail": api_error_detail(
+                code="request_validation_failed",
+                message="The request failed validation.",
+                correlation_id=correlation_id,
+                public=True,
+            )
+        },
+    )
 
 _project_purge_stop_event: Optional[asyncio.Event] = None
 _project_purge_task: Optional[asyncio.Task[Any]] = None
@@ -518,15 +551,30 @@ def debug_config_endpoint(
             "project_namespaces": [namespace.model_dump(mode="json") for namespace in list_project_namespaces()],
         }
     except LLMProviderConfigError as e:
+        correlation_id = new_error_correlation_id()
+        log_exception(logger, "Debug config rejected", e, correlation_id=correlation_id, level=logging.WARNING)
         raise HTTPException(
             status_code=400,
-            detail=api_error_detail(code="llm_config_invalid", message=str(e), exc=e, provider=provider, model=model),
+            detail=api_error_detail(
+                code="llm_config_invalid",
+                message=str(e),
+                exc=e,
+                provider=provider,
+                model=model,
+                correlation_id=correlation_id,
+            ),
         ) from e
     except Exception as e:
-        logger.exception("Debug config failed.")
+        correlation_id = new_error_correlation_id()
+        log_exception(logger, "Debug config failed", e, correlation_id=correlation_id)
         raise HTTPException(
             status_code=500,
-            detail=api_error_detail(code="debug_config_failed", message=f"Debug config failed: {str(e)}", exc=e),
+            detail=api_error_detail(
+                code="debug_config_failed",
+                message="Debug config failed.",
+                exc=e,
+                correlation_id=correlation_id,
+            ),
         ) from e
 
 
@@ -538,15 +586,23 @@ def runtime_config_endpoint(user: UserContext = Depends(optional_user_context)):
         _, contract = _resolved_client_runtime_config()
         return contract
     except LLMProviderConfigError as e:
+        correlation_id = new_error_correlation_id()
+        log_exception(logger, "Runtime config rejected", e, correlation_id=correlation_id, level=logging.WARNING)
         raise HTTPException(
             status_code=400,
-            detail=api_error_detail(code="llm_config_invalid", message=str(e), exc=e),
+            detail=api_error_detail(code="llm_config_invalid", message=str(e), exc=e, correlation_id=correlation_id),
         ) from e
     except Exception as e:
-        logger.exception("Runtime config resolution failed.")
+        correlation_id = new_error_correlation_id()
+        log_exception(logger, "Runtime config resolution failed", e, correlation_id=correlation_id)
         raise HTTPException(
             status_code=500,
-            detail=api_error_detail(code="runtime_config_failed", message=f"Runtime config failed: {str(e)}", exc=e),
+            detail=api_error_detail(
+                code="runtime_config_failed",
+                message="Runtime config failed.",
+                exc=e,
+                correlation_id=correlation_id,
+            ),
         ) from e
 
 @app.post("/generate", response_model=Dict[str, Any])
@@ -626,6 +682,7 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
 
     job_id = request.client_job_id or f"job_frontend_{uuid4().hex}"
     message_id = f"msg_{uuid4().hex}"
+    correlation_id = new_error_correlation_id()
     if request.source_project_id:
         source_project = get_generated_project(request.source_project_id)
         if not source_project:
@@ -651,7 +708,7 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
     JOB_STORE.create_job(
         job_id=job_id,
         message_id=message_id,
-        correlation_id=None,
+        correlation_id=correlation_id,
         action="forma.generate_project",
         sender="frontend",
         recipient="forma",
@@ -698,7 +755,12 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
         if generation_status == "partial":
             JOB_STORE.mark_partial(job_id, response)
         elif generation_status == "failed":
-            JOB_STORE.mark_failed(job_id, "A required root generation stage failed; partial diagnostics were preserved.")
+            JOB_STORE.mark_failed(
+                job_id,
+                "A required root generation stage failed.",
+                error_code="generation_root_failed",
+                correlation_id=correlation_id,
+            )
         else:
             JOB_STORE.mark_succeeded(job_id, response)
         job = JOB_STORE.get_job(job_id)
@@ -736,8 +798,21 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
         ) from e
     except ValueError as e:
         error_debug = exception_debug_payload(e, context=payload) if debug_mode_enabled() else None
-        JOB_STORE.mark_failed(job_id, runtime_safe_error_message(str(e), provider=request.provider, model=request.model), error_debug)
-        logger.warning("Generation request rejected for job_id=%s: %s", job_id, e, exc_info=debug_mode_enabled())
+        JOB_STORE.mark_failed(
+            job_id,
+            "The generation request is invalid.",
+            error_debug,
+            error_code="generation_request_invalid",
+            correlation_id=correlation_id,
+        )
+        log_exception(
+            logger,
+            "Generation request rejected",
+            e,
+            correlation_id=correlation_id,
+            context={"job_id": job_id, "workflow": request.workflow},
+            level=logging.WARNING,
+        )
         raise HTTPException(
             status_code=400,
             detail=api_error_detail(
@@ -752,8 +827,21 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
         ) from e
     except LLMProviderConfigError as e:
         error_debug = exception_debug_payload(e, context=payload) if debug_mode_enabled() else None
-        JOB_STORE.mark_failed(job_id, runtime_safe_error_message(str(e), provider=request.provider, model=request.model), error_debug)
-        logger.warning("Generation LLM config failed for job_id=%s: %s", job_id, e, exc_info=debug_mode_enabled())
+        JOB_STORE.mark_failed(
+            job_id,
+            "The requested model configuration is invalid.",
+            error_debug,
+            error_code="llm_config_invalid",
+            correlation_id=correlation_id,
+        )
+        log_exception(
+            logger,
+            "Generation LLM config failed",
+            e,
+            correlation_id=correlation_id,
+            context={"job_id": job_id, "workflow": request.workflow},
+            level=logging.WARNING,
+        )
         raise HTTPException(
             status_code=400,
             detail=api_error_detail(
@@ -768,14 +856,20 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
         ) from e
     except LLMProviderOutputError as e:
         error_debug = exception_debug_payload(e, context=payload) if debug_mode_enabled() else None
-        JOB_STORE.mark_failed(job_id, runtime_safe_error_message(str(e), provider=request.provider, model=request.model), error_debug)
-        logger.warning(
-            "LLM output rejected for job_id=%s provider=%s model=%s: %s",
+        JOB_STORE.mark_failed(
             job_id,
-            request.provider,
-            request.model,
+            "The model provider returned an invalid response.",
+            error_debug,
+            error_code="llm_output_invalid",
+            correlation_id=correlation_id,
+        )
+        log_exception(
+            logger,
+            "LLM output rejected",
             e,
-            exc_info=debug_mode_enabled(),
+            correlation_id=correlation_id,
+            context={"job_id": job_id, "workflow": request.workflow},
+            level=logging.WARNING,
         )
         raise HTTPException(
             status_code=status.HTTP_502_BAD_GATEWAY,
@@ -791,8 +885,14 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
         ) from e
     except AlphaGenerationUnavailableError as e:
         error_debug = exception_debug_payload(e, context=payload) if debug_mode_enabled() else None
-        JOB_STORE.mark_failed(job_id, runtime_safe_error_message(str(e), provider=request.provider, model=request.model), error_debug)
         code = "alpha_generation_unavailable" if str(e) == ALPHA_GENERATION_UNAVAILABLE_MESSAGE else "llm_generation_unavailable"
+        JOB_STORE.mark_failed(
+            job_id,
+            "Generation is currently unavailable.",
+            error_debug,
+            error_code=code,
+            correlation_id=correlation_id,
+        )
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=api_error_detail(
@@ -807,8 +907,20 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
         ) from e
     except Exception as e:
         error_debug = exception_debug_payload(e, context=payload) if debug_mode_enabled() else None
-        JOB_STORE.mark_failed(job_id, runtime_safe_error_message(str(e), provider=request.provider, model=request.model), error_debug)
-        logger.exception("Generation failed for job_id=%s provider=%s model=%s", job_id, request.provider, request.model)
+        JOB_STORE.mark_failed(
+            job_id,
+            "Generation could not be completed.",
+            error_debug,
+            error_code="generation_failed",
+            correlation_id=correlation_id,
+        )
+        log_exception(
+            logger,
+            "Generation failed",
+            e,
+            correlation_id=correlation_id,
+            context={"job_id": job_id, "workflow": request.workflow},
+        )
         raise HTTPException(
             status_code=500,
             detail=api_error_detail(
@@ -1295,8 +1407,40 @@ async def register_a2a_agent(agent_id: str, registration: A2AAgentRegistration):
 @app.post("/a2a/messages")
 async def send_a2a_message(message: A2AMessage, user: UserContext = Depends(require_user_context)):
     """Submits an A2A message and queues an async result for the sender."""
-    ack = await submit_a2a_message(message, user)
-    return ack.model_dump()
+    request_correlation_id = message.correlation_id or new_error_correlation_id()
+    try:
+        ack = await submit_a2a_message(message.model_copy(update={"correlation_id": request_correlation_id}), user)
+        return ack.model_dump()
+    except PermissionError as exc:
+        correlation_id = new_error_correlation_id()
+        detail = api_error_detail(
+            code="authorization_required",
+            message="You are not authorized to perform this action.",
+            correlation_id=correlation_id,
+            public=True,
+        )
+        log_exception(logger, "A2A request unauthorized", exc, correlation_id=correlation_id, level=logging.WARNING)
+        raise HTTPException(status_code=403, detail=detail) from exc
+    except ValueError as exc:
+        correlation_id = new_error_correlation_id()
+        detail = api_error_detail(
+            code="a2a_invalid_request",
+            message="The A2A request is invalid.",
+            correlation_id=correlation_id,
+            public=True,
+        )
+        log_exception(logger, "A2A request rejected", exc, correlation_id=correlation_id)
+        raise HTTPException(status_code=400, detail=detail) from exc
+    except Exception as exc:
+        correlation_id = new_error_correlation_id()
+        detail = api_error_detail(
+            code="a2a_submit_failed",
+            message="The A2A request could not be submitted.",
+            correlation_id=correlation_id,
+            public=True,
+        )
+        log_exception(logger, "A2A request failed", exc, correlation_id=correlation_id)
+        raise HTTPException(status_code=500, detail=detail) from exc
 
 
 @app.get("/a2a/agents/{agent_id}/events")

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -31,6 +31,11 @@ Job metadata is stored in the primary application database selected by `DATABASE
 
 Server-owned actions queue an `ack` event followed by a `result` or `error` event for the sender. Messages addressed to another agent are brokered into that agent's queue. Every submitted message is persisted with a `job_id` and lifecycle status.
 
+## Error Contract
+Transport errors never return raw exception text, provider responses, database details, prompts, or filesystem paths. A2A error events and REST errors use a stable `code`, public `message`, and generated `correlation_id` in the form `err_<uuid-hex>`. MCP keeps the JSON-RPC numeric error code and places the Forma `code` and `correlation_id` under `error.data`. Use the correlation ID to locate redacted operator diagnostics in server logs.
+
+Persisted job failures use the same public message contract and retain only the error code, error type, and correlation ID in `error_debug`; exception text and tracebacks are not persisted.
+
 `data_sources: ["past_jobs"]` adds lightweight, owner-scoped retrieval over completed generation jobs. Forma ranks recent stored project outputs by lexical overlap with the new prompt and supplies a compact context window to the generator. Retrieval and generation run asynchronously; no embeddings or external retrieval infrastructure are used.
 
 ## REST Listen Flow

--- a/forma_core/debug.py
+++ b/forma_core/debug.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from forma_core.config import config
+import logging
 import re
 import traceback
+import uuid
 from typing import Any, Dict, Optional
 
+from forma_core.config import config
 from forma_core.config.runtime import forma_dev_mode_enabled
 
 
@@ -24,6 +26,93 @@ RUNTIME_CONTEXT_PATTERN = re.compile(
     r"\s+for\s+provider=[^\s:]+(?:\s+model=[^\s:]+)?\s*:",
     re.IGNORECASE,
 )
+FILE_PATH_PATTERN = re.compile(
+    r"(?<![\w])(?:[A-Za-z]:[\\/]|\\\\)(?:[^\s\"'<>]+[\\/])*[^\s\"'<>]+"
+    r"|(?<![\w])/(?:[^\s\"'<>]+/)*[^\s\"'<>]+"
+)
+DATABASE_DETAIL_PATTERN = re.compile(
+    r"(?is)\b(?:sqlite(?:3)?|postgres(?:ql)?|psycopg|sqlalchemy)\b[^\r\n]{0,500}"
+    r"|\bsupabase\s+(?:response|error|exception|database)\b[^\r\n]{0,500}"
+    r"|\bdatabase\s+(?:detail|error|exception|response)\b\s*[:=][^\r\n]{0,500}"
+)
+PROVIDER_RESPONSE_PATTERN = re.compile(
+    r"(?is)\b(?:provider\s+response|response\s+(?:body|payload))\s*[:=]\s*[^\r\n]{0,1000}"
+)
+
+PUBLIC_ERROR_MESSAGES = {
+    "authentication_required": "Authentication is required.",
+    "authorization_required": "You are not authorized to perform this action.",
+    "request_invalid": "The request is invalid.",
+    "request_validation_failed": "The request failed validation.",
+    "invalid_params": "The request parameters are invalid.",
+    "method_not_found": "The requested method is not available.",
+    "mcp_tool_failed": "The MCP tool could not complete the request.",
+    "a2a_protocol_error": "The A2A message could not be processed.",
+    "a2a_action_failed": "The A2A action could not be completed.",
+    "a2a_invalid_request": "The A2A request is invalid.",
+    "a2a_submit_failed": "The A2A request could not be submitted.",
+    "mcp_invalid_request": "The MCP request is invalid.",
+    "mcp_invalid_params": "The MCP request parameters are invalid.",
+    "mcp_method_not_found": "The requested MCP method is not available.",
+    "mcp_request_failed": "The MCP request could not be completed.",
+    "generation_input_invalid": "The generation request is missing valid input.",
+    "generation_request_invalid": "The generation request is invalid.",
+    "generation_cancelled": "Generation was stopped by the user.",
+    "generation_failed": "Generation could not be completed.",
+    "generation_root_failed": "A required generation stage failed.",
+    "llm_config_invalid": "The requested model configuration is invalid.",
+    "llm_output_invalid": "The model provider returned an invalid response.",
+    "llm_generation_unavailable": "Generation is temporarily unavailable.",
+    "alpha_generation_unavailable": "Generation is currently unavailable.",
+    "debug_config_failed": "Runtime configuration could not be loaded.",
+    "runtime_config_failed": "Runtime configuration could not be resolved.",
+    "video_provider_failed": "The video provider could not complete the request.",
+    "video_review_config_invalid": "The video review configuration is invalid.",
+    "video_review_output_invalid": "The video review provider returned an invalid response.",
+    "image_model_test_failed": "The image model test could not be completed.",
+    "image_generation_failed": "Image generation could not be completed.",
+    "internal_error": "The server could not complete the request.",
+    "storage_failed": "The requested storage operation could not be completed.",
+    "project_not_found": "Project not found.",
+    "design_brief_not_found": "DesignBrief not found.",
+    "chat_not_found": "Chat not found.",
+    "invalid_workflow_transition": "The project workflow cannot perform that transition.",
+    "readiness_not_ready": "The project is not ready for this action.",
+}
+
+ERROR_CONTENT_KEYS = {
+    "authorization_header",
+    "body",
+    "content",
+    "image_data",
+    "prompt",
+    "prompt_text",
+    "project_prompt",
+    "provider_body",
+    "provider_response",
+    "raw_provider_response",
+    "request_body",
+    "raw_body",
+    "raw_response",
+    "response",
+    "response_body",
+    "response_payload",
+    "response_text",
+    "source_url",
+    "source_prompt",
+    "text",
+    "user_prompt",
+}
+ERROR_DETAIL_KEYS = {
+    "error",
+    "error_detail",
+    "error_message",
+    "error_text",
+    "exception",
+    "failure",
+    "failure_detail",
+    "traceback",
+}
 
 
 def _env_bool(name: str, default: bool = False) -> bool:
@@ -32,6 +121,20 @@ def _env_bool(name: str, default: bool = False) -> bool:
 
 def debug_mode_enabled() -> bool:
     return any(_env_bool(name) for name in DEBUG_ENV_VARS)
+
+
+def new_error_correlation_id() -> str:
+    return f"err_{uuid.uuid4().hex}"
+
+
+def _normalized_error_code(code: str) -> str:
+    normalized = re.sub(r"[^a-zA-Z0-9_.-]", "_", str(code or "").strip())
+    return normalized[:80] or "request_failed"
+
+
+def public_error_message(code: str, fallback: Optional[str] = None) -> str:
+    del fallback
+    return PUBLIC_ERROR_MESSAGES.get(_normalized_error_code(code), "The request could not be completed.")
 
 
 def get_debug_mode_config() -> Dict[str, Any]:
@@ -67,7 +170,44 @@ def redact_debug_text(value: str) -> str:
             redacted = pattern.sub(lambda match: f"{match.group(1)}=<redacted>", redacted)
         else:
             redacted = pattern.sub("<redacted>", redacted)
+    redacted = PROVIDER_RESPONSE_PATTERN.sub(
+        lambda match: re.sub(r"\s*[:=].*", ": <redacted>", match.group(0), count=1),
+        redacted,
+    )
+    redacted = DATABASE_DETAIL_PATTERN.sub("database detail=<redacted>", redacted)
+    redacted = FILE_PATH_PATTERN.sub("<redacted path>", redacted)
     return redacted
+
+
+def redact_error_value(value: Any) -> Any:
+    """Redact content-bearing fields before errors enter durable or operator output."""
+    if isinstance(value, dict):
+        redacted: Dict[str, Any] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            normalized_key = key_text.casefold()
+            if (
+                normalized_key in ERROR_DETAIL_KEYS
+                or normalized_key.endswith("_error")
+                or normalized_key.endswith("_failure")
+            ):
+                redacted[key] = (
+                    item
+                    if isinstance(item, str) and item in PUBLIC_ERROR_MESSAGES.values()
+                    else "<redacted>"
+                )
+            elif SECRET_KEY_PATTERN.search(key_text) or normalized_key in ERROR_CONTENT_KEYS:
+                redacted[key] = "<redacted>"
+            else:
+                redacted[key] = redact_error_value(item)
+        return redacted
+    if isinstance(value, list):
+        return [redact_error_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [redact_error_value(item) for item in value]
+    if isinstance(value, str):
+        return redact_debug_text(value)
+    return value
 
 
 def runtime_safe_error_message(
@@ -103,15 +243,32 @@ def exception_debug_payload(
     exc: BaseException,
     *,
     context: Optional[Dict[str, Any]] = None,
+    correlation_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     payload: Dict[str, Any] = {
         "error_type": exc.__class__.__name__,
         "error": redact_debug_text(str(exc)),
         "traceback": redact_debug_text("".join(traceback.format_exception(type(exc), exc, exc.__traceback__))),
     }
+    if correlation_id:
+        payload["correlation_id"] = correlation_id
     if context:
-        payload["context"] = redact_debug_value(context)
+        payload["context"] = redact_error_value(context)
     return payload
+
+
+def log_exception(
+    logger: logging.Logger,
+    message: str,
+    exc: BaseException,
+    *,
+    correlation_id: str,
+    context: Optional[Dict[str, Any]] = None,
+    level: int = logging.ERROR,
+) -> None:
+    """Write searchable, redacted diagnostics without emitting a raw traceback."""
+    diagnostics = exception_debug_payload(exc, context=context, correlation_id=correlation_id)
+    logger.log(level, "%s diagnostics=%s", message, diagnostics)
 
 
 def api_error_detail(
@@ -123,20 +280,34 @@ def api_error_detail(
     provider: Optional[str] = None,
     model: Optional[str] = None,
     context: Optional[Dict[str, Any]] = None,
+    correlation_id: Optional[str] = None,
+    public: bool = False,
 ) -> Dict[str, Any]:
-    runtime_details_visible = forma_dev_mode_enabled()
+    # Public transport callers must opt into the stable, diagnostic-free contract.
+    if not public:
+        runtime_details_visible = forma_dev_mode_enabled()
+        detail: Dict[str, Any] = {
+            "code": code,
+            "message": runtime_safe_error_message(message, provider=provider, model=model),
+        }
+        if runtime_details_visible and provider:
+            detail["provider"] = provider
+        if runtime_details_visible and model:
+            detail["model"] = model
+        if runtime_details_visible and debug_mode_enabled() and exc is not None:
+            detail["debug"] = exception_debug_payload(exc, context=context)
+        elif runtime_details_visible and debug_mode_enabled() and context:
+            detail["debug"] = {"context": redact_debug_value(context)}
+        if job_id:
+            detail["job_id"] = job_id
+        return detail
+
+    normalized_code = _normalized_error_code(code)
     detail: Dict[str, Any] = {
-        "code": code,
-        "message": runtime_safe_error_message(message, provider=provider, model=model),
+        "code": normalized_code,
+        "message": public_error_message(normalized_code, message),
+        "correlation_id": correlation_id or new_error_correlation_id(),
     }
     if job_id:
         detail["job_id"] = job_id
-    if runtime_details_visible and provider:
-        detail["provider"] = provider
-    if runtime_details_visible and model:
-        detail["model"] = model
-    if runtime_details_visible and debug_mode_enabled() and exc is not None:
-        detail["debug"] = exception_debug_payload(exc, context=context)
-    elif runtime_details_visible and debug_mode_enabled() and context:
-        detail["debug"] = {"context": redact_debug_value(context)}
     return detail

--- a/forma_core/jobs/store.py
+++ b/forma_core/jobs/store.py
@@ -14,6 +14,12 @@ from forma_core.jobs.repositories import (
 )
 from forma_core.jobs.source_usage import infer_source_usage
 from forma_core.persistence.providers import SQLiteProvider, SupabaseProvider, create_sqlite_provider
+from forma_core.debug import (
+    new_error_correlation_id,
+    public_error_message,
+    redact_debug_value,
+    redact_error_value,
+)
 
 load_dotenv()
 
@@ -25,11 +31,28 @@ def _utc_now() -> str:
 
 
 def _redact_payload(payload: Dict[str, Any]) -> Dict[str, Any]:
-    redacted = dict(payload or {})
+    redacted = redact_debug_value(dict(payload or {}))
     if redacted.get("image_data"):
         redacted["image_data"] = "<redacted>"
         redacted["image_data_present"] = True
     return redacted
+
+
+def _persisted_error_debug(
+    error_debug: Optional[Dict[str, Any]],
+    correlation_id: str,
+    error_code: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    if not error_debug and not error_code:
+        return None
+    payload: Dict[str, Any] = {
+        "correlation_id": correlation_id,
+    }
+    if error_code:
+        payload["code"] = str(error_code)[:80]
+    if error_debug:
+        payload["error_type"] = str(error_debug.get("error_type") or "Error")
+    return payload
 
 
 def _operation_summary(operations: List[Dict[str, Any]]) -> Dict[str, Any]:
@@ -225,6 +248,7 @@ class JobMetadataStore:
     ) -> Dict[str, Any]:
         self.init_db()
         now = _utc_now()
+        correlation_id = correlation_id or new_error_correlation_id()
         source_usage = infer_source_usage(action=action, payload=payload)
         assert self._repository is not None
         self._repository.create(
@@ -256,6 +280,7 @@ class JobMetadataStore:
         now = _utc_now()
         event_payload = dict(event or {})
         event_payload.setdefault("observed_at", now)
+        event_payload = redact_error_value(event_payload)
         assert self._repository is not None
         self._repository.append_progress_event(job_id, event_payload, now)
 
@@ -283,7 +308,7 @@ class JobMetadataStore:
     ) -> None:
         self.init_db()
         now = _utc_now()
-        result_summary = summarize_result(result)
+        result_summary = redact_error_value(summarize_result(result))
         current = self.get_job(job_id) or {}
         if str(current.get("status") or "").lower() in {"cancelled", "canceled"}:
             return
@@ -309,12 +334,24 @@ class JobMetadataStore:
             },
         )
 
-    def mark_failed(self, job_id: str, error: str, error_debug: Optional[Dict[str, Any]] = None) -> None:
+    def mark_failed(
+        self,
+        job_id: str,
+        error: str,
+        error_debug: Optional[Dict[str, Any]] = None,
+        *,
+        error_code: Optional[str] = None,
+        correlation_id: Optional[str] = None,
+    ) -> None:
         self.init_db()
         now = _utc_now()
         current = self.get_job(job_id) or {}
         if str(current.get("status") or "").lower() in {"cancelled", "canceled"}:
             return
+        resolved_correlation_id = str(
+            correlation_id or current.get("correlation_id") or new_error_correlation_id()
+        )
+        safe_error = public_error_message(error_code or "internal_error", error)
         assert self._repository is not None
         self._repository.complete(
             job_id,
@@ -323,8 +360,9 @@ class JobMetadataStore:
                 "status": "failed",
                 "completed_at": now,
                 "updated_at": now,
-                "error_debug_json": error_debug,
-                "error": error,
+                "correlation_id": resolved_correlation_id,
+                "error_debug_json": _persisted_error_debug(error_debug, resolved_correlation_id, error_code),
+                "error": safe_error,
             },
         )
 
@@ -333,7 +371,7 @@ class JobMetadataStore:
         self.init_db()
         now = _utc_now()
         assert self._repository is not None
-        return self._repository.cancel(job_id, now, reason)
+        return self._repository.cancel(job_id, now, redact_debug_text(reason))
 
     def is_cancelled(self, job_id: str) -> bool:
         job = self.get_job(job_id)

--- a/tests/api/test_a2a_image_logging.py
+++ b/tests/api/test_a2a_image_logging.py
@@ -128,10 +128,11 @@ class A2AImageLoggingTests(unittest.TestCase):
         operation = next(item for item in metadata["operation_statuses"] if item["id"] == "image_generation")
         self.assertEqual("failed", metadata["image_output_status"])
         self.assertEqual("configuration", metadata["image_output_error_type"])
-        self.assertEqual("Image provider API key is missing.", metadata["image_output_error"])
+        self.assertEqual("Image generation could not be completed.", metadata["image_output_error"])
+        self.assertRegex(metadata["image_output_error_correlation_id"], r"^err_[0-9a-f]{32}$")
         self.assertEqual("none", metadata["image_output_debug"]["provider"])
         self.assertEqual("https://api.example.test/v1", operation["details"]["image_output_debug"]["base_url"])
-        self.assertIn("debug=", "\n".join(logs.output))
+        self.assertIn("code=image_generation_failed", "\n".join(logs.output))
 
 
 if __name__ == "__main__":

--- a/tests/api/test_mcp_agent_compatibility.py
+++ b/tests/api/test_mcp_agent_compatibility.py
@@ -74,6 +74,16 @@ class McpAgentCompatibilityTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertIsNone(response)
 
+    async def test_invalid_mcp_params_use_sanitized_error_contract(self) -> None:
+        response = await handle_mcp_json_rpc(
+            {"jsonrpc": "2.0", "id": "invalid", "method": "tools/call", "params": []}
+        )
+
+        self.assertEqual(-32602, response["error"]["code"])
+        self.assertEqual("The MCP request parameters are invalid.", response["error"]["message"])
+        self.assertEqual("mcp_invalid_params", response["error"]["data"]["code"])
+        self.assertRegex(response["error"]["data"]["correlation_id"], r"^err_[0-9a-f]{32}$")
+
     async def test_batch_omits_notification_responses(self) -> None:
         response = await handle_mcp_json_rpc(
             [
@@ -219,8 +229,57 @@ class McpAgentCompatibilityTests(unittest.IsolatedAsyncioTestCase):
             )
 
         self.assertEqual(-32000, response["error"]["code"])
-        self.assertIn("only be updated by its owner", response["error"]["message"])
+        self.assertEqual("The MCP tool could not complete the request.", response["error"]["message"])
+        self.assertEqual("mcp_tool_failed", response["error"]["data"]["code"])
+        self.assertRegex(response["error"]["data"]["correlation_id"], r"^err_[0-9a-f]{32}$")
         update_project.assert_not_called()
+
+    async def test_mcp_tool_error_does_not_echo_exception_details(self) -> None:
+        with patch.object(
+            a2a,
+            "call_forma_action",
+            new=AsyncMock(
+                side_effect=RuntimeError(
+                    "provider response: api_key=sk-testsecret123456 at C:\\secret\\forma.db"
+                )
+            ),
+        ):
+            response = await handle_mcp_json_rpc(
+                {
+                    "jsonrpc": "2.0",
+                    "id": "safe-error",
+                    "method": "tools/call",
+                    "params": {"name": "forma.debug_config", "arguments": {}},
+                },
+                self._user(),
+            )
+
+        serialized = str(response)
+        self.assertEqual("The MCP tool could not complete the request.", response["error"]["message"])
+        self.assertNotIn("sk-testsecret123456", serialized)
+        self.assertNotIn("forma.db", serialized)
+        self.assertNotIn("provider response", serialized.lower())
+
+    async def test_queued_a2a_error_event_is_sanitized(self) -> None:
+        message = A2AMessage(sender="test-agent", action="forma.generate_project")
+        with patch.object(
+            a2a,
+            "call_forma_action",
+            new=AsyncMock(side_effect=RuntimeError("provider response: sk-testsecret123456 at C:\\secret\\db")),
+        ), patch.object(a2a.JOB_STORE, "mark_running"), patch.object(
+            a2a.JOB_STORE, "mark_failed"
+        ) as mark_failed, patch.object(a2a.A2A_HUB, "publish", new=AsyncMock()) as publish:
+            await a2a._process_server_message(message)
+
+        event = publish.await_args.args[0]
+        serialized = str(event.model_dump())
+        self.assertEqual("error", event.type)
+        self.assertEqual("a2a_action_failed", event.payload["error"]["code"])
+        self.assertRegex(event.payload["error"]["correlation_id"], r"^err_[0-9a-f]{32}$")
+        self.assertNotIn("sk-testsecret123456", serialized)
+        self.assertNotIn("provider response", serialized.lower())
+        mark_failed.assert_called_once()
+        self.assertEqual("a2a_action_failed", mark_failed.call_args.kwargs["error_code"])
 
     async def test_mcp_action_forwards_authenticated_context(self) -> None:
         user = self._user()

--- a/tests/observability/test_debug_mode.py
+++ b/tests/observability/test_debug_mode.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
 
 import os
-import tempfile
 import unittest
 from contextlib import contextmanager
 from typing import Any, Iterator
 
 from forma_core.jobs.store import JobMetadataStore
-from forma_core.debug import api_error_detail, exception_debug_payload, redact_debug_value
+from forma_core.debug import api_error_detail, exception_debug_payload, redact_debug_value, redact_error_value
 
 
 DEBUG_ENV_KEYS = ("FORMA_DEBUG", "FORMA_DEBUG_MODE", "API_DEBUG", "DEBUG")
@@ -140,32 +139,52 @@ class DebugModeTests(unittest.TestCase):
         self.assertEqual("<redacted>", redacted["nested"]["token"])
         self.assertEqual("visible", redacted["ok"])
 
-    def test_failed_job_persists_debug_payload_when_provided(self) -> None:
-        with tempfile.NamedTemporaryFile(suffix=".db") as file:
-            store = JobMetadataStore(file.name, backend="sqlite")
-            store.create_job(
-                job_id="job_debug_test",
-                message_id="msg_debug_test",
-                correlation_id=None,
-                action="forma.generate_project",
-                sender="test",
-                recipient="forma",
-                payload={"prompt": "blink an LED", "image_data": "data:image/png;base64,abc"},
-                server_owned=True,
-            )
-            try:
-                raise ValueError("bad runtime")
-            except ValueError as exc:
-                store.mark_failed("job_debug_test", str(exc), exception_debug_payload(exc, context={"api_key": "sk-testsecret123456"}))
+    def test_redact_error_value_removes_error_details_and_sensitive_text(self) -> None:
+        redacted = redact_error_value(
+            {
+                "error": "provider response=secret body",
+                "path": r"C:\\secrets\\forma.db",
+                "database": "sqlite database locked",
+                "prompt": "Build a private sensor",
+            }
+        )
 
-            job = store.get_job("job_debug_test")
+        self.assertEqual("<redacted>", redacted["error"])
+        self.assertNotIn("forma.db", str(redacted))
+        self.assertNotIn("sqlite database locked", str(redacted))
+        self.assertEqual("<redacted>", redacted["prompt"])
+
+    def test_failed_job_persists_debug_payload_when_provided(self) -> None:
+        store = JobMetadataStore(":memory:", backend="sqlite")
+        store.create_job(
+            job_id="job_debug_test",
+            message_id="msg_debug_test",
+            correlation_id=None,
+            action="forma.generate_project",
+            sender="test",
+            recipient="forma",
+            payload={"prompt": "blink an LED", "image_data": "data:image/png;base64,abc"},
+            server_owned=True,
+        )
+        try:
+            raise ValueError("bad runtime")
+        except ValueError as exc:
+            store.mark_failed(
+                "job_debug_test",
+                str(exc),
+                exception_debug_payload(exc, context={"api_key": "sk-testsecret123456"}),
+                error_code="generation_failed",
+            )
+
+        job = store.get_job("job_debug_test")
 
         self.assertIsNotNone(job)
         assert job is not None
         self.assertEqual("failed", job["status"])
-        self.assertEqual("bad runtime", job["error"])
+        self.assertEqual("Generation could not be completed.", job["error"])
+        self.assertEqual("generation_failed", job["error_debug"]["code"])
         self.assertEqual("ValueError", job["error_debug"]["error_type"])
-        self.assertEqual("<redacted>", job["error_debug"]["context"]["api_key"])
+        self.assertRegex(job["error_debug"]["correlation_id"], r"^err_[0-9a-f]{32}$")
         self.assertEqual("<redacted>", job["payload"]["image_data"])
 
     def test_supabase_create_job_fails_when_required_schema_column_is_missing(self) -> None:


### PR DESCRIPTION
Closes #336

## Summary
- Add stable public error codes, sanitized messages, and correlation IDs across MCP and A2A transports.
- Redact raw exception details from logs, queued events, job results, and persisted failure diagnostics.
- Document the A2A error contract and add regression coverage for MCP/A2A visibility and redaction.

## Validation
- Focused unittest suite: 39 tests passed.
- compileall passed.
- git diff --check passed.
- Full discovery remains environment-dependent on Windows due SQLite temporary-file lock failures during cleanup.