### PR TITLE
feat: publish reusable Forma GUI package

### DIFF
--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -70,12 +70,12 @@ import {
   type ProjectImageCandidate,
 } from "../lib/project-images";
 import {
-  ProjectGallery,
   PROJECT_GALLERY_PAGE_SIZE,
   buildProjectGalleryItems,
   previewableImageSrc,
   type ProjectGalleryItem,
 } from "./forma-workspace/project-gallery";
+import { FormaProjectBrowser, type FormaProjectSummary } from "@caid-technologies/forma-gui";
 import {
   AssemblyPanel,
   BomPanel,
@@ -385,6 +385,22 @@ function normalizeApiUrl(value: string) {
   const trimmed = value.trim().replace(/\/+$/, "");
   if (!trimmed) return "/api";
   return trimmed.endsWith("/api") ? trimmed : `${trimmed}/api`;
+}
+
+function formaBrowserProjectFromGalleryItem(item: ProjectGalleryItem): FormaProjectSummary {
+  return {
+    project_id: item.projectId,
+    title: item.title,
+    created_at: item.createdAt,
+    creator_display: item.creatorDisplay,
+    creator_image_url: item.creatorImageUrl,
+    parts_count: item.partsCount,
+    save_count: item.saveCount,
+    remix_count: item.remixCount,
+    saved: item.saved,
+    can_chat: item.canChat,
+    image_url: item.image ? previewableImageSrc(item.image) : null,
+  };
 }
 
 function downloadBrowserFile(contents: string, filename: string, mimeType: string) {
@@ -1809,6 +1825,10 @@ export function FormaWorkspace({
     })),
     [authRequired, formaDevMode, isSignedIn, projectHistory, projectGalleryImages]
   );
+  const projectBrowserItems = useMemo(
+    () => projectGalleryItems.map(formaBrowserProjectFromGalleryItem),
+    [projectGalleryItems]
+  );
   const myProjectGalleryItems = useMemo(
     () => buildProjectGalleryItems(
       myProjectHistory,
@@ -1819,6 +1839,10 @@ export function FormaWorkspace({
       canChat: item.canChat && (!authRequired || Boolean(isSignedIn)),
     })),
     [authRequired, formaDevMode, isSignedIn, myProjectHistory, projectGalleryImages]
+  );
+  const myProjectBrowserItems = useMemo(
+    () => myProjectGalleryItems.map(formaBrowserProjectFromGalleryItem),
+    [myProjectGalleryItems]
   );
   const chatHistoryLoaded = myProjectHistoryLoaded && privateChatsLoaded;
   const projectsPageLoading = !projectHistoryLoaded;
