### PR TITLE
feat: add one-command local OpenCode setup

### DIFF
--- a/.agents/skills/forma-hardware/SKILL.md
+++ b/.agents/skills/forma-hardware/SKILL.md
@@ -47,13 +47,30 @@ It reads `FORMA_MCP_URL`, defaulting to `http://127.0.0.1:8000/mcp`, and optiona
 4. Call `forma.compile_project` with `project_ir` and the correct `authoring_agent` (`openclaw`, `nemoclaw`, `opencode`, `claude`, or `codex`). With the bundled client:
 
 ```bash
-python <skill-directory>/scripts/forma.py compile "$PROJECT_DIR/forma-project.json" --authoring-agent openclaw --output "$PROJECT_DIR/compiled-project.json"
-python <skill-directory>/scripts/forma.py compile "$PROJECT_DIR/forma-project.json" --authoring-agent nemoclaw --output "$PROJECT_DIR/compiled-project.json"
-python <skill-directory>/scripts/forma.py compile "$PROJECT_DIR/forma-project.json" --authoring-agent opencode --output "$PROJECT_DIR/compiled-project.json"
+python <skill-directory>/scripts/forma.py compile "$PROJECT_DIR/forma-project.json" --authoring-agent openclaw --output "$PROJECT_DIR/compiled-project.json" --update-project
+python <skill-directory>/scripts/forma.py compile "$PROJECT_DIR/forma-project.json" --authoring-agent nemoclaw --output "$PROJECT_DIR/compiled-project.json" --update-project
+python <skill-directory>/scripts/forma.py compile "$PROJECT_DIR/forma-project.json" --authoring-agent opencode --output "$PROJECT_DIR/compiled-project.json" --update-project
 ```
 
+When using the bundled client, add `--update-project` so the canonical local
+manifest contains the returned compiled IR and can be uploaded later. The
+client also writes `validation.json`, `wiring.mmd`, and `schematic.svg` beside
+the manifest when those compiler artifacts are returned:
+
+```bash
+python <skill-directory>/scripts/forma.py compile "$PROJECT_DIR/forma-project.json" --authoring-agent opencode --output "$PROJECT_DIR/compiled-project.json" --update-project
+```
+
+When using a native MCP tool, replace the manifest's `project_ir` with the
+returned `project_ir`, preserve the manifest wrapper and artifacts, and update
+its `project_id` from the compiler response before uploading. Save returned
+`validation`, `mermaid_code`, and `svg_schematic` values as local artifact
+files and reference them from the manifest. Never leave the pre-compiled draft
+as the uploadable project.
+
 5. Fix practical agent-authored errors and compile again. Treat every `CRITICAL` finding as blocking.
-6. Report artifact paths, power assumptions, major components, and remaining findings. Label the result as an AI-assisted prototype plan.
+6. Run `forma-oss status --path "$PROJECT_DIR"` before presenting the project.
+7. Report artifact paths, power assumptions, major components, and remaining findings. Label the result as an AI-assisted prototype plan.
 
 ## Validate existing IR
 

--- a/.agents/skills/forma-hardware/scripts/forma.py
+++ b/.agents/skills/forma-hardware/scripts/forma.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import sys
@@ -111,6 +112,104 @@ def _write(value: Any, output: str | None) -> None:
         print(path)
 
 
+def _update_project_manifest(project_path: str, compiled: Any) -> None:
+    """Replace a local draft manifest with the compiler's canonical IR."""
+    if project_path == "-":
+        raise FormaClientError("--update-project requires a file-backed project, not stdin.")
+
+    compiled_ir = compiled.get("project_ir") if isinstance(compiled, dict) else None
+    if not isinstance(compiled_ir, dict):
+        raise FormaClientError("Forma did not return a compiled project IR.")
+
+    path = Path(project_path)
+    try:
+        original = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise FormaClientError(f"Could not read the local project manifest: {path}") from exc
+
+    metadata = compiled_ir.get("assembly_metadata")
+    metadata = metadata if isinstance(metadata, dict) else {}
+    if isinstance(original, dict) and (
+        "project_ir" in original or "hardware_ir" in original or original.get("format") == "forma-project"
+    ):
+        manifest = dict(original)
+    else:
+        manifest = {"format": "forma-project", "version": 1}
+
+    manifest["format"] = str(manifest.get("format") or "forma-project")
+    manifest["version"] = int(manifest.get("version") or 1)
+    manifest["project_ir"] = compiled_ir
+    manifest["project_id"] = str(
+        compiled.get("project_id") or metadata.get("project_id") or manifest.get("project_id") or ""
+    ).strip()
+    if not manifest["project_id"]:
+        raise FormaClientError("Forma did not return a project ID for the local manifest.")
+
+    overview = compiled_ir.get("overview")
+    overview = overview if isinstance(overview, dict) else {}
+    if not str(manifest.get("title") or "").strip():
+        manifest["title"] = str(overview.get("title") or "Untitled Forma Project")
+    if not str(manifest.get("prompt") or "").strip():
+        manifest["prompt"] = str(metadata.get("source_prompt") or metadata.get("project_prompt") or "")
+
+    generated_artifacts = _write_compiled_artifacts(path, compiled)
+    if generated_artifacts:
+        existing_artifacts = manifest.get("artifacts")
+        existing_artifacts = existing_artifacts if isinstance(existing_artifacts, list) else []
+        generated_paths = {item["path"] for item in generated_artifacts}
+        manifest["artifacts"] = [
+            item
+            for item in existing_artifacts
+            if not isinstance(item, dict) or item.get("path") not in generated_paths
+        ] + generated_artifacts
+
+    temporary = path.with_suffix(f"{path.suffix}.tmp")
+    try:
+        temporary.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        temporary.replace(path)
+    except OSError as exc:
+        raise FormaClientError(f"Could not write the compiled project manifest: {path}") from exc
+
+
+def _write_compiled_artifacts(project_path: Path, compiled: dict[str, Any]) -> list[dict[str, str]]:
+    """Materialize compiler renderings next to the canonical project manifest."""
+    outputs: list[tuple[str, str, str]] = []
+    validation = compiled.get("validation")
+    if validation is not None:
+        outputs.append(
+            (
+                "validation.json",
+                json.dumps(validation, indent=2, sort_keys=True) + "\n",
+                "application/json",
+            )
+        )
+    mermaid_code = compiled.get("mermaid_code")
+    if isinstance(mermaid_code, str) and mermaid_code.strip():
+        outputs.append(("wiring.mmd", mermaid_code.rstrip() + "\n", "text/vnd.mermaid"))
+    svg_schematic = compiled.get("svg_schematic")
+    if isinstance(svg_schematic, str) and svg_schematic.strip():
+        outputs.append(("schematic.svg", svg_schematic.rstrip() + "\n", "image/svg+xml"))
+
+    references: list[dict[str, str]] = []
+    for filename, content, media_type in outputs:
+        artifact_path = project_path.parent / filename
+        data = content.encode("utf-8")
+        temporary = artifact_path.with_suffix(f"{artifact_path.suffix}.tmp")
+        try:
+            temporary.write_bytes(data)
+            temporary.replace(artifact_path)
+        except OSError as exc:
+            raise FormaClientError(f"Could not write compiled artifact: {artifact_path}") from exc
+        references.append(
+            {
+                "path": filename,
+                "sha256": hashlib.sha256(data).hexdigest(),
+                "media_type": media_type,
+            }
+        )
+    return references
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Call Forma from any Agent Skills host.")
     commands = parser.add_subparsers(dest="command", required=True)
