### PR TITLE
feat: add local-first forma-oss CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,28 @@ forma-core iterate project.json "Keep the components but reshape the product as 
 python -m forma_core --help
 ```
 
+**Forma OSS CLI:**
+
+The first-party `forma-oss` CLI is local-first. `init`, `build`, `status`, and
+validation work without an account or network connection. Cloud operations are
+always explicit; provider credentials are excluded from project uploads.
+
+```bash
+forma-oss --help
+forma-oss init ./my-project
+forma-oss build "plant watering monitor" --path ./my-project --simulation
+forma-oss status --path ./my-project
+forma-oss login
+forma-oss projects push --path ./my-project
+forma-oss projects pull --path ./my-project
+forma-oss keys set openai --scope local
+forma-oss keys list --scope both
+```
+
+CLI sessions and local provider keys use the operating system credential store
+through `keyring`. A plaintext fallback is disabled by default and can only be
+enabled explicitly with `FORMA_ALLOW_PLAINTEXT_CREDENTIALS=1`.
+
 **Developer utilities:**
 
 ```bash

--- a/apps/api/auth.py
+++ b/apps/api/auth.py
@@ -15,6 +15,7 @@ from fastapi import HTTPException, Request, status
 from jwt import PyJWKClient
 
 from apps.api.auth_mode import clerk_auth_required
+from apps.api.cli_auth_store import is_cli_access_token, resolve_access_token
 from forma_core.config import config
 
 
@@ -311,10 +312,28 @@ def _authenticated_clerk_context(auth_claims: Dict[str, Any]) -> UserContext:
 
 async def optional_user_context(request: Request) -> UserContext:
     """Resolve a request identity without requiring the caller to be signed in."""
+    token = _request_bearer_token(request)
+    if token:
+        cli_identity = resolve_access_token(token)
+        if cli_identity is not None:
+            claims = {
+                "sub": cli_identity.subject,
+                "email": cli_identity.email,
+                "name": cli_identity.display_name,
+            }
+            return UserContext(
+                provider="forma-cli",
+                subject=cli_identity.subject,
+                owner_user_id=cli_identity.subject,
+                is_authenticated=True,
+                is_admin=False,
+                claims=claims,
+            )
+        if not deployed_auth_required() and is_cli_access_token(token):
+            return _anonymous_clerk_context()
+
     if not deployed_auth_required():
         return _local_user_context()
-
-    token = _request_bearer_token(request)
     if not token:
         return _anonymous_clerk_context()
     return _authenticated_clerk_context(verify_clerk_bearer_token(token))
@@ -401,7 +420,6 @@ async def require_mcp_user_context(request: Request) -> UserContext:
 async def require_deployed_clerk_auth(request: Request) -> Optional[Dict[str, Any]]:
     """Compatibility wrapper for routes that still consume raw Clerk claims."""
     if not deployed_auth_required():
-        await require_user_context(request)
         return None
 
     context = await optional_user_context(request)
@@ -413,7 +431,7 @@ async def require_deployed_clerk_auth(request: Request) -> Optional[Dict[str, An
 async def optional_deployed_clerk_auth(request: Request) -> Optional[Dict[str, Any]]:
     """Compatibility wrapper for routes that still consume raw Clerk claims."""
     context = await optional_user_context(request)
-    if context.provider == "local" or not _request_bearer_token(request):
+    if not deployed_auth_required() or context.provider == "local" or not _request_bearer_token(request):
         return None
     return dict(context.claims)
 

--- a/apps/api/cli_auth_api.py
+++ b/apps/api/cli_auth_api.py
@@ -1,0 +1,166 @@
+"""Device authorization and account endpoints for the Forma OSS CLI."""
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from apps.api.auth import UserContext, require_user_context
+from apps.api.cli_auth_store import (
+    CliIdentity,
+    approve_device,
+    create_device_session,
+    deny_device,
+    device_status,
+    exchange_device,
+    refresh_access,
+    revoke_tokens,
+)
+from forma_core.config import config
+
+
+router = APIRouter(prefix="/cli", tags=["cli"])
+
+
+class DeviceAuthorizationRequest(BaseModel):
+    client_name: str = Field(default="forma-oss", max_length=100)
+
+
+class DeviceCodeRequest(BaseModel):
+    device_code: str = Field(min_length=1, max_length=200)
+
+
+class UserCodeRequest(BaseModel):
+    user_code: str = Field(min_length=3, max_length=20)
+
+
+class RefreshTokenRequest(BaseModel):
+    refresh_token: str = Field(min_length=1, max_length=500)
+
+
+def _web_url() -> str:
+    return (
+        config.optional("FORMA_WEB_URL")
+        or config.optional("NEXT_PUBLIC_APP_URL")
+        or config.optional("FRONTEND_URL")
+        or "http://127.0.0.1:3000"
+    ).rstrip("/")
+
+
+def _api_url() -> str:
+    return (
+        config.optional("FORMA_API_URL")
+        or config.optional("NEXT_PUBLIC_API_URL")
+        or "http://127.0.0.1:8000"
+    ).rstrip("/")
+
+
+@router.post("/device/authorize")
+def authorize_device(request: DeviceAuthorizationRequest) -> dict[str, object]:
+    session = create_device_session()
+    return {
+        "device_code": session.device_code,
+        "user_code": session.user_code,
+        "verification_uri": f"{_web_url()}/cli/authorize?code={session.user_code}",
+        "expires_in": max(1, round(session.expires_at - time.time())),
+        "interval": 5,
+        "client_name": request.client_name,
+    }
+
+
+@router.post("/device/poll")
+def poll_device(request: DeviceCodeRequest) -> dict[str, object]:
+    current = device_status(request.device_code)
+    if current == "pending":
+        return {"status": "authorization_pending", "interval": 5}
+    if current == "approved":
+        return {"status": "approved"}
+    return {"status": current, "message": f"Device authorization is {current}."}
+
+
+@router.post("/device/approve")
+async def approve_device_endpoint(
+    request: UserCodeRequest,
+    user: UserContext = Depends(require_user_context),
+) -> dict[str, object]:
+    if not user.owner_user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Sign in before approving a CLI session.")
+    claims = user.claims
+    identity = CliIdentity(
+        subject=user.owner_user_id,
+        provider=user.provider,
+        email=claims.get("email") if isinstance(claims.get("email"), str) else None,
+        display_name=claims.get("name") if isinstance(claims.get("name"), str) else None,
+    )
+    if not approve_device(request.user_code, identity):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="CLI authorization code is invalid or expired.")
+    return {"ok": True, "status": "approved"}
+
+
+@router.post("/device/deny")
+async def deny_device_endpoint(
+    request: UserCodeRequest,
+    _user: UserContext = Depends(require_user_context),
+) -> dict[str, object]:
+    if not deny_device(request.user_code):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="CLI authorization code is invalid or expired.")
+    return {"ok": True, "status": "denied"}
+
+
+@router.post("/device/token")
+def exchange_device_token(request: DeviceCodeRequest) -> dict[str, object]:
+    issued = exchange_device(request.device_code)
+    if issued is None:
+        current = device_status(request.device_code)
+        detail = "CLI authorization is not approved." if current == "pending" else "CLI authorization code is invalid or expired."
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=detail)
+    access_token, refresh_token, expires_in = issued
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token,
+        "token_type": "Bearer",
+        "expires_in": expires_in,
+    }
+
+
+@router.post("/token/refresh")
+def refresh_token(request: RefreshTokenRequest) -> dict[str, object]:
+    issued = refresh_access(request.refresh_token)
+    if issued is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Refresh token is invalid or expired.")
+    access_token, refresh_token_value, expires_in = issued
+    return {
+        "access_token": access_token,
+        "refresh_token": refresh_token_value,
+        "token_type": "Bearer",
+        "expires_in": expires_in,
+    }
+
+
+@router.post("/token/revoke")
+async def revoke_token(request: Request, body: Optional[RefreshTokenRequest] = None) -> dict[str, object]:
+    authorization = request.headers.get("authorization", "")
+    _, _, access_token = authorization.partition(" ")
+    revoke_tokens(
+        refresh_token=body.refresh_token if body else None,
+        access_token=access_token.strip() or None,
+    )
+    return {"ok": True}
+
+
+@router.get("/whoami")
+async def cli_whoami(user: UserContext = Depends(require_user_context)) -> dict[str, object]:
+    claims = user.claims
+    return {
+        "subject": user.owner_user_id or user.subject or "unknown",
+        "provider": user.provider,
+        "email": claims.get("email") if isinstance(claims.get("email"), str) else None,
+        "display_name": claims.get("name") if isinstance(claims.get("name"), str) else None,
+        "api_url": _api_url(),
+    }
+
+
+__all__ = ["router"]

