### PR TITLE
fix: make native CAD optional and keep hosted CLI projects visible

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,10 @@ python -m forma_core --help
 **Forma OSS CLI:**
 
 The first-party `forma-oss` CLI is local-first. `init`, `build`, `status`, and
-validation work without an account or network connection. Cloud operations are
-always explicit; provider credentials are excluded from project uploads.
+validation work without an account or network connection. Cloud operations target
+the hosted Forma deployment by default; set `FORMA_API_URL` to a local API URL when
+developing against a local server. Provider credentials are excluded from project
+uploads.
 
 ```bash
 forma-oss --help

--- a/apps/api/a2a.py
+++ b/apps/api/a2a.py
@@ -898,8 +898,7 @@ def build_generation_response(
         raise ValueError("Provide a prompt or reference image.")
     if not has_prompt:
         prompt_text = "Infer a buildable hardware project from the uploaded reference image."
-    existing_project_for_cad = get_generated_project(project_id) if project_id else None
-    cad_required = existing_project_for_cad is None
+    cad_required = False
     normalized_data_sources = normalize_generation_data_sources(data_sources)
     context_requested = PAST_JOBS_DATA_SOURCE in normalized_data_sources
     resolved_past_job_context = past_job_context or PastJobContext(
@@ -1892,15 +1891,13 @@ async def _call_mcp_tool(
             )
         except (TypeError, ValueError, AttributeError) as exc:
             raise ValueError("project_id must be a UUID when supplied.") from exc
-        existing_project = get_generated_project(compile_project_id, include_deleted=True)
-        if existing_project is None:
-            ensure_native_cad_model(
-                project,
-                project_id=compile_project_id,
-                required=True,
-                authoring_agent=arguments.get("authoring_agent"),
-                workflow="default",
-            )
+        ensure_native_cad_model(
+            project,
+            project_id=compile_project_id,
+            required=False,
+            authoring_agent=arguments.get("authoring_agent"),
+            workflow="default",
+        )
         persistence = _persist_mcp_compile(
             project,
             {**arguments, "project_id": compile_project_id},

--- a/apps/api/cli_auth_api.py
+++ b/apps/api/cli_auth_api.py
@@ -41,30 +41,55 @@ class RefreshTokenRequest(BaseModel):
     refresh_token: str = Field(min_length=1, max_length=500)
 
 
-def _web_url() -> str:
-    return (
+def _configured_web_url() -> Optional[str]:
+    value = (
         config.optional("FORMA_WEB_URL")
         or config.optional("NEXT_PUBLIC_APP_URL")
         or config.optional("FRONTEND_URL")
-        or "http://127.0.0.1:3000"
-    ).rstrip("/")
+    )
+    return value.rstrip("/") if value else None
 
 
-def _api_url() -> str:
-    return (
-        config.optional("FORMA_API_URL")
-        or config.optional("NEXT_PUBLIC_API_URL")
-        or "http://127.0.0.1:8000"
-    ).rstrip("/")
+def _request_origin(request: Request) -> Optional[str]:
+    host = (request.headers.get("x-forwarded-host") or request.headers.get("host") or "").split(",", 1)[0].strip()
+    if not host:
+        return None
+    scheme = (request.headers.get("x-forwarded-proto") or request.url.scheme).split(",", 1)[0].strip()
+    return f"{scheme}://{host}".rstrip("/")
+
+
+def _web_url(request: Optional[Request] = None) -> str:
+    configured = _configured_web_url()
+    if configured:
+        return configured
+    if request is not None and (config.optional("FORMA_DEPLOYMENT_MODE") or "local").lower() == "hosted":
+        origin = _request_origin(request)
+        if origin:
+            return origin
+    return "http://127.0.0.1:3000"
+
+
+def _api_url(request: Optional[Request] = None) -> str:
+    configured = config.optional("FORMA_API_URL") or config.optional("NEXT_PUBLIC_API_URL")
+    if configured:
+        return configured.rstrip("/")
+    if request is not None and (config.optional("FORMA_DEPLOYMENT_MODE") or "local").lower() == "hosted":
+        origin = _request_origin(request)
+        if origin:
+            return f"{origin}/api"
+    return "http://127.0.0.1:8000"
 
 
 @router.post("/device/authorize")
-def authorize_device(request: DeviceAuthorizationRequest) -> dict[str, object]:
+def authorize_device(
+    request: DeviceAuthorizationRequest,
+    http_request: Request,
+) -> dict[str, object]:
     session = create_device_session()
     return {
         "device_code": session.device_code,
         "user_code": session.user_code,
-        "verification_uri": f"{_web_url()}/cli/authorize?code={session.user_code}",
+        "verification_uri": f"{_web_url(http_request)}/cli/authorize?code={session.user_code}",
         "expires_in": max(1, round(session.expires_at - time.time())),
         "interval": 5,
         "client_name": request.client_name,
@@ -152,14 +177,17 @@ async def revoke_token(request: Request, body: Optional[RefreshTokenRequest] = N
 
 
 @router.get("/whoami")
-async def cli_whoami(user: UserContext = Depends(require_user_context)) -> dict[str, object]:
+async def cli_whoami(
+    request: Request,
+    user: UserContext = Depends(require_user_context),
+) -> dict[str, object]:
     claims = user.claims
     return {
         "subject": user.owner_user_id or user.subject or "unknown",
         "provider": user.provider,
         "email": claims.get("email") if isinstance(claims.get("email"), str) else None,
         "display_name": claims.get("name") if isinstance(claims.get("name"), str) else None,
-        "api_url": _api_url(),
+        "api_url": _api_url(request),
     }
 
 

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -79,6 +79,7 @@ from forma_core.database import (
     delete_generated_project,
     delete_project_chat,
     ensure_project_action_allowed,
+    get_cli_project_revision,
     get_database_config,
     get_generated_project,
     get_latest_design_brief,
@@ -118,6 +119,7 @@ from forma_core.workspaces.projects.models import (
     ProjectContributionConsentRequest, ProjectUpdateRequest, ValidationIssue, ValidationReport, VideoSelfCorrectRequest,
 )
 from forma_core.workspaces.projects import ProjectStateError
+from forma_core.workspaces.projects.manifest import ProjectManifest
 from forma_core.workspaces.workflow import WorkflowStateError
 from forma_core.signups.models import AlphaSignupRequest, AlphaSignupResponse
 from forma_core.agents.orchestrator import HardwarePipelineOrchestrator
@@ -1924,6 +1926,58 @@ def _without_downloadable_project_assets(hardware_ir: Dict[str, Any]) -> Dict[st
     return sanitized
 
 
+def _cli_project_response(project_id: str, owner_user_id: str) -> Optional[Dict[str, Any]]:
+    """Adapt an authenticated CLI revision to the web project's response shape."""
+    revision = get_cli_project_revision(project_id, owner_user_id)
+    if revision is None:
+        return None
+
+    manifest = ProjectManifest.from_document(revision.get("manifest") or {})
+    project_ir = json.loads(json.dumps(manifest.project_ir))
+    metadata = project_ir.get("assembly_metadata")
+    metadata = dict(metadata) if isinstance(metadata, dict) else {}
+    metadata.update(
+        {
+            "project_id": str(revision["project_id"]),
+            "chat_id": None,
+            "can_chat": False,
+            "project_revision": revision.get("revision"),
+            "cloud_revision_id": revision.get("revision_id"),
+            "source_prompt": manifest.prompt,
+            "project_source": "cli",
+        }
+    )
+    project_ir["assembly_metadata"] = metadata
+
+    project_object = None
+    mermaid_code = None
+    svg_schematic = None
+    try:
+        typed_ir = HardwareIR.model_validate(project_ir)
+        project_ir = typed_ir.model_dump(mode="json")
+        project_object = build_project_object(typed_ir).model_dump(mode="json")
+        mermaid_code = generate_mermaid_chart(typed_ir)
+        svg_schematic = generate_svg_schematic(typed_ir)
+    except ValidationError:
+        # Keep older CLI manifests inspectable even if they predate HardwareIR.
+        pass
+
+    return {
+        "project_id": str(revision["project_id"]),
+        "chat_id": None,
+        "prompt": manifest.prompt,
+        "created_at": revision.get("created_at"),
+        "can_chat": False,
+        "project_ir": project_ir,
+        "project_object": project_object,
+        "mermaid_code": mermaid_code,
+        "svg_schematic": svg_schematic,
+        "generation_status": metadata.get("generation_status", "succeeded"),
+        "project_readiness": metadata.get("project_readiness", "complete"),
+        "generation_stages": (metadata.get("generation_run") or {}).get("records", {}),
+    }
+
+
 @app.get("/projects")
 def list_projects_endpoint(
     user: UserContext = Depends(optional_user_context),
@@ -2067,6 +2121,9 @@ def get_project_endpoint(project_id: str, user: UserContext = Depends(optional_u
             revision = get_latest_project_revision(project_id, owner_user_id)
             brief = get_latest_design_brief(project_id, owner_user_id)
         except (ProjectStateError, DesignBriefNotFoundError) as exc:
+            cli_response = _cli_project_response(project_id, owner_user_id)
+            if cli_response is not None:
+                return cli_response
             raise HTTPException(status_code=404, detail="Project not found.") from exc
         ir = revision.state.model_copy(deep=True)
         ir.assembly_metadata = {

--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -76,7 +76,7 @@ import {
   type ProjectGalleryItem,
 } from "./forma-workspace/project-gallery";
 import CadModelPanel from "./forma-workspace/cad-model-panel";
-import { projectCadModel, projectHasMechanicalPreview } from "../lib/cad-model";
+import { projectCadModel, resolveCadModel } from "../lib/cad-model";
 import { FormaProjectBrowser, type FormaProjectSummary } from "@isayahc/forma-gui";
 import {
   AssemblyPanel,
@@ -1713,6 +1713,9 @@ export function FormaWorkspace({
   const [activeGeneration, setActiveGeneration] = useState<ActiveGenerationState | null>(null);
   const [activeTab, setActiveTab] = useState("overview");
   const [projectIR, setProjectIR] = useState<any>(null);
+  const currentCadModel = projectCadModel(projectIR);
+  const currentCadDescriptor = resolveCadModel(currentCadModel);
+  const hasRenderableCadModel = Boolean(currentCadDescriptor && currentCadDescriptor.kind !== "unsupported");
   const [projectHistory, setProjectHistory] = useState<any[]>([]);
   const [myProjectHistory, setMyProjectHistory] = useState<any[]>([]);
   const [projectHistoryPage, setProjectHistoryPage] = useState(0);
@@ -3012,8 +3015,10 @@ export function FormaWorkspace({
 
 
   useEffect(() => {
-    if (!normalizeTab(activeTab)) setActiveTab("overview");
-  }, [activeTab]);
+    if (!normalizeTab(activeTab) || (activeTab === "cad" && !hasRenderableCadModel)) {
+      setActiveTab("overview");
+    }
+  }, [activeTab, hasRenderableCadModel]);
 
 
   useEffect(() => {
@@ -5019,11 +5024,12 @@ export function FormaWorkspace({
     return false;
   });
   const visibleWorkspaceTabs = useMemo(
-    () => workspaceTabs,
-    []
+    () => hasRenderableCadModel ? workspaceTabs : workspaceTabs.filter((item) => item.id !== "cad"),
+    [hasRenderableCadModel]
   );
-  const activeWorkspaceTab = workspaceTabMeta(activeTab);
-  const activeWorkspaceNamespace = workspaceNamespaceForTab(activeTab);
+  const effectiveActiveTab = activeTab === "cad" && !hasRenderableCadModel ? "overview" : activeTab;
+  const activeWorkspaceTab = workspaceTabMeta(effectiveActiveTab);
+  const activeWorkspaceNamespace = workspaceNamespaceForTab(effectiveActiveTab);
   const displayedWorkspaceNamespace = activeWorkspaceNamespace;
   const projectNamespaceContent = (() => {
     switch (activeWorkspaceTab.id) {
@@ -5065,22 +5071,7 @@ export function FormaWorkspace({
           />
         );
       case "cad": {
-        const cadModel = projectCadModel(projectIR);
-        if (!cadModel && projectHasMechanicalPreview(projectIR)) {
-          return (
-            <MechanicalPanel
-              toggles={mechToggles}
-              setToggles={setMechToggles}
-              electricalActive={mechElectricalActive}
-              setElectricalActive={setMechElectricalActive}
-              components={components}
-              features={imageFeatures}
-              metadata={projectIR?.assembly_metadata || {}}
-              mechanical={projectIR?.mechanical || {}}
-            />
-          );
-        }
-        return <CadModelPanel cadModel={cadModel} />;
+        return <CadModelPanel cadModel={currentCadModel} />;
       }
       case "schematic":
         return <SchematicCanvas project={schematicProject} />;

--- a/apps/web/lib/cad-model.ts
+++ b/apps/web/lib/cad-model.ts
@@ -203,16 +203,7 @@ function sourceDescriptor(value: unknown): CadModelDescriptor {
 
 export function projectCadModel(project: unknown): unknown {
   const record = asRecord(project);
-  if (!record) return null;
-  const mechanical = asRecord(record.mechanical);
-  const metadata = asRecord(record.assembly_metadata);
-  return record.cad_model ?? mechanical?.cad_model ?? metadata?.cad_model ?? null;
-}
-
-export function projectHasMechanicalPreview(project: unknown): boolean {
-  const record = asRecord(project);
-  const mechanical = asRecord(record?.mechanical);
-  return Array.isArray(mechanical?.component_placements) && mechanical.component_placements.length > 0;
+  return record?.cad_model ?? null;
 }
 
 export function resolveCadModel(value: unknown): CadModelDescriptor | null {

--- a/apps/web/test/cad-model.test.ts
+++ b/apps/web/test/cad-model.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 
-import { projectCadModel, projectHasMechanicalPreview, resolveCadModel } from "../lib/cad-model.ts";
+import { projectCadModel, resolveCadModel } from "../lib/cad-model.ts";
 
 const mesh = {
   shapeId: "body",
@@ -9,16 +9,17 @@ const mesh = {
   faces: [0, 1, 2],
 };
 
-test("project CAD models can be read from the canonical or mechanical payload", () => {
+test("project CAD models are read from the canonical payload", () => {
   assert.equal(projectCadModel({ cad_model: "body.step" }), "body.step");
-  assert.deepEqual(projectCadModel({ mechanical: { cad_model: { shape_id: "body" } } }), { shape_id: "body" });
-  assert.equal(projectCadModel({ assembly_metadata: { cad_model: "legacy.step" } }), "legacy.step");
+  assert.equal(projectCadModel({ mechanical: { cad_model: { shape_id: "body" } } }), null);
+  assert.equal(projectCadModel({ assembly_metadata: { cad_model: "legacy.step" } }), null);
 });
 
-test("mechanical placements provide a CAD-tab fallback when no native model is attached", () => {
-  assert.equal(projectHasMechanicalPreview({ mechanical: { component_placements: [{ ref_des: "U1" }] } }), true);
-  assert.equal(projectHasMechanicalPreview({ mechanical: { component_placements: [] } }), false);
-  assert.equal(projectHasMechanicalPreview({ mechanical: null }), false);
+test("mechanical placements do not resolve into a CAD model", () => {
+  const project = { mechanical: { component_placements: [{ ref_des: "U1" }] } };
+
+  assert.equal(projectCadModel(project), null);
+  assert.equal(resolveCadModel(projectCadModel(project)), null);
 });
 
 test("renderable adapter meshes normalize into a viewport payload", () => {

--- a/forma_cli/app.py
+++ b/forma_cli/app.py
@@ -369,7 +369,7 @@ def build_parser() -> argparse.ArgumentParser:
     build.add_argument("--simulation", action="store_true")
     build.add_argument(
         "--assembly-step",
-        help="Optional native STEP file; otherwise assembly.step is generated from the project layout.",
+        help="Optional native STEP file to attach to the project.",
     )
     build.set_defaults(func=cmd_build)
     imported = subparsers.add_parser(

--- a/forma_cli/config.py
+++ b/forma_cli/config.py
@@ -9,7 +9,9 @@ import tomllib
 from typing import Any
 
 
-DEFAULT_API_URL = "http://127.0.0.1:8000"
+# Cloud CLI commands target the hosted Forma deployment by default. Set
+# FORMA_API_URL to a local API URL when developing against a local server.
+DEFAULT_API_URL = "https://caid-technologies.us/api"
 CONFIG_FILENAME = "config.json"
 LINKAGE_FILENAME = "project.toml"
 

--- a/forma_cli/local.py
+++ b/forma_cli/local.py
@@ -121,32 +121,9 @@ def _resolve_assembly_step_source(root: Path, requested: str | Path | None) -> P
     return source
 
 
-def _generated_assembly_step_text(project: Any) -> str:
-    overview = getattr(project, "overview", None)
-    title = str(getattr(overview, "title", None) or "Forma assembly").replace("'", "''")
-    component_count = len(getattr(project, "components", []) or [])
-    return "\n".join(
-        (
-            "ISO-10303-21;",
-            "HEADER;",
-            "FILE_DESCRIPTION(('Forma generated assembly'),'2;1');",
-            f"FILE_NAME('assembly.step','2026-08-30T00:00:00',('Forma'),('CAID'),'{title}','Forma CLI','');",
-            "FILE_SCHEMA(('CONFIG_CONTROL_DESIGN'));",
-            "ENDSEC;",
-            "DATA;",
-            f"/* {title} / {component_count} HardwareIR components / placement-envelope preview */",
-            "ENDSEC;",
-            "END-ISO-10303-21;",
-            "",
-        )
-    )
-
-
-def _prepare_assembly_step(root: Path, source: Path | None, project: Any) -> Path:
+def _prepare_assembly_step(root: Path, source: Path | None) -> Path | None:
     if source is None:
-        destination = (root / "assembly.step").resolve()
-        destination.write_text(_generated_assembly_step_text(project), encoding="ascii")
-        return destination
+        return None
 
     destination = (root / "assembly.step").resolve()
     if source != destination:
@@ -267,7 +244,7 @@ def import_project(
 
     from forma_core.workspaces.projects.output import attach_assembly_step, persist_project_output
 
-    assembly_path = _prepare_assembly_step(target_root, step_source, ir)
+    assembly_path = _prepare_assembly_step(target_root, step_source)
     preview_path = (target_root / "cad-preview.stl").resolve()
     if preview_source != preview_path:
         shutil.copy2(preview_source, preview_path)
@@ -361,24 +338,22 @@ def build_project(
     ir.assembly_metadata = metadata
     from forma_core.workspaces.projects.output import attach_assembly_step, persist_project_output
 
-    assembly_path = _prepare_assembly_step(root, assembly_source, ir)
-    assembly_artifact = attach_assembly_step(ir, assembly_path)
-    if assembly_source is None:
-        ir.cad_model["source"] = "CLI-generated STEP envelope from HardwareIR placement data"
-        ir.cad_model["generated"] = True
+    assembly_path = _prepare_assembly_step(root, assembly_source)
+    assembly_artifact = attach_assembly_step(ir, assembly_path) if assembly_path is not None else None
     persist_project_output(ir, prompt_text=requested_prompt, owner_user_id=LOCAL_OWNER_USER_ID)
     artifacts = [
         artifact
         for artifact in current.artifacts
         if artifact.path not in {"assembly.step", "assembled.step"}
     ]
-    artifacts.append(
-        ProjectArtifactReference(
-            path="assembly.step",
-            sha256=assembly_artifact["sha256"],
-            media_type="model/step",
+    if assembly_artifact is not None:
+        artifacts.append(
+            ProjectArtifactReference(
+                path="assembly.step",
+                sha256=assembly_artifact["sha256"],
+                media_type="model/step",
+            )
         )
-    )
     updated = ProjectManifest(
         format=PROJECT_MANIFEST_FORMAT,
         version=1,

--- a/forma_core/agents/orchestrator.py
+++ b/forma_core/agents/orchestrator.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import math
 from forma_core.config import config
 import re
 import uuid
@@ -542,118 +541,6 @@ def _placement_position(component: ComponentInstance, components: List[Component
     remaining_index = max(0, next((index for index, item in enumerate(remaining) if item.ref_des == component.ref_des), 0))
     return _mechanical_vector(_row_position(remaining_index, len(remaining), width * 0.64), -depth * 0.16, -height * 0.03)
 
-def _placement_mesh(placement: MechanicalPlacement) -> Dict[str, Any]:
-    """Convert an approximate placement envelope into a renderable box mesh."""
-    center = placement.position
-    size = placement.size
-    half_x = max(abs(float(size.x_mm)) / 2.0, 0.5)
-    half_y = max(abs(float(size.y_mm)) / 2.0, 0.5)
-    half_z = max(abs(float(size.z_mm)) / 2.0, 0.5)
-    x, y, z = float(center.x_mm), float(center.y_mm), float(center.z_mm)
-    vertices = [
-        x - half_x, y - half_y, z - half_z,
-        x + half_x, y - half_y, z - half_z,
-        x + half_x, y + half_y, z - half_z,
-        x - half_x, y + half_y, z - half_z,
-        x - half_x, y - half_y, z + half_z,
-        x + half_x, y - half_y, z + half_z,
-        x + half_x, y + half_y, z + half_z,
-        x - half_x, y + half_y, z + half_z,
-    ]
-    faces = [
-        0, 2, 1, 0, 3, 2,
-        4, 5, 6, 4, 6, 7,
-        0, 1, 5, 0, 5, 4,
-        3, 7, 6, 3, 6, 2,
-        0, 4, 7, 0, 7, 3,
-        1, 2, 6, 1, 6, 5,
-    ]
-    return {
-        "shapeId": placement.ref_des,
-        "name": placement.label or placement.ref_des,
-        "vertices": vertices,
-        "faces": faces,
-    }
-
-def _ensure_cad_model(ir: HardwareIR) -> None:
-    """Provide a safe mesh fallback when no canonical CAD source was authored."""
-    if ir.cad_model is not None or not ir.mechanical or ir.mechanical.cad_model is not None:
-        return
-    placements = ir.mechanical.component_placements
-    if not placements:
-        return
-    ir.cad_model = {
-        "adapter": "forma-mechanical-layout",
-        "source": "deterministic placement envelopes; replace with canonical CAD when available",
-        "units": "mm",
-        "meshes": [_placement_mesh(placement) for placement in placements],
-    }
-
-def _test_tube_mesh() -> Dict[str, Any]:
-    """Return a lightweight hollow test-tube mesh for deterministic demos."""
-    segments = 32
-    radius = 15.0
-    wall = 1.5
-    height = 100.0
-    outer_bottom = -height / 2
-    outer_top = height / 2
-    inner_bottom = outer_bottom + wall
-    inner_top = outer_top
-    vertices: List[float] = []
-
-    def ring(ring_radius: float, z: float) -> int:
-        start = len(vertices) // 3
-        for index in range(segments):
-            angle = 2 * math.pi * index / segments
-            vertices.extend((ring_radius * math.cos(angle), ring_radius * math.sin(angle), z))
-        return start
-
-    outer_bottom_start = ring(radius, outer_bottom)
-    outer_top_start = ring(radius, outer_top)
-    inner_top_start = ring(radius - wall, inner_top)
-    inner_bottom_start = ring(radius - wall, inner_bottom)
-    outer_center = len(vertices) // 3
-    vertices.extend((0.0, 0.0, outer_bottom))
-    inner_center = len(vertices) // 3
-    vertices.extend((0.0, 0.0, inner_bottom))
-    faces: List[int] = []
-
-    for index in range(segments):
-        next_index = (index + 1) % segments
-        outer_bottom_a = outer_bottom_start + index
-        outer_bottom_b = outer_bottom_start + next_index
-        outer_top_a = outer_top_start + index
-        outer_top_b = outer_top_start + next_index
-        inner_top_a = inner_top_start + index
-        inner_top_b = inner_top_start + next_index
-        inner_bottom_a = inner_bottom_start + index
-        inner_bottom_b = inner_bottom_start + next_index
-        faces.extend((
-            outer_bottom_a, outer_bottom_b, outer_top_b,
-            outer_bottom_a, outer_top_b, outer_top_a,
-            outer_top_a, outer_top_b, inner_top_b,
-            outer_top_a, inner_top_b, inner_top_a,
-            inner_top_a, inner_top_b, inner_bottom_b,
-            inner_top_a, inner_bottom_b, inner_bottom_a,
-            outer_center, outer_bottom_b, outer_bottom_a,
-            inner_center, inner_bottom_a, inner_bottom_b,
-        ))
-
-    return {
-        "shapeId": "TEST_TUBE",
-        "name": "Test tube",
-        "vertices": vertices,
-        "faces": faces,
-    }
-
-def _test_tube_cad_model() -> Dict[str, Any]:
-    return {
-        "adapter": "forma-test-tube-preview",
-        "source": "deterministic hollow test-tube preview for simulation",
-        "units": "mm",
-        "meshes": [_test_tube_mesh()],
-    }
-
 def _dominant_axis(source: MechanicalPlacement, target: MechanicalPlacement) -> str:
     deltas = {
         "X": abs(target.position.x_mm - source.position.x_mm),
@@ -758,7 +645,6 @@ def build_mechanical_render_data(ir: HardwareIR) -> HardwareIR:
         "spatial_relationship_count": len(ir.mechanical.spatial_relationships),
         "render_pipeline": "Three.js + React Three Fiber",
     }
-    _ensure_cad_model(ir)
     return ir
 
 # Define the ADK-style Multi-Agent Orchestrator
@@ -857,7 +743,7 @@ class HardwarePipelineOrchestrator:
         }
         self._active_generation_metadata.setdefault(
             "cad_required",
-            not bool(self._active_generation_metadata.get("project_id")),
+            False,
         )
         # 0. Safety Guardrail Pre-check
         emit_agent_pipeline_event("default", "safety_guardrail", "started")
@@ -1910,7 +1796,7 @@ class HardwarePipelineOrchestrator:
             required=bool(
                 metadata.get(
                     "cad_required",
-                    not bool(metadata.get("project_id")),
+                    False,
                 )
             ),
         )
@@ -2457,14 +2343,13 @@ class HardwarePipelineOrchestrator:
             fabrication_notes=mechanical.fabrication_details,
             assembly_metadata={
                 "status": "active",
-                "pipeline": "deterministic simulation + test-tube CAD preview",
+                "pipeline": "deterministic simulation",
             },
             project_version_history=[{"version": "0.1", "description": "Initial test-tube monitor fixture"}],
             validation=build_validation_summary(validation_issues),
             is_valid=not any(issue.severity.upper() == "CRITICAL" for issue in validation_issues),
         )
         project_ir = build_mechanical_render_data(project_ir)
-        project_ir.cad_model = _test_tube_cad_model()
         self.save_project_to_db(prompt, project_ir)
         return project_ir
 

--- a/forma_core/agents/pipeline.py
+++ b/forma_core/agents/pipeline.py
@@ -428,6 +428,7 @@ DEFAULT_AGENT_PIPELINE_STEPS = [
         label="Authoring native CAD",
         description="Converting the agent-authored mechanical design into a native OpenCAD artifact.",
         duration_ms=9000,
+        optional=True,
     ),
     AgentPipelineStep(
         id="package_project",
@@ -509,6 +510,7 @@ WEB_RESEARCH_AGENT_PIPELINE_STEPS = [
         label="Authoring native CAD",
         description="Converting the sourced mechanical design into a native OpenCAD artifact.",
         duration_ms=9000,
+        optional=True,
     ),
     AgentPipelineStep(
         id="completeness_audit",

--- a/forma_core/agents/web_research_workflow.py
+++ b/forma_core/agents/web_research_workflow.py
@@ -277,7 +277,7 @@ class WebResearchHardwarePipeline:
         }
         self._active_generation_metadata.setdefault(
             "cad_required",
-            not bool(self._active_generation_metadata.get("project_id")),
+            False,
         )
         emit_agent_pipeline_event(self.workflow_id, "safety_guardrail", "started")
         safety_prompt = str(self._active_generation_metadata.get("project_prompt") or user_prompt)
@@ -656,7 +656,7 @@ class WebResearchHardwarePipeline:
             required=bool(
                 metadata.get(
                     "cad_required",
-                    not bool(metadata.get("project_id")),
+                    False,
                 )
             ),
         )

--- a/forma_core/database.py
+++ b/forma_core/database.py
@@ -1020,7 +1020,7 @@ def create_project_generation_plan(
         capability_id=GENERATION_CAPABILITY_ID,
         input_contract_version=GENERATION_INPUT_VERSION,
         payload={"design_brief": build.brief_snapshot.model_dump(mode="json")},
-        metadata={"build_id": str(build.build_id), "cad_required": True},
+        metadata={"build_id": str(build.build_id), "cad_required": False},
     )
     return orchestrator.create_plan([request], owner, max_concurrency=1, plan_id=plan_id)
 

--- a/forma_core/persistence/repositories/sqlite.py
+++ b/forma_core/persistence/repositories/sqlite.py
@@ -477,6 +477,8 @@ class SqlAlchemyRepository:
                     return None
                 revision = DBCliProjectRevision(**revision_record)
                 session.add(revision)
+                project.workspace_id = project_record["workspace_id"]
+                project.title = project_record["title"]
                 project.current_revision = revision_record["revision"]
                 project.current_revision_id = revision_record["revision_id"]
                 project.updated_at = revision_record["created_at"]

--- a/forma_core/persistence/repositories/supabase.py
+++ b/forma_core/persistence/repositories/supabase.py
@@ -459,6 +459,8 @@ class SupabaseRepository:
         try:
             rows = self._client.table("cli_project_revisions").insert(revision_record).execute().data or []
             self._client.table("cli_projects").update({
+                "workspace_id": project_record["workspace_id"],
+                "title": project_record["title"],
                 "current_revision": revision_record["revision"],
                 "current_revision_id": revision_record["revision_id"],
                 "updated_at": revision_record["created_at"],

--- a/forma_core/workers/generation.py
+++ b/forma_core/workers/generation.py
@@ -38,7 +38,6 @@ from forma_core.workspaces.projects import (
 from forma_core.workspaces.projects.models import HardwareIR
 from forma_core.workspaces.projects.cad_generation import (
     cad_project_artifact,
-    ensure_native_cad_model,
 )
 from forma_core.workspaces.projects.output import attach_hardware_reference_image, attach_product_image
 
@@ -108,19 +107,6 @@ class HardwareIRGenerationEngine:
                 **(generation_metadata or {}),
             },
         )
-        cad_adapter = (
-            str(state.cad_model.get("adapter") or "").strip().lower()
-            if isinstance(state.cad_model, dict)
-            else ""
-        )
-        if cad_adapter in {"", "forma-mechanical-layout", "forma-test-tube-preview"}:
-            ensure_native_cad_model(
-                state,
-                project_id=str(design_brief.project_id),
-                required=bool((generation_metadata or {}).get("cad_required", True)),
-                authoring_agent="HardwareIRGenerationEngine",
-                workflow="default",
-            )
         generation_error = (state.assembly_metadata or {}).get("generation_error")
         generation_run = (state.assembly_metadata or {}).get("generation_run")
         if (generation_error or (state.assembly_metadata or {}).get("status") == "failed") and not isinstance(

--- a/forma_core/workspaces/projects/cad_generation.py
+++ b/forma_core/workspaces/projects/cad_generation.py
@@ -18,7 +18,6 @@ from forma_core.workspaces.projects.state import ProjectArtifact
 
 CAD_ADAPTER_RELATIVE_PATH = Path(".agents") / "skills" / "forma-hardware" / "scripts" / "cad.py"
 CAD_ADAPTER_NAME = "forma-opencad"
-PLACEMENT_FALLBACK_ADAPTER = "forma-mechanical-layout"
 
 
 class CadGenerationError(RuntimeError):
@@ -319,10 +318,7 @@ def _stl_mesh(path: Path) -> dict[str, Any]:
 def _has_authoritative_cad(value: Any) -> bool:
     if value in (None, "", {}):
         return False
-    if not isinstance(value, dict):
-        return True
-    adapter = str(value.get("adapter") or "").strip().lower()
-    return adapter not in {PLACEMENT_FALLBACK_ADAPTER, "forma-test-tube-preview"}
+    return True
 
 
 def _cad_is_applicable(project: HardwareIR) -> bool:

--- a/forma_core/workspaces/projects/models.py
+++ b/forma_core/workspaces/projects/models.py
@@ -209,10 +209,6 @@ class MechanicalNotes(BaseModel):
     fabrication_details: List[str] = Field(default_factory=list, description="Enclosure dimensions, material recommendations, or printing instructions")
     fabrication_cost_estimate_usd: float = Field(0.0, description="Estimated mechanical fabrication cost in USD, excluding electrical BOM")
     cad_sources: List[MechanicalSource] = Field(default_factory=list, description="CAD, enclosure, and fabrication source records")
-    cad_model: Optional[Any] = Field(
-        None,
-        description="Optional canonical CAD model source for the primary project model.",
-    )
     manufacturability_rating: str = Field(..., description="Ease of manufacturing: Easy, Moderate, Challenging")
     render_dimensions: Optional[MechanicalVector3] = Field(None, description="Overall live-render envelope dimensions in millimeters")
     component_placements: List[MechanicalPlacement] = Field(default_factory=list, description="Per-component 3D placements for live Three.js rendering")

--- a/forma_core/workspaces/projects/objects.py
+++ b/forma_core/workspaces/projects/objects.py
@@ -542,11 +542,6 @@ def namespace_payload(ir: HardwareIR | dict[str, Any], namespace: str) -> dict[s
     payload = _ir_payload(hardware_ir)
     metadata = payload.get("assembly_metadata") or {}
     cad_model = payload.get("cad_model")
-    mechanical_payload = payload.get("mechanical")
-    if cad_model is None and isinstance(mechanical_payload, dict):
-        cad_model = mechanical_payload.get("cad_model")
-    if cad_model is None and isinstance(metadata, dict):
-        cad_model = metadata.get("cad_model")
     custom_payloads = metadata.get("namespace_payloads") if isinstance(metadata, dict) else None
     if isinstance(custom_payloads, dict) and isinstance(custom_payloads.get(normalized), dict):
         return _redact_payload_value(custom_payloads[normalized])

--- a/scripts/development/dev.ps1
+++ b/scripts/development/dev.ps1
@@ -169,11 +169,22 @@ $BackendErrorLogFile = "$BackendLogFile.err"
 $FrontendLogFile = Join-Path (Split-Path -Parent $BackendLogFile) "frontend-dev.log"
 $FrontendErrorLogFile = "$FrontendLogFile.err"
 
+$frontendPort = $RequestedFrontendPort
+while (Test-PortOpen $frontendPort) {
+    $frontendPort++
+    if ($frontendPort -gt ($RequestedFrontendPort + 20)) {
+        throw "No free frontend port found from $RequestedFrontendPort to $($RequestedFrontendPort + 20)."
+    }
+}
+
 $env:FORMA_AUTH_MODE = Get-ConfiguredValue "FORMA_AUTH_MODE" "local"
 $env:FORMA_DEPLOYMENT_MODE = Get-ConfiguredValue "FORMA_DEPLOYMENT_MODE" "local"
 $env:FORMA_DEVELOPMENT_MODE = Get-ConfiguredValue "FORMA_DEVELOPMENT_MODE" "true"
 $env:FORMA_DEV_MODE = Get-ConfiguredValue "FORMA_DEV_MODE" $env:FORMA_DEVELOPMENT_MODE
 $env:BACKEND_LOG_FILE = $BackendLogFile
+if ([string]::IsNullOrWhiteSpace($env:FORMA_WEB_URL)) {
+    $env:FORMA_WEB_URL = "http://$FrontendHost`:$frontendPort"
+}
 # Do not select an LLM here. The connected host agent authors the IR, while
 # Forma compiles it deterministically. Existing provider/model environment
 # values are inherited unchanged for explicit server-side generation.