@@ -121,6 +220,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--authoring-agent",
         required=True,
         choices=("openclaw", "opencode", "nemoclaw", "claude", "codex", "other"),
+    )
+    compile_parser.add_argument(
+        "--update-project",
+        action="store_true",
+        help="Replace the input manifest's project_ir with the compiled response.",
     )
     validate_parser = commands.add_parser("validate")
     validate_parser.add_argument("project")
@@ -157,7 +261,17 @@ def run(args: argparse.Namespace) -> Any:
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
-        _write(run(args), args.output)
+        result = run(args)
+        if args.command == "compile" and args.update_project:
+            same_output = (
+                args.output
+                and args.output != "-"
+                and Path(args.output).expanduser().resolve() == Path(args.project).expanduser().resolve()
+            )
+            if same_output:
+                raise FormaClientError("--output must differ from the input when using --update-project.")
+            _update_project_manifest(args.project, result)
+        _write(result, args.output)
         return 0
     except (FormaClientError, OSError, ValueError, json.JSONDecodeError) as exc:
         print(f"forma: {exc}", file=sys.stderr)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,31 @@ the host agent's model, and persists a generated encryption key under
 `.forma/`. Use `BACKEND_PORT`,
 `FRONTEND_PORT`, `BACKEND_HOST`, or `FRONTEND_HOST` to override defaults.
 