--- a/apps/api/cli_auth_store.py
+++ b/apps/api/cli_auth_store.py
@@ -1,0 +1,389 @@
+"""Short-lived CLI device sessions and opaque bearer-token state."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import hashlib
+import secrets
+import threading
+import time
+from typing import Any, Optional
+
+from forma_core.config import config
+
+
+DEVICE_LIFETIME_SECONDS = 600
+ACCESS_LIFETIME_SECONDS = 3600
+REFRESH_LIFETIME_SECONDS = 60 * 60 * 24 * 30
+
+
+@dataclass(frozen=True)
+class CliIdentity:
+    subject: str
+    provider: str
+    email: str | None = None
+    display_name: str | None = None
+
+
+@dataclass
+class _DeviceSession:
+    device_code: str
+    user_code: str
+    expires_at: float
+    status: str = "pending"
+    identity: CliIdentity | None = None
+    consumed: bool = False
+
+
+@dataclass
+class _RefreshSession:
+    identity: CliIdentity
+    expires_at: float
+
+
+@dataclass
+class _AccessSession:
+    identity: CliIdentity
+    expires_at: float
+    refresh_token: str
+
+
+_LOCK = threading.RLock()
+_DB_INIT_LOCK = threading.Lock()
+_DB_INITIALIZED = False
+_DEVICES: dict[str, _DeviceSession] = {}
+_DEVICES_BY_USER_CODE: dict[str, str] = {}
+_REFRESH_TOKENS: dict[str, _RefreshSession] = {}
+_ACCESS_TOKENS: dict[str, _AccessSession] = {}
+_REVOKED_ACCESS_TOKENS: set[str] = set()
+
+
+def _use_memory_store() -> bool:
+    return (config.optional("FORMA_CLI_AUTH_STORAGE") or "database").strip().lower() == "memory"
+
+
+def _database() -> Any:
+    global _DB_INITIALIZED
+    from forma_core import database
+
+    if not _DB_INITIALIZED:
+        with _DB_INIT_LOCK:
+            if not _DB_INITIALIZED:
+                database.init_db()
+                _DB_INITIALIZED = True
+    return database
+
+
+def _hash(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _identity_from_record(record: Any) -> CliIdentity | None:
+    subject = str(getattr(record, "owner_user_id", "") or "").strip()
+    provider = str(getattr(record, "provider", "") or "").strip()
+    if not subject or not provider:
+        return None
+    return CliIdentity(
+        subject=subject,
+        provider=provider,
+        email=getattr(record, "email", None),
+        display_name=getattr(record, "display_name", None),
+    )
+
+
+def _identity_fields(identity: CliIdentity) -> dict[str, str | None]:
+    return {
+        "owner_user_id": identity.subject,
+        "provider": identity.provider,
+        "email": identity.email,
+        "display_name": identity.display_name,
+    }
+
+
+def _cleanup_memory(now: float | None = None) -> None:
+    current = now or time.time()
+    for code, session in list(_DEVICES.items()):
+        if session.expires_at <= current:
+            _DEVICES.pop(code, None)
+            _DEVICES_BY_USER_CODE.pop(session.user_code, None)
+    for token, session in list(_REFRESH_TOKENS.items()):
+        if session.expires_at <= current:
+            _REFRESH_TOKENS.pop(token, None)
+    for token, session in list(_ACCESS_TOKENS.items()):
+        if session.expires_at <= current:
+            _ACCESS_TOKENS.pop(token, None)
+
+
+def create_device_session() -> _DeviceSession:
+    with _LOCK:
+        if _use_memory_store():
+            _cleanup_memory()
+            while True:
+                user_code = "-".join(
+                    "".join(secrets.choice("ABCDEFGHJKLMNPQRSTUVWXYZ23456789") for _ in range(4))
+                    for _ in range(2)
+                )
+                if user_code not in _DEVICES_BY_USER_CODE:
+                    break
+            session = _DeviceSession(
+                device_code=secrets.token_urlsafe(32),
+                user_code=user_code,
+                expires_at=time.time() + DEVICE_LIFETIME_SECONDS,
+            )
+            _DEVICES[session.device_code] = session
+            _DEVICES_BY_USER_CODE[session.user_code] = session.device_code
+            return session
+
+        while True:
+            user_code = "-".join(
+                "".join(secrets.choice("ABCDEFGHJKLMNPQRSTUVWXYZ23456789") for _ in range(4))
+                for _ in range(2)
+            )
+            device_code = secrets.token_urlsafe(32)
+            try:
+                _database().insert_cli_device_authorization({
+                    "device_code_hash": _hash(device_code),
+                    "user_code_hash": _hash(user_code),
+                    "status": "pending",
+                    "expires_at": time.time() + DEVICE_LIFETIME_SECONDS,
+                    "owner_user_id": None,
+                    "provider": None,
+                    "email": None,
+                    "display_name": None,
+                    "consumed": False,
+                    "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                })
+            except Exception as exc:
+                if "unique" not in str(exc).lower() and "duplicate" not in str(exc).lower():
+                    raise
+                continue
+            return _DeviceSession(device_code=device_code, user_code=user_code, expires_at=time.time() + DEVICE_LIFETIME_SECONDS)
+
+
+def device_status(device_code: str) -> str:
+    with _LOCK:
+        now = time.time()
+        if _use_memory_store():
+            _cleanup_memory(now)
+            session = _DEVICES.get(device_code)
+            return "expired" if session is None else session.status
+        record = _database().get_cli_device_authorization(_hash(device_code))
+        if record is None or float(record.expires_at) <= now:
+            return "expired"
+        return str(record.status)
+
+
+def approve_device(user_code: str, identity: CliIdentity) -> bool:
+    with _LOCK:
+        if _use_memory_store():
+            _cleanup_memory()
+            device_code = _DEVICES_BY_USER_CODE.get(user_code.strip().upper())
+            session = _DEVICES.get(device_code or "")
+            if session is None or session.status != "pending":
+                return False
+            session.status = "approved"
+            session.identity = identity
+            return True
+        record = _database().get_cli_device_authorization(user_code_hash=_hash(user_code.strip().upper()))
+        if record is None or float(record.expires_at) <= time.time():
+            return False
+        updated = _database().update_cli_device_authorization(
+            record.device_code_hash,
+            _identity_fields(identity) | {"status": "approved"},
+            expected_status="pending",
+            expected_consumed=False,
+        )
+        return updated is not None
+
+
+def deny_device(user_code: str) -> bool:
+    with _LOCK:
+        if _use_memory_store():
+            session = _DEVICES.get(_DEVICES_BY_USER_CODE.get(user_code.strip().upper(), ""))
+            if session is None:
+                return False
+            session.status = "denied"
+            return True
+        record = _database().get_cli_device_authorization(user_code_hash=_hash(user_code.strip().upper()))
+        if record is None or float(record.expires_at) <= time.time():
+            return False
+        return _database().update_cli_device_authorization(
+            record.device_code_hash,
+            {"status": "denied"},
+            expected_status="pending",
+            expected_consumed=False,
+        ) is not None
+
+
+def exchange_device(device_code: str) -> tuple[str, str, int] | None:
+    with _LOCK:
+        now = time.time()
+        if _use_memory_store():
+            _cleanup_memory(now)
+            session = _DEVICES.get(device_code)
+            if session is None or session.status != "approved" or session.consumed or session.identity is None:
+                return None
+            session.consumed = True
+            refresh_token = secrets.token_urlsafe(48)
+            access_token = secrets.token_urlsafe(48)
+            identity = session.identity
+            _REFRESH_TOKENS[refresh_token] = _RefreshSession(identity=identity, expires_at=now + REFRESH_LIFETIME_SECONDS)
+            _ACCESS_TOKENS[access_token] = _AccessSession(
+                identity=identity, expires_at=now + ACCESS_LIFETIME_SECONDS, refresh_token=refresh_token
+            )
+            return access_token, refresh_token, ACCESS_LIFETIME_SECONDS
+
+        record = _database().get_cli_device_authorization(_hash(device_code))
+        identity = _identity_from_record(record) if record is not None else None
+        if (
+            record is None
+            or float(record.expires_at) <= now
+            or str(record.status) != "approved"
+            or bool(record.consumed)
+            or identity is None
+        ):
+            return None
+        consumed = _database().update_cli_device_authorization(
+            record.device_code_hash,
+            {"consumed": True},
+            expected_status="approved",
+            expected_consumed=False,
+        )
+        if consumed is None:
+            return None
+        return _issue_tokens(identity, now)
+
+
+def _issue_tokens(identity: CliIdentity, now: float) -> tuple[str, str, int]:
+    refresh_token = secrets.token_urlsafe(48)
+    access_token = secrets.token_urlsafe(48)
+    database = _database()
+    refresh_hash = _hash(refresh_token)
+    fields = _identity_fields(identity)
+    database.insert_cli_token_session({
+        "token_hash": refresh_hash,
+        "token_type": "refresh",
+        "refresh_token_hash": refresh_hash,
+        **fields,
+        "expires_at": now + REFRESH_LIFETIME_SECONDS,
+        "revoked_at": None,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now)),
+    })
+    database.insert_cli_token_session({
+        "token_hash": _hash(access_token),
+        "token_type": "access",
+        "refresh_token_hash": refresh_hash,
+        **fields,
+        "expires_at": now + ACCESS_LIFETIME_SECONDS,
+        "revoked_at": None,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now)),
+    })
+    return access_token, refresh_token, ACCESS_LIFETIME_SECONDS
+
+
+def refresh_access(refresh_token: str) -> tuple[str, str, int] | None:
+    with _LOCK:
+        now = time.time()
+        if _use_memory_store():
+            _cleanup_memory(now)
+            session = _REFRESH_TOKENS.get(refresh_token)
+            if session is None:
+                return None
+            access_token = secrets.token_urlsafe(48)
+            _ACCESS_TOKENS[access_token] = _AccessSession(
+                identity=session.identity, expires_at=now + ACCESS_LIFETIME_SECONDS, refresh_token=refresh_token
+            )
+            return access_token, refresh_token, ACCESS_LIFETIME_SECONDS
+        record = _database().get_cli_token_session(_hash(refresh_token))
+        identity = _identity_from_record(record) if record is not None else None
+        if (
+            record is None
+            or str(record.token_type) != "refresh"
+            or record.revoked_at is not None
+            or float(record.expires_at) <= now
+            or identity is None
+        ):
+            return None
+        return _issue_access_token(identity, _hash(refresh_token), now), refresh_token, ACCESS_LIFETIME_SECONDS
+
+
+def _issue_access_token(identity: CliIdentity, refresh_token_hash: str, now: float) -> str:
+    access_token = secrets.token_urlsafe(48)
+    _database().insert_cli_token_session({
+        "token_hash": _hash(access_token),
+        "token_type": "access",
+        "refresh_token_hash": refresh_token_hash,
+        **_identity_fields(identity),
+        "expires_at": now + ACCESS_LIFETIME_SECONDS,
+        "revoked_at": None,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now)),
+    })
+    return access_token
+
+
+def resolve_access_token(access_token: str) -> Optional[CliIdentity]:
+    with _LOCK:
+        now = time.time()
+        if _use_memory_store():
+            _cleanup_memory(now)
+            session = _ACCESS_TOKENS.get(access_token)
+            return session.identity if session is not None else None
+        record = _database().get_cli_token_session(_hash(access_token))
+        if (
+            record is None
+            or str(record.token_type) != "access"
+            or record.revoked_at is not None
+            or float(record.expires_at) <= now
+        ):
+            return None
+        return _identity_from_record(record)
+
+
+def is_cli_access_token(access_token: str) -> bool:
+    """Distinguish an invalid CLI token from an unrelated local-mode bearer value."""
+    with _LOCK:
+        if _use_memory_store():
+            return access_token in _ACCESS_TOKENS or access_token in _REVOKED_ACCESS_TOKENS
+        return _database().get_cli_token_session(_hash(access_token)) is not None
+
+
+def revoke_tokens(refresh_token: str | None = None, access_token: str | None = None) -> None:
+    with _LOCK:
+        if _use_memory_store():
+            if refresh_token:
+                _REFRESH_TOKENS.pop(refresh_token, None)
+            if access_token:
+                _REVOKED_ACCESS_TOKENS.add(access_token)
+                session = _ACCESS_TOKENS.pop(access_token, None)
+                if session and not refresh_token:
+                    _REFRESH_TOKENS.pop(session.refresh_token, None)
+            if refresh_token:
+                for token, session in list(_ACCESS_TOKENS.items()):
+                    if session.refresh_token == refresh_token:
+                        _REVOKED_ACCESS_TOKENS.add(token)
+                        _ACCESS_TOKENS.pop(token, None)
+            return
+        database = _database()
+        refresh_hash = _hash(refresh_token) if refresh_token else None
+        if access_token and not refresh_hash:
+            access_record = database.get_cli_token_session(_hash(access_token))
+            refresh_hash = getattr(access_record, "refresh_token_hash", None)
+        database.revoke_cli_token_sessions(
+            token_hash=_hash(access_token) if access_token else None,
+            refresh_token_hash=refresh_hash,
+            revoked_at=time.time(),
+        )
+
+
+__all__ = [
+    "CliIdentity",
+    "approve_device",
+    "create_device_session",
+    "deny_device",
+    "device_status",
+    "exchange_device",
+    "is_cli_access_token",
+    "refresh_access",
+    "resolve_access_token",
+    "revoke_tokens",
+]

--- a/apps/api/cli_credentials_api.py
+++ b/apps/api/cli_credentials_api.py
@@ -1,0 +1,103 @@
+"""CLI-facing managed credential API that never returns raw secret values."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from apps.api.auth import UserContext, require_user_context
+from forma_core.user_integrations import (
+    UserIntegrationStore,
+    integration_definition_by_id,
+    integration_status_payload,
+)
+
+
+router = APIRouter(prefix="/cli/credentials", tags=["cli"])
+
+
+class CredentialUpdateRequest(BaseModel):
+    provider: str = Field(min_length=1, max_length=80)
+    value: str = Field(min_length=1, max_length=1000)
+    label: str | None = Field(default=None, max_length=120)
+
+
+def _store(user: UserContext) -> UserIntegrationStore:
+    if not user.owner_user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Sign in to manage credentials.")
+    return UserIntegrationStore.for_user(user.owner_user_id)
+
+
+def _credential_metadata(item: dict[str, Any]) -> dict[str, Any] | None:
+    secret_fields = [field for field in item.get("fields", []) if field.get("secret")]
+    if not secret_fields:
+        return None
+    secret = secret_fields[0]
+    if not secret.get("saved"):
+        return None
+    return {
+        "provider": item.get("id"),
+        "credential_id": f"forma-cli-{item.get('id')}-api-key",
+        "label": item.get("label") or item.get("id"),
+        "masked_value": secret.get("masked_value"),
+        "updated_at": item.get("updated_at"),
+        "configured": True,
+    }
+
+
+@router.get("")
+async def list_cli_credentials(user: UserContext = Depends(require_user_context)) -> dict[str, object]:
+    payload = integration_status_payload(_store(user))
+    items = [
+        metadata
+        for item in payload.get("integrations", [])
+        if isinstance(item, dict)
+        for metadata in [_credential_metadata(item)]
+        if metadata is not None
+    ]
+    return {"items": items}
+
+
+@router.post("")
+async def set_cli_credential(
+    request: CredentialUpdateRequest,
+    user: UserContext = Depends(require_user_context),
+) -> dict[str, Any]:
+    provider = request.provider.strip().lower().replace("_", "-")
+    try:
+        definition = integration_definition_by_id(provider)
+    except KeyError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown provider.") from exc
+    secret_fields = [field for field in definition.fields if field.secret]
+    if not secret_fields:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Provider has no managed credential field.")
+    _store(user).update_integration(
+        provider,
+        enabled=True,
+        field_values={secret_fields[0].id: request.value},
+    )
+    return {
+        "provider": provider,
+        "credential_id": f"forma-cli-{provider}-api-key",
+        "label": request.label or provider,
+        "configured": True,
+    }
+
+
+@router.delete("/{provider}")
+async def remove_cli_credential(
+    provider: str,
+    user: UserContext = Depends(require_user_context),
+) -> dict[str, object]:
+    normalized = provider.strip().lower().replace("_", "-")
+    try:
+        integration_definition_by_id(normalized)
+    except KeyError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Unknown provider.") from exc
+    _store(user).clear_integration(normalized)
+    return {"ok": True, "provider": normalized}
+
+
+__all__ = ["router"]