@@ -5362,36 +5386,46 @@ export function FormaWorkspace({
             : "min-h-0 flex-1 overflow-y-auto px-4 pb-6 pt-16 sm:px-5 md:py-8"
         }`}>
           {homeView === "projects" ? (
-              <ProjectGallery
+              <FormaProjectBrowser
                 sectionRef={projectsSectionRef}
-                items={projectGalleryItems}
+                projects={projectBrowserItems}
                 title="Community"
                 loading={projectsPageLoading}
-                onOpenProjectPage={(projectId) => router.push(projectRoute(projectId))}
-                onToggleSave={canInteractWithGallery ? handleToggleProjectSave : undefined}
-                onRemixProject={canInteractWithGallery ? handleRemixProject : undefined}
+                onOpenProject={(projectId) => router.push(projectRoute(projectId))}
+                onToggleSave={canInteractWithGallery ? (project) => {
+                  const item = projectGalleryItems.find((candidate) => candidate.projectId === project.project_id);
+                  return item ? handleToggleProjectSave(item) : undefined;
+                } : undefined}
+                onRemixProject={canInteractWithGallery ? (project) => {
+                  const item = projectGalleryItems.find((candidate) => candidate.projectId === project.project_id);
+                  return item ? handleRemixProject(item) : undefined;
+                } : undefined}
                 onVisibleProjectIdsChange={handleVisibleProjectGalleryIdsChange}
                 totalItems={projectHistoryTotal}
                 currentPage={projectHistoryPage}
                 onPageChange={handleProjectHistoryPageChange}
                 searchValue={projectSearchInput}
                 onSearchValueChange={setProjectSearchInput}
-                standalone
               />
 	          ) : homeView === "my-projects" ? (
-              <ProjectGallery
+              <FormaProjectBrowser
                 sectionRef={projectsSectionRef}
-                items={myProjectGalleryItems}
+                projects={myProjectBrowserItems}
                 title="My projects"
                 loading={myProjectsPageLoading}
-                onOpenProjectPage={(projectId) => router.push(projectRoute(projectId))}
-                onToggleSave={canInteractWithGallery ? handleToggleProjectSave : undefined}
-                onRemixProject={canInteractWithGallery ? handleRemixProject : undefined}
+                onOpenProject={(projectId) => router.push(projectRoute(projectId))}
+                onToggleSave={canInteractWithGallery ? (project) => {
+                  const item = myProjectGalleryItems.find((candidate) => candidate.projectId === project.project_id);
+                  return item ? handleToggleProjectSave(item) : undefined;
+                } : undefined}
+                onRemixProject={canInteractWithGallery ? (project) => {
+                  const item = myProjectGalleryItems.find((candidate) => candidate.projectId === project.project_id);
+                  return item ? handleRemixProject(item) : undefined;
+                } : undefined}
                 onVisibleProjectIdsChange={handleVisibleProjectGalleryIdsChange}
                 totalItems={myProjectHistoryTotal}
                 currentPage={myProjectHistoryPage}
                 onPageChange={handleMyProjectHistoryPageChange}
-                standalone
               />
           ) : homeView === "jobs" ? (
             <>

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,3 +1,5 @@
+@import "@caid-technologies/forma-gui/styles.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,6 +8,7 @@
       "name": "forma-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@caid-technologies/forma-gui": "file:../../packages/forma-gui",
         "@clerk/nextjs": "^5.7.5",
         "@next/env": "15.5.21",
         "@opennextjs/cloudflare": "1.20.2",
@@ -33,6 +34,19 @@
         "tailwindcss": "^3.4",
         "typescript": "^5",
         "wrangler": "4.118.0"
+      }
+    },
+    "../../packages/forma-gui": {
+      "name": "@caid-technologies/forma-gui",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0 <20",
+        "react-dom": ">=18.2.0 <20"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1158,6 +1172,10 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@caid-technologies/forma-gui": {
+      "resolved": "../../packages/forma-gui",
+      "link": true
     },
     "node_modules/@clerk/backend": {
       "version": "1.14.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },
   "dependencies": {
+    "@caid-technologies/forma-gui": "file:../../packages/forma-gui",
     "@clerk/nextjs": "^5.7.5",
     "@next/env": "15.5.21",
     "@opennextjs/cloudflare": "1.20.2",

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,6 +1,6 @@
 # Frontend
 
-The frontend is a **Next.js 14** app that visualizes Hardware IR and provides the interactive CAD-style experience.
+The frontend is a **Next.js 15** app that visualizes Hardware IR and provides the interactive CAD-style experience.
 
 ## Core UI features
 - **Prompt input** with optional image upload.
@@ -34,6 +34,18 @@ The UI communicates with the backend API:
 - `GET /api/components` – component catalog
 - `GET /api/projects` – history of generated projects
 - `POST /api/generate` – run the agent pipeline
+
+## Installable viewer package
+
+The reusable project browser and project detail viewer are packaged for publication as `@caid-technologies/forma-gui`:
+
+```bash
+npm install @caid-technologies/forma-gui
+```
+
+Import `@caid-technologies/forma-gui/styles.css` once, then configure `FormaApiClient` with a `baseUrl` and optional `getHeaders` callback. The callback is the authentication boundary for hosted deployments; local single-user APIs can omit it. The package exposes typed `FormaProjectBrowser`, `FormaProjectDetail`, and canonical project contracts without importing Clerk, provider credentials, routing, Tailwind, React Flow, or Three.js.
+
+The first-party project and my-projects pages consume the package browser through the local `file:../../packages/forma-gui` dependency while the package is developed in this repository. Run `npm run build` and `npm test` from `packages/forma-gui` before publishing a semver release.
 
 If the backend is offline, the UI can still load example JSONs from `apps/web/public/examples/`.
 

--- a/packages/forma-gui/README.md
+++ b/packages/forma-gui/README.md
@@ -1,0 +1,68 @@
+# `@caid-technologies/forma-gui`
+
+Reusable React components for browsing and viewing Forma hardware projects. The package is intentionally a browser-safe viewer surface: it does not import Clerk, provider SDKs, backend credentials, or application routing.
+
+## Install
+
+```bash
+npm install @caid-technologies/forma-gui
+```
+
+React 18 or 19 and React DOM 18 or 19 are peer dependencies.
+
+## Usage
+
+Import the package CSS once from the application entry point:
+
+```tsx
+import {
+  FormaApiClient,
+  FormaProjectBrowser,
+  FormaProjectDetail,
+} from "@caid-technologies/forma-gui";
+import "@caid-technologies/forma-gui/styles.css";
+
+const forma = new FormaApiClient({
+  baseUrl: process.env.NEXT_PUBLIC_FORMA_API_URL,
+  getHeaders: async () => {
+    const token = await getHostedSessionToken();
+    return token ? { Authorization: `Bearer ${token}` } : {};
+  },
+});
+
+export function Projects() {
+  return <FormaProjectBrowser client={forma} onOpenProject={(id) => console.log(id)} />;
+}
+
+export function Project({ projectId }: { projectId: string }) {
+  return <FormaProjectDetail client={forma} projectId={projectId} />;
+}
+```
+
+`baseUrl` may be an origin such as `https://forma.example.com` or an API root ending in `/api`. The client normalizes both forms. For local single-user APIs, omit `getHeaders`; no Clerk or hosted authentication assumption is built into the package.
+
+## API surface
+
+- `FormaApiClient.listProjects()` loads `/projects` or `/my/projects` with search and pagination.
+- `FormaApiClient.getProject(projectId)` loads the canonical project response from `/projects/{id}`.
+- `FormaApiClient.getImageSummary(projectId)` loads `/projects/{id}/image-summary`.
+- `FormaProjectBrowser` supports controlled project lists or client-backed loading, search, pagination, open/save/remix callbacks, and loading/empty/unauthorized/unavailable states.
+- `FormaProjectDetail` renders overview, BOM, validation, schematic, mechanical, assembly, and artifact sections. Use `renderSection` when a host needs to replace a section while keeping the typed loading and error shell.
+- `FormaApiError` exposes `status`, `code`, `correlationId`, and `unauthorized` without retaining raw response text.
+
+The components use CSS variables with `--forma-*` fallbacks. Override the `--forma-gui-*` variables or the corresponding application variables to match a host theme. The package does not include Tailwind, React Flow, Three.js, image hosting, or router CSS. Schematic SVG is displayed as an image data URL rather than injected into the DOM.
+
+## Security boundary
+
+Keep API tokens in the host application's request callback. Do not put provider credentials, server-only environment variables, or long-lived tokens in project data, local storage, or public build-time variables. For hosted deployments, return short-lived session headers from `getHeaders`; for local deployments, configure a same-origin or local API base URL.
+
+## Publishing
+
+From `packages/forma-gui`:
+
+```bash
+npm run pack:check
+npm publish --access public
+```
+
+Use semver for releases. `dist/` is generated and included in the npm tarball; it is not required in the source repository. A companion `npx` launcher is intentionally deferred until a command-line workflow has a separate stable contract.

--- a/packages/forma-gui/package.json
+++ b/packages/forma-gui/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@caid-technologies/forma-gui",
+  "version": "0.1.0",
+  "description": "Reusable React project browser and hardware project viewer for Forma APIs.",
+  "type": "module",
+  "sideEffects": ["./dist/styles.css"],
+  "files": ["dist", "README.md"],
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./styles.css": "./dist/styles.css",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json && node scripts/copy-css.mjs",
+    "clean": "node -e \"require('fs').rmSync('dist', { recursive: true, force: true })\"",
+    "prepare": "npm run build",
+    "test": "npm run build && node --test test/*.test.mjs",
+    "pack:check": "npm run build && npm pack --dry-run"
+  },
+  "peerDependencies": {
+    "react": ">=18.2.0 <20",
+    "react-dom": ">=18.2.0 <20"
+  },
+  "devDependencies": {
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "typescript": "^5.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/forma-gui/scripts/copy-css.mjs
+++ b/packages/forma-gui/scripts/copy-css.mjs
@@ -1,0 +1,17 @@
+import { copyFileSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+mkdirSync(resolve(packageRoot, "dist"), { recursive: true });
+copyFileSync(resolve(packageRoot, "src/styles.css"), resolve(packageRoot, "dist/styles.css"));
+
+for (const file of readdirSync(resolve(packageRoot, "dist"), { recursive: true })) {
+  if (typeof file !== "string" || !file.endsWith(".js")) continue;
+  const path = resolve(packageRoot, "dist", file);
+  const source = readFileSync(path, "utf8");
+  const rewritten = source.replace(/((?:from\s+|import\s*\(\s*)["'])(\.[^"']+)(["'])/g, (match, prefix, specifier, suffix) => (
+    /\.[cm]?[jt]sx?$/.test(specifier) ? match : `${prefix}${specifier}.js${suffix}`
+  ));
+  if (rewritten !== source) writeFileSync(path, rewritten);
+}

--- a/packages/forma-gui/src/api.ts
+++ b/packages/forma-gui/src/api.ts
@@ -1,0 +1,144 @@
+import type { FormaProjectListResponse, FormaProjectResponse, FormaProjectSummary } from "./contracts";
+
+export type FormaApiRequest = {
+  path: string;
+  method: string;
+};
+
+export type FormaApiClientOptions = {
+  /** API origin or API root. A missing `/api` suffix is added automatically. */
+  baseUrl?: string;
+  getHeaders?: (request: FormaApiRequest) => HeadersInit | Promise<HeadersInit>;
+  fetcher?: typeof fetch;
+};
+
+export class FormaApiError extends Error {
+  readonly status: number;
+  readonly code: string | null;
+  readonly correlationId: string | null;
+
+  constructor(message: string, status: number, code: string | null = null, correlationId: string | null = null) {
+    super(message);
+    this.name = "FormaApiError";
+    this.status = status;
+    this.code = code;
+    this.correlationId = correlationId;
+  }
+
+  get unauthorized() {
+    return this.status === 401 || this.status === 403;
+  }
+}
+
+function normalizeBaseUrl(value: string | undefined) {
+  const trimmed = (value || "/api").trim().replace(/\/+$/, "");
+  if (!trimmed) return "/api";
+  return trimmed.endsWith("/api") ? trimmed : `${trimmed}/api`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+function asString(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function statusMessage(status: number) {
+  if (status === 401 || status === 403) return "Authorization is required to view this project.";
+  if (status === 404) return "The requested Forma project was not found.";
+  if (status === 429) return "Forma is temporarily rate limited. Try again shortly.";
+  if (status >= 500) return "Forma could not complete that request.";
+  return "Forma returned an unexpected response.";
+}
+
+function errorFields(body: unknown) {
+  const root = asRecord(body);
+  const detail = root ? root.detail ?? root.error ?? root : body;
+  const record = asRecord(detail);
+  const code = asString(record?.code) || asString(root?.code);
+  const correlationId = asString(record?.correlation_id) || asString(root?.correlation_id);
+  return {
+    code,
+    correlationId,
+    message: code || correlationId
+      ? asString(record?.message) || asString(record?.detail) || asString(root?.message)
+      : null,
+  };
+}
+
+export class FormaApiClient {
+  readonly baseUrl: string;
+  private readonly getHeaders?: FormaApiClientOptions["getHeaders"];
+  private readonly fetcher: typeof fetch;
+
+  constructor(options: FormaApiClientOptions = {}) {
+    this.baseUrl = normalizeBaseUrl(options.baseUrl);
+    this.getHeaders = options.getHeaders;
+    const fetcher = options.fetcher || (typeof fetch === "function" ? fetch.bind(globalThis) : null);
+    if (!fetcher) throw new Error("FormaApiClient requires a fetch implementation in this environment.");
+    this.fetcher = fetcher;
+  }
+
+  async listProjects(options: {
+    scope?: "community" | "mine";
+    search?: string;
+    limit?: number;
+    offset?: number;
+  } = {}): Promise<FormaProjectListResponse> {
+    const params = new URLSearchParams();
+    if (options.search?.trim()) params.set("q", options.search.trim());
+    if (options.limit !== undefined) params.set("limit", String(Math.max(1, Math.floor(options.limit))));
+    if (options.offset !== undefined) params.set("offset", String(Math.max(0, Math.floor(options.offset))));
+    const path = options.scope === "mine" ? "/my/projects" : "/projects";
+    const response = await this.request<FormaProjectListResponse | FormaProjectSummary[]>(`${path}?${params.toString()}`);
+    if (Array.isArray(response)) {
+      return { items: response, total: response.length };
+    }
+    return {
+      items: Array.isArray(response?.items) ? response.items : [],
+      total: Number.isFinite(Number(response?.total)) ? Math.max(0, Number(response.total)) : 0,
+      limit: response?.limit,
+      offset: response?.offset,
+    };
+  }
+
+  getProject(projectId: string) {
+    return this.request<FormaProjectResponse>(`/projects/${encodeURIComponent(projectId)}`);
+  }
+
+  getImageSummary(projectId: string) {
+    return this.request<Record<string, unknown>>(`/projects/${encodeURIComponent(projectId)}/image-summary`);
+  }
+
+  private async request<T>(path: string, init: RequestInit = {}): Promise<T> {
+    const method = (init.method || "GET").toUpperCase();
+    const headers = new Headers(init.headers);
+    headers.set("Accept", "application/json");
+    const configuredHeaders = await this.getHeaders?.({ path, method });
+    if (configuredHeaders) {
+      new Headers(configuredHeaders).forEach((value, key) => headers.set(key, value));
+    }
+
+    let response: Response;
+    try {
+      response = await this.fetcher(`${this.baseUrl}${path}`, { ...init, headers });
+    } catch {
+      throw new FormaApiError("Forma is unavailable. Check the API URL and try again.", 0, "api_unavailable");
+    }
+
+    let body: unknown = null;
+    try {
+      body = await response.json();
+    } catch {
+      // Empty responses are valid for some API operations.
+    }
+    if (!response.ok) {
+      const fields = errorFields(body);
+      throw new FormaApiError(fields.message || statusMessage(response.status), response.status, fields.code, fields.correlationId);
+    }
+    return body as T;
+  }
+}
+
+export type { FormaProjectListResponse, FormaProjectResponse, FormaProjectSummary } from "./contracts";

--- a/packages/forma-gui/src/components/project-browser.tsx
+++ b/packages/forma-gui/src/components/project-browser.tsx
@@ -1,0 +1,222 @@
+"use client";
+
+import { useEffect, useMemo, useState, type RefObject } from "react";
+import type { FormaProjectSummary } from "../contracts";
+import { FormaApiClient, FormaApiError } from "../api";
+
+export type FormaProjectBrowserProps = {
+  client?: FormaApiClient;
+  /** Pass this prop to use controlled data from an existing application query. */
+  projects?: FormaProjectSummary[];
+  totalItems?: number;
+  currentPage?: number;
+  onPageChange?: (page: number) => void;
+  searchValue?: string;
+  onSearchValueChange?: (value: string) => void;
+  scope?: "community" | "mine";
+  pageSize?: number;
+  title?: string;
+  loading?: boolean;
+  error?: unknown;
+  onOpenProject?: (projectId: string, project: FormaProjectSummary) => void;
+  onToggleSave?: (project: FormaProjectSummary) => void | Promise<void>;
+  onRemixProject?: (project: FormaProjectSummary) => void | Promise<void>;
+  onVisibleProjectIdsChange?: (projectIds: string[]) => void;
+  sectionRef?: RefObject<HTMLElement | null>;
+  className?: string;
+};
+
+type LocalState = {
+  projects: FormaProjectSummary[];
+  total: number;
+  loading: boolean;
+  error: unknown;
+};
+
+function errorLabel(error: unknown) {
+  if (error instanceof FormaApiError && error.unauthorized) return "Authorization required";
+  if (error instanceof Error && error.message) return error.message;
+  return "Projects could not be loaded. Check the Forma API and try again.";
+}
+
+function imageSrc(project: FormaProjectSummary) {
+  const direct = project.image_url || project.product_image_url;
+  if (typeof direct === "string" && direct.trim()) return direct;
+  if (typeof project.product_image_data === "string" && project.product_image_data.trim()) {
+    return project.product_image_data.startsWith("data:")
+      ? project.product_image_data
+      : `data:${project.product_image_content_type || "image/png"};base64,${project.product_image_data}`;
+  }
+  return null;
+}
+
+function formatAge(value: string | null | undefined) {
+  if (!value) return "";
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) return "";
+  const days = Math.floor(Math.max(0, Date.now() - timestamp) / 86_400_000);
+  if (days === 0) return "Today";
+  if (days === 1) return "1 day";
+  if (days < 31) return `${days} days`;
+  const months = Math.floor(days / 30);
+  return months === 1 ? "1 month" : `${months} months`;
+}
+
+function displayName(project: FormaProjectSummary) {
+  return project.creator_display?.trim() || project.creator_username?.trim() || "Forma builder";
+}
+
+export function FormaProjectBrowser({
+  client,
+  projects,
+  totalItems,
+  currentPage,
+  onPageChange,
+  searchValue,
+  onSearchValueChange,
+  scope = "community",
+  pageSize = 12,
+  title = "Projects",
+  loading: controlledLoading,
+  error: controlledError,
+  onOpenProject,
+  onToggleSave,
+  onRemixProject,
+  onVisibleProjectIdsChange,
+  sectionRef,
+  className = "",
+}: FormaProjectBrowserProps) {
+  const controlled = projects !== undefined;
+  const [localSearch, setLocalSearch] = useState("");
+  const [localPage, setLocalPage] = useState(0);
+  const [state, setState] = useState<LocalState>({ projects: [], total: 0, loading: !controlled && Boolean(client), error: null });
+  const search = searchValue ?? localSearch;
+  const page = currentPage ?? localPage;
+
+  useEffect(() => {
+    if (controlled || !client) return;
+    let active = true;
+    setState((current) => ({ ...current, loading: true, error: null }));
+    void client.listProjects({ scope, search, limit: pageSize, offset: page * pageSize })
+      .then((result) => {
+        if (active) setState({ projects: result.items, total: result.total, loading: false, error: null });
+      })
+      .catch((error: unknown) => {
+        if (active) setState({ projects: [], total: 0, loading: false, error });
+      });
+    return () => {
+      active = false;
+    };
+  }, [client, controlled, page, pageSize, scope, search]);
+
+  const visibleProjects = controlled ? projects : state.projects;
+  const total = totalItems ?? (controlled ? visibleProjects.length : state.total);
+  const loading = controlledLoading ?? (!controlled && state.loading);
+  const error = controlledError ?? (!controlled && !client ? new Error("Configure a FormaApiClient to load projects.") : state.error);
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+  const safePage = Math.min(Math.max(page, 0), pageCount - 1);
+  const visibleIds = useMemo(() => visibleProjects.map((project) => project.project_id), [visibleProjects]);
+  const setPage = (nextPage: number) => {
+    const next = Math.min(Math.max(nextPage, 0), pageCount - 1);
+    if (onPageChange) onPageChange(next);
+    else setLocalPage(next);
+  };
+  const setSearch = (value: string) => {
+    if (onSearchValueChange) onSearchValueChange(value);
+    else {
+      setLocalSearch(value);
+      setLocalPage(0);
+    }
+  };
+
+  useEffect(() => {
+    onVisibleProjectIdsChange?.(visibleIds);
+  }, [onVisibleProjectIdsChange, visibleIds]);
+
+  return (
+    <section ref={sectionRef} className={`forma-gui forma-gui-browser ${className}`} aria-busy={loading}>
+      <div className="forma-gui-browser-heading">
+        <div>
+          <h2>{title}</h2>
+          <p>{loading ? "Loading projects..." : `${total} ${total === 1 ? "project" : "projects"}`}</p>
+        </div>
+        <label className="forma-gui-search">
+          <span className="forma-gui-visually-hidden">Search projects</span>
+          <input type="search" value={search} onChange={(event) => setSearch(event.target.value)} placeholder="Search projects" />
+        </label>
+      </div>
+
+      {loading ? (
+        <div className="forma-gui-card-grid" aria-label="Loading projects">
+          {Array.from({ length: Math.min(pageSize, 8) }, (_, index) => <div className="forma-gui-card forma-gui-card-skeleton" key={index} />)}
+        </div>
+      ) : error ? (
+        <div className="forma-gui-state forma-gui-state-error" role="alert">
+          <strong>{error instanceof FormaApiError && error.unauthorized ? "Sign-in required" : "Projects unavailable"}</strong>
+          <span>{errorLabel(error)}</span>
+        </div>
+      ) : visibleProjects.length === 0 ? (
+        <div className="forma-gui-state"><strong>{search.trim() ? "No matching projects" : "No projects yet"}</strong><span>{search.trim() ? "Try a different search." : "Generated projects will appear here."}</span></div>
+      ) : (
+        <>
+          <div className="forma-gui-card-grid">
+            {visibleProjects.map((project) => <ProjectCard key={project.project_id} project={project} onOpenProject={onOpenProject} onToggleSave={onToggleSave} onRemixProject={onRemixProject} />)}
+          </div>
+          {pageCount > 1 && (
+            <nav className="forma-gui-pagination" aria-label="Project pages">
+              <button type="button" onClick={() => setPage(safePage - 1)} disabled={safePage === 0}>Previous</button>
+              <span>Page {safePage + 1} of {pageCount}</span>
+              <button type="button" onClick={() => setPage(safePage + 1)} disabled={safePage >= pageCount - 1}>Next</button>
+            </nav>
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+function ProjectCard({
+  project,
+  onOpenProject,
+  onToggleSave,
+  onRemixProject,
+}: {
+  project: FormaProjectSummary;
+  onOpenProject?: FormaProjectBrowserProps["onOpenProject"];
+  onToggleSave?: FormaProjectBrowserProps["onToggleSave"];
+  onRemixProject?: FormaProjectBrowserProps["onRemixProject"];
+}) {
+  const [saveBusy, setSaveBusy] = useState(false);
+  const [remixBusy, setRemixBusy] = useState(false);
+  const image = imageSrc(project);
+  const open = () => onOpenProject?.(project.project_id, project);
+  const save = async (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (!onToggleSave || saveBusy) return;
+    setSaveBusy(true);
+    try { await onToggleSave(project); } finally { setSaveBusy(false); }
+  };
+  const remix = async (event: React.MouseEvent) => {
+    event.stopPropagation();
+    if (!onRemixProject || remixBusy) return;
+    setRemixBusy(true);
+    try { await onRemixProject(project); } finally { setRemixBusy(false); }
+  };
+
+  return (
+    <article className="forma-gui-card" role={onOpenProject ? "link" : undefined} tabIndex={onOpenProject ? 0 : undefined} onClick={open} onKeyDown={(event) => { if (onOpenProject && (event.key === "Enter" || event.key === " ")) { event.preventDefault(); open(); } }}>
+      <div className="forma-gui-card-image">
+        {image ? <img src={image} alt={`${project.title} preview`} /> : <span aria-hidden="true">FORMA / PROJECT</span>}
+      </div>
+      <div className="forma-gui-card-body">
+        <div className="forma-gui-card-title-row"><h3>{project.title || "Untitled project"}</h3><span>{project.parts_count || 0} parts</span></div>
+        <p className="forma-gui-card-description">{project.description || project.prompt || "Hardware project"}</p>
+        <div className="forma-gui-card-meta"><span>{displayName(project)}</span><span>{formatAge(project.created_at)}</span></div>
+        {(onToggleSave || onRemixProject) && <div className="forma-gui-card-actions">
+          {onToggleSave && <button type="button" onClick={save} disabled={saveBusy} aria-pressed={Boolean(project.saved)}>{project.saved ? "Saved" : "Save"}</button>}
+          {onRemixProject && <button type="button" onClick={remix} disabled={remixBusy}>Remix</button>}
+        </div>}
+      </div>
+    </article>
+  );
+}

--- a/packages/forma-gui/src/components/project-detail.tsx
+++ b/packages/forma-gui/src/components/project-detail.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import type { FormaArtifact, FormaHardwareProject, FormaProjectResponse, FormaValidationFinding } from "../contracts";
+import { FormaApiClient, FormaApiError } from "../api";
+
+export type FormaProjectDetailSection = "overview" | "bom" | "validation" | "schematic" | "mechanical" | "assembly" | "artifacts";
+
+export type FormaProjectDetailProps = {
+  client?: FormaApiClient;
+  projectId?: string;
+  /** A response from `FormaApiClient.getProject`, useful for server-loaded or controlled views. */
+  project?: FormaProjectResponse;
+  initialSection?: FormaProjectDetailSection;
+  activeSection?: FormaProjectDetailSection;
+  onSectionChange?: (section: FormaProjectDetailSection) => void;
+  onBack?: () => void;
+  renderSection?: (section: FormaProjectDetailSection, project: FormaProjectResponse) => ReactNode;
+  loading?: boolean;
+  error?: unknown;
+  className?: string;
+};
+
+const sections: Array<{ id: FormaProjectDetailSection; label: string }> = [
+  { id: "overview", label: "Overview" },
+  { id: "bom", label: "BOM" },
+  { id: "validation", label: "Validation" },
+  { id: "schematic", label: "Schematic" },
+  { id: "mechanical", label: "Mechanical" },
+  { id: "assembly", label: "Assembly" },
+  { id: "artifacts", label: "Artifacts" },
+];
+
+function asText(value: unknown, fallback = "") {
+  return typeof value === "string" && value.trim() ? value.trim() : fallback;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+}
+
+function asNumber(value: unknown, fallback = 0) {
+  const number = Number(value);
+  return Number.isFinite(number) ? number : fallback;
+}
+
+function errorLabel(error: unknown) {
+  if (error instanceof FormaApiError && error.unauthorized) return "Sign-in or project access is required.";
+  if (error instanceof Error && error.message) return error.message;
+  return "The project could not be loaded. Check the Forma API and try again.";
+}
+
+function projectData(response: FormaProjectResponse) {
+  return response.project_ir || asRecord(response.project_object).project_ir as FormaHardwareProject || {};
+}
+
+function projectImage(response: FormaProjectResponse, ir: FormaHardwareProject) {
+  const metadata = asRecord(ir.assembly_metadata);
+  const direct = metadata.product_image_url || metadata.image_output_url;
+  if (typeof direct === "string" && direct.trim()) return direct;
+  const data = metadata.product_image_data;
+  if (typeof data === "string" && data.trim()) return data.startsWith("data:") ? data : `data:${asText(metadata.product_image_content_type, "image/png")};base64,${data}`;
+  return null;
+}
+
+function validationFindings(ir: FormaHardwareProject): FormaValidationFinding[] {
+  const validation = ir.validation || {};
+  return [
+    ...(validation.critical || []),
+    ...(validation.warning || []),
+    ...(validation.info || []),
+    ...(ir.validation_issues || []),
+  ];
+}
+
+function projectArtifacts(response: FormaProjectResponse, ir: FormaHardwareProject): FormaArtifact[] {
+  const mechanical = ir.mechanical || {};
+  return [...(response.artifacts || []), ...(mechanical.cad_sources || [])].filter((artifact, index, all) => {
+    const url = asText(artifact.url || artifact.href || artifact.file_url);
+    return Boolean(url) && all.findIndex((candidate) => asText(candidate.url || candidate.href || candidate.file_url) === url) === index;
+  });
+}
+
+export function FormaProjectDetail({
+  client,
+  projectId,
+  project,
+  initialSection = "overview",
+  activeSection,
+  onSectionChange,
+  onBack,
+  renderSection,
+  loading: controlledLoading,
+  error: controlledError,
+  className = "",
+}: FormaProjectDetailProps) {
+  const [loadedProject, setLoadedProject] = useState<FormaProjectResponse | null>(project || null);
+  const [localLoading, setLocalLoading] = useState(!project && Boolean(projectId && client));
+  const [localError, setLocalError] = useState<unknown>(null);
+  const [localSection, setLocalSection] = useState<FormaProjectDetailSection>(initialSection);
+  const currentProject = project || loadedProject;
+  const section = activeSection || localSection;
+
+  useEffect(() => {
+    if (project) {
+      setLoadedProject(project);
+      setLocalLoading(false);
+      setLocalError(null);
+      return;
+    }
+    if (!client || !projectId) {
+      setLocalLoading(false);
+      return;
+    }
+    let active = true;
+    setLocalLoading(true);
+    setLocalError(null);
+    void client.getProject(projectId)
+      .then((response) => { if (active) setLoadedProject(response); })
+      .catch((error: unknown) => { if (active) setLocalError(error); })
+      .finally(() => { if (active) setLocalLoading(false); });
+    return () => { active = false; };
+  }, [client, project, projectId]);
+
+  const loading = controlledLoading ?? localLoading;
+  const error = controlledError ?? localError ?? (!currentProject && !client ? new Error("Configure a FormaApiClient or pass a project response.") : null);
+  const setSection = (next: FormaProjectDetailSection) => {
+    if (onSectionChange) onSectionChange(next);
+    else setLocalSection(next);
+  };
+
+  if (loading) return <div className={`forma-gui forma-gui-detail ${className}`} aria-busy="true"><div className="forma-gui-state"><strong>Loading project</strong><span>Fetching the canonical project package from Forma.</span></div></div>;
+  if (error) return <div className={`forma-gui forma-gui-detail ${className}`}><div className="forma-gui-state forma-gui-state-error" role="alert"><strong>{error instanceof FormaApiError && error.unauthorized ? "Project access required" : "Project unavailable"}</strong><span>{errorLabel(error)}</span>{onBack && <button type="button" onClick={onBack}>Back to projects</button>}</div></div>;
+  if (!currentProject) return null;
+
+  const ir = projectData(currentProject);
+  const title = asText(ir.overview?.title, asText(currentProject.title, "Untitled hardware project"));
+  const content = renderSection ? renderSection(section, currentProject) : <DefaultSection section={section} response={currentProject} ir={ir} />;
+
+  return (
+    <section className={`forma-gui forma-gui-detail ${className}`}>
+      <header className="forma-gui-detail-header">
+        {onBack && <button type="button" className="forma-gui-back" onClick={onBack}>← Projects</button>}
+        <div><span className="forma-gui-kicker">Forma project</span><h1>{title}</h1></div>
+      </header>
+      <nav className="forma-gui-tabs" aria-label="Project sections">
+        {sections.map((item) => <button key={item.id} type="button" onClick={() => setSection(item.id)} aria-current={section === item.id ? "page" : undefined}>{item.label}</button>)}
+      </nav>
+      <div className="forma-gui-detail-content">{content}</div>
+    </section>
+  );
+}
+
+function DefaultSection({ section, response, ir }: { section: FormaProjectDetailSection; response: FormaProjectResponse; ir: FormaHardwareProject }) {
+  switch (section) {
+    case "bom": return <BomSection ir={ir} />;
+    case "validation": return <ValidationSection ir={ir} />;
+    case "schematic": return <SchematicSection response={response} />;
+    case "mechanical": return <MechanicalSection ir={ir} />;
+    case "assembly": return <AssemblySection ir={ir} />;
+    case "artifacts": return <ArtifactsSection artifacts={projectArtifacts(response, ir)} />;
+    default: return <OverviewSection response={response} ir={ir} />;
+  }
+}
+
+function OverviewSection({ response, ir }: { response: FormaProjectResponse; ir: FormaHardwareProject }) {
+  const metadata = asRecord(ir.assembly_metadata);
+  const components = ir.components || [];
+  const bom = ir.bom?.length ? ir.bom : components;
+  const findings = validationFindings(ir);
+  const totalCost = bom.reduce((sum, item) => sum + asNumber(item.extended_price, asNumber(item.unit_price) * Math.max(1, asNumber(item.quantity, 1))), 0);
+  const image = projectImage(response, ir);
+  const features = ir.overview?.features || [];
+  const workflow = asText(metadata.workflow);
+  const status = asText(response.generation_status, asText(response.status, asText(response.readiness, "ready"))).replace(/_/g, " ");
+  return <div className="forma-gui-stack">
+    {image && <img className="forma-gui-hero" src={image} alt={`${asText(ir.overview?.title, "Project")} concept`} />}
+    <div className="forma-gui-panel"><span className="forma-gui-kicker">Technical description</span><p className="forma-gui-lead">{asText(ir.overview?.description, asText(response.prompt, "No project description is available."))}</p>{features.length > 0 && <div className="forma-gui-tags">{features.slice(0, 16).map((feature) => <span key={feature}>{feature}</span>)}</div>}</div>
+    <div className="forma-gui-stat-grid"><Stat label="Parts" value={String(components.length || bom.length)} /><Stat label="Estimated cost" value={`$${totalCost.toFixed(2)}`} /><Stat label="Validation" value={findings.length ? `${findings.length} findings` : "Passed"} /><Stat label="Status" value={status} /></div>
+    {workflow && <div className="forma-gui-note">Workflow: {workflow}</div>}
+  </div>;
+}
+
+function BomSection({ ir }: { ir: FormaHardwareProject }) {
+  const items = ir.bom?.length ? ir.bom : ir.components || [];
+  return <div className="forma-gui-panel"><div className="forma-gui-section-heading"><div><span className="forma-gui-kicker">Bill of materials</span><h2>{items.length} line items</h2></div></div>{items.length ? <div className="forma-gui-table-wrap"><table className="forma-gui-table"><thead><tr><th>Part</th><th>Category</th><th>Qty</th><th>Unit</th><th>Total</th></tr></thead><tbody>{items.map((item, index) => { const quantity = Math.max(1, asNumber(item.quantity, 1)); const unit = asNumber(item.unit_price); const total = asNumber(item.extended_price, unit * quantity); const key = asText(item.line_id, asText(item.part_number, asText(item.ref_des))) || String(index); return <tr key={key}><td><strong>{asText(item.name, asText(item.part_number, "Unnamed part"))}</strong><small>{asText(item.rationale)}</small></td><td>{asText(item.category, "Part")}</td><td>{quantity}</td><td>${unit.toFixed(2)}</td><td>${total.toFixed(2)}</td></tr>; })}</tbody></table></div> : <Empty text="No bill of materials is attached to this project." />}</div>;
+}
+
+function ValidationSection({ ir }: { ir: FormaHardwareProject }) {
+  const findings = validationFindings(ir);
+  return <div className="forma-gui-panel"><div className="forma-gui-section-heading"><div><span className="forma-gui-kicker">Electrical and safety review</span><h2>{findings.length ? `${findings.length} findings` : "Circuit approved"}</h2></div></div>{findings.length ? <div className="forma-gui-findings">{findings.map((finding, index) => <article key={`${finding.code || finding.description || finding.message}-${index}`} className={`forma-gui-finding forma-gui-finding-${asText(finding.severity, "info").toLowerCase()}`}><span>{asText(finding.severity, "info")}</span><p>{asText(finding.description, asText(finding.message, "Validation finding"))}</p>{finding.category && <small>{asText(finding.category)}</small>}</article>)}</div> : <div className="forma-gui-success">All electrical nets validated safely.</div>}</div>;
+}
+
+function SchematicSection({ response }: { response: FormaProjectResponse }) {
+  if (response.svg_schematic) {
+    return <div className="forma-gui-panel"><span className="forma-gui-kicker">Electrical schematic</span><img className="forma-gui-schematic" src={`data:image/svg+xml;charset=utf-8,${encodeURIComponent(response.svg_schematic)}`} alt="Project electrical schematic" /></div>;
+  }
+  return <div className="forma-gui-panel"><span className="forma-gui-kicker">Electrical schematic</span>{response.mermaid_code ? <pre className="forma-gui-code">{response.mermaid_code}</pre> : <Empty text="No schematic artifact is attached to this project." />}</div>;
+}
+
+function MechanicalSection({ ir }: { ir: FormaHardwareProject }) {
+  const mechanical = ir.mechanical || {};
+  const dimensions = mechanical.render_dimensions || mechanical.external_dimensions_mm;
+  const placements = mechanical.component_placements || [];
+  return <div className="forma-gui-stack"><div className="forma-gui-panel"><span className="forma-gui-kicker">Mechanical package</span><h2>Enclosure and placement</h2>{dimensions && <div className="forma-gui-dimensions">{Object.entries(dimensions).slice(0, 6).map(([key, value]) => <Stat key={key} label={key.replace(/_mm$/, "")} value={String(value)} />)}</div>}<p className="forma-gui-muted">{placements.length ? `${placements.length} component placements defined.` : "No component placements are attached to this project."}</p></div><ArtifactsSection artifacts={mechanical.cad_sources || []} /></div>;
+}
+
+function AssemblySection({ ir }: { ir: FormaHardwareProject }) {
+  const steps = ir.assembly || [];
+  return <div className="forma-gui-panel"><span className="forma-gui-kicker">Build documentation</span><h2>Assembly sequence</h2>{steps.length ? <div className="forma-gui-steps">{steps.map((step, index) => <article key={`${step.step_num || index}-${step.title}`}><strong>{step.step_num || index + 1}</strong><div><h3>{asText(step.title, "Assembly step")}</h3><p>{asText(step.description, "Follow the project notes for this step.")}</p>{step.danger_flag && <div className="forma-gui-warning">{asText(step.danger_message, "Review safety constraints before continuing.")}</div>}</div></article>)}</div> : <Empty text="No assembly instructions are attached to this project." />}</div>;
+}
+
+function ArtifactsSection({ artifacts }: { artifacts: FormaArtifact[] }) {
+  return <div className="forma-gui-panel"><span className="forma-gui-kicker">Project files</span><h2>Artifacts</h2>{artifacts.length ? <div className="forma-gui-artifacts">{artifacts.map((artifact, index) => { const href = asText(artifact.url || artifact.href || artifact.file_url); return <a key={`${href}-${index}`} href={href} target="_blank" rel="noreferrer"><span>{asText(artifact.label, asText(artifact.name, "Project artifact"))}</span><small>{asText(artifact.format, asText(artifact.type, "Open file"))}</small></a>; })}</div> : <Empty text="No downloadable artifacts are attached to this project." />}</div>;
+}
+
+function Stat({ label, value }: { label: string; value: string }) { return <div className="forma-gui-stat"><span>{label}</span><strong>{value}</strong></div>; }
+function Empty({ text }: { text: string }) { return <div className="forma-gui-empty">{text}</div>; }

--- a/packages/forma-gui/src/contracts.ts
+++ b/packages/forma-gui/src/contracts.ts
@@ -1,0 +1,138 @@
+export type JsonObject = Record<string, unknown>;
+
+export type FormaProjectSummary = {
+  project_id: string;
+  title: string;
+  description?: string | null;
+  prompt?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+  visibility?: "public" | "private" | string;
+  can_chat?: boolean;
+  creator_display?: string | null;
+  creator_username?: string | null;
+  creator_image_url?: string | null;
+  parts_count?: number;
+  save_count?: number;
+  remix_count?: number;
+  saved?: boolean;
+  product_image_url?: string | null;
+  product_image_data?: string | null;
+  product_image_content_type?: string | null;
+  image_url?: string | null;
+  [key: string]: unknown;
+};
+
+export type FormaComponent = {
+  name?: string;
+  category?: string;
+  part_number?: string;
+  ref_des?: string;
+  quantity?: number;
+  unit_price?: number;
+  extended_price?: number;
+  rationale?: string;
+  instance_refs?: string[];
+  source_url?: string;
+  sourcing_url?: string;
+  [key: string]: unknown;
+};
+
+export type FormaBomItem = FormaComponent & {
+  line_id?: string;
+  part_definition_id?: string;
+};
+
+export type FormaValidationFinding = {
+  severity?: string;
+  category?: string;
+  code?: string;
+  description?: string;
+  message?: string;
+  [key: string]: unknown;
+};
+
+export type FormaAssemblyStep = {
+  step_num?: number;
+  title?: string;
+  description?: string;
+  danger_flag?: boolean;
+  danger_message?: string;
+  affected_components?: string[];
+  [key: string]: unknown;
+};
+
+export type FormaArtifact = {
+  name?: string;
+  label?: string;
+  url?: string;
+  href?: string;
+  file_url?: string;
+  type?: string;
+  format?: string;
+  [key: string]: unknown;
+};
+
+export type FormaMechanicalData = {
+  render_dimensions?: JsonObject | null;
+  external_dimensions_mm?: JsonObject | null;
+  component_placements?: JsonObject[];
+  spatial_relationships?: JsonObject[];
+  cad_sources?: FormaArtifact[];
+  fabrication_cost_estimate_usd?: number;
+  [key: string]: unknown;
+};
+
+export type FormaHardwareProject = {
+  overview?: {
+    title?: string;
+    description?: string;
+    features?: string[];
+    [key: string]: unknown;
+  };
+  requirements?: JsonObject | JsonObject[];
+  system_architecture?: JsonObject | null;
+  components?: FormaComponent[];
+  bom?: FormaBomItem[];
+  nets?: JsonObject[];
+  buses?: JsonObject[];
+  pin_mappings?: JsonObject[];
+  assembly?: FormaAssemblyStep[];
+  mechanical?: FormaMechanicalData;
+  validation?: {
+    critical?: FormaValidationFinding[];
+    warning?: FormaValidationFinding[];
+    info?: FormaValidationFinding[];
+    [key: string]: unknown;
+  };
+  validation_issues?: FormaValidationFinding[];
+  constraints?: string[];
+  assembly_metadata?: JsonObject;
+  [key: string]: unknown;
+};
+
+export type FormaProjectResponse = {
+  project_id?: string;
+  chat_id?: string;
+  title?: string;
+  prompt?: string;
+  status?: string | null;
+  generation_status?: string | null;
+  readiness?: string | null;
+  stage?: string | null;
+  created_at?: string;
+  can_chat?: boolean;
+  project_ir?: FormaHardwareProject;
+  project_object?: JsonObject;
+  mermaid_code?: string | null;
+  svg_schematic?: string | null;
+  artifacts?: FormaArtifact[];
+  [key: string]: unknown;
+};
+
+export type FormaProjectListResponse = {
+  items: FormaProjectSummary[];
+  total: number;
+  limit?: number;
+  offset?: number;
+};

--- a/packages/forma-gui/src/index.ts
+++ b/packages/forma-gui/src/index.ts
@@ -1,0 +1,16 @@
+export { FormaApiClient, FormaApiError, type FormaApiClientOptions, type FormaApiRequest } from "./api";
+export { FormaProjectBrowser, type FormaProjectBrowserProps } from "./components/project-browser";
+export { FormaProjectDetail, type FormaProjectDetailProps, type FormaProjectDetailSection } from "./components/project-detail";
+export type {
+  FormaArtifact,
+  FormaAssemblyStep,
+  FormaBomItem,
+  FormaComponent,
+  FormaHardwareProject,
+  FormaMechanicalData,
+  FormaProjectListResponse,
+  FormaProjectResponse,
+  FormaProjectSummary,
+  FormaValidationFinding,
+  JsonObject,
+} from "./contracts";

--- a/packages/forma-gui/src/styles.css
+++ b/packages/forma-gui/src/styles.css
@@ -1,0 +1,97 @@
+.forma-gui {
+  --forma-gui-page: var(--forma-page, #141519);
+  --forma-gui-surface: var(--forma-surface, #17181d);
+  --forma-gui-muted-surface: var(--forma-surface-muted, #101115);
+  --forma-gui-border: var(--forma-border, #2c2f37);
+  --forma-gui-text: var(--forma-text-strong, #f8fafc);
+  --forma-gui-body: var(--forma-text-body, #cbd5e1);
+  --forma-gui-muted: var(--forma-text-muted, #94a3b8);
+  --forma-gui-accent: rgb(var(--forma-green-rgb, 52 211 153));
+  box-sizing: border-box;
+  color: var(--forma-gui-body);
+  font-family: Inter, ui-sans-serif, system-ui, sans-serif;
+}
+
+.forma-gui *, .forma-gui *::before, .forma-gui *::after { box-sizing: border-box; }
+.forma-gui button, .forma-gui input { font: inherit; }
+.forma-gui button { cursor: pointer; }
+.forma-gui button:disabled { cursor: not-allowed; opacity: .5; }
+.forma-gui-visually-hidden { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+.forma-gui-browser, .forma-gui-detail { width: 100%; min-width: 0; background: var(--forma-gui-page); }
+.forma-gui-browser { padding: clamp(1rem, 3vw, 2rem); }
+.forma-gui-browser-heading, .forma-gui-detail-header, .forma-gui-section-heading { display: flex; align-items: end; justify-content: space-between; gap: 1rem; }
+.forma-gui-browser-heading { margin-bottom: 1.25rem; }
+.forma-gui-browser h2, .forma-gui-detail h1, .forma-gui-detail h2, .forma-gui-detail h3, .forma-gui-browser h3 { color: var(--forma-gui-text); margin: 0; }
+.forma-gui-browser h2 { font-size: 1.1rem; }
+.forma-gui-browser-heading p, .forma-gui-muted { color: var(--forma-gui-muted); font-size: .8rem; margin: .35rem 0 0; }
+.forma-gui-search { width: min(100%, 20rem); }
+.forma-gui-search input { width: 100%; height: 2.35rem; border: 1px solid var(--forma-gui-border); border-radius: .55rem; background: var(--forma-gui-surface); color: var(--forma-gui-text); padding: 0 .75rem; outline: none; }
+.forma-gui-search input:focus { border-color: var(--forma-gui-accent); }
+.forma-gui-card-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(min(100%, 15rem), 1fr)); gap: .75rem; }
+.forma-gui-card { min-width: 0; overflow: hidden; border: 1px solid var(--forma-gui-border); border-radius: .8rem; background: var(--forma-gui-surface); transition: border-color .15s ease, transform .15s ease; }
+.forma-gui-card[role="link"] { cursor: pointer; }
+.forma-gui-card[role="link"]:hover, .forma-gui-card[role="link"]:focus-visible { border-color: var(--forma-gui-accent); outline: none; transform: translateY(-1px); }
+.forma-gui-card-image { display: grid; aspect-ratio: 4 / 3; place-items: center; overflow: hidden; border-bottom: 1px solid var(--forma-gui-border); background: var(--forma-gui-muted-surface); color: var(--forma-gui-muted); font: 600 .62rem/1.2 ui-monospace, monospace; letter-spacing: .14em; }
+.forma-gui-card-image img { width: 100%; height: 100%; object-fit: cover; }
+.forma-gui-card-body { display: grid; gap: .75rem; padding: .9rem; }
+.forma-gui-card-title-row { display: flex; align-items: start; justify-content: space-between; gap: .5rem; }
+.forma-gui-card-title-row h3 { overflow: hidden; font-size: .9rem; line-height: 1.3; text-overflow: ellipsis; }
+.forma-gui-card-title-row span, .forma-gui-card-meta { color: var(--forma-gui-muted); font-size: .7rem; white-space: nowrap; }
+.forma-gui-card-description { display: -webkit-box; min-height: 2.6em; overflow: hidden; margin: 0; color: var(--forma-gui-muted); font-size: .78rem; line-height: 1.45; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
+.forma-gui-card-meta { display: flex; justify-content: space-between; gap: .75rem; }
+.forma-gui-card-actions { display: flex; gap: .5rem; }
+.forma-gui-card-actions button, .forma-gui-pagination button, .forma-gui-state button, .forma-gui-back { border: 1px solid var(--forma-gui-border); border-radius: .45rem; background: transparent; color: var(--forma-gui-body); padding: .4rem .65rem; font-size: .72rem; }
+.forma-gui-card-actions button:hover, .forma-gui-pagination button:hover, .forma-gui-state button:hover, .forma-gui-back:hover { border-color: var(--forma-gui-accent); color: var(--forma-gui-text); }
+.forma-gui-pagination { display: flex; align-items: center; justify-content: center; gap: 1rem; padding-top: 1rem; color: var(--forma-gui-muted); font-size: .75rem; }
+.forma-gui-state { display: grid; gap: .35rem; min-height: 9rem; place-content: center; border: 1px dashed var(--forma-gui-border); border-radius: .8rem; padding: 2rem; text-align: center; }
+.forma-gui-state strong { color: var(--forma-gui-text); font-size: .9rem; }
+.forma-gui-state span { color: var(--forma-gui-muted); font-size: .78rem; }
+.forma-gui-state-error { border-color: color-mix(in srgb, #fb7185 45%, var(--forma-gui-border)); }
+.forma-gui-card-skeleton { min-height: 17rem; animation: forma-gui-pulse 1.4s ease-in-out infinite; background: linear-gradient(110deg, var(--forma-gui-surface) 30%, var(--forma-gui-muted-surface) 45%, var(--forma-gui-surface) 60%); background-size: 200% 100%; }
+@keyframes forma-gui-pulse { to { background-position-x: -200%; } }
+.forma-gui-detail { min-height: 100%; }
+.forma-gui-detail-header { align-items: center; padding: 1.1rem clamp(1rem, 3vw, 2rem); border-bottom: 1px solid var(--forma-gui-border); background: var(--forma-gui-surface); }
+.forma-gui-detail-header h1 { margin-top: .25rem; font-size: clamp(1.1rem, 2vw, 1.5rem); }
+.forma-gui-kicker { display: block; color: var(--forma-gui-muted); font-size: .65rem; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
+.forma-gui-tabs { display: flex; gap: .2rem; overflow-x: auto; padding: .45rem .75rem; border-bottom: 1px solid var(--forma-gui-border); background: var(--forma-gui-surface); }
+.forma-gui-tabs button { flex: 0 0 auto; border: 0; border-radius: .45rem; background: transparent; color: var(--forma-gui-muted); padding: .5rem .7rem; font-size: .75rem; }
+.forma-gui-tabs button:hover, .forma-gui-tabs button[aria-current="page"] { background: color-mix(in srgb, var(--forma-gui-accent) 13%, transparent); color: var(--forma-gui-accent); }
+.forma-gui-detail-content { max-width: 64rem; margin: 0 auto; padding: clamp(1rem, 3vw, 2rem); }
+.forma-gui-stack { display: grid; gap: 1rem; }
+.forma-gui-panel { min-width: 0; border: 1px solid var(--forma-gui-border); border-radius: .8rem; background: var(--forma-gui-surface); padding: clamp(1rem, 2vw, 1.35rem); }
+.forma-gui-panel h2 { margin-top: .3rem; font-size: 1rem; }
+.forma-gui-lead { max-width: 52rem; margin: .8rem 0 0; color: var(--forma-gui-body); font-size: .9rem; line-height: 1.7; }
+.forma-gui-hero { width: 100%; max-height: 28rem; border: 1px solid var(--forma-gui-border); border-radius: .8rem; object-fit: cover; }
+.forma-gui-tags { display: flex; flex-wrap: wrap; gap: .4rem; margin-top: 1rem; }
+.forma-gui-tags span { border: 1px solid var(--forma-gui-border); border-radius: .35rem; color: var(--forma-gui-muted); padding: .3rem .45rem; font-size: .68rem; }
+.forma-gui-stat-grid, .forma-gui-dimensions { display: grid; grid-template-columns: repeat(auto-fit, minmax(8rem, 1fr)); gap: .65rem; }
+.forma-gui-stat { display: grid; gap: .3rem; border: 1px solid var(--forma-gui-border); border-radius: .55rem; background: var(--forma-gui-muted-surface); padding: .75rem; }
+.forma-gui-stat span { color: var(--forma-gui-muted); font-size: .65rem; text-transform: uppercase; letter-spacing: .08em; }
+.forma-gui-stat strong { color: var(--forma-gui-text); font-size: .9rem; }
+.forma-gui-note, .forma-gui-empty { color: var(--forma-gui-muted); font-size: .78rem; }
+.forma-gui-table-wrap { overflow-x: auto; margin-top: 1rem; }
+.forma-gui-table { width: 100%; min-width: 36rem; border-collapse: collapse; font-size: .78rem; }
+.forma-gui-table th { color: var(--forma-gui-muted); font-size: .65rem; font-weight: 700; letter-spacing: .08em; text-align: left; text-transform: uppercase; }
+.forma-gui-table th, .forma-gui-table td { border-bottom: 1px solid var(--forma-gui-border); padding: .75rem .5rem; vertical-align: top; }
+.forma-gui-table td { color: var(--forma-gui-body); }
+.forma-gui-table td:first-child { color: var(--forma-gui-text); }
+.forma-gui-table small { display: block; max-width: 25rem; margin-top: .25rem; color: var(--forma-gui-muted); line-height: 1.4; }
+.forma-gui-findings, .forma-gui-steps, .forma-gui-artifacts { display: grid; gap: .65rem; margin-top: 1rem; }
+.forma-gui-finding, .forma-gui-success, .forma-gui-warning { border: 1px solid var(--forma-gui-border); border-radius: .55rem; padding: .75rem; }
+.forma-gui-finding > span { color: var(--forma-gui-accent); font-size: .65rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+.forma-gui-finding p { margin: .4rem 0; color: var(--forma-gui-body); font-size: .8rem; line-height: 1.5; }
+.forma-gui-finding small { color: var(--forma-gui-muted); }
+.forma-gui-finding-error, .forma-gui-finding-critical { border-color: #fb718577; }
+.forma-gui-finding-warning { border-color: #fbbf2477; }
+.forma-gui-success { border-color: #34d39977; color: var(--forma-gui-accent); font-size: .8rem; }
+.forma-gui-schematic { display: block; width: 100%; max-height: 42rem; margin-top: 1rem; border: 1px solid var(--forma-gui-border); border-radius: .55rem; background: #fff; object-fit: contain; }
+.forma-gui-code { max-height: 36rem; overflow: auto; margin: 1rem 0 0; border-radius: .55rem; background: var(--forma-gui-muted-surface); color: var(--forma-gui-body); padding: 1rem; font: .72rem/1.55 ui-monospace, SFMono-Regular, Consolas, monospace; white-space: pre-wrap; }
+.forma-gui-steps article { display: grid; grid-template-columns: 2.25rem 1fr; gap: .75rem; border-bottom: 1px solid var(--forma-gui-border); padding: .75rem 0; }
+.forma-gui-steps article > strong { display: grid; place-items: center; width: 2rem; height: 2rem; border: 1px solid var(--forma-gui-border); border-radius: .45rem; color: var(--forma-gui-text); font-size: .8rem; }
+.forma-gui-steps h3 { font-size: .85rem; }
+.forma-gui-steps p { margin: .4rem 0 0; color: var(--forma-gui-body); font-size: .8rem; line-height: 1.55; }
+.forma-gui-warning { margin-top: .65rem; border-color: #fb718577; color: #fda4af; font-size: .75rem; line-height: 1.5; }
+.forma-gui-artifacts a { display: flex; justify-content: space-between; gap: 1rem; border: 1px solid var(--forma-gui-border); border-radius: .55rem; color: var(--forma-gui-text); padding: .75rem; text-decoration: none; }
+.forma-gui-artifacts a:hover { border-color: var(--forma-gui-accent); }
+.forma-gui-artifacts small { color: var(--forma-gui-muted); }
+@media (max-width: 600px) { .forma-gui-browser-heading, .forma-gui-detail-header { align-items: stretch; flex-direction: column; } .forma-gui-search { width: 100%; } .forma-gui-card-grid { grid-template-columns: 1fr; } .forma-gui-artifacts a { align-items: start; flex-direction: column; gap: .35rem; } }

--- a/packages/forma-gui/test/api.test.mjs
+++ b/packages/forma-gui/test/api.test.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { FormaApiClient, FormaApiError, FormaProjectBrowser, FormaProjectDetail } from "../dist/index.js";
+
+test("FormaApiClient normalizes an origin and supplies request headers", async () => {
+  const calls = [];
+  const client = new FormaApiClient({
+    baseUrl: "https://forma.example.test/",
+    getHeaders: ({ path, method }) => ({
+      Authorization: `Bearer ${path}:${method}`,
+      "X-Client": "forma-gui-test",
+    }),
+    fetcher: async (url, init) => {
+      calls.push({ url: String(url), headers: new Headers(init?.headers) });
+      return new Response(JSON.stringify({ items: [{ project_id: "p-1", title: "Monitor" }], total: 1 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    },
+  });
+
+  const result = await client.listProjects({ search: "monitor", limit: 6, offset: 12 });
+
+  assert.deepEqual(result.items, [{ project_id: "p-1", title: "Monitor" }]);
+  assert.equal(result.total, 1);
+  assert.equal(calls[0].url, "https://forma.example.test/api/projects?q=monitor&limit=6&offset=12");
+  assert.equal(calls[0].headers.get("authorization"), "Bearer /projects?q=monitor&limit=6&offset=12:GET");
+  assert.equal(calls[0].headers.get("x-client"), "forma-gui-test");
+});
+
+test("FormaApiClient preserves canonical error metadata without exposing raw error text", async () => {
+  const client = new FormaApiClient({
+    baseUrl: "/api",
+    fetcher: async () => new Response(JSON.stringify({ detail: "provider key secret should not reach the UI" }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    }),
+  });
+
+  await assert.rejects(
+    client.getProject("project-1"),
+    (error) => {
+      assert.ok(error instanceof FormaApiError);
+      assert.equal(error.status, 500);
+      assert.equal(error.code, null);
+      assert.equal(error.correlationId, null);
+      assert.equal(error.message, "Forma could not complete that request.");
+      return true;
+    },
+  );
+});
+
+test("FormaApiClient does not trust an unstructured error message", async () => {
+  const client = new FormaApiClient({
+    fetcher: async () => new Response(JSON.stringify({ detail: { message: "provider response with a secret" } }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    }),
+  });
+
+  await assert.rejects(
+    client.getProject("project-1"),
+    (error) => {
+      assert.equal(error.message, "Forma could not complete that request.");
+      return true;
+    },
+  );
+});
+
+test("FormaApiClient exposes canonical unauthorized metadata", async () => {
+  const client = new FormaApiClient({
+    fetcher: async () => new Response(JSON.stringify({
+      detail: {
+        code: "project_access_denied",
+        message: "You do not have access to this project.",
+        correlation_id: "err_123",
+      },
+    }), { status: 403, headers: { "Content-Type": "application/json" } }),
+  });
+
+  await assert.rejects(
+    client.getProject("private-project"),
+    (error) => {
+      assert.ok(error instanceof FormaApiError);
+      assert.equal(error.unauthorized, true);
+      assert.equal(error.code, "project_access_denied");
+      assert.equal(error.correlationId, "err_123");
+      assert.equal(error.message, "You do not have access to this project.");
+      return true;
+    },
+  );
+});
+
+test("the published component entry point renders browser and detail views", () => {
+  const project = {
+    project_id: "project-1",
+    title: "Pocket monitor",
+    parts_count: 2,
+    project_ir: {
+      overview: { title: "Pocket monitor", description: "A low-voltage field monitor." },
+      components: [
+        { name: "Controller", category: "microcontroller", quantity: 1, unit_price: 12 },
+      ],
+      validation: { critical: [], warning: [], info: [] },
+    },
+  };
+
+  const browser = renderToStaticMarkup(React.createElement(FormaProjectBrowser, {
+    projects: [project],
+    onOpenProject: () => {},
+  }));
+  const detail = renderToStaticMarkup(React.createElement(FormaProjectDetail, {
+    project,
+    activeSection: "bom",
+  }));
+
+  assert.match(browser, /Pocket monitor/);
+  assert.match(detail, /Controller/);
+  assert.match(detail, /Bill of materials/);
+});

--- a/packages/forma-gui/tsconfig.build.json
+++ b/packages/forma-gui/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmit": false,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/forma-gui/tsconfig.json
+++ b/packages/forma-gui/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2020",
+    "lib": ["DOM", "ES2020"],
+    "esModuleInterop": true,
+    "isolatedModules": true
+  }
+}


### PR DESCRIPTION
Closes #345

## Summary
- Add the versioned ESM/type declaration package @isayahc/forma-gui under packages/forma-gui.
- Target the existing npm package with release version 