+### OpenCode local workflow
+
+The recommended user path is to have OpenCode author the design while Forma
+runs locally. The installer creates a local OpenCode workspace, installs the
+complete `forma-hardware` skill, configures the local MCP endpoint, installs the
+`forma-oss` CLI, and starts the backend and frontend. It does not configure a
+simulation model.
+
+Use the public [OpenCode installation page](https://caid-technologies.us/install/opencode)
+for copyable commands, or run the platform installer directly:
+
+```bash
+curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/caid-technologies/Forma-OSS/main/scripts/development/install-opencode.sh | bash
+```
+
+On Windows PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/caid-technologies/Forma-OSS/main/scripts/development/install-opencode.ps1 | iex
+```
+
+OpenCode supplies the configured model, calls the local `forma.compile_project`
+tool, and writes the compiled project into `~/forma-workspace`. No Forma login
+is needed for local generation, validation, rendering, or status.
+
 ### Python Package (PyPI)
 The reusable core is published on PyPI as [`caid-forma-core`](https://pypi.org/project/caid-forma-core/). The distribution name is `caid-forma-core`; the Python import package is `forma_core`.
 
@@ -143,12 +168,22 @@ uploads.
 ```bash
 forma-oss --help
 forma-oss init ./my-project
-forma-oss build "plant watering monitor" --path ./my-project --simulation
 forma-oss status --path ./my-project
 forma-oss render --path ./my-project --output ./my-project/mechanical-render.png
+forma-oss build "plant watering monitor" --path ./my-project --provider openai --model gpt-5.5
+```
+
+Cloud operations require an explicit login:
+
+```bash
 forma-oss login
 forma-oss projects push --path ./my-project
 forma-oss projects pull --path ./my-project
+```
+
+Provider credentials for direct CLI generation can be stored locally:
+
+```bash
 forma-oss keys set openai --scope local
 forma-oss keys list --scope both
 ```

--- a/apps/web/app/forma-workspace/about-view.tsx
+++ b/apps/web/app/forma-workspace/about-view.tsx
@@ -106,6 +106,10 @@ export default function AboutView() {
             description="Forma helps builders turn early hardware ideas into project plans with parts, wiring, validation, build notes, and generated artifacts."
             actions={
               <>
+                <Link href="/install/opencode" className={BUTTON_OUTLINE_CLASS}>
+                  OpenCode setup
+                  <ArrowUpRight className="h-3.5 w-3.5" />
+                </Link>
                 <span className={BUTTON_OUTLINE_CLASS}>
                   <Mail className="h-3.5 w-3.5" />
                   <span className="select-all">{legalContactEmail}</span>

--- a/apps/web/app/forma-workspace/sidebar.tsx
+++ b/apps/web/app/forma-workspace/sidebar.tsx
@@ -731,6 +731,7 @@ export function ChatSidebar({
         <SidebarSectionLabel compact={compact}>General</SidebarSectionLabel>
         <div className={`space-y-0.5 ${compact ? "mt-1" : ""}`}>
           <SidebarNavLink href="/settings" icon={Settings} label="Settings" compact={compact} onNavigate={onNavigate} />
+          <SidebarNavLink href="/install/opencode" icon={Terminal} label="OpenCode setup" compact={compact} onNavigate={onNavigate} />
           <SidebarNavLink href="/about" icon={Handshake} label="About" compact={compact} onNavigate={onNavigate} />
         </div>
         {authRequired && <SidebarAccountDock compact={compact} />}

--- a/apps/web/app/install/opencode/page.tsx
+++ b/apps/web/app/install/opencode/page.tsx
@@ -1,0 +1,295 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import type { ReactNode } from "react";
+import {
+  ArrowRight,
+  ArrowUpRight,
+  AlertTriangle,
+  Check,
+  ExternalLink,
+  Monitor,
+  ShieldCheck,
+  Terminal,
+} from "lucide-react";
+
+import PublicAppShell, {
+  PUBLIC_BUTTON_OUTLINE_CLASS,
+  PUBLIC_BUTTON_PRIMARY_CLASS,
+  PUBLIC_CARD_CLASS,
+} from "../../../components/public-app-shell";
+import CopyButton from "../../../components/copy-button";
+
+export const metadata: Metadata = {
+  title: "Install Forma for OpenCode | Forma",
+  description: "Run Forma locally through OpenCode and upload projects only when you choose.",
+};
+
+const UNIX_INSTALL_COMMAND =
+  "curl --proto '=https' --tlsv1.2 -fsSL https://raw.githubusercontent.com/caid-technologies/Forma-OSS/main/scripts/development/install-opencode.sh | bash";
+const WINDOWS_INSTALL_COMMAND =
+  "irm https://raw.githubusercontent.com/caid-technologies/Forma-OSS/main/scripts/development/install-opencode.ps1 | iex";
+const UNIX_OPEN_COMMAND = "cd ~/forma-workspace\nopencode mcp list\nopencode";
+const WINDOWS_OPEN_COMMAND = 'Set-Location "$HOME\\forma-workspace"\nopencode mcp list\nopencode';
+const EXAMPLE_PROMPT =
+  "Use the Forma hardware skill to build a real 3.3V plant-watering monitor with an ESP32, capacitive soil sensor, OLED status display, and a low-voltage pump driver. Ask only essential clarification questions. Author a complete Hardware IR, call the local Forma compiler, fix every CRITICAL validation finding, and save the final compiled project manifest in the local Forma workspace. Do not use simulation.";
+const UNIX_UPLOAD_COMMAND =
+  "forma-oss login\nforma-oss projects push --path ~/forma-workspace/<project-id>";
+const WINDOWS_UPLOAD_COMMAND =
+  'forma-oss login\nforma-oss projects push --path "$HOME\\forma-workspace\\<project-id>"';
+
+function CommandBlock({
+  label,
+  value,
+  description,
+}: {
+  label: string;
+  value: string;
+  description?: string;
+}) {
+  return (
+    <div className="overflow-hidden rounded-xl border border-[#303640] bg-[#0c0f14]">
+      <div className="flex items-center justify-between gap-3 border-b border-[#252a32] px-3 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Terminal className="h-3.5 w-3.5 shrink-0 text-cyan-300" aria-hidden="true" />
+          <span className="truncate text-[11px] font-medium uppercase tracking-[0.14em] text-slate-400">{label}</span>
+        </div>
+        <CopyButton value={value} label={`Copy ${label}`} />
+      </div>
+      <pre className="overflow-x-auto whitespace-pre-wrap break-words px-4 py-3 font-mono text-xs leading-6 text-cyan-100">
+        <code>{value}</code>
+      </pre>
+      {description ? <p className="border-t border-[#252a32] px-4 py-2.5 text-xs leading-5 text-slate-500">{description}</p> : null}
+    </div>
+  );
+}
+
+function Requirement({ children }: { children: ReactNode }) {
+  return (
+    <li className="flex items-start gap-2.5 text-sm leading-6 text-slate-300">
+      <Check className="mt-1 h-3.5 w-3.5 shrink-0 text-emerald-300" aria-hidden="true" />
+      <span>{children}</span>
+    </li>
+  );
+}
+
+function StepLabel({ number, children }: { number: string; children: ReactNode }) {
+  return (
+    <div className="flex items-center gap-2 text-[11px] font-medium uppercase tracking-[0.16em] text-emerald-300">
+      <span className="inline-flex h-5 w-5 items-center justify-center rounded-full border border-emerald-400/40 bg-emerald-400/10 text-[10px] text-emerald-200">
+        {number}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+export default function OpenCodeInstallPage() {
+  return (
+    <PublicAppShell badge="Local setup" title="Install Forma for OpenCode">
+      <main className="mx-auto w-full max-w-5xl space-y-5 pb-8 font-sans">
+        <section className={`${PUBLIC_CARD_CLASS} overflow-hidden`}>
+          <div className="grid gap-0 lg:grid-cols-[1.15fr_0.85fr]">
+            <div className="border-b border-[#2c2f37] p-6 lg:border-b-0 lg:border-r lg:p-8">
+              <p className="text-[11px] font-medium uppercase tracking-[0.2em] text-cyan-300">Forma OSS / OpenCode</p>
+              <h2 className="mt-3 max-w-2xl text-3xl font-semibold tracking-[-0.03em] text-white sm:text-4xl">
+                Build hardware locally. Upload only when you are ready.
+              </h2>
+              <p className="mt-4 max-w-2xl text-sm leading-7 text-slate-400">
+                OpenCode supplies the model and authors the design. Forma runs locally, validates the wiring,
+                renders the project, and keeps the working files on your machine.
+              </p>
+              <div className="mt-6 flex flex-wrap gap-2">
+                <span className="rounded-full border border-emerald-400/25 bg-emerald-400/10 px-2.5 py-1 text-[11px] text-emerald-200">
+                  No Forma login for local work
+                </span>
+                <span className="rounded-full border border-cyan-400/25 bg-cyan-400/10 px-2.5 py-1 text-[11px] text-cyan-200">
+                  No simulation path
+                </span>
+                <span className="rounded-full border border-[#39404b] bg-[#11151c] px-2.5 py-1 text-[11px] text-slate-300">
+                  Cloud upload is opt-in
+                </span>
+              </div>
+            </div>
+            <div className="bg-[radial-gradient(circle_at_top_right,rgba(34,211,238,0.14),transparent_55%),#11151c] p-6 lg:p-8">
+              <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.16em] text-slate-400">
+                <Monitor className="h-4 w-4 text-cyan-300" aria-hidden="true" />
+                Local boundary
+              </div>
+              <div className="mt-6 space-y-3 font-mono text-xs">
+                <div className="rounded-lg border border-[#39404b] bg-[#0c0f14] p-3 text-slate-400">OpenCode model</div>
+                <div className="flex justify-center text-cyan-300" aria-hidden="true">v</div>
+                <div className="rounded-lg border border-cyan-400/30 bg-cyan-400/10 p-3 text-cyan-100">Hardware IR + local MCP</div>
+                <div className="flex justify-center text-cyan-300" aria-hidden="true">v</div>
+                <div className="rounded-lg border border-emerald-400/30 bg-emerald-400/10 p-3 text-emerald-100">Forma validation + SQLite</div>
+                <div className="flex justify-center text-emerald-300" aria-hidden="true">v</div>
+                <div className="rounded-lg border border-[#39404b] bg-[#0c0f14] p-3 text-slate-300">forma-project.json</div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className={`${PUBLIC_CARD_CLASS} p-5 sm:p-6`}>
+          <StepLabel number="1">Check the prerequisites</StepLabel>
+          <div className="mt-4 grid gap-5 lg:grid-cols-[1fr_1fr]">
+            <div>
+              <h2 className="text-xl font-semibold tracking-tight text-white">Bring OpenCode and a model</h2>
+              <p className="mt-2 text-sm leading-6 text-slate-400">
+                Forma does not select a server model or replace failed requests with examples. OpenCode must already
+                be installed and authenticated with the provider you want to use.
+              </p>
+            </div>
+            <ul className="space-y-2">
+              <Requirement>OpenCode with a configured model provider. A local provider is supported.</Requirement>
+              <Requirement>Git, Python 3.11+, Node.js 18+, and npm for the local Forma runtime.</Requirement>
+              <Requirement>Nothing from this setup requires Bun.</Requirement>
+            </ul>
+          </div>
+        </section>
+
+        <section className={`${PUBLIC_CARD_CLASS} p-5 sm:p-6`}>
+          <StepLabel number="2">Install and start the local runtime</StepLabel>
+          <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h2 className="text-xl font-semibold tracking-tight text-white">One command per platform</h2>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-slate-400">
+                The installer uses a pinned checkout when `FORMA_OSS_REF` is supplied, reports the installed revision,
+                preserves your OpenCode settings by using a dedicated local workspace, and starts the backend and UI.
+              </p>
+            </div>
+            <a
+              href="https://github.com/caid-technologies/Forma-OSS/tree/main/scripts/development"
+              target="_blank"
+              rel="noreferrer"
+              className={PUBLIC_BUTTON_OUTLINE_CLASS}
+            >
+              Review installer source
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+            </a>
+          </div>
+          <div className="mt-5 grid gap-3 lg:grid-cols-2">
+            <CommandBlock
+              label="macOS / Linux"
+              value={UNIX_INSTALL_COMMAND}
+              description="Keep this terminal open while the local Forma backend and UI are running."
+            />
+            <CommandBlock
+              label="Windows PowerShell"
+              value={WINDOWS_INSTALL_COMMAND}
+              description="The script uses native PowerShell process and path handling."
+            />
+          </div>
+          <div className="mt-4 flex items-start gap-2.5 rounded-lg border border-amber-300/20 bg-amber-300/5 px-3 py-2.5 text-xs leading-5 text-amber-100/80">
+            <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0 text-amber-300" aria-hidden="true" />
+            <p>Review the installer source before running it. It clones the public repository, installs the local CLI, and starts the local services.</p>
+          </div>
+        </section>
+
+        <section className={`${PUBLIC_CARD_CLASS} p-5 sm:p-6`}>
+          <StepLabel number="3">OpenCode and build</StepLabel>
+          <div className="mt-4 grid gap-5 lg:grid-cols-[0.8fr_1.2fr]">
+            <div>
+              <h2 className="text-xl font-semibold tracking-tight text-white">Use the Forma skill</h2>
+              <p className="mt-2 text-sm leading-6 text-slate-400">
+                Open a second terminal. The installer creates `~/forma-workspace`, installs the complete shared skill,
+                and configures its local MCP entry. The project is created by your OpenCode model, not by a demo fixture.
+              </p>
+              <div className="mt-4">
+                <CommandBlock label="Start OpenCode" value={UNIX_OPEN_COMMAND} />
+              </div>
+              <p className="mt-3 text-xs leading-5 text-slate-500">
+                On Windows, use the PowerShell equivalent below. `opencode mcp list` should show `forma` connected before
+                you start the prompt.
+              </p>
+              <div className="mt-3">
+                <CommandBlock label="Windows PowerShell" value={WINDOWS_OPEN_COMMAND} />
+              </div>
+            </div>
+            <div className="overflow-hidden rounded-xl border border-[#303640] bg-[#0c0f14]">
+              <div className="flex items-center justify-between gap-3 border-b border-[#252a32] px-3 py-2">
+                <div className="flex items-center gap-2">
+                  <ShieldCheck className="h-3.5 w-3.5 text-emerald-300" aria-hidden="true" />
+                  <span className="text-[11px] font-medium uppercase tracking-[0.14em] text-slate-400">Real project prompt</span>
+                </div>
+                <CopyButton value={EXAMPLE_PROMPT} label="Copy example prompt" />
+              </div>
+              <p className="p-4 text-sm leading-7 text-slate-200">{EXAMPLE_PROMPT}</p>
+              <div className="border-t border-[#252a32] px-4 py-3 text-xs leading-5 text-slate-500">
+                The normal path calls `forma.compile_project`, applies deterministic electrical validation, and keeps the
+                final project in the local workspace. There is no simulation fallback.
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className={`${PUBLIC_CARD_CLASS} p-5 sm:p-6`}>
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <StepLabel number="4">Keep or upload</StepLabel>
+              <h2 className="mt-3 text-xl font-semibold tracking-tight text-white">The cloud boundary is explicit</h2>
+              <p className="mt-2 max-w-3xl text-sm leading-6 text-slate-400">
+                Local generation, validation, rendering, and status do not require an account. Sign in only when you
+                want to send a completed project to Forma Cloud.
+              </p>
+            </div>
+            <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/25 bg-emerald-400/10 px-2.5 py-1 text-[11px] text-emerald-200">
+              <ArrowUpRight className="h-3.5 w-3.5" aria-hidden="true" />
+              Opt-in upload
+            </div>
+          </div>
+          <div className="mt-5 grid gap-3 lg:grid-cols-2">
+            <CommandBlock
+              label="macOS / Linux"
+              value={UNIX_UPLOAD_COMMAND}
+              description="The CLI stores the session in the OS credential store and redacts secrets before upload."
+            />
+            <CommandBlock
+              label="Windows PowerShell"
+              value={WINDOWS_UPLOAD_COMMAND}
+              description="After a successful push, the CLI reports the cloud project URL and keeps local linkage."
+            />
+          </div>
+          <div className="mt-5 flex flex-wrap gap-2">
+            <Link href="/about" className={PUBLIC_BUTTON_OUTLINE_CLASS}>
+              About Forma
+              <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+            </Link>
+            <a
+              href="https://github.com/caid-technologies/Forma-OSS"
+              target="_blank"
+              rel="noreferrer"
+              className={PUBLIC_BUTTON_PRIMARY_CLASS}
+            >
+              View the source
+              <ArrowUpRight className="h-3.5 w-3.5" aria-hidden="true" />
+            </a>
+          </div>
+        </section>
+
+        <section className={`${PUBLIC_CARD_CLASS} p-5 sm:p-6`}>
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-4 w-4 text-amber-300" aria-hidden="true" />
+            <h2 className="text-lg font-semibold tracking-tight text-white">Troubleshooting</h2>
+          </div>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            <details className="rounded-lg border border-[#2c2f37] bg-[#11151c] p-3">
+              <summary className="cursor-pointer text-sm font-medium text-slate-200">Missing Python or Node</summary>
+              <p className="mt-2 text-xs leading-5 text-slate-500">Install Python 3.11+ and Node.js 18+, then rerun the same setup command. The installer leaves existing files untouched when a prerequisite check fails.</p>
+            </details>
+            <details className="rounded-lg border border-[#2c2f37] bg-[#11151c] p-3">
+              <summary className="cursor-pointer text-sm font-medium text-slate-200">Forma is not connected</summary>
+              <p className="mt-2 text-xs leading-5 text-slate-500">Keep the installer terminal open and run `opencode mcp list` from `forma-workspace`. The local endpoint is `http://127.0.0.1:8000/mcp`.</p>
+            </details>
+            <details className="rounded-lg border border-[#2c2f37] bg-[#11151c] p-3">
+              <summary className="cursor-pointer text-sm font-medium text-slate-200">OpenCode cannot run the prompt</summary>
+              <p className="mt-2 text-xs leading-5 text-slate-500">Authenticate a model provider in OpenCode. Forma does not provide a hidden simulation model or silently substitute an example project.</p>
+            </details>
+            <details className="rounded-lg border border-[#2c2f37] bg-[#11151c] p-3">
+              <summary className="cursor-pointer text-sm font-medium text-slate-200">Upload asks you to log in</summary>
+              <p className="mt-2 text-xs leading-5 text-slate-500">That is expected. Run `forma-oss login` only for cloud operations, then rerun the push command.</p>
+            </details>
+          </div>
+        </section>
+      </main>
+    </PublicAppShell>
+  );
+}

