### PR TITLE
feat: generate native OpenCAD project artifacts

### DIFF
--- a/.agents/skills/forma-hardware/scripts/cad.py
+++ b/.agents/skills/forma-hardware/scripts/cad.py
@@ -338,4 +338,10 @@ def main(argv: list[str] | None = None) -> int:
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    # OCCT can raise an access violation while tearing down native globals on
+    # Windows after a successful export. Flush the JSON result before exiting
+    # directly so callers do not lose a valid artifact to interpreter teardown.
+    exit_code = main()
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(exit_code)

--- a/apps/api/a2a.py
+++ b/apps/api/a2a.py
@@ -44,6 +44,7 @@ from forma_core.workspaces.projects.models import (
     ConnectionNet,
     HardwareIR,
 )
+from forma_core.workspaces.projects.cad_generation import ensure_native_cad_model
 from forma_core.observability import (
     get_langfuse_debug_config,
     propagate_observation_attributes,
@@ -897,6 +898,8 @@ def build_generation_response(
         raise ValueError("Provide a prompt or reference image.")
     if not has_prompt:
         prompt_text = "Infer a buildable hardware project from the uploaded reference image."
+    existing_project_for_cad = get_generated_project(project_id) if project_id else None
+    cad_required = existing_project_for_cad is None
     normalized_data_sources = normalize_generation_data_sources(data_sources)
     context_requested = PAST_JOBS_DATA_SOURCE in normalized_data_sources
     resolved_past_job_context = past_job_context or PastJobContext(
@@ -979,6 +982,7 @@ def build_generation_response(
                     "retry_stage": normalized_retry_stage,
                     "prior_generation_run": prior_generation_run,
                     "retry_stage_replay": retry_stage_replay,
+                    "cad_required": cad_required,
                 },
             )
             ensure_agent_pipeline_active()
@@ -1879,7 +1883,29 @@ async def _call_mcp_tool(
         issues = validate_circuit(project.components, project.nets, project.requirements)
         project.validation = build_validation_summary(issues)
         project.is_valid = not project.validation.critical
-        persistence = _persist_mcp_compile(project, arguments, user_context)
+        requested_project_id = arguments.get("project_id") or (project.assembly_metadata or {}).get("project_id")
+        try:
+            compile_project_id = (
+                str(uuid.UUID(str(requested_project_id).strip()))
+                if requested_project_id
+                else str(uuid.uuid4())
+            )
+        except (TypeError, ValueError, AttributeError) as exc:
+            raise ValueError("project_id must be a UUID when supplied.") from exc
+        existing_project = get_generated_project(compile_project_id, include_deleted=True)
+        if existing_project is None:
+            ensure_native_cad_model(
+                project,
+                project_id=compile_project_id,
+                required=True,
+                authoring_agent=arguments.get("authoring_agent"),
+                workflow="default",
+            )
+        persistence = _persist_mcp_compile(
+            project,
+            {**arguments, "project_id": compile_project_id},
+            user_context,
+        )
         return {
             **persistence,
             "project_ir": project.model_dump(mode="json"),

--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -76,7 +76,7 @@ import {
   type ProjectGalleryItem,
 } from "./forma-workspace/project-gallery";
 import CadModelPanel from "./forma-workspace/cad-model-panel";
-import { projectCadModel } from "../lib/cad-model";
+import { projectCadModel, projectHasMechanicalPreview } from "../lib/cad-model";
 import { FormaProjectBrowser, type FormaProjectSummary } from "@isayahc/forma-gui";
 import {
   AssemblyPanel,
@@ -5064,8 +5064,24 @@ export function FormaWorkspace({
             mechanical={projectIR?.mechanical || {}}
           />
         );
-      case "cad":
-        return <CadModelPanel cadModel={projectCadModel(projectIR)} />;
+      case "cad": {
+        const cadModel = projectCadModel(projectIR);
+        if (!cadModel && projectHasMechanicalPreview(projectIR)) {
+          return (
+            <MechanicalPanel
+              toggles={mechToggles}
+              setToggles={setMechToggles}
+              electricalActive={mechElectricalActive}
+              setElectricalActive={setMechElectricalActive}
+              components={components}
+              features={imageFeatures}
+              metadata={projectIR?.assembly_metadata || {}}
+              mechanical={projectIR?.mechanical || {}}
+            />
+          );
+        }
+        return <CadModelPanel cadModel={cadModel} />;
+      }
       case "schematic":
         return <SchematicCanvas project={schematicProject} />;
       case "assembly":

--- a/apps/web/lib/cad-model.ts
+++ b/apps/web/lib/cad-model.ts
@@ -209,6 +209,12 @@ export function projectCadModel(project: unknown): unknown {
   return record.cad_model ?? mechanical?.cad_model ?? metadata?.cad_model ?? null;
 }
 
+export function projectHasMechanicalPreview(project: unknown): boolean {
+  const record = asRecord(project);
+  const mechanical = asRecord(record?.mechanical);
+  return Array.isArray(mechanical?.component_placements) && mechanical.component_placements.length > 0;
+}
+
 export function resolveCadModel(value: unknown): CadModelDescriptor | null {
   if (value === null || value === undefined || value === "") return null;
 

--- a/apps/web/test/cad-model.test.ts
+++ b/apps/web/test/cad-model.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { projectCadModel, resolveCadModel } from "../lib/cad-model.ts";
+import { projectCadModel, projectHasMechanicalPreview, resolveCadModel } from "../lib/cad-model.ts";
 
 const mesh = {
   shapeId: "body",
@@ -13,6 +13,12 @@ test("project CAD models can be read from the canonical or mechanical payload", 
   assert.equal(projectCadModel({ cad_model: "body.step" }), "body.step");
   assert.deepEqual(projectCadModel({ mechanical: { cad_model: { shape_id: "body" } } }), { shape_id: "body" });
   assert.equal(projectCadModel({ assembly_metadata: { cad_model: "legacy.step" } }), "legacy.step");
+});
+
+test("mechanical placements provide a CAD-tab fallback when no native model is attached", () => {
+  assert.equal(projectHasMechanicalPreview({ mechanical: { component_placements: [{ ref_des: "U1" }] } }), true);
+  assert.equal(projectHasMechanicalPreview({ mechanical: { component_placements: [] } }), false);
+  assert.equal(projectHasMechanicalPreview({ mechanical: null }), false);
 });
 
 test("renderable adapter meshes normalize into a viewport payload", () => {

--- a/forma_core/agents/orchestrator.py
+++ b/forma_core/agents/orchestrator.py
@@ -62,6 +62,7 @@ from forma_core.workspaces.projects.models import (
     SystemArchitecture, component_detail_payload, component_instance_count,
     expand_component_instances,
 )
+from forma_core.workspaces.projects.cad_generation import ensure_native_cad_model
 from forma_core.validation import validate_circuit, check_safety_violations, build_validation_summary
 from forma_core.wiring import (
     WiringIntent,
@@ -128,6 +129,10 @@ DEFAULT_GENERATION_STAGE_SPECS = [
             "wiring_netlist",
             "mechanical_fabrication",
         ],
+    ),
+    GenerationStageSpec(
+        stage_id="cad_generation",
+        dependencies=["mechanical_fabrication", "assembly"],
     ),
     GenerationStageSpec(stage_id="package_project"),
 ]
@@ -850,6 +855,10 @@ class HardwarePipelineOrchestrator:
             for key, value in (generation_metadata or {}).items()
             if value is not None and value != ""
         }
+        self._active_generation_metadata.setdefault(
+            "cad_required",
+            not bool(self._active_generation_metadata.get("project_id")),
+        )
         # 0. Safety Guardrail Pre-check
         emit_agent_pipeline_event("default", "safety_guardrail", "started")
         safety_prompt = str(self._active_generation_metadata.get("project_prompt") or user_prompt)
@@ -1876,6 +1885,11 @@ class HardwarePipelineOrchestrator:
             ),
             schema=DefaultAssemblyOutput,
         )
+        cad_snapshot = self._project_ir_from_stage_run(stage_run, model_validation=model_validation)
+        stage_run.run(
+            "cad_generation",
+            lambda: self._generate_cad_stage(cad_snapshot, metadata),
+        )
         stage_run.run(
             "package_project",
             lambda: {
@@ -1884,6 +1898,26 @@ class HardwarePipelineOrchestrator:
             },
         )
         return self._project_ir_from_stage_run(stage_run, model_validation=model_validation)
+
+    def _generate_cad_stage(
+        self,
+        project: HardwareIR,
+        metadata: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        ensure_native_cad_model(
+            project,
+            project_id=metadata.get("project_id"),
+            required=bool(
+                metadata.get(
+                    "cad_required",
+                    not bool(metadata.get("project_id")),
+                )
+            ),
+        )
+        return {
+            "cad_model": project.cad_model,
+            "cad_generation": (project.assembly_metadata or {}).get("cad_generation"),
+        }
 
     def _generate_default_overview(
         self,
@@ -2141,6 +2175,7 @@ class HardwarePipelineOrchestrator:
         bom = stage_run.output("bom", DefaultBomOutput)
         mechanical = stage_run.output("mechanical_fabrication", MechanicalNotes)
         assembly_output = stage_run.output("assembly", DefaultAssemblyOutput)
+        cad_output = stage_run.output("cad_generation") or {}
         components = list(selection.components) if selection is not None else []
         nets = list(validation.nets if validation is not None else (wiring.nets if wiring is not None else []))
         pin_mappings = derive_pin_mappings(components, nets)
@@ -2169,6 +2204,19 @@ class HardwarePipelineOrchestrator:
         ]
         generation_status = self._default_generation_status(stage_run)
         issues = list(validation.issues) if validation is not None else []
+        cad_record = stage_run.records.get("cad_generation")
+        if (
+            self._active_generation_metadata.get("cad_required") is True
+            and cad_record is not None
+            and cad_record.status.value == "failed"
+        ):
+            generation_status = "failed"
+            issues.append(ValidationIssue(
+                severity="CRITICAL",
+                category="CAD Generation Failure",
+                description=str((cad_record.error or {}).get("message") or "Native CAD generation failed."),
+                troubleshooting="Install the OpenCAD runtime/adapter or retry native CAD generation.",
+            ))
         root_failure = next((
             record
             for record in stage_run.records.values()
@@ -2191,6 +2239,7 @@ class HardwarePipelineOrchestrator:
             pin_mappings=pin_mappings,
             assembly=list(assembly_output.steps) if assembly_output is not None else [],
             mechanical=mechanical,
+            cad_model=cad_output.get("cad_model") if isinstance(cad_output, dict) else None,
             constraints=constraints,
             power_rails=extract_power_rails(components, nets),
             estimated_current_draw_ma=estimate_current_draw(components),
@@ -2223,13 +2272,20 @@ class HardwarePipelineOrchestrator:
                 "component_reconciliation_added": (
                     selection.reconciled_component_parts if selection is not None else []
                 ),
+                "cad_generation": (
+                    cad_output.get("cad_generation") if isinstance(cad_output, dict) else None
+                ),
             },
             project_version_history=[{
                 "version": "0.2",
                 "description": "Dependency-aware staged default generation",
             }],
             validation=build_validation_summary(issues),
-            is_valid=bool(validation is not None and validation.is_valid),
+            is_valid=bool(
+                validation is not None
+                and validation.is_valid
+                and not any(issue.severity.upper() == "CRITICAL" for issue in issues)
+            ),
         )
         return build_mechanical_render_data(project_ir) if mechanical is not None else project_ir
 
@@ -2244,6 +2300,8 @@ class HardwarePipelineOrchestrator:
         statuses = {stage_id: record.status.value for stage_id, record in stage_run.records.items()}
         if statuses.get("system_architecture") != "succeeded":
             return "draft"
+        if statuses.get("cad_generation") in {"failed", "blocked"}:
+            return "partial"
         non_package = [status for stage_id, status in statuses.items() if stage_id != "package_project"]
         if (
             non_package

--- a/forma_core/agents/pipeline.py
+++ b/forma_core/agents/pipeline.py
@@ -423,6 +423,13 @@ DEFAULT_AGENT_PIPELINE_STEPS = [
         duration_ms=5500,
     ),
     AgentPipelineStep(
+        id="cad_generation",
+        agent="OpenCAD Authoring Agent",
+        label="Authoring native CAD",
+        description="Converting the agent-authored mechanical design into a native OpenCAD artifact.",
+        duration_ms=9000,
+    ),
+    AgentPipelineStep(
         id="package_project",
         agent="Project Packager",
         label="Packaging project artifacts",
@@ -495,6 +502,13 @@ WEB_RESEARCH_AGENT_PIPELINE_STEPS = [
         label="Writing build steps",
         description="Producing build instructions grounded in the sourced parts and generated wiring.",
         duration_ms=5500,
+    ),
+    AgentPipelineStep(
+        id="cad_generation",
+        agent="OpenCAD Authoring Agent",
+        label="Authoring native CAD",
+        description="Converting the sourced mechanical design into a native OpenCAD artifact.",
+        duration_ms=9000,
     ),
     AgentPipelineStep(
         id="completeness_audit",

--- a/forma_core/agents/web_research_workflow.py
+++ b/forma_core/agents/web_research_workflow.py
@@ -46,6 +46,7 @@ from forma_core.workspaces.projects.models import (
     component_instance_count,
     expand_component_instances,
 )
+from forma_core.workspaces.projects.cad_generation import ensure_native_cad_model
 from forma_core.observability import serialize_for_langfuse, start_observation, update_observation
 from forma_core.agents.pipeline import (
     GenerationStageRun,
@@ -129,6 +130,10 @@ WEB_GENERATION_STAGE_SPECS = [
     GenerationStageSpec(
         stage_id="completeness_audit",
         dependencies=["validation_repair", "mechanical_fabrication", "assembly"],
+    ),
+    GenerationStageSpec(
+        stage_id="cad_generation",
+        dependencies=["mechanical_fabrication", "assembly"],
     ),
     GenerationStageSpec(stage_id="package_project"),
 ]
@@ -270,6 +275,10 @@ class WebResearchHardwarePipeline:
             for key, value in (generation_metadata or {}).items()
             if value is not None and value != ""
         }
+        self._active_generation_metadata.setdefault(
+            "cad_required",
+            not bool(self._active_generation_metadata.get("project_id")),
+        )
         emit_agent_pipeline_event(self.workflow_id, "safety_guardrail", "started")
         safety_prompt = str(self._active_generation_metadata.get("project_prompt") or user_prompt)
         safety_error = check_safety_violations(safety_prompt)
@@ -614,6 +623,15 @@ class WebResearchHardwarePipeline:
             ),
             schema=CompletenessAudit,
         )
+        cad_snapshot = self._project_ir_from_stage_run(
+            stage_run,
+            user_prompt=user_prompt,
+            model_validation=model_validation,
+        )
+        stage_run.run(
+            "cad_generation",
+            lambda: self._generate_cad_stage(cad_snapshot, metadata),
+        )
         stage_run.run(
             "package_project",
             lambda: {
@@ -626,6 +644,26 @@ class WebResearchHardwarePipeline:
             user_prompt=user_prompt,
             model_validation=model_validation,
         )
+
+    def _generate_cad_stage(
+        self,
+        project: HardwareIR,
+        metadata: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        ensure_native_cad_model(
+            project,
+            project_id=metadata.get("project_id"),
+            required=bool(
+                metadata.get(
+                    "cad_required",
+                    not bool(metadata.get("project_id")),
+                )
+            ),
+        )
+        return {
+            "cad_model": project.cad_model,
+            "cad_generation": (project.assembly_metadata or {}).get("cad_generation"),
+        }
 
     def _project_ir_from_stage_run(
         self,
@@ -642,6 +680,7 @@ class WebResearchHardwarePipeline:
         mechanical = stage_run.output("mechanical_fabrication", MechanicalNotes)
         assembly_wrapper = stage_run.output("assembly", AssemblyWrapper)
         audit = stage_run.output("completeness_audit", CompletenessAudit)
+        cad_output = stage_run.output("cad_generation") or {}
         research = stage_run.output("external_research", ExternalSourceLibrary)
 
         nets = list(validation.nets if validation is not None else (wiring.nets if wiring is not None else []))
@@ -661,6 +700,19 @@ class WebResearchHardwarePipeline:
             )
 
         generation_status = self._generation_status(stage_run)
+        cad_record = stage_run.records.get("cad_generation")
+        if (
+            self._active_generation_metadata.get("cad_required") is True
+            and cad_record is not None
+            and cad_record.status.value == "failed"
+        ):
+            generation_status = "failed"
+            all_issues.append(ValidationIssue(
+                severity="CRITICAL",
+                category="CAD Generation Failure",
+                description=str((cad_record.error or {}).get("message") or "Native CAD generation failed."),
+                troubleshooting="Install the OpenCAD runtime/adapter or retry native CAD generation.",
+            ))
         stage_snapshot = stage_run.snapshot(include_outputs=True)
         public_generation_metadata = {
             key: value
@@ -682,6 +734,7 @@ class WebResearchHardwarePipeline:
             pin_mappings=pin_mappings,
             assembly=assembly,
             mechanical=mechanical,
+            cad_model=cad_output.get("cad_model") if isinstance(cad_output, dict) else None,
             constraints=constraints,
             power_rails=extract_power_rails(components, nets),
             estimated_current_draw_ma=estimate_current_draw(components),
@@ -709,6 +762,9 @@ class WebResearchHardwarePipeline:
                 "external_research": research.source_metadata() if research is not None else None,
                 "sourcing_notes": selection.sourcing_notes if selection is not None else [],
                 "completeness_audit": audit.model_dump(mode="json") if audit is not None else None,
+                "cad_generation": (
+                    cad_output.get("cad_generation") if isinstance(cad_output, dict) else None
+                ),
             },
             project_version_history=[{
                 "version": "0.2",
@@ -735,6 +791,8 @@ class WebResearchHardwarePipeline:
         statuses = {stage_id: record.status.value for stage_id, record in stage_run.records.items()}
         if statuses.get("web_architect") != "succeeded":
             return "draft"
+        if statuses.get("cad_generation") in {"failed", "blocked"}:
+            return "partial"
         non_package_statuses = [
             status for stage_id, status in statuses.items()
             if stage_id != "package_project"

--- a/forma_core/agents/workflows.py
+++ b/forma_core/agents/workflows.py
@@ -11,6 +11,7 @@ from forma_core.jobs.source_usage import (
     normalize_generation_workflow_id,
     source_usage_for_workflow,
 )
+from forma_core.workspaces.projects.cad_generation import ensure_native_cad_model
 from forma_core.workspaces.projects.models import HardwareIR
 
 
@@ -119,4 +120,16 @@ def generate_project_with_workflow(
         "workflow": normalized,
         "source_usage": (ir.assembly_metadata or {}).get("source_usage") or source_usage,
     }
+    ir_metadata = ir.assembly_metadata or {}
+    cad_required = (generation_metadata or {}).get("cad_required")
+    if cad_required is None:
+        cad_required = ir_metadata.get("cad_required") is True
+    if cad_required is True and "cad_generation" not in ir_metadata:
+        ensure_native_cad_model(
+            ir,
+            project_id=ir_metadata.get("project_id"),
+            required=True,
+            authoring_agent=ir_metadata.get("authoring_agent"),
+            workflow=normalized,
+        )
     return ir

--- a/forma_core/database.py
+++ b/forma_core/database.py
@@ -1020,7 +1020,7 @@ def create_project_generation_plan(
         capability_id=GENERATION_CAPABILITY_ID,
         input_contract_version=GENERATION_INPUT_VERSION,
         payload={"design_brief": build.brief_snapshot.model_dump(mode="json")},
-        metadata={"build_id": str(build.build_id)},
+        metadata={"build_id": str(build.build_id), "cad_required": True},
     )
     return orchestrator.create_plan([request], owner, max_concurrency=1, plan_id=plan_id)
 

--- a/forma_core/workers/generation.py
+++ b/forma_core/workers/generation.py
@@ -36,6 +36,10 @@ from forma_core.workspaces.projects import (
     ProjectSystem,
 )
 from forma_core.workspaces.projects.models import HardwareIR
+from forma_core.workspaces.projects.cad_generation import (
+    cad_project_artifact,
+    ensure_native_cad_model,
+)
 from forma_core.workspaces.projects.output import attach_hardware_reference_image, attach_product_image
 
 
@@ -104,6 +108,19 @@ class HardwareIRGenerationEngine:
                 **(generation_metadata or {}),
             },
         )
+        cad_adapter = (
+            str(state.cad_model.get("adapter") or "").strip().lower()
+            if isinstance(state.cad_model, dict)
+            else ""
+        )
+        if cad_adapter in {"", "forma-mechanical-layout", "forma-test-tube-preview"}:
+            ensure_native_cad_model(
+                state,
+                project_id=str(design_brief.project_id),
+                required=bool((generation_metadata or {}).get("cad_required", True)),
+                authoring_agent="HardwareIRGenerationEngine",
+                workflow="default",
+            )
         generation_error = (state.assembly_metadata or {}).get("generation_error")
         generation_run = (state.assembly_metadata or {}).get("generation_run")
         if (generation_error or (state.assembly_metadata or {}).get("status") == "failed") and not isinstance(
@@ -252,6 +269,9 @@ def build_generation_draft(design_brief: DesignBrief, state: HardwareIR) -> Proj
             uri=f"{revision_base}/assembly",
             media_type="application/json",
         ))
+    cad_artifact = cad_project_artifact(state, str(design_brief.project_id))
+    if cad_artifact is not None:
+        artifacts.append(cad_artifact)
 
     generation_run = (state.assembly_metadata or {}).get("generation_run") or {}
     generation_records = generation_run.get("records") if isinstance(generation_run, dict) else {}

--- a/forma_core/workspaces/projects/cad_generation.py
+++ b/forma_core/workspaces/projects/cad_generation.py
@@ -1,0 +1,455 @@
+"""Native CAD generation from agent-authored HardwareIR."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import struct
+import subprocess
+import sys
+from typing import Any
+from uuid import uuid4
+
+from forma_core.config import config
+from forma_core.workspaces.projects.models import HardwareIR
+from forma_core.workspaces.projects.state import ProjectArtifact
+
+
+CAD_ADAPTER_RELATIVE_PATH = Path(".agents") / "skills" / "forma-hardware" / "scripts" / "cad.py"
+CAD_ADAPTER_NAME = "forma-opencad"
+PLACEMENT_FALLBACK_ADAPTER = "forma-mechanical-layout"
+
+
+class CadGenerationError(RuntimeError):
+    """Raised when a required native CAD artifact cannot be generated."""
+
+
+def _positive(value: Any, default: float) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    return number if number > 0 else default
+
+
+def _project_dimensions(project: HardwareIR) -> tuple[float, float, float]:
+    mechanical = project.mechanical
+    render_dimensions = mechanical.render_dimensions if mechanical is not None else None
+    if render_dimensions is not None:
+        return (
+            _positive(render_dimensions.x_mm, 80.0),
+            _positive(render_dimensions.y_mm, 60.0),
+            _positive(render_dimensions.z_mm, 30.0),
+        )
+
+    placements = mechanical.component_placements if mechanical is not None else []
+    if placements:
+        bounds = [
+            (
+                float(placement.position.x_mm) - abs(float(placement.size.x_mm)) / 2.0,
+                float(placement.position.x_mm) + abs(float(placement.size.x_mm)) / 2.0,
+                float(placement.position.y_mm) - abs(float(placement.size.y_mm)) / 2.0,
+                float(placement.position.y_mm) + abs(float(placement.size.y_mm)) / 2.0,
+                float(placement.position.z_mm) - abs(float(placement.size.z_mm)) / 2.0,
+                float(placement.position.z_mm) + abs(float(placement.size.z_mm)) / 2.0,
+            )
+            for placement in placements
+        ]
+        return tuple(
+            max(20.0, max(item[index + 1] for item in bounds) - min(item[index] for item in bounds) + 12.0)
+            for index in (0, 2, 4)
+        )  # type: ignore[return-value]
+
+    return 80.0, 60.0, 30.0
+
+
+def _placement_payload(project: HardwareIR) -> list[dict[str, Any]]:
+    mechanical = project.mechanical
+    if mechanical is None:
+        return []
+    return [
+        {
+            "ref_des": placement.ref_des,
+            "label": placement.label or "",
+            "category": placement.category or "",
+            "x": float(placement.position.x_mm),
+            "y": float(placement.position.y_mm),
+            "z": float(placement.position.z_mm),
+            "sx": max(1.0, abs(float(placement.size.x_mm))),
+            "sy": max(1.0, abs(float(placement.size.y_mm))),
+            "sz": max(1.0, abs(float(placement.size.z_mm))),
+        }
+        for placement in mechanical.component_placements
+    ]
+
+
+def _cad_source(project: HardwareIR) -> str:
+    width, depth, height = _project_dimensions(project)
+    mechanical = project.mechanical
+    enclosure_text = " ".join(
+        (
+            str(mechanical.physical_form if mechanical is not None else ""),
+            str(mechanical.enclosure_type if mechanical is not None else ""),
+        )
+    ).lower()
+    open_frame = "open" in enclosure_text and "enclosure" not in enclosure_text
+    wall = max(1.5, min(3.0, min(width, depth, height) / 12.0))
+    placements = json.dumps(_placement_payload(project), sort_keys=True)
+    return """from opencad import Part, Sketch
+
+
+def xy_prism(x, y, z, length, width, height, name):
+    profile = Sketch(plane="XY", origin=(0.0, 0.0, z), name=name + " profile")
+    profile.rect(length, width, origin=(x, y))
+    return Part(name=name).extrude(profile, depth=height, name=name)
+
+
+def xz_prism(x, y, z, width, height, depth, name):
+    profile = Sketch(plane="XZ", origin=(0.0, y, 0.0), name=name + " profile")
+    profile.rect(width, height, origin=(x, z))
+    return Part(name=name).extrude(profile, depth=depth, name=name)
+
+
+def yz_prism(x, y, z, width, height, depth, name):
+    profile = Sketch(plane="YZ", origin=(x, 0.0, 0.0), name=name + " profile")
+    profile.rect(width, height, origin=(y, z))
+    return Part(name=name).extrude(profile, depth=depth, name=name)
+
+
+def xz_round_prism(x, y, z, radius, depth, name):
+    profile = Sketch(plane="XZ", origin=(0.0, y, 0.0), name=name + " profile")
+    profile.circle(radius, center=(x, z))
+    return Part(name=name).extrude(profile, depth=depth, name=name)
+
+
+def clamp(value, lower, upper):
+    return max(lower, min(value, upper))
+
+
+WIDTH = %r
+DEPTH = %r
+HEIGHT = %r
+WALL = %r
+OPEN_FRAME = %r
+PLACEMENTS = %s
+
+if OPEN_FRAME:
+    model = xy_prism(-WIDTH / 2.0, -DEPTH / 2.0, -HEIGHT / 2.0, WIDTH, DEPTH, WALL, "Open frame base")
+else:
+    outer = xy_prism(-WIDTH / 2.0, -DEPTH / 2.0, -HEIGHT / 2.0, WIDTH, DEPTH, HEIGHT, "Beacon outer envelope")
+    cavity = xy_prism(
+        -WIDTH / 2.0 + WALL,
+        -DEPTH / 2.0 + WALL,
+        -HEIGHT / 2.0 + WALL,
+        WIDTH - 2.0 * WALL,
+        DEPTH - 2.0 * WALL,
+        HEIGHT,
+        "Open interior cavity",
+    )
+    model = outer.cut(cavity, name="Enclosure tray")
+
+display = next((item for item in PLACEMENTS if "display" in (item["category"] + " " + item["label"]).lower() or "oled" in item["label"].lower()), None)
+if display and not OPEN_FRAME:
+    opening_width = clamp(display["sx"], 8.0, WIDTH - 4.0 * WALL)
+    opening_height = clamp(display["sz"], 8.0, HEIGHT - 4.0 * WALL)
+    opening_x = clamp(display["x"] - opening_width / 2.0, -WIDTH / 2.0 + WALL, WIDTH / 2.0 - WALL - opening_width)
+    opening_z = clamp(display["z"] - opening_height / 2.0, -HEIGHT / 2.0 + WALL, HEIGHT / 2.0 - WALL - opening_height)
+    display_cutout = xz_prism(opening_x, -DEPTH / 2.0 - 1.0, opening_z, opening_width, opening_height, WALL + 2.0, "OLED display cutout")
+    model = model.cut(display_cutout, name="Front display opening")
+
+    bezel_width = min(WIDTH - 2.0 * WALL, opening_width + 8.0)
+    bezel_height = min(HEIGHT - 2.0 * WALL, opening_height + 8.0)
+    bezel = xz_prism(
+        display["x"] - bezel_width / 2.0,
+        -DEPTH / 2.0 - WALL - 1.0,
+        display["z"] - bezel_height / 2.0,
+        bezel_width,
+        bezel_height,
+        WALL + 1.5,
+        "OLED bezel",
+    )
+    bezel_hole = xz_prism(
+        opening_x,
+        -DEPTH / 2.0 - WALL - 2.0,
+        opening_z,
+        opening_width,
+        opening_height,
+        WALL + 4.0,
+        "OLED bezel window",
+    )
+    model = model.union(bezel.cut(bezel_hole, name="OLED bezel frame"), name="Display bezel connected")
+
+power = next((item for item in PLACEMENTS if "usb" in (item["category"] + " " + item["label"]).lower() or "power" in item["category"].lower()), None)
+if power and not OPEN_FRAME:
+    usb_width = clamp(min(power["sx"], 20.0), 8.0, WIDTH - 4.0 * WALL)
+    usb_height = clamp(min(power["sz"], 12.0), 6.0, HEIGHT - 4.0 * WALL)
+    usb_x = clamp(power["x"] - usb_width / 2.0, -WIDTH / 2.0 + WALL, WIDTH / 2.0 - WALL - usb_width)
+    usb_z = clamp(power["z"] - usb_height / 2.0, -HEIGHT / 2.0 + WALL, HEIGHT / 2.0 - WALL - usb_height)
+    usb_cutout = xz_prism(usb_x, DEPTH / 2.0 - 1.0, usb_z, usb_width, usb_height, WALL + 2.0, "USB entry cutout")
+    model = model.cut(usb_cutout, name="Rear USB opening")
+
+sensors = [item for item in PLACEMENTS if "sensor" in (item["category"] + " " + item["label"]).lower()]
+if sensors and not OPEN_FRAME:
+    for side, side_x in (("left", -WIDTH / 2.0 - 1.0), ("right", WIDTH / 2.0 - WALL + 1.0)):
+        for slot_index, slot_y in enumerate((-DEPTH * 0.30, -DEPTH * 0.10, DEPTH * 0.10, DEPTH * 0.30), start=1):
+            vent = yz_prism(side_x, slot_y - DEPTH * 0.045, 0.0, DEPTH * 0.09, 2.5, WALL + 2.0, side + " vent " + str(slot_index))
+            model = model.cut(vent, name=side.title() + " ventilation slot " + str(slot_index))
+
+led = next((item for item in PLACEMENTS if "led" in (item["category"] + " " + item["label"]).lower() or "rgb" in item["label"].lower()), None)
+if led and not OPEN_FRAME:
+    light = xz_round_prism(led["x"], -DEPTH / 2.0 - 1.0, led["z"], min(4.0, led["sx"] / 2.0), WALL + 2.0, "Status light opening")
+    model = model.cut(light, name="Status light cutout")
+
+for item in PLACEMENTS:
+    if "enclosure" in (item["category"] + " " + item["label"]).lower():
+        continue
+    rail_width = clamp(item["sx"], 8.0, WIDTH - 2.0 * WALL)
+    rail_depth = clamp(min(item["sy"], 4.0), 2.0, DEPTH - 2.0 * WALL)
+    rail_x = clamp(item["x"] - rail_width / 2.0, -WIDTH / 2.0 + WALL, WIDTH / 2.0 - WALL - rail_width)
+    rail_y = clamp(item["y"] - rail_depth / 2.0, -DEPTH / 2.0 + WALL, DEPTH / 2.0 - WALL - rail_depth)
+    rail = xy_prism(rail_x, rail_y, -HEIGHT / 2.0 - 0.5, rail_width, rail_depth, max(2.0, min(item["sz"] / 2.0, HEIGHT / 3.0)), item["ref_des"] + " mounting rail")
+    model = model.union(rail, name=item["ref_des"] + " rail connected")
+
+model
+""" % (width, depth, height, wall, open_frame, placements)
+
+
+def _adapter_path() -> Path:
+    configured = config.optional("FORMA_CAD_ADAPTER_PATH")
+    candidates = [Path(configured)] if configured else []
+    candidates.extend(
+        (
+            Path(__file__).resolve().parents[3] / CAD_ADAPTER_RELATIVE_PATH,
+            Path.cwd() / CAD_ADAPTER_RELATIVE_PATH,
+        )
+    )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate.resolve()
+    raise CadGenerationError(
+        "The Forma OpenCAD adapter is unavailable. Install the hardware skill or set "
+        "FORMA_CAD_ADAPTER_PATH to its cad.py script."
+    )
+
+
+def _cad_workspace(project_id: str | None) -> Path:
+    root = Path(config.optional("FORMA_CAD_WORKSPACE") or (Path.home() / "forma-workspace")).expanduser()
+    root.mkdir(parents=True, exist_ok=True)
+    project_key = "".join(
+        character if character.isalnum() or character in {"-", "_"} else "_"
+        for character in str(project_id or uuid4())
+    ).strip("._") or str(uuid4())
+    project_root = root / project_key / "cad"
+    project_root.mkdir(parents=True, exist_ok=True)
+    (project_root / "outputs").mkdir(exist_ok=True)
+    return project_root
+
+
+def _run_adapter(adapter: Path, model: Path, output: Path, tree: Path | None = None) -> dict[str, Any]:
+    command = [sys.executable, str(adapter), "build", str(model), str(output), "--force"]
+    if tree is not None:
+        command.extend(("--tree-output", str(tree)))
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=config.number("FORMA_CAD_TIMEOUT_SECONDS", 900.0),
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise CadGenerationError(f"OpenCAD generation could not complete: {exc}") from exc
+    try:
+        payload = json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        detail = (completed.stderr or completed.stdout or "unknown OpenCAD error").strip()
+        if completed.returncode != 0:
+            raise CadGenerationError(f"OpenCAD generation failed: {detail[-1200:]}") from exc
+        raise CadGenerationError("OpenCAD adapter returned invalid build metadata.") from exc
+    if not isinstance(payload, dict) or not payload.get("valid"):
+        raise CadGenerationError("OpenCAD adapter did not return a valid CAD artifact.")
+    if completed.returncode != 0 and not output.is_file():
+        detail = (completed.stderr or completed.stdout or "unknown OpenCAD error").strip()
+        raise CadGenerationError(f"OpenCAD generation failed: {detail[-1200:]}")
+    return payload
+
+
+def _stl_mesh(path: Path) -> dict[str, Any]:
+    data = path.read_bytes()
+    vertices: list[float] = []
+    faces: list[int] = []
+    vertex_ids: dict[tuple[float, float, float], int] = {}
+
+    def add_triangle(points: list[tuple[float, float, float]]) -> None:
+        if len(points) != 3:
+            return
+        face = []
+        for point in points:
+            vertex_id = vertex_ids.setdefault(point, len(vertices) // 3)
+            if vertex_id == len(vertices) // 3:
+                vertices.extend(point)
+            face.append(vertex_id)
+        faces.extend(face)
+
+    binary_count = int.from_bytes(data[80:84], "little") if len(data) >= 84 else -1
+    if binary_count >= 0 and 84 + binary_count * 50 == len(data):
+        for index in range(binary_count):
+            offset = 84 + index * 50 + 12
+            add_triangle([struct.unpack_from("<3f", data, offset + point * 12) for point in range(3)])
+    else:
+        points: list[tuple[float, float, float]] = []
+        for line in data.decode("ascii", errors="replace").splitlines():
+            fields = line.strip().split()
+            if len(fields) == 4 and fields[0].lower() == "vertex":
+                points.append(tuple(float(value) for value in fields[1:4]))
+                if len(points) == 3:
+                    add_triangle(points)
+                    points = []
+    if not faces:
+        raise CadGenerationError("OpenCAD STL preview contains no triangles.")
+    return {
+        "shapeId": "native-cad-model",
+        "name": "Forma OpenCAD model",
+        "vertices": vertices,
+        "faces": faces,
+    }
+
+
+def _has_authoritative_cad(value: Any) -> bool:
+    if value in (None, "", {}):
+        return False
+    if not isinstance(value, dict):
+        return True
+    adapter = str(value.get("adapter") or "").strip().lower()
+    return adapter not in {PLACEMENT_FALLBACK_ADAPTER, "forma-test-tube-preview"}
+
+
+def _cad_is_applicable(project: HardwareIR) -> bool:
+    if project.mechanical is None:
+        return False
+    return bool(project.mechanical.component_placements or project.components or project.mechanical.render_dimensions)
+
+
+def _set_cad_status(project: HardwareIR, *, status: str, required: bool, error: str | None = None) -> None:
+    metadata = dict(project.assembly_metadata or {})
+    cad = project.cad_model if isinstance(project.cad_model, dict) else {}
+    record: dict[str, Any] = {
+        "adapter": str(cad.get("adapter") or CAD_ADAPTER_NAME),
+        "status": status,
+        "required": required,
+    }
+    if error:
+        record["error"] = error[:500]
+    metadata["cad_generation"] = record
+    project.assembly_metadata = metadata
+
+
+def ensure_native_cad_model(
+    project: HardwareIR,
+    *,
+    project_id: str | None,
+    required: bool,
+    authoring_agent: str | None = None,
+    workflow: str | None = None,
+) -> bool:
+    """Generate native CAD when requested, preserving legacy optional behavior."""
+    if _has_authoritative_cad(project.cad_model):
+        _set_cad_status(project, status="provided", required=required)
+        return False
+    if not _cad_is_applicable(project):
+        _set_cad_status(project, status="not_applicable", required=required)
+        return False
+
+    if workflow:
+        from forma_core.agents.pipeline import emit_agent_pipeline_event
+
+        emit_agent_pipeline_event(workflow, "cad_generation", "started", details={"required": required})
+    try:
+        root = _cad_workspace(project_id)
+        model_path = root / "assembly.py"
+        step_path = root / "outputs" / "assembly.step"
+        stl_path = root / "outputs" / "assembly.stl"
+        tree_path = root / "outputs" / "assembly.tree.json"
+        model_path.write_text(_cad_source(project), encoding="utf-8")
+        adapter = _adapter_path()
+        step_summary = _run_adapter(adapter, model_path, step_path, tree_path)
+        _run_adapter(adapter, model_path, stl_path)
+        step_bytes = step_path.read_bytes()
+        checksum = hashlib.sha256(step_bytes).hexdigest()
+        project.cad_model = {
+            "adapter": CAD_ADAPTER_NAME,
+            "source": "Native OpenCAD generated from agent-authored HardwareIR",
+            "authoring_agent": authoring_agent,
+            "authoring_mode": "hardware-ir-to-opencad",
+            "generated": True,
+            "format": "step",
+            "units": "mm",
+            "filename": step_path.name,
+            "path": str(step_path),
+            "bytes": len(step_bytes),
+            "sha256": checksum,
+            "preview_filename": stl_path.name,
+            "preview_path": str(stl_path),
+            "model_source_path": str(model_path),
+            "feature_tree_path": str(tree_path),
+            "opencad_version": step_summary.get("opencad_version"),
+            "meshes": [_stl_mesh(stl_path)],
+        }
+        _set_cad_status(project, status="succeeded", required=required)
+        if workflow:
+            from forma_core.agents.pipeline import emit_agent_pipeline_event
+
+            emit_agent_pipeline_event(
+                workflow,
+                "cad_generation",
+                "completed",
+                details={"adapter": CAD_ADAPTER_NAME, "format": "step", "bytes": len(step_bytes)},
+            )
+        return True
+    except Exception as exc:
+        _set_cad_status(project, status="failed", required=required, error=str(exc))
+        if workflow:
+            from forma_core.agents.pipeline import emit_agent_pipeline_event
+
+            emit_agent_pipeline_event(
+                workflow,
+                "cad_generation",
+                "failed" if required else "skipped",
+                details={"required": required, "error": str(exc)[:500]},
+            )
+        if required:
+            if isinstance(exc, CadGenerationError):
+                raise
+            raise CadGenerationError(str(exc)) from exc
+        return False
+
+
+def cad_project_artifact(project: HardwareIR, project_id: str) -> ProjectArtifact | None:
+    """Return the canonical revision artifact for a generated CAD model."""
+    cad = project.cad_model
+    if not isinstance(cad, dict) or str(cad.get("adapter") or "").strip().lower() != CAD_ADAPTER_NAME:
+        return None
+    checksum = str(cad.get("sha256") or "").strip()
+    return ProjectArtifact(
+        artifact_id="native-cad-model",
+        kind="cad",
+        uri=f"forma://projects/{project_id}/cad/assembly.step",
+        media_type="model/step",
+        checksum=f"sha256:{checksum}" if checksum and not checksum.startswith("sha256:") else checksum or None,
+        metadata={
+            "adapter": CAD_ADAPTER_NAME,
+            "preview_path": cad.get("preview_path"),
+            "model_source_path": cad.get("model_source_path"),
+            "feature_tree_path": cad.get("feature_tree_path"),
+            "format": cad.get("format", "step"),
+        },
+    )
+
+
+__all__ = [
+    "CAD_ADAPTER_NAME",
+    "CadGenerationError",
+    "cad_project_artifact",
+    "ensure_native_cad_model",
+]

--- a/tests/projects/test_cad_generation.py
+++ b/tests/projects/test_cad_generation.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from forma_core.config import config
+from forma_core.workspaces.projects.cad_generation import (
+    CadGenerationError,
+    _cad_source,
+    cad_project_artifact,
+    ensure_native_cad_model,
+)
+from forma_core.workspaces.projects.models import (
+    ComponentInstance,
+    HardwareIR,
+    MechanicalNotes,
+    MechanicalPlacement,
+    MechanicalVector3,
+)
+
+
+def mechanical_project() -> HardwareIR:
+    return HardwareIR(
+        mechanical=MechanicalNotes(
+            enclosure_type="Open frame",
+            mounting_guidance="Use a flat base plate.",
+            manufacturability_rating="Easy",
+            render_dimensions=MechanicalVector3(x_mm=80, y_mm=60, z_mm=30),
+        )
+    )
+
+
+def complex_mechanical_project() -> HardwareIR:
+    placements = [
+        MechanicalPlacement(
+            ref_des=f"U{index}",
+            label=f"Module {index}",
+            category="Controller" if index % 4 == 0 else "Power",
+            position=MechanicalVector3(
+                x_mm=-55 + (index % 4) * 36,
+                y_mm=-25 + (index // 4) * 18,
+                z_mm=-14 + (index % 3) * 12,
+            ),
+            size=MechanicalVector3(
+                x_mm=18 + (index % 3) * 7,
+                y_mm=12 + (index % 2) * 5,
+                z_mm=8 + (index % 4) * 3,
+            ),
+        )
+        for index in range(1, 17)
+    ]
+    placements.extend([
+        MechanicalPlacement(
+            ref_des="DISP1",
+            label="OLED 2.8 inch display",
+            category="Display",
+            position=MechanicalVector3(x_mm=0, y_mm=-48, z_mm=4),
+            size=MechanicalVector3(x_mm=48, y_mm=5, z_mm=28),
+        ),
+        MechanicalPlacement(
+            ref_des="PWR1",
+            label="USB-C rear power input",
+            category="Power",
+            position=MechanicalVector3(x_mm=0, y_mm=48, z_mm=-3),
+            size=MechanicalVector3(x_mm=16, y_mm=8, z_mm=10),
+        ),
+        *[
+            MechanicalPlacement(
+                ref_des=f"SEN{index}",
+                label=f"{label} sensor",
+                category="Sensor",
+                position=MechanicalVector3(x_mm=-42 + (index - 1) * 28, y_mm=0, z_mm=12),
+                size=MechanicalVector3(x_mm=18, y_mm=14, z_mm=8),
+            )
+            for index, label in enumerate(("Air quality", "Temperature", "Humidity", "Pressure"), start=1)
+        ],
+        MechanicalPlacement(
+            ref_des="LED1",
+            label="RGB status LED",
+            category="Indicator",
+            position=MechanicalVector3(x_mm=52, y_mm=-48, z_mm=-12),
+            size=MechanicalVector3(x_mm=8, y_mm=4, z_mm=8),
+        ),
+        MechanicalPlacement(
+            ref_des="ENC1",
+            label="Outer enclosure",
+            category="Enclosure",
+            position=MechanicalVector3(x_mm=0, y_mm=0, z_mm=0),
+            size=MechanicalVector3(x_mm=160, y_mm=110, z_mm=50),
+        ),
+    ])
+    components = [
+        ComponentInstance(
+            ref_des=placement.ref_des,
+            part_number=f"STRESS-{placement.ref_des}",
+            name=placement.label or placement.ref_des,
+            category=placement.category or "Mechanical",
+            rationale="Complex CAD stress fixture component",
+        )
+        for placement in placements
+    ]
+    return HardwareIR(
+        components=components,
+        mechanical=MechanicalNotes(
+            physical_form="Curved desktop instrument enclosure",
+            enclosure_type="3D printed enclosure",
+            mounting_guidance="Use internal rails and serviceable rear access.",
+            fabrication_details=[
+                "Print shell in two halves with internal rails.",
+                "Keep sensor vents open on both side walls.",
+            ],
+            manufacturability_rating="Moderate",
+            render_dimensions=MechanicalVector3(x_mm=160, y_mm=110, z_mm=50),
+            component_placements=placements,
+        ),
+    )
+
+
+class CadGenerationTests(unittest.TestCase):
+    def test_required_generation_publishes_native_model_and_revision_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as workspace:
+            def fake_run(_adapter: Path, _model: Path, output: Path, tree: Path | None = None) -> dict:
+                if output.suffix == ".step":
+                    output.write_bytes(b"ISO-10303-21;HEADER;ENDSEC;DATA;ENDSEC;END-ISO-10303-21;")
+                else:
+                    output.write_text(
+                        "solid model\n"
+                        "facet normal 0 0 1\n"
+                        "outer loop\n"
+                        "vertex 0 0 0\n"
+                        "vertex 1 0 0\n"
+                        "vertex 0 1 0\n"
+                        "endloop\nendfacet\nendsolid model\n",
+                        encoding="ascii",
+                    )
+                if tree is not None:
+                    tree.write_text("{}", encoding="utf-8")
+                return {"valid": True, "opencad_version": "0.2.3"}
+
+            project = mechanical_project()
+            with patch.dict("os.environ", {"FORMA_CAD_WORKSPACE": workspace}, clear=False), patch(
+                "forma_core.workspaces.projects.cad_generation._adapter_path",
+                return_value=Path(__file__),
+            ), patch(
+                "forma_core.workspaces.projects.cad_generation._run_adapter",
+                side_effect=fake_run,
+            ):
+                self.assertTrue(ensure_native_cad_model(
+                    project,
+                    project_id="11111111-1111-4111-8111-111111111111",
+                    required=True,
+                ))
+
+            self.assertEqual("forma-opencad", project.cad_model["adapter"])
+            self.assertEqual("succeeded", project.assembly_metadata["cad_generation"]["status"])
+            artifact = cad_project_artifact(project, "11111111-1111-4111-8111-111111111111")
+            self.assertIsNotNone(artifact)
+            self.assertEqual("model/step", artifact.media_type)
+            self.assertTrue(artifact.checksum.startswith("sha256:"))
+
+    def test_legacy_generation_failure_is_best_effort(self) -> None:
+        project = mechanical_project()
+        with patch(
+            "forma_core.workspaces.projects.cad_generation._adapter_path",
+            side_effect=CadGenerationError("adapter unavailable"),
+        ):
+            self.assertFalse(ensure_native_cad_model(
+                project,
+                project_id="22222222-2222-4222-8222-222222222222",
+                required=False,
+            ))
+
+        self.assertEqual("failed", project.assembly_metadata["cad_generation"]["status"])
+        self.assertFalse(project.cad_model)
+
+    def test_new_generation_failure_is_reported_as_required(self) -> None:
+        project = mechanical_project()
+        with patch(
+            "forma_core.workspaces.projects.cad_generation._adapter_path",
+            side_effect=CadGenerationError("adapter unavailable"),
+        ):
+            with self.assertRaises(CadGenerationError):
+                ensure_native_cad_model(
+                    project,
+                    project_id="33333333-3333-4333-8333-333333333333",
+                    required=True,
+                )
+
+        self.assertEqual("failed", project.assembly_metadata["cad_generation"]["status"])
+
+    def test_complex_mechanical_source_covers_cutouts_vents_and_mounting_rails(self) -> None:
+        source = _cad_source(complex_mechanical_project())
+
+        self.assertEqual(24, source.count('"ref_des":'))
+        for feature in (
+            "Front display opening",
+            "OLED bezel",
+            "Rear USB opening",
+            "ventilation slot",
+            "Status light cutout",
+            "mounting rail",
+        ):
+            self.assertIn(feature, source)
+
+    @unittest.skipUnless(
+        config.boolean("FORMA_CAD_RUN_INTEGRATION_TESTS"),
+        "Set FORMA_CAD_RUN_INTEGRATION_TESTS=true to run native OpenCAD integration tests.",
+    )
+    def test_complex_mechanical_model_exports_with_native_opencad(self) -> None:
+        with tempfile.TemporaryDirectory() as workspace:
+            with patch.dict("os.environ", {"FORMA_CAD_WORKSPACE": workspace}, clear=False):
+                project = complex_mechanical_project()
+                self.assertTrue(ensure_native_cad_model(
+                    project,
+                    project_id="77777777-7777-4777-8777-777777777777",
+                    required=True,
+                    authoring_agent="OpenCAD stress fixture",
+                ))
+
+        self.assertEqual("forma-opencad", project.cad_model["adapter"])
+        self.assertGreater(project.cad_model["bytes"], 500_000)
+        self.assertGreater(len(project.cad_model["meshes"][0]["faces"]), 900)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Generate native STEP/STL OpenCAD artifacts from agent-authored HardwareIR for new projects.
- Persist canonical CAD revision artifacts and expose native CAD or mechanical fallback data in the workspace.
- Add a complex mechanical regression fixture covering enclosure cutouts, vents, display bezel, status light, and mounting rails.
- Preserve best-effort CAD behavior for legacy projects.

## Validation
- 24 focused Python tests passed, including the real OpenCAD integration export.
- 5 frontend CAD tests passed with Node 24 TypeScript stripping.
- 
pm run lint passed with existing image warnings.
- 
pm run build passed.
- Python compileall and git diff --check passed.

Closes #357