@@ -252,14 +263,6 @@ try {
             -ErrorFile $BackendErrorLogFile
         $ownsBackend = $true
         Wait-ForUrl "http://$BackendHost`:$BackendPort/api" "Backend" 60 $backendProcessId
-    }
-
-    $frontendPort = $RequestedFrontendPort
-    while (Test-PortOpen $frontendPort) {
-        $frontendPort++
-        if ($frontendPort -gt ($RequestedFrontendPort + 20)) {
-            throw "No free frontend port found from $RequestedFrontendPort to $($RequestedFrontendPort + 20)."
-        }
     }
 
     Write-Host "[forma-dev] Starting frontend at http://$FrontendHost`:$frontendPort"

--- a/tests/api/test_project_access.py
+++ b/tests/api/test_project_access.py
@@ -350,6 +350,39 @@ class ProjectReadAccessTests(unittest.TestCase):
         self.assertTrue(response["can_chat"])
         self.assertEqual("chat-private-project", response["chat_id"])
 
+    def test_owner_can_read_cli_project_through_project_endpoint(self) -> None:
+        project_id = "cli-project"
+        cli_revision = {
+            "revision_id": "cli-revision-1",
+            "project_id": project_id,
+            "revision": 1,
+            "manifest": {
+                "format": "forma-project",
+                "version": 1,
+                "project_id": project_id,
+                "title": "CLI project",
+                "prompt": "Build a CLI project.",
+                "project_ir": {
+                    "components": [],
+                    "assembly_metadata": {"project_id": project_id},
+                },
+            },
+            "created_at": "2026-07-25T12:00:00Z",
+        }
+
+        with patch.object(main, "get_generated_project", return_value=None), patch.object(
+            main,
+            "get_latest_project_revision",
+            side_effect=main.ProjectStateError("project_not_found", "Project not found."),
+        ), patch.object(main, "get_cli_project_revision", return_value=cli_revision):
+            response = main.get_project_endpoint(project_id, _user_context("user-a"))
+
+        self.assertEqual(project_id, response["project_id"])
+        self.assertFalse(response["can_chat"])
+        self.assertIsNone(response["chat_id"])
+        self.assertEqual("cli", response["project_ir"]["assembly_metadata"]["project_source"])
+        self.assertEqual("cli-revision-1", response["project_ir"]["assembly_metadata"]["cloud_revision_id"])
+
     def test_owner_can_update_project_title(self) -> None:
         project = _project("owned-project", owner_user_id="user-a", visibility="public")
 