--- a/apps/web/app/install/page.tsx
+++ b/apps/web/app/install/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function InstallPage() {
+  redirect("/install/opencode");
+}

--- a/apps/web/components/legal-footer.tsx
+++ b/apps/web/components/legal-footer.tsx
@@ -36,6 +36,9 @@ export default function LegalFooter() {
             ))}
           </div>
           <div className="flex flex-wrap gap-x-4 gap-y-2 sm:justify-end">
+            <Link href="/install/opencode" className="hover:text-white">
+              Install for OpenCode
+            </Link>
             <Link href="/about" className="hover:text-white">
               About
             </Link>

--- a/docs/agent-clients.md
+++ b/docs/agent-clients.md
@@ -61,7 +61,16 @@ overrides.
 
 ## OpenCode
 
-OpenCode also discovers `.agents/skills/forma-hardware/SKILL.md`. Add Forma to `opencode.json`:
+The one-command local setup is documented at
+[Install Forma for OpenCode](https://caid-technologies.us/install/opencode). It
+clones or reuses a Forma checkout, starts the local backend and frontend,
+copies the complete skill into `~/forma-workspace`, and preserves existing
+OpenCode settings while adding the local MCP entry. From an existing checkout,
+run `scripts/development/setup-opencode.py` followed by `dev.sh` (or the
+PowerShell equivalents).
+
+OpenCode also discovers `.agents/skills/forma-hardware/SKILL.md`. The setup
+helper writes this `opencode.json` entry:
 
 ```json
 {
@@ -107,5 +116,9 @@ If MCP is not configured in the host, the skill's standard-library client can ca
 
 ```bash
 python .agents/skills/forma-hardware/scripts/forma.py tools
-python .agents/skills/forma-hardware/scripts/forma.py compile project.json --authoring-agent opencode --output compiled.json
+python .agents/skills/forma-hardware/scripts/forma.py compile project.json --authoring-agent opencode --output compiled.json --update-project
 ```
+
+The `--update-project` flag replaces the draft manifest's `project_ir` with the
+compiled response and updates its project ID, so the local manifest is ready
+for an intentional `forma-oss login` followed by cloud upload.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -8,6 +8,66 @@ Forma OSS runs a FastAPI backend and a Next.js frontend. Supabase is supported f
 - **Supabase project** (optional, recommended for deployed persistent storage)
 - **Docker** (optional, for containerized frontend and backend images)
 
+## OpenCode local setup
+
+Forma can run entirely locally while OpenCode supplies the model and authors
+the Hardware IR. Local generation, validation, rendering, and project status do
+not require a Forma account. The account is only needed when a project is
+uploaded to Forma Cloud.
+
+The website provides copyable installers for macOS/Linux and Windows:
+
+- [Install Forma for OpenCode](https://caid-technologies.us/install/opencode)
+
+From an existing checkout, the equivalent setup commands are:
+
+```bash
+python3 scripts/development/setup-opencode.py --root . --workspace "$HOME/forma-workspace" --install-cli
+./scripts/development/dev.sh
+```
+
+On Windows PowerShell:
+
+```powershell
+py -3 .\scripts\development\setup-opencode.py --root . --workspace "$HOME\forma-workspace" --install-cli
+.\scripts\development\dev.ps1
+```
+
+Open the local workspace in a second terminal after the services start:
+
+```bash
+cd ~/forma-workspace
+opencode mcp list
+opencode
+```
+
+The local MCP endpoint is `http://127.0.0.1:8000/mcp`. OpenCode should call
+`forma.compile_project`, which performs deterministic normalization,
+validation, schematic generation, and local persistence without invoking a
+server-side LLM or substituting simulation output.
+
+The final compiled response must be written back to the local
+`forma-project.json`. The shared skill's bundled client supports this directly
+and materializes the returned validation, Mermaid, and SVG artifacts beside the
+manifest:
+
+```bash
+python .agents/skills/forma-hardware/scripts/forma.py compile \
+  "$HOME/forma-workspace/<project-id>/forma-project.json" \
+  --authoring-agent opencode \
+  --output "$HOME/forma-workspace/<project-id>/compiled-project.json" \
+  --update-project
+```
+
+To upload later, authenticate explicitly and push the local project:
+
+```bash
+forma-oss login
+forma-oss projects push --path "$HOME/forma-workspace/<project-id>"
+```
+
+Provider credentials and local secrets are excluded from the upload payload.
+
 ## Docker setup
 From the repo root:
 

--- a/forma_cli/app.py
+++ b/forma_cli/app.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import argparse
 import getpass
 import json
+import os
 from pathlib import Path
 import sys
 import time
+from urllib.parse import quote
 import webbrowser
 from typing import Any
 
@@ -214,7 +216,8 @@ def cmd_projects_push(args: argparse.Namespace) -> int:
         print("Upload cancelled.")
         return 1
     linkage = load_linkage(root)
-    revision = _client(args).push_project(
+    client = _client(args)
+    revision = client.push_project(
         manifest.upload_payload(),
         parent_revision_id=linkage.get("revision_id"),
     )
@@ -229,10 +232,12 @@ def cmd_projects_push(args: argparse.Namespace) -> int:
         manifest_digest=_manifest_digest(manifest.upload_payload()),
     )
     payload = revision.model_dump(mode="json")
+    payload["project_url"] = _project_url(client.base_url or api_url(), revision.project_id)
     if args.json:
         _print_json(payload)
     else:
         print(f"Uploaded private project {revision.project_id} revision {revision.revision_id}")
+        print(f"Project URL: {payload['project_url']}")
     return 0
 
 
@@ -279,6 +284,18 @@ def _manifest_digest(value: Any) -> str:
 
     canonical = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(canonical).hexdigest()
+
+
+def _project_url(api_endpoint: str, project_id: str) -> str:
+    """Build the browser URL without coupling the CLI to the web client."""
+    web_endpoint = (
+        os.environ.get("FORMA_WEB_URL")
+        or os.environ.get("NEXT_PUBLIC_APP_URL")
+        or api_endpoint.rstrip("/")
+    ).rstrip("/")
+    if web_endpoint.endswith("/api"):
+        web_endpoint = web_endpoint[:-4].rstrip("/")
+    return f"{web_endpoint}/project/{quote(project_id, safe='')}"
 
 
 def _local_key_rows(store: CredentialStore) -> list[dict[str, Any]]:

--- a/scripts/development/dev.ps1
+++ b/scripts/development/dev.ps1
@@ -229,6 +229,12 @@ try {
         Invoke-Checked $VenvPip @("install", "-r", (Join-Path $RootDir "apps\api\requirements.txt"))
     }
 
+    & $VenvPython -c "import forma_cli" *> $null
+    if ($LASTEXITCODE -ne 0) {
+        Write-Host "[forma-dev] Installing the forma-oss CLI"
+        Invoke-Checked $VenvPip @("install", "-e", $RootDir)
+    }
+
     $npmCommand = Get-Command npm.cmd -ErrorAction SilentlyContinue
     if ($null -eq $npmCommand) {
         $npmCommand = Get-Command npm -ErrorAction SilentlyContinue

--- a/scripts/development/dev.sh
+++ b/scripts/development/dev.sh
@@ -125,6 +125,11 @@ if ! "$VENV_DIR/bin/python" -m uvicorn --version >/dev/null 2>&1; then
   "$VENV_DIR/bin/pip" install -r "$ROOT_DIR/apps/api/requirements.txt"
 fi
 
+if ! "$VENV_DIR/bin/python" -c 'import forma_cli' >/dev/null 2>&1; then
+  log "Installing the forma-oss CLI"
+  "$VENV_DIR/bin/pip" install -e "$ROOT_DIR"
+fi
+
 if [ ! -d "$ROOT_DIR/apps/web/node_modules" ]; then
   log "Installing frontend dependencies"
   (cd "$ROOT_DIR/apps/web" && npm install)

--- a/scripts/development/install-opencode.ps1
+++ b/scripts/development/install-opencode.ps1
@@ -1,0 +1,82 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+function Fail-Setup {
+    param([Parameter(Mandatory = $true)][string]$Message)
+    throw "forma install: $Message"
+}
+
+$repoUrl = if ([string]::IsNullOrWhiteSpace($env:FORMA_OSS_REPO_URL)) {
+    "https://github.com/caid-technologies/Forma-OSS.git"
+} else {
+    $env:FORMA_OSS_REPO_URL
+}
+$localAppData = if ([string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {
+    Join-Path $HOME "AppData\Local"
+} else {
+    $env:LOCALAPPDATA
+}
+$installDir = if ([string]::IsNullOrWhiteSpace($env:FORMA_OSS_INSTALL_DIR)) {
+    Join-Path $localAppData "Forma\forma-oss"
+} else {
+    $env:FORMA_OSS_INSTALL_DIR
+}
+$workspaceDir = if ([string]::IsNullOrWhiteSpace($env:FORMA_WORKSPACE_DIR)) {
+    Join-Path $HOME "forma-workspace"
+} else {
+    $env:FORMA_WORKSPACE_DIR
+}
+
+$git = Get-Command git -ErrorAction SilentlyContinue
+if ($null -eq $git) {
+    Fail-Setup "git was not found on PATH. Install Git and rerun this command."
+}
+
+$python = Get-Command py -ErrorAction SilentlyContinue
+$pythonArgs = @("-3")
+if ($null -eq $python) {
+    $python = Get-Command python -ErrorAction SilentlyContinue
+    $pythonArgs = @()
+}
+if ($null -eq $python) {
+    Fail-Setup "Python 3.11 or newer was not found on PATH. Install Python and rerun this command."
+}
+
+if ((Test-Path -LiteralPath $installDir) -and -not (Test-Path -LiteralPath (Join-Path $installDir ".git"))) {
+    Fail-Setup "$installDir exists but is not a Forma Git checkout. Set FORMA_OSS_INSTALL_DIR to another path."
+}
+
+if (-not (Test-Path -LiteralPath (Join-Path $installDir ".git"))) {
+    $parent = Split-Path -Parent $installDir
+    New-Item -ItemType Directory -Path $parent -Force | Out-Null
+    $cloneArgs = @("clone", "--depth", "1")
+    if (-not [string]::IsNullOrWhiteSpace($env:FORMA_OSS_REF)) {
+        $cloneArgs += @("--branch", $env:FORMA_OSS_REF)
+    }
+    $cloneArgs += @($repoUrl, $installDir)
+    & $git.Source @cloneArgs
+    if ($LASTEXITCODE -ne 0) {
+        Fail-Setup "Could not clone Forma OSS."
+    }
+} else {
+    Write-Host "Using existing Forma checkout at $installDir"
+}
+
+$pythonExecutable = (& $python.Source @pythonArgs -c "import sys; print(sys.executable)" | Out-String).Trim()
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($pythonExecutable)) {
+    Fail-Setup "Could not resolve the Python executable used for the local runtime."
+}
+$env:PYTHON_BIN = $pythonExecutable
+
+$setupScript = Join-Path $installDir "scripts\development\setup-opencode.py"
+& $python.Source @pythonArgs $setupScript --root $installDir --workspace $workspaceDir --install-cli
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+Write-Host ""
+Write-Host "Starting the local Forma backend and UI. Keep this terminal open."
+Write-Host ""
+& (Join-Path $installDir "scripts\development\dev.ps1")

--- a/scripts/development/install-opencode.sh
+++ b/scripts/development/install-opencode.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+REPO_URL="${FORMA_OSS_REPO_URL:-https://github.com/caid-technologies/Forma-OSS.git}"
+INSTALL_DIR="${FORMA_OSS_INSTALL_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/forma-oss}"
+WORKSPACE_DIR="${FORMA_WORKSPACE_DIR:-$HOME/forma-workspace}"
+REF="${FORMA_OSS_REF:-}"
+
+fail() {
+  printf 'forma install: %s\n' "$1" >&2
+  exit 2
+}
+
+command -v git >/dev/null 2>&1 || fail "git was not found on PATH. Install Git and rerun this command."
+
+if command -v python3 >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python3)"
+elif command -v python >/dev/null 2>&1; then
+  PYTHON_BIN="$(command -v python)"
+else
+  fail "Python 3.11 or newer was not found on PATH. Install Python and rerun this command."
+fi
+
+if [ -e "$INSTALL_DIR" ] && [ ! -d "$INSTALL_DIR/.git" ]; then
+  fail "$INSTALL_DIR exists but is not a Forma Git checkout. Set FORMA_OSS_INSTALL_DIR to another path."
+fi
+
+if [ ! -d "$INSTALL_DIR/.git" ]; then
+  mkdir -p "$(dirname "$INSTALL_DIR")"
+  clone_args=(clone --depth 1)
+  if [ -n "$REF" ]; then
+    clone_args+=(--branch "$REF")
+  fi
+  clone_args+=("$REPO_URL" "$INSTALL_DIR")
+  git "${clone_args[@]}"
+else
+  printf 'Using existing Forma checkout at %s\n' "$INSTALL_DIR"
+fi
+
+export PYTHON_BIN
+
+"$PYTHON_BIN" "$INSTALL_DIR/scripts/development/setup-opencode.py" \
+  --root "$INSTALL_DIR" \
+  --workspace "$WORKSPACE_DIR" \
+  --install-cli
+
+printf '\nStarting the local Forma backend and UI. Keep this terminal open.\n\n'
+exec bash "$INSTALL_DIR/scripts/development/dev.sh"

--- a/scripts/development/setup-opencode.py
+++ b/scripts/development/setup-opencode.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Prepare a local Forma workspace for OpenCode.
+
+This helper deliberately uses only the Python standard library so the bootstrap
+scripts can run before the backend environment has been installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any
+
+
+LOCAL_MCP_URL = "http://127.0.0.1:8000/mcp"
+OPENCODE_SCHEMA = "https://opencode.ai/config.json"
+SKILL_RELATIVE_PATH = Path(".agents") / "skills" / "forma-hardware"
+
+
+class SetupError(RuntimeError):
+    """Raised when local OpenCode setup cannot be completed safely."""
+
+
+def _command_version(command: str) -> str:
+    executable = shutil.which(command)
+    if not executable:
+        raise SetupError(f"{command} was not found on PATH.")
+    try:
+        result = subprocess.run(
+            [executable, "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise SetupError(f"Could not read the installed {command} version.") from exc
+    return (result.stdout or result.stderr).strip()
+
+
+def _major_version(value: str) -> int | None:
+    match = re.search(r"(?:^|\s|v)(\d+)(?:\.\d+)?", value)
+    return int(match.group(1)) if match else None
+
+
+def _require_runtime_prerequisites() -> dict[str, str]:
+    if sys.version_info < (3, 11):
+        raise SetupError(
+            f"Python 3.11 or newer is required; found {sys.version_info.major}.{sys.version_info.minor}."
+        )
+
+    versions = {"python": ".".join(str(part) for part in sys.version_info[:3])}
+    node_version = _command_version("node")
+    node_major = _major_version(node_version)
+    if node_major is None or node_major < 18:
+        raise SetupError(f"Node.js 18 or newer is required; found {node_version or 'an unknown version'}.")
+    versions["node"] = node_version
+    versions["npm"] = _command_version("npm")
+
+    try:
+        versions["opencode"] = _command_version("opencode")
+    except SetupError as exc:
+        raise SetupError(
+            "OpenCode was not found on PATH. Install OpenCode from https://opencode.ai/docs/cli/ "
+            "and run this setup again."
+        ) from exc
+    return versions
+
+
+def _repo_version(root: Path) -> str:
+    version_file = root / "forma_core" / "_version.py"
+    try:
+        content = version_file.read_text(encoding="utf-8")
+    except OSError:
+        return "unknown"
+    match = re.search(r'__version__\s*=\s*["\']([^"\']+)', content)
+    return match.group(1) if match else "unknown"
+
+
+def _git_revision(root: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--short", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
+def _install_cli(root: Path) -> None:
+    command = [sys.executable, "-m", "pip", "install"]
+    if sys.prefix == getattr(sys, "base_prefix", sys.prefix):
+        command.append("--user")
+    command.extend(("--editable", str(root)))
+    try:
+        subprocess.run(command, check=True)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise SetupError("Could not install the forma-oss CLI from the local checkout.") from exc
+
+
+def _copy_skill(root: Path, workspace: Path) -> Path:
+    source = root / SKILL_RELATIVE_PATH
+    if not source.is_dir():
+        raise SetupError(f"The Forma hardware skill is missing from the checkout: {source}")
+    destination = workspace / SKILL_RELATIVE_PATH
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(source, destination, dirs_exist_ok=True)
+    return destination
+
+
+def _write_json(path: Path, payload: dict[str, Any]) -> None:
+    temporary = path.with_suffix(f"{path.suffix}.tmp")
+    temporary.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.replace(path)
+
+
+def _configure_opencode(workspace: Path) -> Path:
+    workspace.mkdir(parents=True, exist_ok=True)
+    config_path = workspace / "opencode.json"
+    payload: dict[str, Any] = {}
+    if config_path.exists():
+        try:
+            loaded = json.loads(config_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise SetupError(
+                f"{config_path} is not valid JSON. No configuration was changed; repair it and rerun setup."
+            ) from exc
+        if not isinstance(loaded, dict):
+            raise SetupError(f"{config_path} must contain a JSON object. No configuration was changed.")
+        payload = loaded
+
+    payload.setdefault("$schema", OPENCODE_SCHEMA)
+    mcp = payload.get("mcp")
+    if mcp is None:
+        mcp = {}
+    if not isinstance(mcp, dict):
+        raise SetupError(f"The mcp setting in {config_path} must be an object. No configuration was changed.")
+
+    expected = {
+        "type": "remote",
+        "url": LOCAL_MCP_URL,
+        "enabled": True,
+        "oauth": False,
+    }
+    existing = mcp.get("forma")
+    if existing is None:
+        mcp["forma"] = expected
+    elif not isinstance(existing, dict):
+        raise SetupError(
+            f"The existing forma MCP entry in {config_path} is not an object. "
+            "No configuration was changed."
+        )
+    elif existing.get("url") not in {None, LOCAL_MCP_URL}:
+        raise SetupError(
+            f"The existing forma MCP entry points to {existing.get('url')!r}, not the local endpoint. "
+            "No configuration was changed."
+        )
+    else:
+        mcp["forma"] = {**expected, **existing, "url": LOCAL_MCP_URL}
+    payload["mcp"] = mcp
+    _write_json(config_path, payload)
+    return config_path
+
+
+def configure(root: Path, workspace: Path, *, install_cli: bool) -> dict[str, str]:
+    root = root.expanduser().resolve()
+    workspace = workspace.expanduser().resolve()
+    if not root.is_dir():
+        raise SetupError(f"Forma checkout does not exist: {root}")
+
+    versions = _require_runtime_prerequisites()
+    if install_cli:
+        _install_cli(root)
+    skill_path = _copy_skill(root, workspace)
+    config_path = _configure_opencode(workspace)
+    return {
+        "forma_version": _repo_version(root),
+        "git_revision": _git_revision(root),
+        "workspace": str(workspace),
+        "skill": str(skill_path),
+        "opencode_config": str(config_path),
+        **versions,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Prepare a local Forma workspace for OpenCode.")
+    parser.add_argument("--root", required=True, help="Forma OSS checkout to use for the local runtime.")
+    parser.add_argument(
+        "--workspace",
+        default=str(Path.home() / "forma-workspace"),
+        help="OpenCode workspace that will contain the local skill and MCP configuration.",
+    )
+    parser.add_argument(
+        "--install-cli",
+        action="store_true",
+        help="Install the checkout's forma-oss command into the current Python environment.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        details = configure(Path(args.root), Path(args.workspace), install_cli=args.install_cli)
+    except SetupError as exc:
+        print(f"forma setup: {exc}", file=sys.stderr)
+        return 2
+
+    print("Forma local OpenCode setup is ready.")
+    print(f"  Forma version: {details['forma_version']} ({details['git_revision']})")
+    print(f"  OpenCode: {details['opencode']}")
+    print(f"  Workspace: {details['workspace']}")
+    print(f"  MCP: {LOCAL_MCP_URL}")
+    print("  No simulation or server-side model was configured.")
+    print("")
+    print("Open a second terminal and run:")
+    print(f"  opencode {details['workspace']}")
+    print("  forma-oss login  # only when you choose to upload a project")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tooling/test_opencode_setup.py
+++ b/tests/tooling/test_opencode_setup.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import tempfile
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_module(path: Path, name: str):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class OpenCodeSetupTests(unittest.TestCase):
+    def test_local_opencode_config_preserves_existing_settings(self) -> None:
+        setup = load_module(
+            REPO_ROOT / "scripts" / "development" / "setup-opencode.py",
+            "forma_opencode_setup",
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            workspace = Path(temporary) / "workspace"
+            workspace.mkdir()
+            config_path = workspace / "opencode.json"
+            config_path.write_text(
+                json.dumps(
+                    {
+                        "$schema": "https://example.test/schema.json",
+                        "model": "provider/model",
+                        "mcp": {"other": {"type": "remote", "url": "https://example.test/mcp"}},
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            setup._configure_opencode(workspace)
+            payload = json.loads(config_path.read_text(encoding="utf-8"))
+
+            self.assertEqual("provider/model", payload["model"])
+            self.assertIn("other", payload["mcp"])
+            self.assertEqual("http://127.0.0.1:8000/mcp", payload["mcp"]["forma"]["url"])
+            self.assertTrue(payload["mcp"]["forma"]["enabled"])
+            self.assertFalse(payload["mcp"]["forma"]["oauth"])
+
+    def test_skill_copy_includes_nested_helper_files(self) -> None:
+        setup = load_module(
+            REPO_ROOT / "scripts" / "development" / "setup-opencode.py",
+            "forma_opencode_setup_skill",
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary) / "forma"
+            source = root / setup.SKILL_RELATIVE_PATH
+            (source / "scripts").mkdir(parents=True)
+            (source / "references").mkdir()
+            (source / "SKILL.md").write_text("skill", encoding="utf-8")
+            (source / "scripts" / "forma.py").write_text("client", encoding="utf-8")
+            (source / "references" / "configuration.md").write_text("configuration", encoding="utf-8")
+
+            destination = setup._copy_skill(root, Path(temporary) / "workspace")
+
+            self.assertEqual("skill", (destination / "SKILL.md").read_text(encoding="utf-8"))
+            self.assertTrue((destination / "scripts" / "forma.py").is_file())
+            self.assertTrue((destination / "references" / "configuration.md").is_file())
+
+    def test_compiler_response_updates_uploadable_manifest(self) -> None:
+        client = load_module(
+            REPO_ROOT / ".agents" / "skills" / "forma-hardware" / "scripts" / "forma.py",
+            "forma_skill_client_manifest",
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            project_path = Path(temporary) / "forma-project.json"
+            project_path.write_text(
+                json.dumps(
+                    {
+                        "format": "forma-project",
+                        "version": 1,
+                        "project_id": "draft-id",
+                        "title": "Draft project",
+                        "prompt": "Build a monitor",
+                        "project_ir": {"components": [], "nets": []},
+                        "artifacts": [{"path": "notes.md"}],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            compiled = {
+                "project_id": "compiled-id",
+                "project_ir": {
+                    "overview": {"title": "Compiled project"},
+                    "assembly_metadata": {
+                        "project_id": "compiled-id",
+                        "source_prompt": "Build a monitor",
+                    },
+                    "components": [{"reference": "U1"}],
+                    "nets": [],
+                },
+                "validation": {"critical": [], "warnings": []},
+                "mermaid_code": "flowchart LR\n  U1 --> U2",
+                "svg_schematic": "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>",
+            }
+
+            client._update_project_manifest(str(project_path), compiled)
+            payload = json.loads(project_path.read_text(encoding="utf-8"))
+
+            self.assertEqual("compiled-id", payload["project_id"])
+            self.assertEqual(compiled["project_ir"], payload["project_ir"])
+            self.assertIn({"path": "notes.md"}, payload["artifacts"])
+            self.assertEqual(
+                {"path": "validation.json", "media_type": "application/json"},
+                {key: value for key, value in payload["artifacts"][1].items() if key != "sha256"},
+            )
+            self.assertEqual("Draft project", payload["title"])
+            self.assertTrue((Path(temporary) / "validation.json").is_file())
+            self.assertTrue((Path(temporary) / "wiring.mmd").is_file())
+            self.assertTrue((Path(temporary) / "schematic.svg").is_file())
+
+    def test_compile_parser_exposes_manifest_update(self) -> None:
+        client = load_module(
+            REPO_ROOT / ".agents" / "skills" / "forma-hardware" / "scripts" / "forma.py",
+            "forma_skill_client_parser",
+        )
+        args = client.build_parser().parse_args(
+            [
+                "compile",
+                "forma-project.json",
+                "--authoring-agent",
+                "opencode",
+                "--update-project",
+            ]
+        )
+        self.assertTrue(args.update_project)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tooling/test_oss_cli.py
+++ b/tests/tooling/test_oss_cli.py
@@ -319,6 +319,10 @@ class OssCliTests(unittest.TestCase):
 
             payload = json.loads(stdout.getvalue())
             self.assertEqual("revision-1", payload["revision_id"])
+            self.assertEqual(
+                f"https://api.example.test/project/{manifest.project_id}",
+                payload["project_url"],
+            )
             self.assertIn("This will upload", stderr.getvalue())
 
 


### PR DESCRIPTION
Closes #136

## Summary
- Add macOS/Linux and Windows one-command installers for a local OpenCode workspace.
- Configure the local Forma MCP endpoint, preserve OpenCode settings, and copy the complete hardware skill.
- Persist compiled project IR plus validation, Mermaid, and SVG artifacts locally.
- Add the public /install/opencode onboarding page, navigation, CLI project URLs, and documentation.

## Validation
- 26 focused Python tests passed.
- MCP compatibility tests passed: 17 tests.
- TypeScript check and Next.js production build passed.
- ESLint passed with 10 existing image warnings.
- PowerShell syntax validation passed.
- OpenCode 1.18.19 setup and mcp list smoke tests passed.
- Full suite still has unrelated provider-preflight, Windows SQLite cleanup, and existing integration failures.