--- a/apps/api/cli_projects_api.py
+++ b/apps/api/cli_projects_api.py
@@ -1,0 +1,82 @@
+"""Private project/revision synchronization endpoints for the Forma CLI."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, Field
+
+from apps.api.auth import UserContext, require_user_context
+from forma_core.database import (
+    CliProjectConflictError,
+    get_cli_project_revision,
+    insert_cli_project_revision,
+    list_cli_projects,
+)
+from forma_core.workspaces.projects.manifest import ProjectManifest
+
+
+router = APIRouter(prefix="/cli/projects", tags=["cli"])
+
+
+class ProjectPushRequest(BaseModel):
+    manifest: dict[str, Any]
+    parent_revision_id: str | None = Field(default=None, max_length=200)
+
+
+def _owner(user: UserContext) -> str:
+    if not user.owner_user_id:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Sign in to use cloud projects.")
+    return user.owner_user_id
+
+
+@router.get("")
+async def list_cli_projects_endpoint(user: UserContext = Depends(require_user_context)) -> dict[str, object]:
+    return {"items": list_cli_projects(_owner(user))}
+
+
+@router.post("/push")
+async def push_cli_project(
+    request: ProjectPushRequest,
+    user: UserContext = Depends(require_user_context),
+) -> dict[str, Any]:
+    owner = _owner(user)
+    try:
+        manifest = ProjectManifest.from_document(request.manifest)
+        payload = manifest.upload_payload()
+        return insert_cli_project_revision(
+            payload,
+            owner,
+            expected_revision_id=request.parent_revision_id,
+        )
+    except CliProjectConflictError as exc:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.get("/{project_id}/revisions/{revision_id}")
+async def get_cli_project_revision_endpoint(
+    project_id: str,
+    revision_id: str,
+    user: UserContext = Depends(require_user_context),
+) -> dict[str, Any]:
+    revision = get_cli_project_revision(project_id, _owner(user), revision_id)
+    if revision is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Cloud project revision not found.")
+    return revision
+
+
+@router.get("/{project_id}")
+async def get_latest_cli_project_revision(
+    project_id: str,
+    user: UserContext = Depends(require_user_context),
+) -> dict[str, Any]:
+    revision = get_cli_project_revision(project_id, _owner(user))
+    if revision is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Cloud project not found.")
+    return revision
+
+
+__all__ = ["router"]

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -153,6 +153,9 @@ from apps.api.readiness_api import router as readiness_router
 from apps.api.worker_plans_api import router as worker_plans_router
 from apps.api.user_integrations_api import router as user_integrations_router
 from apps.api.user_settings_api import router as user_settings_router
+from apps.api.cli_auth_api import router as cli_auth_router
+from apps.api.cli_projects_api import router as cli_projects_router
+from apps.api.cli_credentials_api import router as cli_credentials_router
 from apps.api.auth import (
     UserContext,
     clerk_user_profile,
@@ -341,6 +344,9 @@ app.include_router(readiness_router)
 app.include_router(worker_plans_router)
 app.include_router(user_integrations_router)
 app.include_router(user_settings_router)
+app.include_router(cli_auth_router)
+app.include_router(cli_projects_router)
+app.include_router(cli_credentials_router)
 
 
 def _deployment_runtime_config(llm_config: Dict[str, Any]) -> Dict[str, Any]:

--- a/apps/web/app/cli/authorize/page.tsx
+++ b/apps/web/app/cli/authorize/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useEffect, useState } from "react";
+import PublicAppShell from "../../../components/public-app-shell";
+import { useFormaAuth } from "../../../lib/forma-auth";
+import { webConfig } from "../../../lib/config/environment";
+
+export default function CliAuthorizePage() {
+  const searchParams = useSearchParams();
+  const code = searchParams.get("code") || "";
+  const auth = useFormaAuth();
+  const [state, setState] = useState<"idle" | "approving" | "approved" | "error">("idle");
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    if (!code || !auth.isLoaded || (auth.authRequired && !auth.isSignedIn)) return;
+    let cancelled = false;
+    void (async () => {
+      setState("approving");
+      const token = await auth.getToken();
+      const response = await fetch(`${webConfig.apiBaseUrl}/cli/device/approve`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ user_code: code }),
+      });
+      if (cancelled) return;
+      if (!response.ok) {
+        setState("error");
+        setMessage("This CLI authorization code is invalid or expired.");
+        return;
+      }
+      setState("approved");
+      setMessage("Return to your terminal. Forma OSS has approved the CLI session.");
+    })().catch(() => {
+      if (!cancelled) {
+        setState("error");
+        setMessage("Forma could not approve this CLI session. Try again from the terminal.");
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [auth, code]);
+
+  return (
+    <PublicAppShell badge="Forma OSS CLI" title="Authorize this terminal">
+      <div className="mx-auto max-w-xl space-y-5 py-8 text-center">
+        {!code && <p>Open this page from the URL printed by `forma-oss login`.</p>}
+        {code && auth.authRequired && !auth.isSignedIn && (
+          <>
+            <p>Sign in to approve the CLI session for your Forma account.</p>
+            <button
+              className="rounded-md bg-slate-100 px-4 py-2 font-medium text-slate-950"
+              onClick={() => auth.openSignIn({ redirectUrl: window.location.href })}
+              type="button"
+            >
+              Sign in to continue
+            </button>
+          </>
+        )}
+        {state === "approving" && <p>Approving CLI session...</p>}
+        {state === "approved" && <p>{message}</p>}
+        {state === "error" && <p>{message}</p>}
+      </div>
+    </PublicAppShell>
+  );
+}

--- a/forma_cli/__init__.py
+++ b/forma_cli/__init__.py
@@ -1,0 +1,5 @@
+"""Local-first command-line client for Forma Cloud."""
+
+from forma_cli.sdk import FormaAPIClient
+
+__all__ = ["FormaAPIClient"]

--- a/forma_cli/app.py
+++ b/forma_cli/app.py
@@ -1,0 +1,353 @@
+"""The first-party ``forma-oss`` command line application."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import sys
+import time
+import webbrowser
+from typing import Any
+
+from forma_core import __version__
+from forma_cli.config import api_url, load_linkage
+from forma_cli.credentials import CredentialStore, CredentialStoreError
+from forma_cli.local import (
+    LOCAL_PROVIDER_ENVIRONMENT,
+    LocalProjectError,
+    build_project,
+    init_project,
+    project_root,
+    read_project,
+    status_project,
+    update_linkage,
+)
+from forma_cli.sdk import FormaAPIClient, FormaAPIError
+
+
+def _print_json(value: Any) -> None:
+    print(json.dumps(value, indent=2, sort_keys=True, default=str))
+
+
+def _client(args: argparse.Namespace) -> FormaAPIClient:
+    return FormaAPIClient(base_url=args.api_url if getattr(args, "api_url", None) else None)
+
+
+def cmd_login(args: argparse.Namespace) -> int:
+    client = _client(args)
+    authorization = client.request_device_authorization()
+    print("Opening Forma in your browser...")
+    print(f"If the browser does not open, visit: {authorization.verification_uri}")
+    if not args.no_browser:
+        webbrowser.open(authorization.verification_uri)
+    print("Waiting for authorization...")
+    deadline = time.monotonic() + authorization.expires_in
+    while time.monotonic() < deadline:
+        result = client.poll_device_authorization(authorization.device_code)
+        if result.status == "approved":
+            client.exchange_device_code(authorization.device_code)
+            identity = client.whoami()
+            account = identity.email or identity.display_name or identity.subject
+            print(f"Logged in as {account}")
+            if client._store.using_plaintext_fallback:
+                print("WARNING: credentials stored in plaintext because the explicit fallback is enabled.")
+            else:
+                print("Credentials stored securely")
+            return 0
+        if result.status in {"expired", "denied"}:
+            raise FormaAPIError(result.message or f"Device authorization {result.status}.")
+        time.sleep(authorization.interval)
+    raise FormaAPIError("Device authorization expired before it was approved.")
+
+
+def cmd_logout(args: argparse.Namespace) -> int:
+    _client(args).revoke()
+    print("Logged out")
+    return 0
+
+
+def cmd_whoami(args: argparse.Namespace) -> int:
+    identity = _client(args).whoami()
+    if args.json:
+        _print_json(identity.model_dump(mode="json"))
+    else:
+        print(identity.email or identity.display_name or identity.subject)
+        print(f"Provider: {identity.provider}")
+        print(f"API endpoint: {identity.api_url}")
+    return 0
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    manifest = init_project(args.path, title=args.title or "")
+    print(f"Initialized Forma project {manifest.project_id}")
+    return 0
+
+
+def cmd_build(args: argparse.Namespace) -> int:
+    manifest = build_project(
+        args.path,
+        prompt=args.prompt,
+        workflow=args.workflow,
+        provider=args.provider,
+        model=args.model,
+        simulation=args.simulation,
+    )
+    print(f"Built {manifest.title or manifest.project_id} at {project_root(args.path) / 'forma-project.json'}")
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    payload = status_project(args.path)
+    if args.json:
+        _print_json(payload)
+    else:
+        print(f"Project: {payload['title'] or payload['project_id']}")
+        print(f"Path: {payload['path']}")
+        print(f"Validation: {'ok' if payload['valid'] else 'failed'}")
+        if payload.get("remote"):
+            print(f"Remote: {payload['remote']}")
+            print(f"Revision: {payload.get('revision_id') or 'none'}")
+    return 0 if payload["valid"] else 1
+
+
+def cmd_projects_list(args: argparse.Namespace) -> int:
+    projects = _client(args).list_projects()
+    if args.json:
+        _print_json([project.model_dump(mode="json") for project in projects])
+    else:
+        for project in projects:
+            revision = project.revision_id or "no revisions"
+            print(f"{project.project_id}\t{project.title or 'Untitled'}\t{revision}")
+    return 0
+
+
+def _confirm_push(args: argparse.Namespace, manifest: Any) -> bool:
+    artifacts = list(getattr(manifest, "artifacts", []) or [])
+    print(f"This will upload the private project manifest and {len(artifacts)} referenced artifact(s).")
+    for artifact in artifacts:
+        print(f"  - {artifact.path}")
+    print("Provider credentials and authentication tokens are excluded.")
+    if args.yes:
+        return True
+    answer = input("Continue? [y/N] ").strip().lower()
+    return answer in {"y", "yes"}
+
+
+def cmd_projects_push(args: argparse.Namespace) -> int:
+    root = project_root(args.path)
+    manifest = read_project(root)
+    if not _confirm_push(args, manifest):
+        print("Upload cancelled.")
+        return 1
+    linkage = load_linkage(root)
+    revision = _client(args).push_project(
+        manifest.upload_payload(),
+        parent_revision_id=linkage.get("revision_id"),
+    )
+    update_linkage(
+        root,
+        version=1,
+        remote=args.api_url.rstrip("/") if args.api_url else api_url(),
+        remote_project_id=revision.project_id,
+        project_id=manifest.project_id,
+        revision_id=revision.revision_id,
+        parent_revision_id=revision.parent_revision_id,
+        manifest_digest=_manifest_digest(manifest.upload_payload()),
+    )
+    payload = revision.model_dump(mode="json")
+    if args.json:
+        _print_json(payload)
+    else:
+        print(f"Uploaded private project {revision.project_id} revision {revision.revision_id}")
+    return 0
+
+
+def cmd_projects_pull(args: argparse.Namespace) -> int:
+    root = project_root(args.path)
+    linkage = load_linkage(root)
+    remote_project_id = args.project_id or linkage.get("remote_project_id") or linkage.get("project_id")
+    if not remote_project_id:
+        raise LocalProjectError("No remote project is linked. Push this project first or pass --project-id.")
+    revision = _client(args).pull_project(remote_project_id, args.revision_id)
+    current_revision = linkage.get("revision_id")
+    if current_revision and current_revision != revision.revision_id:
+        local_manifest = read_project(root)
+        if linkage.get("manifest_digest") and _manifest_digest(local_manifest.upload_payload()) != linkage["manifest_digest"]:
+            raise LocalProjectError(
+                "Local changes diverge from the linked cloud revision; refusing to overwrite them."
+            )
+        if revision.parent_revision_id not in {current_revision, None}:
+            raise LocalProjectError(
+                "Cloud revision ancestry diverges from the linked local revision; refusing to overwrite it."
+            )
+    from forma_core.workspaces.projects.manifest import ProjectManifest, write_project_manifest
+
+    manifest = ProjectManifest.from_document(revision.manifest)
+    write_project_manifest(root / "forma-project.json", manifest)
+    update_linkage(
+        root,
+        remote=args.api_url.rstrip("/") if args.api_url else api_url(),
+        remote_project_id=revision.project_id,
+        project_id=manifest.project_id,
+        revision_id=revision.revision_id,
+        parent_revision_id=revision.parent_revision_id,
+        manifest_digest=_manifest_digest(manifest.upload_payload()),
+    )
+    if args.json:
+        _print_json(revision.model_dump(mode="json"))
+    else:
+        print(f"Pulled private project {revision.project_id} revision {revision.revision_id}")
+    return 0
+
+
+def _manifest_digest(value: Any) -> str:
+    import hashlib
+
+    canonical = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _local_key_rows(store: CredentialStore) -> list[dict[str, Any]]:
+    rows = []
+    for provider in sorted(LOCAL_PROVIDER_ENVIRONMENT):
+        try:
+            configured = bool(store.get(f"provider:{provider}"))
+        except CredentialStoreError:
+            configured = False
+        rows.append({"provider": provider, "scope": "local", "configured": configured})
+    return rows
+
+
+def cmd_keys_list(args: argparse.Namespace) -> int:
+    rows: list[dict[str, Any]] = []
+    if args.scope in {"local", "both"}:
+        rows.extend(_local_key_rows(CredentialStore()))
+    if args.scope in {"cloud", "both"}:
+        rows.extend(
+            {**key.model_dump(mode="json"), "scope": "cloud"}
+            for key in _client(args).list_keys()
+        )
+    if args.json:
+        _print_json(rows)
+    else:
+        for row in rows:
+            masked = row.get("masked_value") or ("configured" if row.get("configured") else "not configured")
+            print(f"{row['scope']}\t{row['provider']}\t{masked}")
+    return 0
+
+
+def cmd_keys_set(args: argparse.Namespace) -> int:
+    if args.scope == "local" and args.provider not in LOCAL_PROVIDER_ENVIRONMENT:
+        raise ValueError(
+            f"Unknown local provider {args.provider!r}. Supported providers: "
+            + ", ".join(sorted(LOCAL_PROVIDER_ENVIRONMENT))
+        )
+    value = args.value or getpass.getpass("Provider key (input hidden): ")
+    if args.scope == "local":
+        CredentialStore().set(f"provider:{args.provider}", value)
+        print(f"Stored {args.provider} in the OS credential store for local generation.")
+    else:
+        result = _client(args).set_key(args.provider, value, label=args.label)
+        print(f"Stored managed {result.provider} credential {result.credential_id or result.label or ''}".rstrip())
+    return 0
+
+
+def cmd_keys_remove(args: argparse.Namespace) -> int:
+    if args.scope == "local" and args.provider not in LOCAL_PROVIDER_ENVIRONMENT:
+        raise ValueError(
+            f"Unknown local provider {args.provider!r}. Supported providers: "
+            + ", ".join(sorted(LOCAL_PROVIDER_ENVIRONMENT))
+        )
+    if args.scope == "local":
+        CredentialStore().delete(f"provider:{args.provider}")
+        print(f"Removed local {args.provider} credential.")
+    else:
+        _client(args).remove_key(args.provider)
+        print(f"Removed managed {args.provider} credential.")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="forma-oss", description="Local-first Forma project CLI.")
+    parser.add_argument("--api-url", default=None, help="Forma API endpoint; defaults to local config or FORMA_API_URL.")
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    login = subparsers.add_parser("login", help="Authenticate with browser/device authorization.")
+    login.add_argument("--no-browser", action="store_true", help="Print the approval URL without opening a browser.")
+    login.set_defaults(func=cmd_login)
+    logout = subparsers.add_parser("logout", help="Revoke the CLI session and remove local credentials.")
+    logout.set_defaults(func=cmd_logout)
+    whoami = subparsers.add_parser("whoami", help="Show the signed-in account and API endpoint.")
+    whoami.add_argument("--json", action="store_true")
+    whoami.set_defaults(func=cmd_whoami)
+
+    init = subparsers.add_parser("init", help="Create a local forma-project.json.")
+    init.add_argument("path", nargs="?", default=".")
+    init.add_argument("--title", default="")
+    init.set_defaults(func=cmd_init)
+    build = subparsers.add_parser("build", help="Generate or rebuild a project locally.")
+    build.add_argument("prompt", nargs="?")
+    build.add_argument("--path", default=".")
+    build.add_argument("--workflow", default="default")
+    build.add_argument("--provider")
+    build.add_argument("--model")
+    build.add_argument("--simulation", action="store_true")
+    build.set_defaults(func=cmd_build)
+    status = subparsers.add_parser("status", help="Validate and show local/remote project state.")
+    status.add_argument("--path", default=".")
+    status.add_argument("--json", action="store_true")
+    status.set_defaults(func=cmd_status)
+
+    projects = subparsers.add_parser("projects", help="Manage explicit cloud project synchronization.")
+    project_commands = projects.add_subparsers(dest="projects_command", required=True)
+    projects_list = project_commands.add_parser("list", help="List private cloud projects.")
+    projects_list.add_argument("--json", action="store_true")
+    projects_list.set_defaults(func=cmd_projects_list)
+    push = project_commands.add_parser("push", help="Upload the canonical local manifest explicitly.")
+    push.add_argument("--path", default=".")
+    push.add_argument("--yes", action="store_true", help="Confirm upload without prompting.")
+    push.add_argument("--json", action="store_true")
+    push.set_defaults(func=cmd_projects_push)
+    pull = project_commands.add_parser("pull", help="Download an exact or latest linked revision.")
+    pull.add_argument("--path", default=".")
+    pull.add_argument("--project-id")
+    pull.add_argument("--revision-id")
+    pull.add_argument("--json", action="store_true")
+    pull.set_defaults(func=cmd_projects_pull)
+
+    keys = subparsers.add_parser("keys", help="Manage local or hosted provider credentials.")
+    key_commands = keys.add_subparsers(dest="keys_command", required=True)
+    keys_list = key_commands.add_parser("list", help="List credential metadata only.")
+    keys_list.add_argument("--scope", choices=("local", "cloud", "both"), default="local")
+    keys_list.add_argument("--json", action="store_true")
+    keys_list.set_defaults(func=cmd_keys_list)
+    keys_set = key_commands.add_parser("set", help="Store a provider credential.")
+    keys_set.add_argument("provider")
+    keys_set.add_argument("--scope", choices=("local", "cloud"), default="local")
+    keys_set.add_argument("--value", help=argparse.SUPPRESS)
+    keys_set.add_argument("--label")
+    keys_set.set_defaults(func=cmd_keys_set)
+    keys_remove = key_commands.add_parser("remove", help="Remove a provider credential.")
+    keys_remove.add_argument("provider")
+    keys_remove.add_argument("--scope", choices=("local", "cloud"), default="local")
+    keys_remove.set_defaults(func=cmd_keys_remove)
+    return parser
+
+
+def app(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return args.func(args)
+    except (CredentialStoreError, FormaAPIError, LocalProjectError, OSError, ValueError, RuntimeError) as exc:
+        print(f"{parser.prog}: {exc}", file=sys.stderr)
+        return 2
+
+
+main = app
+
+
+if __name__ == "__main__":
+    raise SystemExit(app())

--- a/forma_cli/config.py
+++ b/forma_cli/config.py
@@ -1,0 +1,110 @@
+"""Non-secret CLI configuration and local project linkage."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import tomllib
+from typing import Any
+
+
+DEFAULT_API_URL = "http://127.0.0.1:8000"
+CONFIG_FILENAME = "config.json"
+LINKAGE_FILENAME = "project.toml"
+
+
+class CliConfigError(RuntimeError):
+    """Raised when local CLI configuration is invalid or unavailable."""
+
+
+def config_dir() -> Path:
+    configured = os.environ.get("FORMA_CLI_CONFIG_DIR")
+    if configured:
+        return Path(configured).expanduser()
+    if os.name == "nt":
+        root = os.environ.get("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+        return Path(root) / "Forma"
+    return Path(os.environ.get("XDG_CONFIG_HOME", Path.home() / ".config")) / "forma"
+
+
+def config_path() -> Path:
+    return config_dir() / CONFIG_FILENAME
+
+
+def load_config() -> dict[str, Any]:
+    path = config_path()
+    if not path.exists():
+        return {"api_url": os.environ.get("FORMA_API_URL", DEFAULT_API_URL).rstrip("/")}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise CliConfigError(f"Could not read CLI configuration: {path}") from exc
+    if not isinstance(payload, dict):
+        raise CliConfigError(f"CLI configuration must be a JSON object: {path}")
+    return {
+        "api_url": str(payload.get("api_url") or os.environ.get("FORMA_API_URL") or DEFAULT_API_URL).rstrip("/"),
+        **{key: value for key, value in payload.items() if key != "api_url"},
+    }
+
+
+def save_config(values: dict[str, Any]) -> None:
+    path = config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(json.dumps(values, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def api_url() -> str:
+    return str(load_config().get("api_url") or DEFAULT_API_URL).rstrip("/")
+
+
+def linkage_path(project_root: str | Path) -> Path:
+    return Path(project_root) / ".forma" / LINKAGE_FILENAME
+
+
+def load_linkage(project_root: str | Path) -> dict[str, Any]:
+    path = linkage_path(project_root)
+    if not path.exists():
+        return {"version": 1}
+    try:
+        payload = tomllib.loads(path.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise CliConfigError(f"Could not read project linkage: {path}") from exc
+    if not isinstance(payload, dict):
+        raise CliConfigError(f"Project linkage must be a TOML table: {path}")
+    return payload
+
+
+def _toml_value(value: Any) -> str:
+    if value is None:
+        return '""'
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    return json.dumps(str(value))
+
+
+def save_linkage(project_root: str | Path, values: dict[str, Any]) -> None:
+    path = linkage_path(project_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [f"{key} = {_toml_value(value)}" for key, value in values.items() if value is not None]
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+__all__ = [
+    "CliConfigError",
+    "DEFAULT_API_URL",
+    "api_url",
+    "config_dir",
+    "config_path",
+    "linkage_path",
+    "load_config",
+    "load_linkage",
+    "save_config",
+    "save_linkage",
+]

--- a/forma_cli/credentials.py
+++ b/forma_cli/credentials.py
@@ -1,0 +1,141 @@
+"""OS credential-store integration for CLI and local provider secrets."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+import warnings
+
+from forma_cli.config import config_dir
+
+
+SERVICE_NAME = "forma-oss"
+SESSION_KEY = "cli-session"
+_PLAINTEXT_ENV = "FORMA_ALLOW_PLAINTEXT_CREDENTIALS"
+
+
+class CredentialStoreError(RuntimeError):
+    """Raised when secure credential storage cannot be used."""
+
+
+def _plaintext_enabled() -> bool:
+    return os.environ.get(_PLAINTEXT_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _keyring_module():
+    try:
+        import keyring
+    except ImportError as exc:
+        raise CredentialStoreError(
+            "The OS credential store is unavailable because keyring is not installed. "
+            f"Install the CLI dependencies or explicitly set {_PLAINTEXT_ENV}=1 for a warned plaintext fallback."
+        ) from exc
+    return keyring
+
+
+def _plaintext_path() -> Path:
+    configured = os.environ.get("FORMA_CLI_PLAINTEXT_CREDENTIALS_PATH")
+    if configured:
+        return Path(configured).expanduser()
+    return config_dir() / "credentials.json"
+
+
+class CredentialStore:
+    """Store values in keyring, with an opt-in insecure fallback for CI/dev."""
+
+    def __init__(self, *, service: str = SERVICE_NAME, keyring_backend: Any = None) -> None:
+        self.service = service
+        self._keyring_backend = keyring_backend
+        if _plaintext_enabled():
+            warnings.warn(
+                f"{_PLAINTEXT_ENV}=1 is enabled; Forma CLI credentials are being stored in plaintext.",
+                UserWarning,
+                stacklevel=2,
+            )
+
+    @property
+    def using_plaintext_fallback(self) -> bool:
+        return _plaintext_enabled()
+
+    def _backend(self) -> Any:
+        return self._keyring_backend or _keyring_module()
+
+    def _load_plaintext(self) -> dict[str, str]:
+        path = _plaintext_path()
+        if not path.exists():
+            return {}
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            raise CredentialStoreError(f"Could not read plaintext credential fallback: {path}") from exc
+        return {str(key): str(value) for key, value in payload.items()} if isinstance(payload, dict) else {}
+
+    def _save_plaintext(self, values: dict[str, str]) -> None:
+        path = _plaintext_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        temporary = path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(values, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        temporary.replace(path)
+        try:
+            path.chmod(0o600)
+        except OSError:
+            pass
+
+    def get(self, name: str) -> str | None:
+        if _plaintext_enabled():
+            return self._load_plaintext().get(name)
+        try:
+            return self._backend().get_password(self.service, name)
+        except Exception as exc:
+            raise CredentialStoreError(
+                "The OS credential store rejected the credential lookup. "
+                f"Set {_PLAINTEXT_ENV}=1 only if an explicit insecure fallback is acceptable."
+            ) from exc
+
+    def set(self, name: str, value: str) -> None:
+        if not str(value).strip():
+            raise CredentialStoreError("Credential value cannot be empty.")
+        if _plaintext_enabled():
+            values = self._load_plaintext()
+            values[name] = value
+            self._save_plaintext(values)
+            return
+        try:
+            self._backend().set_password(self.service, name, value)
+        except Exception as exc:
+            raise CredentialStoreError(
+                "The OS credential store rejected the credential write. "
+                f"Set {_PLAINTEXT_ENV}=1 only if an explicit insecure fallback is acceptable."
+            ) from exc
+
+    def delete(self, name: str) -> None:
+        if _plaintext_enabled():
+            values = self._load_plaintext()
+            values.pop(name, None)
+            self._save_plaintext(values)
+            return
+        try:
+            self._backend().delete_password(self.service, name)
+        except Exception as exc:
+            # keyring backends commonly report missing entries as errors; deletion is idempotent.
+            message = str(exc).lower()
+            if not any(token in message for token in ("not found", "does not exist", "no such", "missing")):
+                raise CredentialStoreError("The OS credential store rejected credential removal.") from exc
+
+    def get_json(self, name: str) -> dict[str, Any] | None:
+        raw = self.get(name)
+        if not raw:
+            return None
+        try:
+            payload = json.loads(raw)
+        except ValueError as exc:
+            raise CredentialStoreError(f"Stored credential {name!r} is invalid.") from exc
+        return payload if isinstance(payload, dict) else None
+
+    def set_json(self, name: str, value: dict[str, Any]) -> None:
+        self.set(name, json.dumps(value, sort_keys=True))
+
+
+__all__ = ["CredentialStore", "CredentialStoreError", "SERVICE_NAME", "SESSION_KEY"]

--- a/forma_cli/local.py
+++ b/forma_cli/local.py
@@ -1,0 +1,196 @@
+"""Local project discovery and offline operations for ``forma-oss``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+from forma_core.config import config
+from forma_core.workspaces.projects.manifest import (
+    PROJECT_MANIFEST_FORMAT,
+    ProjectManifest,
+    load_project_manifest,
+    write_project_manifest,
+)
+
+from forma_cli.config import load_linkage, save_linkage
+from forma_cli.credentials import CredentialStore, CredentialStoreError
+
+
+PROJECT_FILENAME = "forma-project.json"
+STRICT_GENERATION_ENVIRONMENT = {
+    "FORMA_DISABLE_GENERATION_FALLBACK": "true",
+    "FORMA_STRICT_GENERATION": "true",
+    "LLM_DISABLE_FALLBACK": "true",
+}
+SIMULATION_ENVIRONMENT = {
+    "FORMA_DEV_MODE": "true",
+    "FORMA_DISABLE_GENERATION_FALLBACK": "false",
+    "FORMA_STRICT_GENERATION": "false",
+    "LLM_DISABLE_FALLBACK": "false",
+}
+LOCAL_PROVIDER_ENVIRONMENT = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "baseten": "BASETEN_API_KEY",
+    "cloudflare": "CLOUDFLARE_API_TOKEN",
+    "firecrawl": "FIRECRAWL_API_KEY",
+    "gemini": "GEMINI_API_KEY",
+    "gmi": "GMI_API_KEY",
+    "huggingface": "HF_TOKEN",
+    "nvidia": "NVIDIA_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "runpod": "RUNPOD_API_KEY",
+    "tavily": "TAVILY_API_KEY",
+    "together": "TOGETHER_API_KEY",
+    "xai": "XAI_API_KEY",
+}
+
+
+class LocalProjectError(RuntimeError):
+    """Raised when a local project cannot be read or safely updated."""
+
+
+def project_root(path: str | Path | None = None) -> Path:
+    start = Path(path or Path.cwd()).expanduser().resolve()
+    if start.is_file():
+        start = start.parent
+    for candidate in (start, *start.parents):
+        if (candidate / PROJECT_FILENAME).is_file():
+            return candidate
+    raise LocalProjectError(f"Could not find {PROJECT_FILENAME} from {start}.")
+
+
+def project_path(path: str | Path | None = None) -> Path:
+    return project_root(path) / PROJECT_FILENAME
+
+
+def read_project(path: str | Path | None = None) -> ProjectManifest:
+    return load_project_manifest(project_path(path))
+
+
+def init_project(path: str | Path | None = None, *, title: str = "") -> ProjectManifest:
+    root = Path(path or Path.cwd()).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    target = root / PROJECT_FILENAME
+    if target.exists():
+        raise LocalProjectError(f"A Forma project already exists at {target}.")
+    manifest = ProjectManifest(
+        format=PROJECT_MANIFEST_FORMAT,
+        version=1,
+        project_id=str(uuid4()),
+        title=title.strip(),
+        project_ir={},
+    )
+    write_project_manifest(target, manifest)
+    save_linkage(root, {"version": 1, "project_id": manifest.project_id})
+    return manifest
+
+
+def _local_provider_environment(store: CredentialStore) -> dict[str, str]:
+    values: dict[str, str] = {}
+    for provider, environment_name in LOCAL_PROVIDER_ENVIRONMENT.items():
+        try:
+            value = store.get(f"provider:{provider}")
+        except CredentialStoreError:
+            # Local generation remains usable with environment-supplied keys.
+            value = None
+        if value:
+            values[environment_name] = value
+    return values
+
+
+def build_project(
+    path: str | Path | None = None,
+    *,
+    prompt: str | None = None,
+    workflow: str = "default",
+    provider: str | None = None,
+    model: str | None = None,
+    simulation: bool = False,
+    credential_store: CredentialStore | None = None,
+) -> ProjectManifest:
+    root = project_root(path)
+    current = read_project(root)
+    from forma_core.generation import generate_project_with_workflow
+
+    requested_prompt = (prompt or current.prompt or current.title).strip()
+    if not requested_prompt:
+        raise LocalProjectError("Build requires a prompt. Pass one or set prompt in forma-project.json.")
+    store = credential_store or CredentialStore()
+    generation_environment = SIMULATION_ENVIRONMENT if simulation else STRICT_GENERATION_ENVIRONMENT
+    environment = {**generation_environment, **_local_provider_environment(store)}
+    with config.override(environment):
+        ir = generate_project_with_workflow(
+            workflow,
+            requested_prompt,
+            provider_name="simulation" if simulation else provider,
+            model_name=None if simulation else model,
+            generation_metadata={"project_id": current.project_id, "project_prompt": requested_prompt},
+            persist_project=False,
+        )
+    metadata = dict(ir.assembly_metadata or {})
+    metadata["project_id"] = current.project_id
+    metadata["project_prompt"] = requested_prompt
+    ir.assembly_metadata = metadata
+    updated = ProjectManifest(
+        format=PROJECT_MANIFEST_FORMAT,
+        version=1,
+        project_id=current.project_id,
+        workspace_id=current.workspace_id,
+        title=current.title or (ir.overview.title if ir.overview else requested_prompt),
+        prompt=requested_prompt,
+        project_ir=ir.model_dump(mode="json"),
+        artifacts=current.artifacts,
+    )
+    write_project_manifest(root / PROJECT_FILENAME, updated)
+    return updated
+
+
+def status_project(path: str | Path | None = None) -> dict[str, Any]:
+    root = project_root(path)
+    manifest = read_project(root)
+    try:
+        from forma_core.validation import build_validation_summary, validate_circuit
+        from forma_core.workspaces.projects.models import HardwareIR
+
+        ir = HardwareIR.model_validate(manifest.project_ir)
+        summary = build_validation_summary(validate_circuit(ir.components, ir.nets, ir.requirements))
+        valid = not summary.critical
+        validation = summary.model_dump(mode="json")
+    except Exception as exc:
+        valid = False
+        validation = {"critical": [str(exc)], "warning": [], "info": []}
+    linkage = load_linkage(root)
+    return {
+        "project_id": manifest.project_id,
+        "title": manifest.title,
+        "path": str(root / PROJECT_FILENAME),
+        "valid": valid,
+        "validation": validation,
+        "remote": linkage.get("remote"),
+        "remote_project_id": linkage.get("remote_project_id") or linkage.get("project_id") if linkage.get("remote") else None,
+        "revision_id": linkage.get("revision_id"),
+        "parent_revision_id": linkage.get("parent_revision_id"),
+    }
+
+
+def update_linkage(path: str | Path, **values: Any) -> dict[str, Any]:
+    root = project_root(path)
+    linkage = {**load_linkage(root), **values}
+    save_linkage(root, linkage)
+    return linkage
+
+
+__all__ = [
+    "LOCAL_PROVIDER_ENVIRONMENT",
+    "LocalProjectError",
+    "PROJECT_FILENAME",
+    "build_project",
+    "init_project",
+    "project_path",
+    "project_root",
+    "read_project",
+    "status_project",
+    "update_linkage",
+]

--- a/forma_cli/sdk.py
+++ b/forma_cli/sdk.py
@@ -1,0 +1,293 @@
+"""Typed, dependency-light Forma API client used by the CLI."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from forma_cli.config import api_url
+from forma_cli.credentials import CredentialStore, SESSION_KEY
+
+
+class FormaAPIError(RuntimeError):
+    """An HTTP or transport failure returned by the Forma API."""
+
+    def __init__(self, message: str, *, status_code: int | None = None, detail: Any = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.detail = detail
+
+
+class TokenSet(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    access_token: str
+    refresh_token: str
+    token_type: str = "Bearer"
+    expires_in: int = Field(default=3600, ge=1)
+
+
+class DeviceAuthorization(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    device_code: str
+    user_code: str
+    verification_uri: str
+    expires_in: int = Field(ge=1)
+    interval: int = Field(default=5, ge=1)
+
+
+class DevicePollResult(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    status: str
+    message: str | None = None
+
+
+class AccountIdentity(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    subject: str
+    provider: str
+    email: str | None = None
+    display_name: str | None = None
+    api_url: str
+
+
+class CloudProjectSummary(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    project_id: str
+    workspace_id: str | None = None
+    title: str = ""
+    revision_id: str | None = None
+    revision: int | None = None
+    parent_revision_id: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+
+
+class CloudProjectRevision(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    revision_id: str
+    project_id: str
+    revision: int
+    parent_revision_id: str | None = None
+    manifest: dict[str, Any]
+    created_at: str | None = None
+
+
+class ManagedCredentialMetadata(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    provider: str
+    credential_id: str | None = None
+    label: str | None = None
+    masked_value: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    configured: bool = False
+
+
+@dataclass
+class FormaAPIClient:
+    """Call Forma endpoints without importing backend handlers or Supabase."""
+
+    base_url: str | None = None
+    credential_store: CredentialStore | None = None
+    timeout_seconds: float = 30.0
+
+    def __post_init__(self) -> None:
+        self.base_url = (self.base_url or api_url()).rstrip("/")
+        self.credential_store = self.credential_store or CredentialStore()
+
+    @property
+    def _store(self) -> CredentialStore:
+        assert self.credential_store is not None
+        return self.credential_store
+
+    def _saved_tokens(self) -> TokenSet | None:
+        payload = self._store.get_json(SESSION_KEY)
+        return TokenSet.model_validate(payload) if payload else None
+
+    def _save_tokens(self, tokens: TokenSet) -> TokenSet:
+        self._store.set_json(SESSION_KEY, tokens.model_dump(mode="json"))
+        return tokens
+
+    def _request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        payload: Mapping[str, Any] | None = None,
+        authenticated: bool = False,
+        retry_refresh: bool = True,
+    ) -> Any:
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "forma-oss-cli/0.1",
+        }
+        tokens = self._saved_tokens() if authenticated else None
+        if authenticated:
+            if tokens is None:
+                raise FormaAPIError("Sign in with `forma-oss login` before using cloud commands.")
+            headers["Authorization"] = f"{tokens.token_type} {tokens.access_token}"
+        body = json.dumps(dict(payload)).encode("utf-8") if payload is not None else None
+        if body is not None:
+            headers["Content-Type"] = "application/json"
+        request = Request(f"{self.base_url}/{path.lstrip('/')}", data=body, headers=headers, method=method)
+        try:
+            with urlopen(request, timeout=self.timeout_seconds) as response:
+                raw = response.read()
+        except HTTPError as exc:
+            raw = exc.read()
+            detail = self._decode_json(raw)
+            if exc.code == 401 and authenticated and retry_refresh and tokens and tokens.refresh_token:
+                try:
+                    self.refresh(tokens.refresh_token)
+                except FormaAPIError:
+                    pass
+                else:
+                    return self._request(
+                        path,
+                        method=method,
+                        payload=payload,
+                        authenticated=authenticated,
+                        retry_refresh=False,
+                    )
+            raise FormaAPIError(
+                self._error_message(detail, fallback=f"Forma API request failed ({exc.code})."),
+                status_code=exc.code,
+                detail=detail,
+            ) from exc
+        except URLError as exc:
+            raise FormaAPIError(f"Could not reach Forma API at {self.base_url}: {exc.reason}") from exc
+        except OSError as exc:
+            raise FormaAPIError(f"Could not reach Forma API at {self.base_url}: {exc}") from exc
+        return self._decode_json(raw)
+
+    @staticmethod
+    def _decode_json(raw: bytes) -> Any:
+        if not raw:
+            return {}
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, ValueError) as exc:
+            raise FormaAPIError("Forma API returned an invalid JSON response.") from exc
+
+    @staticmethod
+    def _error_message(detail: Any, *, fallback: str) -> str:
+        if isinstance(detail, dict):
+            message = detail.get("message") or detail.get("detail")
+            if isinstance(message, str) and message.strip():
+                return message.strip()
+        if isinstance(detail, str) and detail.strip():
+            return detail.strip()
+        return fallback
+
+    def request_device_authorization(self) -> DeviceAuthorization:
+        return DeviceAuthorization.model_validate(
+            self._request("/cli/device/authorize", method="POST", payload={"client_name": "forma-oss"})
+        )
+
+    def poll_device_authorization(self, device_code: str) -> DevicePollResult:
+        return DevicePollResult.model_validate(
+            self._request("/cli/device/poll", method="POST", payload={"device_code": device_code})
+        )
+
+    def exchange_device_code(self, device_code: str) -> TokenSet:
+        return self._save_tokens(
+            TokenSet.model_validate(
+                self._request("/cli/device/token", method="POST", payload={"device_code": device_code})
+            )
+        )
+
+    def refresh(self, refresh_token: str | None = None) -> TokenSet:
+        token = refresh_token or (self._saved_tokens().refresh_token if self._saved_tokens() else "")
+        if not token:
+            raise FormaAPIError("No refresh token is available; sign in again.")
+        return self._save_tokens(
+            TokenSet.model_validate(
+                self._request("/cli/token/refresh", method="POST", payload={"refresh_token": token})
+            )
+        )
+
+    def revoke(self) -> None:
+        tokens = self._saved_tokens()
+        if tokens:
+            try:
+                self._request(
+                    "/cli/token/revoke",
+                    method="POST",
+                    payload={"refresh_token": tokens.refresh_token},
+                    authenticated=True,
+                    retry_refresh=False,
+                )
+            finally:
+                self._store.delete(SESSION_KEY)
+
+    def whoami(self) -> AccountIdentity:
+        return AccountIdentity.model_validate(self._request("/cli/whoami", authenticated=True))
+
+    def list_projects(self) -> list[CloudProjectSummary]:
+        payload = self._request("/cli/projects", authenticated=True)
+        items = payload.get("items", payload) if isinstance(payload, dict) else payload
+        return [CloudProjectSummary.model_validate(item) for item in items or []]
+
+    def push_project(
+        self,
+        manifest: Mapping[str, Any],
+        *,
+        parent_revision_id: str | None = None,
+    ) -> CloudProjectRevision:
+        payload = self._request(
+            "/cli/projects/push",
+            method="POST",
+            payload={"manifest": dict(manifest), "parent_revision_id": parent_revision_id},
+            authenticated=True,
+        )
+        return CloudProjectRevision.model_validate(payload)
+
+    def pull_project(self, project_id: str, revision_id: str | None = None) -> CloudProjectRevision:
+        path = f"/cli/projects/{quote(project_id, safe='')}"
+        if revision_id:
+            path += f"/revisions/{quote(revision_id, safe='')}"
+        payload = self._request(path, authenticated=True)
+        return CloudProjectRevision.model_validate(payload)
+
+    def list_keys(self) -> list[ManagedCredentialMetadata]:
+        payload = self._request("/cli/credentials", authenticated=True)
+        items = payload.get("items", payload) if isinstance(payload, dict) else payload
+        return [ManagedCredentialMetadata.model_validate(item) for item in items or []]
+
+    def set_key(self, provider: str, value: str, *, label: str | None = None) -> ManagedCredentialMetadata:
+        payload = self._request(
+            "/cli/credentials",
+            method="POST",
+            payload={"provider": provider, "value": value, "label": label},
+            authenticated=True,
+        )
+        return ManagedCredentialMetadata.model_validate(payload)
+
+    def remove_key(self, provider: str) -> None:
+        self._request(f"/cli/credentials/{quote(provider, safe='')}", method="DELETE", authenticated=True)
+
+
+__all__ = [
+    "AccountIdentity",
+    "CloudProjectRevision",
+    "CloudProjectSummary",
+    "DeviceAuthorization",
+    "DevicePollResult",
+    "FormaAPIClient",
+    "FormaAPIError",
+    "ManagedCredentialMetadata",
+    "TokenSet",
+]

--- a/forma_core/agents/web_research_workflow.py
+++ b/forma_core/agents/web_research_workflow.py
@@ -145,6 +145,7 @@ class WebResearchHardwarePipeline:
         model_name: Optional[str] = None,
         runtime_config: Optional[LLMRuntimeConfig] = None,
         external_source_provider: Optional[str] = None,
+        persist_project: bool = True,
     ):
         self.runtime_config = runtime_config or resolve_llm_runtime_config(
             provider_name=provider_name,
@@ -154,6 +155,7 @@ class WebResearchHardwarePipeline:
         self.use_simulation = not self.llm_provider.is_configured
         self.model_name = self.llm_provider.model_name
         self.external_source_provider = external_source_provider
+        self.persist_project = persist_project
         self.research_client = build_external_source_provider(provider=external_source_provider)
         self._active_generation_metadata: Dict[str, Any] = {}
 
@@ -1115,6 +1117,8 @@ class WebResearchHardwarePipeline:
             **public_generation_metadata,
             "project_id": project_id,
         }
+        if not self.persist_project:
+            return project_id
         try:
             save_generated_project(
                 project_id=project_id,

--- a/forma_core/agents/workflows.py
+++ b/forma_core/agents/workflows.py
@@ -81,6 +81,7 @@ def generate_project_with_workflow(
     model_name: Optional[str] = None,
     external_source_provider: Optional[str] = None,
     generation_metadata: Optional[Dict[str, Any]] = None,
+    persist_project: bool = True,
 ) -> HardwareIR:
     normalized = normalize_workflow_id(workflow_id)
     source_usage = source_usage_for_workflow(normalized, external_provider=external_source_provider)
@@ -89,6 +90,7 @@ def generate_project_with_workflow(
             provider_name=provider_name,
             model_name=model_name,
             external_source_provider=external_source_provider,
+            persist_project=persist_project,
         ).generate_project(
             prompt,
             image_bytes=image_bytes,
@@ -96,7 +98,11 @@ def generate_project_with_workflow(
             generation_metadata=generation_metadata,
         )
     else:
-        ir = HardwarePipelineOrchestrator(provider_name=provider_name, model_name=model_name).generate_project(
+        ir = HardwarePipelineOrchestrator(
+            provider_name=provider_name,
+            model_name=model_name,
+            persist_project=persist_project,
+        ).generate_project(
             prompt,
             image_bytes=image_bytes,
             image_mime_type=image_mime_type,

--- a/forma_core/database.py
+++ b/forma_core/database.py
@@ -77,6 +77,10 @@ class DesignBriefAccessError(PermissionError):
     """The project id is already owned by a different user."""
 
 
+class CliProjectConflictError(RuntimeError):
+    """A CLI sync write was based on a stale remote revision."""
+
+
 def _env(name: str, default: Optional[str] = None) -> Optional[str]:
     value = config.get(name)
     if value is None:
@@ -489,6 +493,142 @@ def list_generated_projects_page(
 
 def get_generated_project(project_id: str, *, include_deleted: bool = False) -> Optional[Any]:
     return _DATABASE_REPOSITORY.get_generated_project(project_id, include_deleted=include_deleted)
+
+
+def list_cli_projects(owner_user_id: str) -> List[Dict[str, Any]]:
+    """Return private CLI project metadata without project payloads."""
+    owner = _normalize_user_id(owner_user_id)
+    if not owner:
+        return []
+    return [
+        {
+            "project_id": str(record.project_id),
+            "workspace_id": getattr(record, "workspace_id", None),
+            "title": getattr(record, "title", ""),
+            "revision_id": getattr(record, "current_revision_id", None),
+            "revision": getattr(record, "current_revision", 0),
+            "updated_at": getattr(record, "updated_at", None),
+            "created_at": getattr(record, "created_at", None),
+        }
+        for record in _DATABASE_REPOSITORY.list_cli_projects(owner)
+    ]
+
+
+def get_cli_project_revision(
+    project_id: str,
+    owner_user_id: str,
+    revision_id: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    owner = _normalize_user_id(owner_user_id)
+    project = str(project_id or "").strip()
+    if not owner or not project:
+        return None
+    record = _DATABASE_REPOSITORY.get_cli_project_revision(project, owner, revision_id)
+    if record is None:
+        return None
+    return {
+        "revision_id": str(record.revision_id),
+        "project_id": str(record.project_id),
+        "revision": int(record.revision),
+        "parent_revision_id": getattr(record, "parent_revision_id", None),
+        "manifest": getattr(record, "manifest_json", {}),
+        "created_at": getattr(record, "created_at", None),
+    }
+
+
+def insert_cli_project_revision(
+    manifest: Dict[str, Any],
+    owner_user_id: str,
+    *,
+    expected_revision_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Create one private project revision with compare-and-swap ancestry."""
+    owner = _normalize_user_id(owner_user_id)
+    project_id = str(manifest.get("project_id") or "").strip()
+    if not owner or not project_id:
+        raise ValueError("A project_id and authenticated owner are required.")
+    existing = _DATABASE_REPOSITORY.get_cli_project(project_id, owner)
+    next_revision = int(getattr(existing, "current_revision", 0)) + 1 if existing else 1
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    revision_id = str(uuid.uuid4())
+    revision_record = {
+        "revision_id": revision_id,
+        "project_id": project_id,
+        "owner_user_id": owner,
+        "revision": next_revision,
+        "parent_revision_id": expected_revision_id,
+        "manifest_json": manifest,
+        "created_at": now,
+    }
+    project_record = {
+        "project_id": project_id,
+        "workspace_id": manifest.get("workspace_id"),
+        "owner_user_id": owner,
+        "title": str(manifest.get("title") or "Untitled Forma Project"),
+        "current_revision": 0,
+        "current_revision_id": None,
+        "created_at": now,
+        "updated_at": now,
+    }
+    saved = _DATABASE_REPOSITORY.insert_cli_project_revision(
+        project_record,
+        revision_record,
+        expected_revision_id,
+    )
+    if saved is None:
+        raise CliProjectConflictError("The cloud project changed since the local project was last pulled.")
+    return {
+        "revision_id": revision_id,
+        "project_id": project_id,
+        "revision": next_revision,
+        "parent_revision_id": expected_revision_id,
+        "manifest": manifest,
+        "created_at": now,
+    }
+
+
+def get_cli_device_authorization(device_code_hash: Optional[str] = None, user_code_hash: Optional[str] = None) -> Optional[Any]:
+    return _DATABASE_REPOSITORY.get_cli_device_authorization(device_code_hash, user_code_hash)
+
+
+def insert_cli_device_authorization(record: Dict[str, Any]) -> Any:
+    return _DATABASE_REPOSITORY.insert_cli_device_authorization(record)
+
+
+def update_cli_device_authorization(
+    device_code_hash: str,
+    updates: Dict[str, Any],
+    *,
+    expected_status: Optional[str] = None,
+    expected_consumed: Optional[bool] = None,
+) -> Optional[Any]:
+    return _DATABASE_REPOSITORY.update_cli_device_authorization(
+        device_code_hash,
+        updates,
+        expected_status=expected_status,
+        expected_consumed=expected_consumed,
+    )
+
+
+def get_cli_token_session(token_hash: str) -> Optional[Any]:
+    return _DATABASE_REPOSITORY.get_cli_token_session(token_hash)
+
+
+def insert_cli_token_session(record: Dict[str, Any]) -> Any:
+    return _DATABASE_REPOSITORY.insert_cli_token_session(record)
+
+
+def revoke_cli_token_sessions(
+    *,
+    token_hash: Optional[str] = None,
+    refresh_token_hash: Optional[str] = None,
+    revoked_at: float,
+) -> int:
+    return _DATABASE_REPOSITORY.revoke_cli_token_sessions(
+        token_hash=token_hash,
+        refresh_token_hash=refresh_token_hash,
+        revoked_at=revoked_at,
+    )
 
 
 def _design_brief_from_record(record: Any) -> DesignBrief:

--- a/forma_core/persistence/models.py
+++ b/forma_core/persistence/models.py
@@ -148,6 +148,72 @@ class DBProjectRevision(Base):
     created_at = Column(String, index=True, nullable=False)
 
 
+class DBCliProject(Base):
+    """Private cloud project identity owned by a CLI user."""
+
+    __tablename__ = "cli_projects"
+
+    project_id = Column(String, primary_key=True)
+    workspace_id = Column(String, nullable=True)
+    owner_user_id = Column(String, index=True, nullable=False)
+    title = Column(String, nullable=False, default="")
+    current_revision = Column(Integer, nullable=False, default=0)
+    current_revision_id = Column(String, nullable=True)
+    created_at = Column(String, nullable=False)
+    updated_at = Column(String, index=True, nullable=False)
+
+
+class DBCliProjectRevision(Base):
+    """Immutable canonical manifest revision uploaded through the CLI."""
+
+    __tablename__ = "cli_project_revisions"
+    __table_args__ = (
+        UniqueConstraint("project_id", "revision", name="uq_cli_project_revisions_project_revision"),
+    )
+
+    revision_id = Column(String, primary_key=True)
+    project_id = Column(String, index=True, nullable=False)
+    owner_user_id = Column(String, index=True, nullable=False)
+    revision = Column(Integer, nullable=False)
+    parent_revision_id = Column(String, nullable=True)
+    manifest_json = Column(JSON, nullable=False)
+    created_at = Column(String, index=True, nullable=False)
+
+
+class DBCliDeviceAuthorization(Base):
+    """Hashed short-lived device authorization state."""
+
+    __tablename__ = "cli_device_authorizations"
+
+    device_code_hash = Column(String, primary_key=True)
+    user_code_hash = Column(String, unique=True, index=True, nullable=False)
+    status = Column(String, index=True, nullable=False, default="pending")
+    expires_at = Column(Float, nullable=False)
+    owner_user_id = Column(String, nullable=True)
+    provider = Column(String, nullable=True)
+    email = Column(String, nullable=True)
+    display_name = Column(String, nullable=True)
+    consumed = Column(Boolean, nullable=False, default=False)
+    created_at = Column(String, nullable=False)
+
+
+class DBCliTokenSession(Base):
+    """Hashed CLI access/refresh token state with revocation support."""
+
+    __tablename__ = "cli_token_sessions"
+
+    token_hash = Column(String, primary_key=True)
+    token_type = Column(String, index=True, nullable=False)
+    refresh_token_hash = Column(String, index=True, nullable=True)
+    owner_user_id = Column(String, index=True, nullable=False)
+    provider = Column(String, nullable=False)
+    email = Column(String, nullable=True)
+    display_name = Column(String, nullable=True)
+    expires_at = Column(Float, nullable=False)
+    revoked_at = Column(Float, nullable=True)
+    created_at = Column(String, nullable=False)
+
+
 class DBProjectValidationReport(Base):
     __tablename__ = "project_validation_reports"
     __table_args__ = (

--- a/forma_core/persistence/repositories/base.py
+++ b/forma_core/persistence/repositories/base.py
@@ -123,6 +123,48 @@ class ApplicationRepository(Protocol):
 
     def insert_initial_project_revision(self, record: Dict[str, Any]) -> Optional[Any]: ...
 
+    def get_cli_project(self, project_id: str, owner_user_id: str) -> Optional[Any]: ...
+
+    def list_cli_projects(self, owner_user_id: str) -> List[Any]: ...
+
+    def get_cli_project_revision(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        revision_id: Optional[str] = None,
+    ) -> Optional[Any]: ...
+
+    def insert_cli_project_revision(
+        self,
+        project_record: Dict[str, Any],
+        revision_record: Dict[str, Any],
+        expected_revision_id: Optional[str],
+    ) -> Optional[Any]: ...
+
+    def get_cli_device_authorization(self, device_code_hash: Optional[str] = None, user_code_hash: Optional[str] = None) -> Optional[Any]: ...
+
+    def insert_cli_device_authorization(self, record: Dict[str, Any]) -> Any: ...
+
+    def update_cli_device_authorization(
+        self,
+        device_code_hash: str,
+        updates: Dict[str, Any],
+        expected_status: Optional[str] = None,
+        expected_consumed: Optional[bool] = None,
+    ) -> Optional[Any]: ...
+
+    def get_cli_token_session(self, token_hash: str) -> Optional[Any]: ...
+
+    def insert_cli_token_session(self, record: Dict[str, Any]) -> Any: ...
+
+    def revoke_cli_token_sessions(
+        self,
+        *,
+        token_hash: Optional[str] = None,
+        refresh_token_hash: Optional[str] = None,
+        revoked_at: float,
+    ) -> int: ...
+
     def get_validation_report(self, report_id: str, owner_user_id: str) -> Optional[Any]: ...
 
     def get_validation_report_by_source_job(

--- a/forma_core/persistence/repositories/sqlite.py
+++ b/forma_core/persistence/repositories/sqlite.py
@@ -21,6 +21,10 @@ from forma_core.persistence.models import (
     DBProjectWorkflow,
     DBProjectWorkflowTransition,
     DBProjectRevision,
+    DBCliProject,
+    DBCliProjectRevision,
+    DBCliDeviceAuthorization,
+    DBCliTokenSession,
     DBProjectValidationReport,
     DBWorkerExecutionPlan,
     DBUserSettings,
@@ -420,6 +424,155 @@ class SqlAlchemyRepository:
                 return revision
         except IntegrityError:
             return None
+
+    def get_cli_project(self, project_id: str, owner_user_id: str) -> Optional[Any]:
+        with self._session() as session:
+            return session.query(DBCliProject).filter(
+                DBCliProject.project_id == project_id,
+                DBCliProject.owner_user_id == owner_user_id,
+            ).first()
+
+    def list_cli_projects(self, owner_user_id: str) -> List[Any]:
+        with self._session() as session:
+            return session.query(DBCliProject).filter(
+                DBCliProject.owner_user_id == owner_user_id,
+            ).order_by(DBCliProject.updated_at.desc()).all()
+
+    def get_cli_project_revision(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        revision_id: Optional[str] = None,
+    ) -> Optional[Any]:
+        with self._session() as session:
+            query = session.query(DBCliProjectRevision).filter(
+                DBCliProjectRevision.project_id == project_id,
+                DBCliProjectRevision.owner_user_id == owner_user_id,
+            )
+            if revision_id:
+                query = query.filter(DBCliProjectRevision.revision_id == revision_id)
+            return query.order_by(DBCliProjectRevision.revision.desc()).first()
+
+    def insert_cli_project_revision(
+        self,
+        project_record: Dict[str, Any],
+        revision_record: Dict[str, Any],
+        expected_revision_id: Optional[str],
+    ) -> Optional[Any]:
+        try:
+            with self._session() as session, session.begin():
+                project = session.query(DBCliProject).filter(
+                    DBCliProject.project_id == project_record["project_id"],
+                ).first()
+                if project is None:
+                    if expected_revision_id is not None:
+                        return None
+                    project = DBCliProject(**project_record)
+                    session.add(project)
+                elif (
+                    project.owner_user_id != project_record["owner_user_id"]
+                    or project.current_revision_id != expected_revision_id
+                    or project.current_revision + 1 != revision_record["revision"]
+                ):
+                    return None
+                revision = DBCliProjectRevision(**revision_record)
+                session.add(revision)
+                project.current_revision = revision_record["revision"]
+                project.current_revision_id = revision_record["revision_id"]
+                project.updated_at = revision_record["created_at"]
+                session.flush()
+                session.refresh(revision)
+                session.expunge(revision)
+                return revision
+        except IntegrityError:
+            return None
+
+    def get_cli_device_authorization(self, device_code_hash: Optional[str] = None, user_code_hash: Optional[str] = None) -> Optional[Any]:
+        with self._session() as session:
+            query = session.query(DBCliDeviceAuthorization)
+            if device_code_hash:
+                query = query.filter(DBCliDeviceAuthorization.device_code_hash == device_code_hash)
+            if user_code_hash:
+                query = query.filter(DBCliDeviceAuthorization.user_code_hash == user_code_hash)
+            return query.first()
+
+    def insert_cli_device_authorization(self, record: Dict[str, Any]) -> Any:
+        with self._session() as session, session.begin():
+            authorization = DBCliDeviceAuthorization(**record)
+            session.add(authorization)
+            session.flush()
+            session.refresh(authorization)
+            session.expunge(authorization)
+            return authorization
+
+    def update_cli_device_authorization(
+        self,
+        device_code_hash: str,
+        updates: Dict[str, Any],
+        expected_status: Optional[str] = None,
+        expected_consumed: Optional[bool] = None,
+    ) -> Optional[Any]:
+        with self._session() as session, session.begin():
+            query = session.query(DBCliDeviceAuthorization).filter(
+                DBCliDeviceAuthorization.device_code_hash == device_code_hash,
+            )
+            if expected_status is not None:
+                query = query.filter(DBCliDeviceAuthorization.status == expected_status)
+            if expected_consumed is not None:
+                query = query.filter(DBCliDeviceAuthorization.consumed == expected_consumed)
+            authorization = query.first()
+            if authorization is None:
+                return None
+            for key, value in updates.items():
+                setattr(authorization, key, value)
+            session.flush()
+            session.refresh(authorization)
+            session.expunge(authorization)
+            return authorization
+
+    def get_cli_token_session(self, token_hash: str) -> Optional[Any]:
+        with self._session() as session:
+            return session.query(DBCliTokenSession).filter(
+                DBCliTokenSession.token_hash == token_hash,
+            ).first()
+
+    def insert_cli_token_session(self, record: Dict[str, Any]) -> Any:
+        with self._session() as session, session.begin():
+            token = DBCliTokenSession(**record)
+            session.add(token)
+            session.flush()
+            session.refresh(token)
+            session.expunge(token)
+            return token
+
+    def revoke_cli_token_sessions(
+        self,
+        *,
+        token_hash: Optional[str] = None,
+        refresh_token_hash: Optional[str] = None,
+        revoked_at: float,
+    ) -> int:
+        with self._session() as session, session.begin():
+            count = 0
+            queries = []
+            if token_hash:
+                queries.append(session.query(DBCliTokenSession).filter(
+                    DBCliTokenSession.token_hash == token_hash,
+                    DBCliTokenSession.revoked_at.is_(None),
+                ))
+            if refresh_token_hash:
+                queries.append(session.query(DBCliTokenSession).filter(
+                    DBCliTokenSession.refresh_token_hash == refresh_token_hash,
+                    DBCliTokenSession.revoked_at.is_(None),
+                ))
+            seen: set[str] = set()
+            for query in queries:
+                for token in query.all():
+                    if token.token_hash not in seen:
+                        token.revoked_at = revoked_at
+                        seen.add(token.token_hash)
+                        count += 1
+            return count
 
     def insert_project_revision(
         self,

--- a/forma_core/persistence/repositories/supabase.py
+++ b/forma_core/persistence/repositories/supabase.py
@@ -398,6 +398,143 @@ class SupabaseRepository:
         payload = data[0] if isinstance(data, list) and data else data
         return _record(payload) if isinstance(payload, dict) else None
 
+    def get_cli_project(self, project_id: str, owner_user_id: str) -> Optional[Any]:
+        rows = (
+            self._client.table("cli_projects")
+            .select("*")
+            .eq("project_id", project_id)
+            .eq("owner_user_id", owner_user_id)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
+    def list_cli_projects(self, owner_user_id: str) -> List[Any]:
+        rows = (
+            self._client.table("cli_projects")
+            .select("*")
+            .eq("owner_user_id", owner_user_id)
+            .order("updated_at", desc=True)
+            .execute()
+            .data
+            or []
+        )
+        return [_record(row) for row in rows]
+
+    def get_cli_project_revision(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        revision_id: Optional[str] = None,
+    ) -> Optional[Any]:
+        query = (
+            self._client.table("cli_project_revisions")
+            .select("*")
+            .eq("project_id", project_id)
+            .eq("owner_user_id", owner_user_id)
+        )
+        if revision_id:
+            query = query.eq("revision_id", revision_id)
+        rows = query.order("revision", desc=True).limit(1).execute().data or []
+        return _record(rows[0]) if rows else None
+
+    def insert_cli_project_revision(
+        self,
+        project_record: Dict[str, Any],
+        revision_record: Dict[str, Any],
+        expected_revision_id: Optional[str],
+    ) -> Optional[Any]:
+        project = self.get_cli_project(project_record["project_id"], project_record["owner_user_id"])
+        if project is None:
+            if expected_revision_id is not None:
+                return None
+            self._client.table("cli_projects").insert(project_record).execute()
+        elif (
+            getattr(project, "current_revision_id", None) != expected_revision_id
+            or int(getattr(project, "current_revision", 0)) + 1 != revision_record["revision"]
+        ):
+            return None
+        try:
+            rows = self._client.table("cli_project_revisions").insert(revision_record).execute().data or []
+            self._client.table("cli_projects").update({
+                "current_revision": revision_record["revision"],
+                "current_revision_id": revision_record["revision_id"],
+                "updated_at": revision_record["created_at"],
+            }).eq("project_id", project_record["project_id"]).eq(
+                "owner_user_id", project_record["owner_user_id"]
+            ).execute()
+        except Exception:
+            return None
+        return _record(rows[0]) if rows else None
+
+    def get_cli_device_authorization(self, device_code_hash: Optional[str] = None, user_code_hash: Optional[str] = None) -> Optional[Any]:
+        query = self._client.table("cli_device_authorizations").select("*")
+        if device_code_hash:
+            query = query.eq("device_code_hash", device_code_hash)
+        if user_code_hash:
+            query = query.eq("user_code_hash", user_code_hash)
+        rows = query.limit(1).execute().data or []
+        return _record(rows[0]) if rows else None
+
+    def insert_cli_device_authorization(self, record: Dict[str, Any]) -> Any:
+        rows = self._client.table("cli_device_authorizations").insert(record).execute().data or []
+        return _record(rows[0]) if rows else _record(record)
+
+    def update_cli_device_authorization(
+        self,
+        device_code_hash: str,
+        updates: Dict[str, Any],
+        expected_status: Optional[str] = None,
+        expected_consumed: Optional[bool] = None,
+    ) -> Optional[Any]:
+        query = self._client.table("cli_device_authorizations").update(updates).eq(
+            "device_code_hash", device_code_hash
+        )
+        if expected_status is not None:
+            query = query.eq("status", expected_status)
+        if expected_consumed is not None:
+            query = query.eq("consumed", expected_consumed)
+        rows = query.select("*").execute().data or []
+        return _record(rows[0]) if rows else None
+
+    def get_cli_token_session(self, token_hash: str) -> Optional[Any]:
+        rows = self._client.table("cli_token_sessions").select("*").eq("token_hash", token_hash).limit(1).execute().data or []
+        return _record(rows[0]) if rows else None
+
+    def insert_cli_token_session(self, record: Dict[str, Any]) -> Any:
+        rows = self._client.table("cli_token_sessions").insert(record).execute().data or []
+        return _record(rows[0]) if rows else _record(record)
+
+    def revoke_cli_token_sessions(
+        self,
+        *,
+        token_hash: Optional[str] = None,
+        refresh_token_hash: Optional[str] = None,
+        revoked_at: float,
+    ) -> int:
+        count = 0
+        seen: set[str] = set()
+        for column, value in (("token_hash", token_hash), ("refresh_token_hash", refresh_token_hash)):
+            if not value:
+                continue
+            rows = (
+                self._client.table("cli_token_sessions")
+                .update({"revoked_at": revoked_at})
+                .eq(column, value)
+                .is_("revoked_at", "null")
+                .execute()
+                .data
+                or []
+            )
+            for row in rows:
+                token_hash_value = str(row.get("token_hash") or "")
+                if token_hash_value and token_hash_value not in seen:
+                    seen.add(token_hash_value)
+                    count += 1
+        return count
+
     def insert_project_revision(
         self,
         record: Dict[str, Any],

--- a/forma_core/persistence/schema.py
+++ b/forma_core/persistence/schema.py
@@ -63,6 +63,34 @@ APPLICATION_SCHEMA: Tuple[TableContract, ...] = (
         ),
     ),
     TableContract(
+        "cli_projects",
+        (
+            "project_id", "workspace_id", "owner_user_id", "title", "current_revision",
+            "current_revision_id", "created_at", "updated_at",
+        ),
+    ),
+    TableContract(
+        "cli_project_revisions",
+        (
+            "revision_id", "project_id", "owner_user_id", "revision", "parent_revision_id",
+            "manifest_json", "created_at",
+        ),
+    ),
+    TableContract(
+        "cli_device_authorizations",
+        (
+            "device_code_hash", "user_code_hash", "status", "expires_at", "owner_user_id", "provider",
+            "email", "display_name", "consumed", "created_at",
+        ),
+    ),
+    TableContract(
+        "cli_token_sessions",
+        (
+            "token_hash", "token_type", "refresh_token_hash", "owner_user_id", "provider", "email",
+            "display_name", "expires_at", "revoked_at", "created_at",
+        ),
+    ),
+    TableContract(
         "project_validation_reports",
         (
             "id", "project_id", "owner_user_id", "project_revision", "design_brief_id",

--- a/forma_core/workspaces/projects/__init__.py
+++ b/forma_core/workspaces/projects/__init__.py
@@ -10,6 +10,15 @@ from forma_core.workspaces.projects.state import (
     ProjectStateService,
     ProjectSystem,
 )
+from forma_core.workspaces.projects.manifest import (
+    PROJECT_MANIFEST_FORMAT,
+    PROJECT_MANIFEST_VERSION,
+    ProjectArtifactReference,
+    ProjectManifest,
+    load_project_manifest,
+    redact_project_secrets,
+    write_project_manifest,
+)
 
 __all__ = [
     "PROJECT_REVISION_SCHEMA_VERSION",
@@ -20,4 +29,11 @@ __all__ = [
     "ProjectStateError",
     "ProjectStateService",
     "ProjectSystem",
+    "PROJECT_MANIFEST_FORMAT",
+    "PROJECT_MANIFEST_VERSION",
+    "ProjectArtifactReference",
+    "ProjectManifest",
+    "load_project_manifest",
+    "redact_project_secrets",
+    "write_project_manifest",
 ]

--- a/forma_core/workspaces/projects/manifest.py
+++ b/forma_core/workspaces/projects/manifest.py
@@ -1,0 +1,138 @@
+"""Portable project manifests used by the local-first Forma CLI."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+from typing import Any, Mapping
+from uuid import uuid4
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+PROJECT_MANIFEST_FORMAT = "forma-project"
+PROJECT_MANIFEST_VERSION = 1
+_SECRET_FIELD_MARKERS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "password",
+    "secret",
+    "token",
+)
+
+
+def _is_secret_field(name: object) -> bool:
+    normalized = str(name).strip().lower().replace("-", "_")
+    return normalized in {"key", "credential", "credentials"} or any(
+        marker in normalized for marker in _SECRET_FIELD_MARKERS
+    )
+
+
+def redact_project_secrets(value: Any) -> Any:
+    """Return a JSON-compatible copy without credential-like fields."""
+    if isinstance(value, Mapping):
+        return {
+            str(key): redact_project_secrets(item)
+            for key, item in value.items()
+            if not _is_secret_field(key)
+        }
+    if isinstance(value, list):
+        return [redact_project_secrets(item) for item in value]
+    if isinstance(value, tuple):
+        return [redact_project_secrets(item) for item in value]
+    return deepcopy(value)
+
+
+class ProjectArtifactReference(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    path: str
+    sha256: str | None = None
+    media_type: str | None = None
+
+
+class ProjectManifest(BaseModel):
+    """Canonical, uploadable representation of one local Forma project."""
+
+    model_config = ConfigDict(extra="allow")
+
+    format: str = PROJECT_MANIFEST_FORMAT
+    version: int = Field(default=PROJECT_MANIFEST_VERSION, ge=1)
+    project_id: str = Field(min_length=1)
+    workspace_id: str | None = None
+    title: str = ""
+    prompt: str = ""
+    project_ir: dict[str, Any] = Field(default_factory=dict)
+    artifacts: list[ProjectArtifactReference] = Field(default_factory=list)
+
+    @classmethod
+    def from_document(cls, document: Mapping[str, Any]) -> "ProjectManifest":
+        """Accept both the canonical wrapper and legacy raw HardwareIR JSON."""
+        raw = dict(document)
+        nested = raw.get("project_ir") or raw.get("hardware_ir")
+        project_ir = dict(nested) if isinstance(nested, Mapping) else raw
+        metadata = project_ir.get("assembly_metadata")
+        metadata = metadata if isinstance(metadata, Mapping) else {}
+        project_id = raw.get("project_id") or metadata.get("project_id") or str(uuid4())
+        overview = project_ir.get("overview")
+        overview = overview if isinstance(overview, Mapping) else {}
+        title = raw.get("title") or overview.get("title") or "Untitled Forma Project"
+        prompt = raw.get("prompt") or metadata.get("project_prompt") or ""
+        artifact_values = []
+        for item in raw.get("artifacts") or []:
+            if not isinstance(item, Mapping):
+                continue
+            artifact = dict(item)
+            artifact.setdefault("path", artifact.get("uri") or artifact.get("name") or "")
+            artifact_values.append(artifact)
+        return cls(
+            format=str(raw.get("format") or PROJECT_MANIFEST_FORMAT),
+            version=int(raw.get("version") or PROJECT_MANIFEST_VERSION),
+            project_id=str(project_id),
+            workspace_id=str(raw["workspace_id"]) if raw.get("workspace_id") else None,
+            title=str(title),
+            prompt=str(prompt),
+            project_ir=project_ir,
+            artifacts=[ProjectArtifactReference.model_validate(item) for item in artifact_values],
+        )
+
+    def upload_payload(self) -> dict[str, Any]:
+        """Build the only payload shape that may cross the cloud boundary."""
+        payload = self.model_dump(mode="json")
+        payload["project_ir"] = redact_project_secrets(payload["project_ir"])
+        payload["artifacts"] = redact_project_secrets(payload["artifacts"])
+        return payload
+
+
+def load_project_manifest(path: str | Path) -> ProjectManifest:
+    project_path = Path(path)
+    with project_path.open(encoding="utf-8") as file:
+        document = json.load(file)
+    if not isinstance(document, Mapping):
+        raise ValueError(f"Project manifest must contain a JSON object: {project_path}")
+    return ProjectManifest.from_document(document)
+
+
+def write_project_manifest(path: str | Path, manifest: ProjectManifest) -> None:
+    project_path = Path(path)
+    safe_payload = redact_project_secrets(manifest.model_dump(mode="json"))
+    project_path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path = project_path.with_suffix(f"{project_path.suffix}.tmp")
+    temporary_path.write_text(
+        json.dumps(safe_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary_path.replace(project_path)
+
+
+__all__ = [
+    "PROJECT_MANIFEST_FORMAT",
+    "PROJECT_MANIFEST_VERSION",
+    "ProjectArtifactReference",
+    "ProjectManifest",
+    "load_project_manifest",
+    "redact_project_secrets",
+    "write_project_manifest",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
 dependencies = [
     "google-auth>=2.29.0",
     "json-repair>=0.30.0",
+    "keyring>=25.0.0",
     "pydantic>=2.12.0",
     "python-dotenv>=1.0.1",
     "sqlalchemy==2.0.31",
@@ -39,6 +40,7 @@ Documentation = "https://github.com/caid-technologies/Forma-OSS#readme"
 
 [project.scripts]
 forma-core = "forma_core.cli.main:main"
+forma-oss = "forma_cli.app:app"
 fabricator = "forma_core.fabricator.main:main"
 
 [tool.vercel]
@@ -86,6 +88,8 @@ include-package-data = true
 include = [
     "forma_core",
     "forma_core.*",
+    "forma_cli",
+    "forma_cli.*",
 ]
 
 [tool.setuptools.package-data]

--- a/supabase/migrations/20260829000100_cli_projects.sql
+++ b/supabase/migrations/20260829000100_cli_projects.sql
@@ -1,0 +1,84 @@
+-- Private project manifests and immutable revision ancestry for forma-oss.
+
+create table if not exists public.cli_projects (
+  project_id text primary key,
+  workspace_id text,
+  owner_user_id text not null,
+  title text not null default '',
+  current_revision integer not null default 0 check (current_revision >= 0),
+  current_revision_id text,
+  created_at text not null,
+  updated_at text not null
+);
+
+create index if not exists idx_cli_projects_owner_updated
+  on public.cli_projects (owner_user_id, updated_at desc);
+
+create table if not exists public.cli_project_revisions (
+  revision_id text primary key,
+  project_id text not null references public.cli_projects(project_id) on delete cascade,
+  owner_user_id text not null,
+  revision integer not null check (revision >= 1),
+  parent_revision_id text,
+  manifest_json jsonb not null,
+  created_at text not null,
+  constraint cli_project_revisions_project_revision_unique unique (project_id, revision)
+);
+
+create index if not exists idx_cli_project_revisions_owner_project
+  on public.cli_project_revisions (owner_user_id, project_id, revision desc);
+
+create table if not exists public.cli_device_authorizations (
+  device_code_hash text primary key,
+  user_code_hash text not null unique,
+  status text not null default 'pending',
+  expires_at double precision not null,
+  owner_user_id text,
+  provider text,
+  email text,
+  display_name text,
+  consumed boolean not null default false,
+  created_at text not null
+);
+
+create index if not exists idx_cli_device_authorizations_user_code
+  on public.cli_device_authorizations (user_code_hash);
+
+create table if not exists public.cli_token_sessions (
+  token_hash text primary key,
+  token_type text not null,
+  refresh_token_hash text,
+  owner_user_id text not null,
+  provider text not null,
+  email text,
+  display_name text,
+  expires_at double precision not null,
+  revoked_at double precision,
+  created_at text not null
+);
+
+create index if not exists idx_cli_token_sessions_refresh_hash
+  on public.cli_token_sessions (refresh_token_hash);
+
+alter table public.cli_projects enable row level security;
+alter table public.cli_project_revisions enable row level security;
+alter table public.cli_device_authorizations enable row level security;
+alter table public.cli_token_sessions enable row level security;
+
+revoke all on table public.cli_projects from anon, authenticated;
+revoke all on table public.cli_project_revisions from anon, authenticated;
+revoke all on table public.cli_device_authorizations from anon, authenticated;
+revoke all on table public.cli_token_sessions from anon, authenticated;
+grant select, insert, update, delete on table public.cli_projects to service_role;
+grant select, insert, update, delete on table public.cli_project_revisions to service_role;
+grant select, insert, update, delete on table public.cli_device_authorizations to service_role;
+grant select, insert, update, delete on table public.cli_token_sessions to service_role;
+
+comment on table public.cli_projects is
+  'Private project identities created explicitly by the forma-oss CLI.';
+comment on table public.cli_project_revisions is
+  'Immutable, secret-free project manifests uploaded by the forma-oss CLI.';
+comment on table public.cli_device_authorizations is
+  'Short-lived hashed device authorization sessions for the forma-oss CLI.';
+comment on table public.cli_token_sessions is
+  'Hashed forma-oss CLI access and refresh token sessions with revocation state.';

--- a/tests/tooling/test_cli_auth_api.py
+++ b/tests/tooling/test_cli_auth_api.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+import unittest
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from apps.api.main import app
+
+
+class CliAuthApiTests(unittest.TestCase):
+    def test_device_flow_can_approve_exchange_and_revoke_in_local_mode(self) -> None:
+        with patch.dict(os.environ, {"FORMA_AUTH_MODE": "local", "FORMA_CLI_AUTH_STORAGE": "memory"}, clear=False):
+            client = TestClient(app)
+            authorization = client.post("/cli/device/authorize", json={})
+            self.assertEqual(200, authorization.status_code)
+            payload = authorization.json()
+
+            approved = client.post("/cli/device/approve", json={"user_code": payload["user_code"]})
+            self.assertEqual(200, approved.status_code)
+            self.assertEqual(
+                "approved",
+                client.post("/cli/device/poll", json={"device_code": payload["device_code"]}).json()["status"],
+            )
+
+            token_response = client.post("/cli/device/token", json={"device_code": payload["device_code"]})
+            self.assertEqual(200, token_response.status_code)
+            tokens = token_response.json()
+            self.assertEqual(
+                200,
+                client.get(
+                    "/cli/whoami",
+                    headers={"Authorization": f"Bearer {tokens['access_token']}"},
+                ).status_code,
+            )
+            self.assertEqual(200, client.post("/cli/token/revoke", json={"refresh_token": tokens["refresh_token"]}).status_code)
+            self.assertEqual(
+                401,
+                client.get(
+                    "/cli/whoami",
+                    headers={"Authorization": f"Bearer {tokens['access_token']}"},
+                ).status_code,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tooling/test_cli_auth_store.py
+++ b/tests/tooling/test_cli_auth_store.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import unittest
+import os
+from unittest.mock import patch
+
+from apps.api.cli_auth_store import (
+    CliIdentity,
+    approve_device,
+    create_device_session,
+    device_status,
+    exchange_device,
+    refresh_access,
+    resolve_access_token,
+    revoke_tokens,
+)
+
+
+class CliAuthStoreTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self._storage = patch.dict(os.environ, {"FORMA_CLI_AUTH_STORAGE": "memory"})
+        self._storage.start()
+        self.addCleanup(self._storage.stop)
+
+    def test_device_approval_issues_opaque_access_and_refresh_tokens(self) -> None:
+        session = create_device_session()
+        self.assertEqual("pending", device_status(session.device_code))
+
+        self.assertTrue(
+            approve_device(
+                session.user_code,
+                CliIdentity(subject="user-1", provider="clerk", email="user@example.test"),
+            )
+        )
+        issued = exchange_device(session.device_code)
+        self.assertIsNotNone(issued)
+        access_token, refresh_token, _ = issued or ("", "", 0)
+        self.assertNotEqual(session.device_code, access_token)
+        self.assertEqual("user-1", (resolve_access_token(access_token) or CliIdentity("", "")).subject)
+
+        refreshed = refresh_access(refresh_token)
+        self.assertIsNotNone(refreshed)
+        refreshed_access, _, _ = refreshed or ("", "", 0)
+        self.assertEqual("user-1", (resolve_access_token(refreshed_access) or CliIdentity("", "")).subject)
+
+        revoke_tokens(refresh_token=refresh_token)
+        self.assertIsNone(resolve_access_token(access_token))
+        self.assertIsNone(resolve_access_token(refreshed_access))
+
+    def test_device_code_cannot_be_exchanged_twice(self) -> None:
+        session = create_device_session()
+        approve_device(session.user_code, CliIdentity(subject="user-2", provider="local"))
+        self.assertIsNotNone(exchange_device(session.device_code))
+        self.assertIsNone(exchange_device(session.device_code))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tooling/test_core_package.py
+++ b/tests/tooling/test_core_package.py
@@ -27,6 +27,7 @@ class CorePackageTests(unittest.TestCase):
         self.assertEqual("apps.api.main:app", pyproject["tool"]["vercel"]["entrypoint"])
         self.assertEqual("forma_core._version.__version__", pyproject["tool"]["setuptools"]["dynamic"]["version"]["attr"])
         self.assertEqual("forma_core.cli.main:main", pyproject["project"]["scripts"]["forma-core"])
+        self.assertEqual("forma_cli.app:app", pyproject["project"]["scripts"]["forma-oss"])
         self.assertEqual(
             "forma_core.fabricator.main:main",
             pyproject["project"]["scripts"]["fabricator"],

--- a/tests/tooling/test_oss_cli.py
+++ b/tests/tooling/test_oss_cli.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from forma_cli.app import build_parser, cmd_projects_pull
+from forma_cli.credentials import CredentialStore
+from forma_cli.local import init_project
+from forma_cli.sdk import CloudProjectRevision, FormaAPIClient
+from forma_core.workspaces.projects.manifest import ProjectManifest, write_project_manifest
+
+
+class FakeKeyring:
+    def __init__(self) -> None:
+        self.values: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service: str, name: str) -> str | None:
+        return self.values.get((service, name))
+
+    def set_password(self, service: str, name: str, value: str) -> None:
+        self.values[(service, name)] = value
+
+    def delete_password(self, service: str, name: str) -> None:
+        self.values.pop((service, name), None)
+
+
+class Response:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+
+    def __enter__(self) -> "Response":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+class OssCliTests(unittest.TestCase):
+    def test_help_hierarchy_contains_initial_command_groups(self) -> None:
+        parser = build_parser()
+        self.assertEqual("forma-oss", parser.prog)
+        self.assertEqual(
+            {"login", "logout", "whoami", "init", "build", "status", "projects", "keys"},
+            set(parser._subparsers._group_actions[0].choices),
+        )
+
+    def test_init_creates_local_manifest_and_non_secret_linkage(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = init_project(temp_dir, title="Sensor")
+            root = Path(temp_dir)
+            self.assertEqual("forma-project", json.loads((root / "forma-project.json").read_text())["format"])
+            linkage = (root / ".forma" / "project.toml").read_text(encoding="utf-8")
+            self.assertIn(f'project_id = "{manifest.project_id}"', linkage)
+            self.assertNotIn("token", linkage.lower())
+
+    def test_upload_payload_redacts_provider_secrets_recursively(self) -> None:
+        manifest = ProjectManifest(
+            project_id="local-project",
+            project_ir={
+                "components": [],
+                "assembly_metadata": {"api_key": "do-not-upload", "safe": "yes"},
+                "nested": {"authorization": "Bearer secret", "safe": "yes"},
+            },
+        )
+
+        payload = manifest.upload_payload()
+
+        serialized = json.dumps(payload)
+        self.assertNotIn("do-not-upload", serialized)
+        self.assertNotIn("Bearer secret", serialized)
+        self.assertEqual("yes", payload["project_ir"]["assembly_metadata"]["safe"])
+
+    def test_local_manifest_writer_does_not_persist_provider_secrets(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "forma-project.json"
+            write_project_manifest(
+                path,
+                ProjectManifest(project_id="local-project", project_ir={"api_key": "secret-value"}),
+            )
+            self.assertNotIn("secret-value", path.read_text(encoding="utf-8"))
+
+    def test_credential_store_uses_keyring_backend_without_exposing_values(self) -> None:
+        keyring = FakeKeyring()
+        store = CredentialStore(keyring_backend=keyring)
+        store.set("provider:openai", "secret-value")
+
+        self.assertEqual("secret-value", store.get("provider:openai"))
+        self.assertNotIn("secret-value", repr({"configured": bool(store.get("provider:openai"))}))
+        store.delete("provider:openai")
+        self.assertIsNone(store.get("provider:openai"))
+
+    def test_sdk_exchange_persists_typed_tokens_in_credential_store(self) -> None:
+        keyring = FakeKeyring()
+        client = FormaAPIClient(
+            base_url="https://api.example.test",
+            credential_store=CredentialStore(keyring_backend=keyring),
+        )
+        with patch(
+            "forma_cli.sdk.urlopen",
+            return_value=Response(
+                {
+                    "access_token": "access",
+                    "refresh_token": "refresh",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                }
+            ),
+        ):
+            tokens = client.exchange_device_code("device")
+
+        self.assertEqual("access", tokens.access_token)
+        self.assertEqual("refresh", client._saved_tokens().refresh_token)
+
+    def test_projects_pull_writes_typed_remote_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            init_project(temp_dir)
+            client = FormaAPIClient(base_url="https://api.example.test", credential_store=CredentialStore(
+                keyring_backend=FakeKeyring()
+            ))
+            client.pull_project = lambda _project_id, _revision_id=None: CloudProjectRevision(
+                revision_id="revision-1",
+                project_id="project-1",
+                revision=1,
+                manifest={"format": "forma-project", "project_id": "project-1", "project_ir": {"components": []}},
+            )  # type: ignore[method-assign]
+            args = type("Args", (), {
+                "path": temp_dir,
+                "project_id": "project-1",
+                "revision_id": None,
+                "json": False,
+                "api_url": None,
+            })()
+            with patch("forma_cli.app.FormaAPIClient", return_value=client):
+                self.assertEqual(0, cmd_projects_pull(args))
+            saved = json.loads((Path(temp_dir) / "forma-project.json").read_text(encoding="utf-8"))
+            self.assertEqual("project-1", saved["project_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add the first-party local-first orma-oss CLI and typed SDK.
- Add secure keyring credentials, explicit cloud sync, managed provider keys, device login, and browser approval.
- Add canonical secret-redacted project manifests and immutable private cloud revisions.
- Persist CLI device/token auth state through SQLite/Supabase repositories.
- Document and test the CLI workflows.

## Verification
- 47 focused tests passed, 1 skipped.
- Real orma-oss init, status, and uild --simulation smoke test passed.
- API push/list/pull passed; stale push returned 409; secrets were not returned.
- Durable SQLite auth approve/resolve/revoke passed.
- Wheel build, CLI help/version, compile, and diff checks passed.

## Notes
- The broader repository suite still has existing Windows SQLite cleanup failures and unrelated frontend TypeScript issues.

Closes #349