### PR TITLE
fix: target existing Forma GUI npm package

### DIFF
--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -75,7 +75,7 @@ import {
   previewableImageSrc,
   type ProjectGalleryItem,
 } from "./forma-workspace/project-gallery";
-import { FormaProjectBrowser, type FormaProjectSummary } from "@caid-technologies/forma-gui";
+import { FormaProjectBrowser, type FormaProjectSummary } from "@isayahc/forma-gui";
 import {
   AssemblyPanel,
   BomPanel,

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -1,4 +1,4 @@
-@import "@caid-technologies/forma-gui/styles.css";
+@import "@isayahc/forma-gui/styles.css";
 
 @tailwind base;
 @tailwind components;

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,8 +8,8 @@
       "name": "forma-frontend",
       "version": "1.0.0",
       "dependencies": {
-        "@caid-technologies/forma-gui": "file:../../packages/forma-gui",
         "@clerk/nextjs": "^5.7.5",
+        "@isayahc/forma-gui": "file:../../packages/forma-gui",
         "@next/env": "15.5.21",
         "@opennextjs/cloudflare": "1.20.2",
         "@react-three/drei": "10.7.7",
@@ -37,8 +37,8 @@
       }
     },
     "../../packages/forma-gui": {
-      "name": "@caid-technologies/forma-gui",
-      "version": "0.1.0",
+      "name": "@isayahc/forma-gui",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -1172,10 +1172,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@caid-technologies/forma-gui": {
-      "resolved": "../../packages/forma-gui",
-      "link": true
     },
     "node_modules/@clerk/backend": {
       "version": "1.14.1",
@@ -2697,6 +2693,10 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@isayahc/forma-gui": {
+      "resolved": "../../packages/forma-gui",
+      "link": true
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@clerk/nextjs": "^5.7.5",
-        "@isayahc/forma-gui": "file:../../packages/forma-gui",
+        "@isayahc/forma-gui": "0.1.1",
         "@next/env": "15.5.21",
         "@opennextjs/cloudflare": "1.20.2",
         "@react-three/drei": "10.7.7",
@@ -34,19 +34,6 @@
         "tailwindcss": "^3.4",
         "typescript": "^5",
         "wrangler": "4.118.0"
-      }
-    },
-    "../../packages/forma-gui": {
-      "name": "@isayahc/forma-gui",
-      "version": "0.1.1",
-      "devDependencies": {
-        "@types/react": "^19.0.0",
-        "@types/react-dom": "^19.0.0",
-        "typescript": "^5.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18.2.0 <20",
-        "react-dom": ">=18.2.0 <20"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2695,8 +2682,13 @@
       }
     },
     "node_modules/@isayahc/forma-gui": {
-      "resolved": "../../packages/forma-gui",
-      "link": true
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@isayahc/forma-gui/-/forma-gui-0.1.1.tgz",
+      "integrity": "sha512-bsXntPEn61qN/A1y4Jk+6ymRQRZlk1GAGb2EyFNioxJuhZY1YcY5rxd8HCwWev3HQECli9GbubLW7Qa2yxIQKA==",
+      "peerDependencies": {
+        "react": ">=18.2.0 <20",
+        "react-dom": ">=18.2.0 <20"
+      }
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,8 +13,8 @@
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },
   "dependencies": {
-    "@isayahc/forma-gui": "file:../../packages/forma-gui",
     "@clerk/nextjs": "^5.7.5",
+    "@isayahc/forma-gui": "0.1.1",
     "@next/env": "15.5.21",
     "@opennextjs/cloudflare": "1.20.2",
     "@react-three/drei": "10.7.7",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,7 +13,7 @@
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },
   "dependencies": {
-    "@caid-technologies/forma-gui": "file:../../packages/forma-gui",
+    "@isayahc/forma-gui": "file:../../packages/forma-gui",
     "@clerk/nextjs": "^5.7.5",
     "@next/env": "15.5.21",
     "@opennextjs/cloudflare": "1.20.2",

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -37,13 +37,13 @@ The UI communicates with the backend API:
 
 ## Installable viewer package
 
-The reusable project browser and project detail viewer are packaged for publication as `@caid-technologies/forma-gui`:
+The reusable project browser and project detail viewer are packaged for publication as `@isayahc/forma-gui`:
 
 ```bash
-npm install @caid-technologies/forma-gui
+npm install @isayahc/forma-gui
 ```
 
-Import `@caid-technologies/forma-gui/styles.css` once, then configure `FormaApiClient` with a `baseUrl` and optional `getHeaders` callback. The callback is the authentication boundary for hosted deployments; local single-user APIs can omit it. The package exposes typed `FormaProjectBrowser`, `FormaProjectDetail`, and canonical project contracts without importing Clerk, provider credentials, routing, Tailwind, React Flow, or Three.js.
+Import `@isayahc/forma-gui/styles.css` once, then configure `FormaApiClient` with a `baseUrl` and optional `getHeaders` callback. The callback is the authentication boundary for hosted deployments; local single-user APIs can omit it. The package exposes typed `FormaProjectBrowser`, `FormaProjectDetail`, and canonical project contracts without importing Clerk, provider credentials, routing, Tailwind, React Flow, or Three.js.
 
 The first-party project and my-projects pages consume the package browser through the local `file:../../packages/forma-gui` dependency while the package is developed in this repository. Run `npm run build` and `npm test` from `packages/forma-gui` before publishing a semver release.
 

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -45,7 +45,7 @@ npm install @isayahc/forma-gui
 
 Import `@isayahc/forma-gui/styles.css` once, then configure `FormaApiClient` with a `baseUrl` and optional `getHeaders` callback. The callback is the authentication boundary for hosted deployments; local single-user APIs can omit it. The package exposes typed `FormaProjectBrowser`, `FormaProjectDetail`, and canonical project contracts without importing Clerk, provider credentials, routing, Tailwind, React Flow, or Three.js.
 
-The first-party project and my-projects pages consume the package browser through the local `file:../../packages/forma-gui` dependency while the package is developed in this repository. Run `npm run build` and `npm test` from `packages/forma-gui` before publishing a semver release.
+The first-party project and my-projects pages consume the published package. Run `npm run build` and `npm test` from `packages/forma-gui` before publishing a semver release.
 
 If the backend is offline, the UI can still load example JSONs from `apps/web/public/examples/`.
 

--- a/packages/forma-gui/README.md
+++ b/packages/forma-gui/README.md
@@ -1,11 +1,11 @@
-# `@caid-technologies/forma-gui`
+# `@isayahc/forma-gui`
 
 Reusable React components for browsing and viewing Forma hardware projects. The package is intentionally a browser-safe viewer surface: it does not import Clerk, provider SDKs, backend credentials, or application routing.
 
 ## Install
 
 ```bash
-npm install @caid-technologies/forma-gui
+npm install @isayahc/forma-gui
 ```
 
 React 18 or 19 and React DOM 18 or 19 are peer dependencies.
@@ -19,8 +19,8 @@ import {
   FormaApiClient,
   FormaProjectBrowser,
   FormaProjectDetail,
-} from "@caid-technologies/forma-gui";
-import "@caid-technologies/forma-gui/styles.css";
+} from "@isayahc/forma-gui";
+import "@isayahc/forma-gui/styles.css";
 
 const forma = new FormaApiClient({
   baseUrl: process.env.NEXT_PUBLIC_FORMA_API_URL,

--- a/packages/forma-gui/package.json
+++ b/packages/forma-gui/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@caid-technologies/forma-gui",
-  "version": "0.1.0",
+  "name": "@isayahc/forma-gui",
+  "version": "0.1.1",
   "description": "Reusable React project browser and hardware project viewer for Forma APIs.",
   "type": "module",
   "sideEffects": ["./dist/styles.css"],


### PR DESCRIPTION
Follow-up to #350.

## Summary
- Rename the package and first-party dependency to the existing npm scope @isayahc/forma-gui.
- Bump the release from 