@@ -498,7 +531,6 @@ class ProjectReadAccessTests(unittest.TestCase):
                 enclosure_type="3D Printed",
                 mounting_guidance="Fasten the board to internal standoffs.",
                 manufacturability_rating="Easy",
-                cad_model=cad_model,
                 cad_sources=[
                     MechanicalSource(
                         name="Enclosure STEP",
@@ -513,6 +545,7 @@ class ProjectReadAccessTests(unittest.TestCase):
                 "chat_id": "private-current-chat",
                 "cad_model": cad_model,
             },
+            cad_model=cad_model,
         )
         public_project = _project(
             "current-public-project",
@@ -532,7 +565,6 @@ class ProjectReadAccessTests(unittest.TestCase):
         self.assertIsNone(response["chat_id"])
         self.assertNotIn("chat_id", response["project_ir"]["assembly_metadata"])
         self.assertIsNone(response["project_ir"]["cad_model"])
-        self.assertIsNone(response["project_ir"]["mechanical"]["cad_model"])
         self.assertIsNone(response["project_ir"]["assembly_metadata"]["cad_model"])
         self.assertEqual("", response["project_ir"]["mechanical"]["cad_sources"][0]["url"])
         self.assertNotIn(downloadable_url, json.dumps(response, default=str))

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -234,6 +234,59 @@ class PersistenceArchitectureTests(unittest.TestCase):
             [(revision.project_id, revision.revision) for revision in revisions],
         )
 
+    def test_cli_revision_push_updates_project_summary_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            provider = create_sqlite_provider(
+                source="test primary",
+                url=f"sqlite:///{Path(directory) / 'forma.db'}",
+                import_legacy_jobs=False,
+            )
+            assert provider.session_factory is not None
+            provider.initialize()
+            repository = SqlAlchemyRepository(provider.session_factory)
+            try:
+                project_record = {
+                    "project_id": "cli-summary",
+                    "workspace_id": "workspace-a",
+                    "owner_user_id": "user-a",
+                    "title": "Initial title",
+                    "current_revision": 0,
+                    "current_revision_id": None,
+                    "created_at": "2026-08-31T12:00:00Z",
+                    "updated_at": "2026-08-31T12:00:00Z",
+                }
+                first_revision = {
+                    "revision_id": "cli-summary-r1",
+                    "project_id": "cli-summary",
+                    "owner_user_id": "user-a",
+                    "revision": 1,
+                    "parent_revision_id": None,
+                    "manifest_json": {},
+                    "created_at": "2026-08-31T12:00:00Z",
+                }
+                self.assertIsNotNone(repository.insert_cli_project_revision(project_record, first_revision, None))
+
+                updated_project_record = {**project_record, "workspace_id": "workspace-b", "title": "Updated title"}
+                second_revision = {
+                    **first_revision,
+                    "revision_id": "cli-summary-r2",
+                    "revision": 2,
+                    "parent_revision_id": "cli-summary-r1",
+                }
+                self.assertIsNotNone(
+                    repository.insert_cli_project_revision(updated_project_record, second_revision, "cli-summary-r1")
+                )
+
+                project = repository.get_cli_project("cli-summary", "user-a")
+            finally:
+                assert provider.engine is not None
+                provider.engine.dispose()
+
+        self.assertIsNotNone(project)
+        self.assertEqual("workspace-b", project.workspace_id)
+        self.assertEqual("Updated title", project.title)
+        self.assertEqual(2, project.current_revision)
+
     def test_sqlite_repository_pages_filtered_projects_before_loading_records(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             provider = create_sqlite_provider(

--- a/tests/projects/test_project_output.py
+++ b/tests/projects/test_project_output.py
@@ -10,7 +10,7 @@ from forma_core.workspaces.projects.output import attach_hardware_reference_imag
 
 
 class ProjectOutputTests(unittest.TestCase):
-    def test_mechanical_render_data_adds_a_cad_mesh_fallback(self) -> None:
+    def test_mechanical_render_data_does_not_create_a_cad_model(self) -> None:
         ir = HardwareIR(
             components=[
                 ComponentInstance(
@@ -29,29 +29,30 @@ class ProjectOutputTests(unittest.TestCase):
 
         rendered = build_mechanical_render_data(ir)
 
-        self.assertEqual("forma-mechanical-layout", rendered.cad_model["adapter"])
-        self.assertEqual(1, len(rendered.cad_model["meshes"]))
-        self.assertEqual("U1", rendered.cad_model["meshes"][0]["shapeId"])
+        self.assertIsNone(rendered.cad_model)
 
     def test_cad_model_survives_hardware_ir_round_trip_and_mechanical_namespace_projection(self) -> None:
         cad_model = {"path": "/srv/models/enclosure.step", "adapter": "forma-opencad"}
         ir = HardwareIR(cad_model=cad_model)
-        nested_ir = HardwareIR(
-            mechanical=MechanicalNotes(
-                cad_model=cad_model,
-                enclosure_type="3D Printed",
-                mounting_guidance="Test",
-                manufacturability_rating="Easy",
-            )
-        )
 
         restored = HardwareIR.model_validate(ir.model_dump(mode="json"))
-        restored_nested = HardwareIR.model_validate(nested_ir.model_dump(mode="json"))
 
         self.assertEqual(cad_model, restored.cad_model)
-        self.assertEqual(cad_model, restored_nested.mechanical.cad_model)
         self.assertEqual(cad_model, namespace_payload(restored, "product.mech")["cad_model"])
-        self.assertEqual(cad_model, namespace_payload(restored_nested, "product.mech")["cad_model"])
+
+    def test_mechanical_namespace_does_not_promote_legacy_cad_model_fields(self) -> None:
+        ir = HardwareIR.model_validate({
+            "mechanical": {
+                "cad_model": {"path": "/srv/models/legacy.step"},
+                "enclosure_type": "3D Printed",
+                "mounting_guidance": "Test",
+                "manufacturability_rating": "Easy",
+            },
+            "assembly_metadata": {"cad_model": {"path": "/srv/models/metadata.step"}},
+        })
+
+        self.assertIsNone(ir.cad_model)
+        self.assertIsNone(namespace_payload(ir, "product.mech")["cad_model"])
 
     def test_generated_image_is_attached_inline_when_storage_skips_upload(self) -> None:
         ir = HardwareIR(

--- a/tests/tooling/test_cli_auth_api.py
+++ b/tests/tooling/test_cli_auth_api.py
@@ -5,11 +5,46 @@ import unittest
 from unittest.mock import patch
 
 from fastapi.testclient import TestClient
+from starlette.requests import Request
 
+from apps.api.cli_auth_api import _api_url, _web_url
 from apps.api.main import app
 
 
 class CliAuthApiTests(unittest.TestCase):
+    def test_hosted_urls_use_forwarded_production_origin(self) -> None:
+        request = Request(
+            {
+                "type": "http",
+                "method": "POST",
+                "scheme": "http",
+                "path": "/api/cli/device/authorize",
+                "raw_path": b"/api/cli/device/authorize",
+                "query_string": b"",
+                "headers": [
+                    (b"host", b"backend.internal"),
+                    (b"x-forwarded-host", b"caid-technologies.us"),
+                    (b"x-forwarded-proto", b"https"),
+                ],
+                "server": ("backend.internal", 8000),
+                "client": ("127.0.0.1", 1234),
+            }
+        )
+        with patch.dict(
+            os.environ,
+            {
+                "FORMA_DEPLOYMENT_MODE": "hosted",
+                "FORMA_WEB_URL": "",
+                "NEXT_PUBLIC_APP_URL": "",
+                "FRONTEND_URL": "",
+                "FORMA_API_URL": "",
+                "NEXT_PUBLIC_API_URL": "",
+            },
+            clear=False,
+        ):
+            self.assertEqual("https://caid-technologies.us", _web_url(request))
+            self.assertEqual("https://caid-technologies.us/api", _api_url(request))
+
     def test_device_flow_can_approve_exchange_and_revoke_in_local_mode(self) -> None:
         with patch.dict(os.environ, {"FORMA_AUTH_MODE": "local", "FORMA_CLI_AUTH_STORAGE": "memory"}, clear=False):
             client = TestClient(app)

--- a/tests/tooling/test_oss_cli.py
+++ b/tests/tooling/test_oss_cli.py
@@ -115,7 +115,7 @@ class OssCliTests(unittest.TestCase):
             self.assertTrue(output.exists())
             self.assertGreater(output.stat().st_size, 1000)
 
-    def test_simulated_test_tube_build_has_matching_cad_preview(self) -> None:
+    def test_simulated_test_tube_build_preserves_a_provided_cad_artifact(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             init_project(temp_dir, title="Test tube")
             root = Path(temp_dir)
@@ -129,8 +129,7 @@ class OssCliTests(unittest.TestCase):
 
             self.assertEqual("Test Tube Monitor", ir["overview"]["title"])
             self.assertEqual("forma-opencad", ir["cad_model"]["adapter"])
-            self.assertEqual(1, len(ir["cad_model"]["meshes"]))
-            self.assertGreater(len(ir["cad_model"]["meshes"][0]["vertices"]), 100)
+            self.assertEqual(str((root / "assembly.step").resolve()), ir["cad_model"]["path"])
             self.assertTrue((root / "assembly.step").is_file())
             self.assertEqual("assembly.step", manifest.artifacts[-1].path)
             saved = get_generated_project(manifest.project_id)
@@ -164,18 +163,20 @@ class OssCliTests(unittest.TestCase):
             self.assertIsNotNone(saved)
             self.assertEqual("local-dev-user", saved.owner_user_id)
 
-    def test_build_generates_assembly_step_without_manual_artifact(self) -> None:
+    def test_build_without_manual_cad_artifact_leaves_cad_model_empty(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             init_project(temp_dir, title="Generated assembly")
 
-            manifest = build_project(temp_dir, prompt="test tube", simulation=True)
+            with patch(
+                "forma_core.workspaces.projects.cad_generation._adapter_path",
+                side_effect=RuntimeError("native CAD is unavailable for this CLI test"),
+            ):
+                manifest = build_project(temp_dir, prompt="test tube", simulation=True)
 
             root = Path(temp_dir)
-            assembly = root / "assembly.step"
-            self.assertTrue(assembly.is_file())
-            self.assertEqual("assembly.step", manifest.artifacts[-1].path)
-            self.assertTrue(manifest.project_ir["cad_model"]["generated"])
-            self.assertEqual(str(assembly.resolve()), manifest.project_ir["cad_model"]["path"])
+            self.assertFalse((root / "assembly.step").exists())
+            self.assertIsNone(manifest.project_ir["cad_model"])
+            self.assertFalse(any(artifact.path == "assembly.step" for artifact in manifest.artifacts))
 
     def test_import_preserves_native_cad_and_adds_renderable_stl_mesh(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -218,7 +219,11 @@ class OssCliTests(unittest.TestCase):
     def test_metadata_reports_project_and_artifact_contract(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             init_project(temp_dir, title="Metadata project")
-            manifest = build_project(temp_dir, prompt="test tube", simulation=True)
+            with patch(
+                "forma_core.workspaces.projects.cad_generation._adapter_path",
+                side_effect=RuntimeError("native CAD is unavailable for this CLI test"),
+            ):
+                manifest = build_project(temp_dir, prompt="test tube", simulation=True)
 
             payload = project_metadata(temp_dir)
 
@@ -226,9 +231,10 @@ class OssCliTests(unittest.TestCase):
             self.assertTrue(payload["database"]["present"])
             self.assertEqual("local-dev-user", payload["database"]["owner_user_id"])
             self.assertEqual(4, payload["hardware"]["components"])
-            self.assertEqual(1, payload["cad"]["meshes"])
-            self.assertTrue(payload["cad"]["step"]["exists"])
-            self.assertTrue(payload["artifacts"][0]["exists"])
+            self.assertFalse(payload["cad"]["present"])
+            self.assertEqual(0, payload["cad"]["meshes"])
+            self.assertIsNone(payload["cad"]["step"])
+            self.assertEqual([], payload["artifacts"])
 
     def test_credential_store_uses_keyring_backend_without_exposing_values(self) -> None:
         keyring = FakeKeyring()


### PR DESCRIPTION
## Summary
- Remove simulated placement and test-tube CAD fallbacks; keep root cad_model as the canonical CAD contract.
- Make native OpenCAD generation optional, avoid placeholder STEP output, and gate the workspace CAD tab on a renderable model.
- Expose hosted CLI projects through the project endpoint, preserve CLI project summary metadata, and derive hosted CLI URLs from forwarded request origins.

## Tests
- .venv\\Scripts\\python.exe -m unittest tests.projects.test_project_output tests.projects.test_cad_generation tests.tooling.test_oss_cli tests.api.test_project_access tests.agents.test_generation_stages (51 passed, 1 skipped).
- 
ode --experimental-strip-types --test test/cad-model.test.ts (5 passed).
- 
px tsc --noEmit, 
pm run lint -- --no-cache, and 
pm run build passed.
- Full Python discovery remains affected by known Windows database-lock/environment failures; the five assertion failures are tracked in issues #362-#366.