### PR TITLE
feat: sync CLI project artifact files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -214,6 +214,13 @@ SUPABASE_S3_BUCKET=contents
 # SUPABASE_IMAGE_SIGNED_URL_SECONDS=86400
 # Optional public URL base for generated object URLs.
 # SUPABASE_STORAGE_PUBLIC_BASE_URL=....
+# CLI project artifacts use a private bucket and project-scoped object keys.
+# Hosted/Supabase deployments use this bucket by default; local/SQLite deployments
+# keep the same API contract on disk unless explicitly configured otherwise.
+# FORMA_CLI_ARTIFACT_BUCKET=cli-project-artifacts
+# FORMA_CLI_ARTIFACT_STORAGE_BACKEND=supabase
+# FORMA_CLI_ARTIFACT_STORAGE_DIR=./.forma/cli-artifacts
+# FORMA_CLI_ARTIFACT_MAX_BYTES=52428800
 
 # Generic provider aliases are supported for all live providers.
 # LLM_API_KEY=your_provider_api_key_here

--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ forma-oss projects push --path ./my-project
 forma-oss projects pull --path ./my-project
 ```
 
+`projects push` validates and uploads every file declared in the local
+manifest. `projects pull` verifies downloaded bytes, restores them beneath the
+project directory, and rewrites native CAD paths before updating the manifest.
+
 Provider credentials for direct CLI generation can be stored locally:
 
 ```bash
@@ -417,6 +421,10 @@ Use the shared `LLM_API_KEY`, `LLM_MODEL`, and `LLM_BASE_URL` variables with `LL
 - `SUPABASE_S3_BUCKET`: Supabase Storage bucket for image uploads (default: `contents`).
 - `SUPABASE_S3_ACCESS_KEY_ID` / `SUPABASE_S3_SECRET_ACCESS_KEY`: Optional S3-compatible fallback credentials. The normal backend path uploads through the Supabase client with `SUPABASE_URL` plus the service-role/secret key.
 - `SUPABASE_IMAGE_SIGNED_URL_SECONDS`: Lifetime for refreshed Supabase Storage read URLs when projects are loaded (default: `86400`).
+- `FORMA_CLI_ARTIFACT_BUCKET`: Private bucket for `forma-oss projects push/pull` artifacts (default: `cli-project-artifacts`).
+- `FORMA_CLI_ARTIFACT_STORAGE_BACKEND`: Optional `supabase`, `s3-compatible`, or `local` override for CLI artifacts. Supabase-primary hosted deployments use Supabase by default; SQLite/local deployments use the local API storage directory by default.
+- `FORMA_CLI_ARTIFACT_STORAGE_DIR`: Local artifact directory when the CLI artifact backend is `local` (default: `./.forma/cli-artifacts`).
+- `FORMA_CLI_ARTIFACT_MAX_BYTES`: Maximum size of one transferred artifact (default: `52428800`).
 - `HF_ARTIFACT_REPO_ID` / `HUGGINGFACE_ARTIFACT_REPO_ID` / `HF_DATASET_REPO_ID`: Optional Hugging Face dataset repo for uploaded benchmark, output, and eval artifacts.
 - `HF_ARTIFACT_PATH_PREFIX`: Optional path prefix inside the artifact repo. Defaults to `forma`.
 - `EXTERNAL_SOURCE_PROVIDER`: External web/source provider for `workflow=web_research`. Firecrawl is the only active provider for now; legacy `auto` or `tavily` values are normalized to `firecrawl`.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -10,6 +10,11 @@ SQLITE_DATABASE_URL=sqlite:///./forma.db
 # Explicit ancillary overrides, if they should differ from the primary database:
 # FORMA_IMAGE_STORAGE_BACKEND=supabase
 # FORMA_WORKSPACE_INTEGRATIONS_BACKEND=supabase
+# CLI project artifacts use a private project-scoped bucket when Supabase is primary.
+# FORMA_CLI_ARTIFACT_BUCKET=cli-project-artifacts
+# FORMA_CLI_ARTIFACT_STORAGE_BACKEND=supabase
+# FORMA_CLI_ARTIFACT_STORAGE_DIR=./.forma/cli-artifacts
+# FORMA_CLI_ARTIFACT_MAX_BYTES=52428800
 
 # Choose exactly one authentication mode:
 #   local - No Clerk runtime or sign-in; Settings belong to this workspace.

--- a/apps/api/cli_projects_api.py
+++ b/apps/api/cli_projects_api.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import hashlib
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field
 
 from apps.api.auth import UserContext, require_user_context
@@ -14,7 +15,15 @@ from forma_core.database import (
     insert_cli_project_revision,
     list_cli_projects,
 )
-from forma_core.workspaces.projects.manifest import ProjectManifest
+from forma_core.persistence.project_artifacts import (
+    ProjectArtifactStorage,
+    ProjectArtifactStorageError,
+)
+from forma_core.workspaces.projects.manifest import (
+    ProjectManifest,
+    normalize_artifact_media_type,
+    validate_artifact_references,
+)
 
 
 router = APIRouter(prefix="/cli/projects", tags=["cli"])
@@ -45,6 +54,12 @@ async def push_cli_project(
     try:
         manifest = ProjectManifest.from_document(request.manifest)
         payload = manifest.upload_payload()
+        payload["artifacts"] = validate_artifact_references(payload.get("artifacts"), require_integrity=True)
+        if payload["artifacts"] and not ProjectArtifactStorage().config.get("enabled"):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="CLI project artifact storage is not configured.",
+            )
         return insert_cli_project_revision(
             payload,
             owner,
@@ -54,6 +69,137 @@ async def push_cli_project(
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+def _revision_artifact(project_id: str, revision_id: str, owner: str, artifact_sha256: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    revision = get_cli_project_revision(project_id, owner, revision_id)
+    if revision is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Cloud project artifact not found or not authorized.",
+        )
+    try:
+        manifest = ProjectManifest.from_document(revision.get("manifest") or {})
+        artifacts = validate_artifact_references(manifest.artifacts, require_integrity=True)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail=str(exc)) from exc
+    normalized_sha256 = str(artifact_sha256 or "").strip().lower()
+    for artifact in artifacts:
+        if artifact.get("sha256") == normalized_sha256:
+            return revision, artifact
+    raise HTTPException(
+        status_code=status.HTTP_404_NOT_FOUND,
+        detail="The requested artifact is not declared by this cloud revision.",
+    )
+
+
+@router.put("/{project_id}/revisions/{revision_id}/artifacts/{artifact_sha256}")
+async def upload_cli_project_artifact(
+    project_id: str,
+    revision_id: str,
+    artifact_sha256: str,
+    request: Request,
+    user: UserContext = Depends(require_user_context),
+) -> dict[str, Any]:
+    _revision, artifact = _revision_artifact(project_id, revision_id, _owner(user), artifact_sha256)
+    try:
+        media_type = normalize_artifact_media_type(request.headers.get("content-type"))
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Artifact Content-Type is required.") from exc
+    if media_type != artifact["media_type"]:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Artifact media type mismatch for {artifact['path']}: "
+                f"expected {artifact['media_type']}, received {media_type}."
+            ),
+        )
+
+    storage = ProjectArtifactStorage()
+    max_bytes = int(storage.config["max_bytes"])
+    content_length = request.headers.get("content-length")
+    try:
+        if content_length is not None:
+            declared_length = int(content_length)
+            if declared_length < 0:
+                raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid Content-Length header.")
+            if declared_length > max_bytes:
+                raise HTTPException(status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail="Project artifact is too large.")
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid Content-Length header.") from exc
+    content_parts: list[bytes] = []
+    content_size = 0
+    async for chunk in request.stream():
+        content_size += len(chunk)
+        if content_size > max_bytes:
+            raise HTTPException(status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE, detail="Project artifact is too large.")
+        content_parts.append(chunk)
+    content = b"".join(content_parts)
+    actual_sha256 = hashlib.sha256(content).hexdigest()
+    if actual_sha256 != artifact["sha256"]:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                f"Artifact hash mismatch for {artifact['path']}: "
+                f"expected {artifact['sha256']}, received {actual_sha256}."
+            ),
+        )
+    if artifact.get("size_bytes") is not None and len(content) != artifact["size_bytes"]:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Artifact size mismatch for {artifact['path']}.",
+        )
+    try:
+        stored = storage.put(project_id, artifact["sha256"], content, artifact["media_type"])
+    except ProjectArtifactStorageError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+    except OSError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail="Project artifact storage is unavailable.") from exc
+    return {
+        "path": artifact["path"],
+        "status": "uploaded",
+        "sha256": stored.sha256,
+        "media_type": stored.media_type,
+        "size_bytes": stored.size_bytes,
+    }
+
+
+@router.get("/{project_id}/revisions/{revision_id}/artifacts/{artifact_sha256}")
+async def download_cli_project_artifact(
+    project_id: str,
+    revision_id: str,
+    artifact_sha256: str,
+    user: UserContext = Depends(require_user_context),
+) -> Response:
+    _revision, artifact = _revision_artifact(project_id, revision_id, _owner(user), artifact_sha256)
+    try:
+        stored = ProjectArtifactStorage().get(project_id, artifact["sha256"], artifact["media_type"])
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Cloud project artifact is missing.") from exc
+    except ProjectArtifactStorageError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+    except OSError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Cloud project artifact is missing.") from exc
+    content = stored.content or b""
+    actual_sha256 = hashlib.sha256(content).hexdigest()
+    if actual_sha256 != artifact["sha256"]:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Stored cloud artifact {artifact['path']} failed its SHA-256 integrity check.",
+        )
+    if artifact.get("size_bytes") is not None and len(content) != artifact["size_bytes"]:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Stored cloud artifact {artifact['path']} failed its size check.",
+        )
+    return Response(
+        content=content,
+        media_type=artifact["media_type"],
+        headers={
+            "X-Forma-Artifact-SHA256": artifact["sha256"],
+            "X-Forma-Artifact-Size": str(len(content)),
+        },
+    )
 
 
 @router.get("/{project_id}/revisions/{revision_id}")

--- a/apps/api/project_deletion.py
+++ b/apps/api/project_deletion.py
@@ -30,6 +30,7 @@ from forma_core.database import (
 )
 from forma_core.jobs.store import JOB_STORE
 from forma_core.persistence.images import delete_project_images
+from forma_core.persistence.project_artifacts import ProjectArtifactStorage
 
 logger = logging.getLogger(__name__)
 
@@ -368,6 +369,12 @@ def purge_project(project_id: str) -> Dict[str, Any]:
     try:
         counts["images"] = delete_project_images(project_id)
         counts["videos"] = delete_project_videos(project_id)
+        artifact_storage = ProjectArtifactStorage()
+        counts["artifacts"] = (
+            artifact_storage.delete_project(project_id)
+            if artifact_storage.config.get("enabled")
+            else 0
+        )
         counts["jobs"] = JOB_STORE.delete_project_jobs(project_id)
 
         consent = get_project_contribution_consent(project_id, owner_user_id) if owner_user_id else None

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -237,6 +237,14 @@ SUPABASE_S3_BUCKET=contents
 # SUPABASE_IMAGE_SIGNED_URL_SECONDS=86400
 # SUPABASE_STORAGE_PUBLIC_BASE_URL=https://your-project-ref.supabase.co
 
+# Optional private storage for forma-oss project artifacts.
+# Supabase-primary hosted deployments use the private bucket through the
+# service-role client; SQLite/local deployments use the local directory.
+# FORMA_CLI_ARTIFACT_BUCKET=cli-project-artifacts
+# FORMA_CLI_ARTIFACT_STORAGE_BACKEND=supabase
+# FORMA_CLI_ARTIFACT_STORAGE_DIR=./.forma/cli-artifacts
+# FORMA_CLI_ARTIFACT_MAX_BYTES=52428800
+
 # Generic provider aliases
 # LLM_API_KEY=your_provider_api_key_here
 # LLM_MODEL=gpt-5.6-sol
@@ -270,6 +278,7 @@ Notes:
 - `REDIS_URL` and `REDIS_CACHE_PREFIX` are required at backend startup whenever `FORMA_DEVELOPMENT_MODE` is false. Development mode can omit them and fall back directly to the primary database.
 - Docker Compose uses `COMPOSE_DATABASE_BACKEND` instead and defaults it to `sqlite`; this prevents host-only loopback Supabase URLs from breaking the container quickstart. `COMPOSE_SQLITE_DATABASE_URL` optionally overrides the container SQLite URL.
 - Image storage and encrypted integration stores follow `DATABASE_BACKEND`. Supabase credentials alone do not activate them when `DATABASE_BACKEND=sqlite`; use `FORMA_IMAGE_STORAGE_BACKEND=supabase` or the workspace/user integration backend overrides for an intentional exception.
+- CLI project artifacts use the private `FORMA_CLI_ARTIFACT_BUCKET` (default `cli-project-artifacts`). `FORMA_CLI_ARTIFACT_STORAGE_BACKEND` may select `supabase`, `s3-compatible`, or `local`; the default follows the primary database backend. Each artifact is stored under a project-scoped hash key and is validated against its declared SHA-256 and media type.
 - Provider availability is `environment configured OR (BYOK enabled AND BYOK configured)`. Environment variables remain workspace/platform defaults, saved BYOK values overlay matching fields, and clearing or disabling BYOK reveals the environment fallback. Generated provider/model allowlists include both sources, so either source can make a provider available without suppressing the other.
 - After those inputs are applied, `GET /api/runtime/config` is authoritative for the frontend. Resolution precedence is request override, saved integration, environment, then provider default; the browser does not repeat this merge.
 - `FORMA_DEPLOYMENT_MODE=hosted` requires a configured deployment provider or signed-in user's BYOK provider for generation. Hosted mode cannot run with `FORMA_DEVELOPMENT_MODE=true`; the frontend keeps the composer visible and directs users without an active provider to Settings.

--- a/forma_cli/app.py
+++ b/forma_cli/app.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import argparse
 import getpass
+import hashlib
 import json
 import os
 from pathlib import Path
 import sys
+import tempfile
 import time
 from urllib.parse import quote
 import webbrowser
@@ -28,7 +30,20 @@ from forma_cli.local import (
     update_linkage,
 )
 from forma_cli.metadata_api import project_metadata, serve_metadata_api
-from forma_cli.sdk import FormaAPIClient, FormaAPIError
+from forma_cli.project_artifacts import (
+    artifact_target,
+    canonical_project_upload_payload,
+    file_digest,
+    prepare_project_upload,
+)
+from forma_cli.sdk import FormaAPIClient, FormaAPIError, ProjectArtifactDownload
+from forma_core.workspaces.projects.manifest import (
+    ProjectManifest,
+    normalize_artifact_media_type,
+    validate_artifact_references,
+    write_project_manifest,
+    rewrite_artifact_paths,
+)
 
 
 def _print_json(value: Any) -> None:
@@ -209,18 +224,201 @@ def _confirm_push(args: argparse.Namespace, manifest: Any) -> bool:
     return answer in {"y", "yes"}
 
 
+def _artifact_summary(statuses: list[dict[str, Any]]) -> dict[str, Any]:
+    counts: dict[str, int] = {}
+    for item in statuses:
+        status = str(item.get("status") or "unknown")
+        counts[status] = counts.get(status, 0) + 1
+    return {
+        "total": len(statuses),
+        "succeeded": sum(value for key, value in counts.items() if key in {"uploaded", "restored", "already_present"}),
+        "failed": sum(value for key, value in counts.items() if key not in {"uploaded", "restored", "already_present"}),
+        "by_status": counts,
+    }
+
+
+def _linkage_artifact_digests(linkage: dict[str, Any]) -> dict[str, str]:
+    value = linkage.get("artifact_digests")
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except ValueError:
+            return {}
+    if not isinstance(value, dict):
+        return {}
+    return {
+        str(path): str(digest).strip().lower()
+        for path, digest in value.items()
+        if str(path).strip() and isinstance(digest, str) and digest.strip()
+    }
+
+
+def _ensure_pull_is_safe(
+    root: Path,
+    linkage: dict[str, Any],
+    local_manifest: ProjectManifest,
+    remote_artifacts: list[dict[str, Any]],
+) -> None:
+    """Reject dirty working trees before any remote bytes can replace files."""
+    current_revision = linkage.get("revision_id")
+    if current_revision:
+        expected_digest = linkage.get("manifest_digest")
+        if not expected_digest:
+            raise LocalProjectError(
+                "The linked project lacks a working-tree integrity record; refusing to overwrite local changes."
+            )
+        try:
+            current_digest = _manifest_digest(canonical_project_upload_payload(root, local_manifest))
+        except (LocalProjectError, ValueError) as exc:
+            raise LocalProjectError(
+                "Local project references cannot be verified; refusing to overwrite local changes."
+            ) from exc
+        if current_digest != expected_digest:
+            raise LocalProjectError(
+                "Local project changes diverge from the linked cloud revision; refusing to overwrite them."
+            )
+    elif (
+        local_manifest.project_ir
+        or local_manifest.artifacts
+        or local_manifest.prompt
+        or local_manifest.title not in {"", "Untitled Forma Project"}
+    ):
+        raise LocalProjectError(
+            "The local project is not pristine and has no linked revision; refusing to overwrite local changes."
+        )
+
+    baseline_digests = _linkage_artifact_digests(linkage)
+    local_digests = {
+        artifact.path: artifact.sha256.strip().lower()
+        for artifact in local_manifest.artifacts
+        if artifact.sha256 and artifact.sha256.strip()
+    }
+    for artifact in remote_artifacts:
+        target = artifact_target(root, artifact["path"])
+        if not target.exists() and not target.is_symlink():
+            continue
+        if target.is_symlink() or target.is_dir():
+            raise LocalProjectError(
+                f"Local artifact target is not a regular file: {artifact['path']}; refusing to overwrite it."
+            )
+        actual_digest = file_digest(target)
+        if actual_digest == artifact["sha256"]:
+            continue
+        baseline = baseline_digests.get(artifact["path"]) or local_digests.get(artifact["path"])
+        if not baseline or actual_digest != baseline:
+            raise LocalProjectError(
+                f"Local artifact {artifact['path']} has changed; refusing to overwrite local changes."
+            )
+
+
+def _restored_manifest(
+    root: Path,
+    manifest: ProjectManifest,
+    artifacts: list[dict[str, Any]],
+) -> ProjectManifest:
+    replacements = {
+        artifact["path"]: str(artifact_target(root, artifact["path"]).resolve())
+        for artifact in artifacts
+    }
+    payload = manifest.model_dump(mode="json")
+    payload["artifacts"] = artifacts
+    payload["project_ir"] = rewrite_artifact_paths(payload.get("project_ir", {}), replacements)
+    return ProjectManifest.model_validate(payload)
+
+
+def _download_parts(download: Any) -> tuple[bytes, str | None, str | None, int | None]:
+    if isinstance(download, ProjectArtifactDownload):
+        return download.content, download.content_type, download.sha256, download.size_bytes
+    if isinstance(download, (bytes, bytearray)):
+        return bytes(download), None, None, None
+    if isinstance(download, tuple):
+        content = bytes(download[0])
+        content_type = download[1] if len(download) > 1 else None
+        sha256 = download[2] if len(download) > 2 else None
+        size_bytes = download[3] if len(download) > 3 else None
+        return content, content_type, sha256, size_bytes
+    if isinstance(download, dict):
+        content = download.get("content", b"")
+        return (
+            bytes(content),
+            download.get("content_type") or download.get("media_type"),
+            download.get("sha256"),
+            download.get("size_bytes"),
+        )
+    content = getattr(download, "content", b"")
+    return (
+        bytes(content),
+        getattr(download, "content_type", None),
+        getattr(download, "sha256", None),
+        getattr(download, "size_bytes", None),
+    )
+
+
 def cmd_projects_push(args: argparse.Namespace) -> int:
     root = project_root(args.path)
     manifest = read_project(root)
+    upload_payload, local_artifacts = prepare_project_upload(root, manifest)
     if not _confirm_push(args, manifest):
-        print("Upload cancelled.")
+        if args.json:
+            _print_json({"ok": False, "operation": "push", "status": "cancelled"})
+        else:
+            print("Upload cancelled.")
         return 1
     linkage = load_linkage(root)
     client = _client(args)
     revision = client.push_project(
-        manifest.upload_payload(),
+        upload_payload,
         parent_revision_id=linkage.get("revision_id"),
     )
+    if revision.project_id != manifest.project_id:
+        raise LocalProjectError("Cloud push returned a different project identity; refusing to update local linkage.")
+    artifact_statuses: list[dict[str, Any]] = []
+    for artifact in local_artifacts:
+        try:
+            content = artifact.source_path.read_bytes()
+        except OSError as exc:
+            raise LocalProjectError(f"Could not read project artifact {artifact.path}: {exc}") from exc
+        if hashlib.sha256(content).hexdigest() != artifact.sha256:
+            raise LocalProjectError(
+                f"Project artifact {artifact.path} changed after validation; refusing to upload it."
+            )
+        try:
+            response = client.upload_project_artifact(
+                revision.project_id,
+                revision.revision_id,
+                artifact.sha256,
+                content,
+                artifact.media_type,
+            )
+        except FormaAPIError as exc:
+            raise LocalProjectError(f"Could not upload project artifact {artifact.path}: {exc}") from exc
+        response_sha256 = str(response.get("sha256") or artifact.sha256).strip().lower()
+        response_media_type = str(response.get("media_type") or artifact.media_type)
+        try:
+            response_media_type = normalize_artifact_media_type(response_media_type)
+        except ValueError as exc:
+            raise LocalProjectError(f"Cloud artifact validation failed for {artifact.path}.") from exc
+        if response_sha256 != artifact.sha256 or response_media_type != artifact.media_type:
+            raise LocalProjectError(f"Cloud artifact validation failed for {artifact.path}.")
+        response_size = response.get("size_bytes")
+        if response_size is not None:
+            try:
+                if int(response_size) != artifact.size_bytes:
+                    raise LocalProjectError(f"Cloud artifact validation failed for {artifact.path}.")
+            except (TypeError, ValueError) as exc:
+                raise LocalProjectError(f"Cloud artifact validation failed for {artifact.path}.") from exc
+        artifact_statuses.append(
+            {
+                "path": artifact.path,
+                "status": str(response.get("status") or "uploaded"),
+                "sha256": artifact.sha256,
+                "media_type": artifact.media_type,
+                "size_bytes": artifact.size_bytes,
+            }
+        )
+    if local_artifacts:
+        # Persist the same portable, secret-free shape that was committed remotely.
+        write_project_manifest(root / "forma-project.json", ProjectManifest.model_validate(upload_payload))
     update_linkage(
         root,
         version=1,
@@ -229,14 +427,22 @@ def cmd_projects_push(args: argparse.Namespace) -> int:
         project_id=manifest.project_id,
         revision_id=revision.revision_id,
         parent_revision_id=revision.parent_revision_id,
-        manifest_digest=_manifest_digest(manifest.upload_payload()),
+        manifest_digest=_manifest_digest(upload_payload),
+        artifact_digests=json.dumps(
+            {artifact.path: artifact.sha256 for artifact in local_artifacts},
+            sort_keys=True,
+        ),
     )
     payload = revision.model_dump(mode="json")
+    payload["operation"] = "push"
+    payload["artifacts"] = artifact_statuses
+    payload["artifact_summary"] = _artifact_summary(artifact_statuses)
     payload["project_url"] = _project_url(client.base_url or api_url(), revision.project_id)
     if args.json:
         _print_json(payload)
     else:
         print(f"Uploaded private project {revision.project_id} revision {revision.revision_id}")
+        print(f"Uploaded {len(artifact_statuses)} project artifact(s)")
         print(f"Project URL: {payload['project_url']}")
     return 0
 
@@ -247,22 +453,73 @@ def cmd_projects_pull(args: argparse.Namespace) -> int:
     remote_project_id = args.project_id or linkage.get("remote_project_id") or linkage.get("project_id")
     if not remote_project_id:
         raise LocalProjectError("No remote project is linked. Push this project first or pass --project-id.")
-    revision = _client(args).pull_project(remote_project_id, args.revision_id)
+    client = _client(args)
+    revision = client.pull_project(remote_project_id, args.revision_id)
+    if revision.project_id != remote_project_id:
+        raise LocalProjectError("Cloud pull returned a different project identity; refusing to update local files.")
     current_revision = linkage.get("revision_id")
     if current_revision and current_revision != revision.revision_id:
-        local_manifest = read_project(root)
-        if linkage.get("manifest_digest") and _manifest_digest(local_manifest.upload_payload()) != linkage["manifest_digest"]:
-            raise LocalProjectError(
-                "Local changes diverge from the linked cloud revision; refusing to overwrite them."
-            )
         if revision.parent_revision_id not in {current_revision, None}:
             raise LocalProjectError(
                 "Cloud revision ancestry diverges from the linked local revision; refusing to overwrite it."
             )
-    from forma_core.workspaces.projects.manifest import ProjectManifest, write_project_manifest
-
     manifest = ProjectManifest.from_document(revision.manifest)
-    write_project_manifest(root / "forma-project.json", manifest)
+    if manifest.project_id != revision.project_id:
+        raise LocalProjectError("Cloud revision manifest identity does not match the revision; refusing to pull it.")
+    remote_artifacts = validate_artifact_references(manifest.artifacts, require_integrity=True)
+    local_manifest = read_project(root)
+    _ensure_pull_is_safe(root, linkage, local_manifest, remote_artifacts)
+
+    artifact_statuses: list[dict[str, Any]] = []
+    restored_manifest: ProjectManifest
+    with tempfile.TemporaryDirectory(prefix="forma-pull-", dir=root) as temporary_dir:
+        stage_root = Path(temporary_dir)
+        for artifact in remote_artifacts:
+            try:
+                downloaded = client.download_project_artifact(
+                    revision.project_id,
+                    revision.revision_id,
+                    artifact["sha256"],
+                )
+            except (FormaAPIError, OSError) as exc:
+                raise LocalProjectError(f"Could not restore project artifact {artifact['path']}: {exc}") from exc
+            content, response_media_type, response_sha256, response_size = _download_parts(downloaded)
+            actual_sha256 = hashlib.sha256(content).hexdigest()
+            if actual_sha256 != artifact["sha256"] or (
+                response_sha256 and str(response_sha256).lower() != artifact["sha256"]
+            ):
+                raise LocalProjectError(f"Downloaded project artifact {artifact['path']} failed its hash check.")
+            if response_media_type:
+                try:
+                    normalized_media_type = normalize_artifact_media_type(response_media_type)
+                except ValueError as exc:
+                    raise LocalProjectError(f"Downloaded project artifact {artifact['path']} has an invalid media type.") from exc
+                if normalized_media_type != artifact["media_type"]:
+                    raise LocalProjectError(f"Downloaded project artifact {artifact['path']} failed its media type check.")
+            if artifact.get("size_bytes") is not None and len(content) != artifact["size_bytes"]:
+                raise LocalProjectError(f"Downloaded project artifact {artifact['path']} failed its size check.")
+            if response_size is not None and int(response_size) != len(content):
+                raise LocalProjectError(f"Downloaded project artifact {artifact['path']} returned an invalid size.")
+            staged = stage_root / Path(*artifact["path"].split("/"))
+            staged.parent.mkdir(parents=True, exist_ok=True)
+            staged.write_bytes(content)
+            target = artifact_target(root, artifact["path"])
+            artifact_statuses.append(
+                {
+                    "path": artifact["path"],
+                    "status": "already_present" if target.is_file() and file_digest(target) == artifact["sha256"] else "restored",
+                    "sha256": artifact["sha256"],
+                    "media_type": artifact["media_type"],
+                    "size_bytes": len(content),
+                }
+            )
+
+        restored_manifest = _restored_manifest(root, manifest, remote_artifacts)
+        for artifact in remote_artifacts:
+            target = artifact_target(root, artifact["path"])
+            target.parent.mkdir(parents=True, exist_ok=True)
+            (stage_root / Path(*artifact["path"].split("/"))).replace(target)
+        write_project_manifest(root / "forma-project.json", restored_manifest)
     update_linkage(
         root,
         remote=args.api_url.rstrip("/") if args.api_url else api_url(),
@@ -270,18 +527,25 @@ def cmd_projects_pull(args: argparse.Namespace) -> int:
         project_id=manifest.project_id,
         revision_id=revision.revision_id,
         parent_revision_id=revision.parent_revision_id,
-        manifest_digest=_manifest_digest(manifest.upload_payload()),
+        manifest_digest=_manifest_digest(canonical_project_upload_payload(root, restored_manifest)),
+        artifact_digests=json.dumps(
+            {artifact["path"]: artifact["sha256"] for artifact in remote_artifacts},
+            sort_keys=True,
+        ),
     )
     if args.json:
-        _print_json(revision.model_dump(mode="json"))
+        payload = revision.model_dump(mode="json")
+        payload["operation"] = "pull"
+        payload["artifacts"] = artifact_statuses
+        payload["artifact_summary"] = _artifact_summary(artifact_statuses)
+        _print_json(payload)
     else:
         print(f"Pulled private project {revision.project_id} revision {revision.revision_id}")
+        print(f"Restored {len(artifact_statuses)} project artifact(s)")
     return 0
 
 
 def _manifest_digest(value: Any) -> str:
-    import hashlib
-
     canonical = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(canonical).hexdigest()
 
@@ -425,7 +689,7 @@ def build_parser() -> argparse.ArgumentParser:
     projects_list = project_commands.add_parser("list", help="List private cloud projects.")
     projects_list.add_argument("--json", action="store_true")
     projects_list.set_defaults(func=cmd_projects_list)
-    push = project_commands.add_parser("push", help="Upload the canonical local manifest explicitly.")
+    push = project_commands.add_parser("push", help="Upload the canonical manifest and referenced artifacts explicitly.")
     push.add_argument("--path", default=".")
     push.add_argument("--yes", action="store_true", help="Confirm upload without prompting.")
     push.add_argument("--json", action="store_true")
@@ -462,7 +726,10 @@ def app(argv: list[str] | None = None) -> int:
     try:
         return args.func(args)
     except (CredentialStoreError, FormaAPIError, LocalProjectError, OSError, ValueError, RuntimeError) as exc:
-        print(f"{parser.prog}: {exc}", file=sys.stderr)
+        if getattr(args, "json", False):
+            _print_json({"ok": False, "error": str(exc), "error_type": exc.__class__.__name__})
+        else:
+            print(f"{parser.prog}: {exc}", file=sys.stderr)
         return 2
 
 

--- a/forma_cli/project_artifacts.py
+++ b/forma_cli/project_artifacts.py
@@ -1,0 +1,182 @@
+"""Local artifact preparation and integrity checks for cloud project sync."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path, PureWindowsPath
+from typing import Any
+
+from forma_cli.local import LocalProjectError
+from forma_core.workspaces.projects.manifest import (
+    ProjectManifest,
+    infer_artifact_media_type,
+    normalize_artifact_media_type,
+    normalize_artifact_path,
+    redact_project_secrets,
+    rewrite_artifact_paths,
+)
+
+
+@dataclass(frozen=True)
+class LocalProjectArtifact:
+    """A validated local file ready to be transferred."""
+
+    path: str
+    source_path: Path
+    sha256: str
+    media_type: str
+    size_bytes: int
+
+
+def _portable_path(root: Path, value: object, *, require_file: bool = True) -> tuple[str, Path]:
+    raw = str(value or "").strip()
+    candidate = Path(raw).expanduser()
+    windows_absolute = PureWindowsPath(raw).is_absolute() or bool(PureWindowsPath(raw).drive)
+    if candidate.is_absolute() or windows_absolute:
+        source = candidate.resolve()
+        try:
+            relative = source.relative_to(root)
+        except ValueError as exc:
+            raise LocalProjectError(
+                f"Project artifact must be inside the project directory: {value!r}"
+            ) from exc
+        portable = relative.as_posix()
+    else:
+        portable = normalize_artifact_path(raw)
+        source = (root / Path(*portable.split("/"))).resolve()
+        try:
+            source.relative_to(root)
+        except ValueError as exc:
+            raise LocalProjectError(
+                f"Project artifact must be inside the project directory: {value!r}"
+            ) from exc
+    if require_file and not source.is_file():
+        raise LocalProjectError(f"Project artifact does not exist: {source}")
+    return portable, source
+
+
+def _file_digest(path: Path) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    size = 0
+    with path.open("rb") as file:
+        while chunk := file.read(1024 * 1024):
+            digest.update(chunk)
+            size += len(chunk)
+    return digest.hexdigest(), size
+
+
+def canonical_project_upload_payload(root: str | Path, manifest: ProjectManifest) -> dict[str, Any]:
+    """Canonicalize local file paths without requiring artifact bytes to exist."""
+    project_root = Path(root).expanduser().resolve()
+    payload = manifest.upload_payload()
+    references: list[dict[str, Any]] = []
+    replacements: dict[str, str] = {}
+    for artifact in manifest.artifacts:
+        portable, source = _portable_path(project_root, artifact.path, require_file=False)
+        lower_portable = portable.lower()
+        if lower_portable == "forma-project.json" or lower_portable == ".forma" or lower_portable.startswith(".forma/"):
+            raise LocalProjectError(f"Project artifact path is reserved: {portable}")
+        reference = redact_project_secrets(artifact.model_dump(mode="json"))
+        reference["path"] = portable
+        if reference.get("sha256"):
+            reference["sha256"] = str(reference["sha256"]).strip().lower()
+        if reference.get("media_type"):
+            reference["media_type"] = normalize_artifact_media_type(reference["media_type"])
+        references.append(reference)
+        replacements[str(artifact.path)] = portable
+        replacements[str(artifact.path).replace("\\", "/")] = portable
+        replacements[str(source)] = portable
+        replacements[source.as_posix()] = portable
+    payload["artifacts"] = references
+    payload["project_ir"] = rewrite_artifact_paths(payload.get("project_ir", {}), replacements)
+    return payload
+
+
+def prepare_project_upload(
+    root: str | Path,
+    manifest: ProjectManifest,
+) -> tuple[dict[str, Any], list[LocalProjectArtifact]]:
+    """Validate referenced files and return a portable upload manifest."""
+    project_root = Path(root).expanduser().resolve()
+    payload = canonical_project_upload_payload(project_root, manifest)
+    references: list[dict[str, Any]] = []
+    prepared: list[LocalProjectArtifact] = []
+    seen_paths: set[str] = set()
+    replacements: dict[str, str] = {}
+
+    for artifact in manifest.artifacts:
+        portable, source = _portable_path(project_root, artifact.path)
+        lower_portable = portable.lower()
+        if lower_portable == "forma-project.json" or lower_portable == ".forma" or lower_portable.startswith(".forma/"):
+            raise LocalProjectError(f"Project artifact path is reserved: {portable}")
+        portable_key = portable.casefold()
+        if portable_key in seen_paths:
+            raise LocalProjectError(f"Project artifact path is duplicated: {portable}")
+        seen_paths.add(portable_key)
+        sha256, size_bytes = _file_digest(source)
+        declared_sha256 = (artifact.sha256 or "").strip().lower()
+        if declared_sha256 and declared_sha256 != sha256:
+            raise LocalProjectError(
+                f"Project artifact hash mismatch for {portable}: "
+                f"manifest declares {declared_sha256}, local file is {sha256}."
+            )
+        try:
+            media_type = normalize_artifact_media_type(artifact.media_type) if artifact.media_type else None
+        except ValueError as exc:
+            raise LocalProjectError(f"Project artifact {portable} has an invalid media type.") from exc
+        media_type = media_type or infer_artifact_media_type(portable)
+        reference = redact_project_secrets(artifact.model_dump(mode="json"))
+        reference.update(
+            {
+                "path": portable,
+                "sha256": sha256,
+                "media_type": media_type,
+                "size_bytes": size_bytes,
+            }
+        )
+        references.append(reference)
+        prepared.append(
+            LocalProjectArtifact(
+                path=portable,
+                source_path=source,
+                sha256=sha256,
+                media_type=media_type,
+                size_bytes=size_bytes,
+            )
+        )
+        replacements[str(artifact.path)] = portable
+        replacements[str(artifact.path).replace("\\", "/")] = portable
+        replacements[str(source)] = portable
+        replacements[source.as_posix()] = portable
+
+    payload["artifacts"] = references
+    payload["project_ir"] = rewrite_artifact_paths(payload.get("project_ir", {}), replacements)
+    return payload, prepared
+
+
+def file_digest(path: str | Path) -> str:
+    """Return a file SHA-256 for working-tree conflict checks."""
+    digest, _size = _file_digest(Path(path))
+    return digest
+
+
+def artifact_target(root: str | Path, path: str) -> Path:
+    """Resolve a remote artifact path beneath the local project root."""
+    project_root = Path(root).expanduser().resolve()
+    portable = normalize_artifact_path(path)
+    target = project_root / Path(*portable.split("/"))
+    try:
+        target.resolve().relative_to(project_root)
+    except ValueError as exc:
+        raise LocalProjectError(f"Project artifact target escapes the project directory: {path!r}") from exc
+    return target
+
+
+__all__ = [
+    "LocalProjectArtifact",
+    "artifact_target",
+    "canonical_project_upload_payload",
+    "file_digest",
+    "prepare_project_upload",
+]

--- a/forma_cli/sdk.py
+++ b/forma_cli/sdk.py
@@ -84,6 +84,16 @@ class CloudProjectRevision(BaseModel):
     created_at: str | None = None
 
 
+@dataclass(frozen=True)
+class ProjectArtifactDownload:
+    """Binary artifact response returned by a cloud project revision."""
+
+    content: bytes
+    content_type: str | None = None
+    sha256: str | None = None
+    size_bytes: int | None = None
+
+
 class ManagedCredentialMetadata(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
@@ -121,17 +131,22 @@ class FormaAPIClient:
         self._store.set_json(SESSION_KEY, tokens.model_dump(mode="json"))
         return tokens
 
-    def _request(
+    def _request_wire(
         self,
         path: str,
         *,
         method: str = "GET",
         payload: Mapping[str, Any] | None = None,
+        body: bytes | None = None,
+        content_type: str | None = None,
+        accept: str = "application/json",
         authenticated: bool = False,
         retry_refresh: bool = True,
-    ) -> Any:
+    ) -> tuple[bytes, dict[str, str]]:
+        if payload is not None and body is not None:
+            raise ValueError("A Forma API request cannot contain both JSON and binary payloads.")
         headers = {
-            "Accept": "application/json",
+            "Accept": accept,
             "User-Agent": "forma-oss-cli/0.1",
         }
         tokens = self._saved_tokens() if authenticated else None
@@ -139,13 +154,17 @@ class FormaAPIClient:
             if tokens is None:
                 raise FormaAPIError("Sign in with `forma-oss login` before using cloud commands.")
             headers["Authorization"] = f"{tokens.token_type} {tokens.access_token}"
-        body = json.dumps(dict(payload)).encode("utf-8") if payload is not None else None
-        if body is not None:
-            headers["Content-Type"] = "application/json"
-        request = Request(f"{self.base_url}/{path.lstrip('/')}", data=body, headers=headers, method=method)
+        request_body = json.dumps(dict(payload)).encode("utf-8") if payload is not None else body
+        if request_body is not None:
+            headers["Content-Type"] = content_type or "application/json"
+        request = Request(f"{self.base_url}/{path.lstrip('/')}", data=request_body, headers=headers, method=method)
         try:
             with urlopen(request, timeout=self.timeout_seconds) as response:
                 raw = response.read()
+                response_headers = {
+                    str(key).lower(): str(value)
+                    for key, value in getattr(response, "headers", {}).items()
+                }
         except HTTPError as exc:
             raw = exc.read()
             detail = self._decode_json(raw)
@@ -155,10 +174,13 @@ class FormaAPIClient:
                 except FormaAPIError:
                     pass
                 else:
-                    return self._request(
+                    return self._request_wire(
                         path,
                         method=method,
                         payload=payload,
+                        body=body,
+                        content_type=content_type,
+                        accept=accept,
                         authenticated=authenticated,
                         retry_refresh=False,
                     )
@@ -171,7 +193,55 @@ class FormaAPIClient:
             raise FormaAPIError(f"Could not reach Forma API at {self.base_url}: {exc.reason}") from exc
         except OSError as exc:
             raise FormaAPIError(f"Could not reach Forma API at {self.base_url}: {exc}") from exc
+        return raw, response_headers
+
+    def _request(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        payload: Mapping[str, Any] | None = None,
+        authenticated: bool = False,
+        retry_refresh: bool = True,
+    ) -> Any:
+        raw, _headers = self._request_wire(
+            path,
+            method=method,
+            payload=payload,
+            authenticated=authenticated,
+            retry_refresh=retry_refresh,
+        )
         return self._decode_json(raw)
+
+    def _request_bytes(
+        self,
+        path: str,
+        *,
+        method: str = "GET",
+        body: bytes | None = None,
+        content_type: str | None = None,
+        authenticated: bool = False,
+        retry_refresh: bool = True,
+    ) -> ProjectArtifactDownload:
+        raw, headers = self._request_wire(
+            path,
+            method=method,
+            body=body,
+            content_type=content_type,
+            accept="application/octet-stream",
+            authenticated=authenticated,
+            retry_refresh=retry_refresh,
+        )
+        try:
+            size_bytes = int(headers["x-forma-artifact-size"]) if headers.get("x-forma-artifact-size") else None
+        except ValueError:
+            size_bytes = None
+        return ProjectArtifactDownload(
+            content=raw,
+            content_type=headers.get("content-type"),
+            sha256=headers.get("x-forma-artifact-sha256"),
+            size_bytes=size_bytes,
+        )
 
     @staticmethod
     def _decode_json(raw: bytes) -> Any:
@@ -255,6 +325,40 @@ class FormaAPIClient:
         )
         return CloudProjectRevision.model_validate(payload)
 
+    def upload_project_artifact(
+        self,
+        project_id: str,
+        revision_id: str,
+        sha256: str,
+        content: bytes,
+        media_type: str,
+    ) -> dict[str, Any]:
+        path = (
+            f"/cli/projects/{quote(project_id, safe='')}/revisions/"
+            f"{quote(revision_id, safe='')}/artifacts/{quote(sha256, safe='')}"
+        )
+        raw, _headers = self._request_wire(
+            path,
+            method="PUT",
+            body=content,
+            content_type=media_type,
+            authenticated=True,
+        )
+        payload = self._decode_json(raw)
+        return payload if isinstance(payload, dict) else {}
+
+    def download_project_artifact(
+        self,
+        project_id: str,
+        revision_id: str,
+        sha256: str,
+    ) -> ProjectArtifactDownload:
+        path = (
+            f"/cli/projects/{quote(project_id, safe='')}/revisions/"
+            f"{quote(revision_id, safe='')}/artifacts/{quote(sha256, safe='')}"
+        )
+        return self._request_bytes(path, authenticated=True)
+
     def pull_project(self, project_id: str, revision_id: str | None = None) -> CloudProjectRevision:
         path = f"/cli/projects/{quote(project_id, safe='')}"
         if revision_id:
@@ -289,5 +393,6 @@ __all__ = [
     "FormaAPIClient",
     "FormaAPIError",
     "ManagedCredentialMetadata",
+    "ProjectArtifactDownload",
     "TokenSet",
 ]

--- a/forma_core/persistence/project_artifacts.py
+++ b/forma_core/persistence/project_artifacts.py
@@ -1,0 +1,286 @@
+"""Private storage for artifacts transferred by the Forma OSS CLI."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from forma_core.config import config
+from forma_core.config.runtime import forma_dev_mode_enabled, primary_database_backend_from_environment
+from forma_core.workspaces.projects.manifest import normalize_artifact_media_type
+
+
+DEFAULT_PROJECT_ARTIFACT_BUCKET = "cli-project-artifacts"
+DEFAULT_PROJECT_ARTIFACT_DIRECTORY = ".forma/cli-artifacts"
+DEFAULT_PROJECT_ARTIFACT_MAX_BYTES = 50 * 1024 * 1024
+
+
+class ProjectArtifactStorageError(RuntimeError):
+    """Raised when private project artifact storage cannot be used."""
+
+
+@dataclass(frozen=True)
+class StoredProjectArtifact:
+    project_id: str
+    sha256: str
+    media_type: str
+    size_bytes: int
+    content: bytes | None = None
+
+
+def _storage_backend() -> str:
+    configured = (config.optional("FORMA_CLI_ARTIFACT_STORAGE_BACKEND") or "").lower()
+    aliases = {
+        "local": "local",
+        "sqlite": "local",
+        "supabase": "supabase",
+        "supabase-client": "supabase",
+        "s3": "s3-compatible",
+        "s3-compatible": "s3-compatible",
+    }
+    if configured:
+        return aliases.get(configured, "local")
+    if forma_dev_mode_enabled():
+        return "local"
+    return "supabase" if primary_database_backend_from_environment() == "supabase" else "local"
+
+
+def get_project_artifact_storage_config() -> dict[str, Any]:
+    """Resolve artifact storage without constructing a remote client."""
+    backend = _storage_backend()
+    bucket = config.optional("FORMA_CLI_ARTIFACT_BUCKET") or DEFAULT_PROJECT_ARTIFACT_BUCKET
+    directory = Path(
+        config.optional("FORMA_CLI_ARTIFACT_STORAGE_DIR") or DEFAULT_PROJECT_ARTIFACT_DIRECTORY
+    ).expanduser()
+    try:
+        max_bytes = max(1, int(config.optional("FORMA_CLI_ARTIFACT_MAX_BYTES") or DEFAULT_PROJECT_ARTIFACT_MAX_BYTES))
+    except ValueError:
+        max_bytes = DEFAULT_PROJECT_ARTIFACT_MAX_BYTES
+    supabase_url = config.optional("SUPABASE_URL") or config.optional("NEXT_PUBLIC_SUPABASE_URL")
+    service_key = config.optional("SUPABASE_SERVICE_ROLE_KEY") or config.optional("SUPABASE_SECRET_KEY")
+    endpoint = config.optional("SUPABASE_S3_ENDPOINT")
+    access_key = config.optional("SUPABASE_S3_ACCESS_KEY_ID") or config.optional("AWS_ACCESS_KEY_ID")
+    secret_key = config.optional("SUPABASE_S3_SECRET_ACCESS_KEY") or config.optional("AWS_SECRET_ACCESS_KEY")
+    enabled = (
+        backend == "local"
+        or backend == "supabase" and bool(supabase_url and service_key)
+        or backend == "s3-compatible" and bool(endpoint and access_key and secret_key)
+    )
+    return {
+        "enabled": enabled,
+        "backend": backend,
+        "bucket": bucket,
+        "directory": directory,
+        "max_bytes": max_bytes,
+        "supabase_url_configured": bool(supabase_url),
+        "service_key_configured": bool(service_key),
+        "endpoint_configured": bool(endpoint),
+        "access_key_configured": bool(access_key),
+        "secret_key_configured": bool(secret_key),
+    }
+
+
+def project_artifact_storage_key(project_id: str, sha256: str) -> str:
+    """Build a server-owned, project-scoped object key."""
+    project_text = str(project_id or "").strip()
+    if not project_text:
+        raise ValueError("Project artifact storage requires a project_id.")
+    digest = str(sha256 or "").strip().lower()
+    if not re.fullmatch(r"[0-9a-f]{64}", digest):
+        raise ValueError("Project artifact storage requires a SHA-256 hash.")
+    project_scope = hashlib.sha256(project_text.encode("utf-8")).hexdigest()
+    return f"projects/{project_scope}/artifacts/{digest}"
+
+
+class ProjectArtifactStorage:
+    """Read and write private objects using Supabase, S3, or local disk."""
+
+    def __init__(self, storage_config: dict[str, Any] | None = None) -> None:
+        self.config = storage_config if storage_config is not None else get_project_artifact_storage_config()
+
+    def _require_enabled(self) -> None:
+        if self.config.get("enabled"):
+            return
+        backend = self.config.get("backend")
+        if backend == "supabase":
+            raise ProjectArtifactStorageError(
+                "CLI artifact storage requires SUPABASE_URL plus SUPABASE_SERVICE_ROLE_KEY or SUPABASE_SECRET_KEY."
+            )
+        if backend == "s3-compatible":
+            raise ProjectArtifactStorageError(
+                "CLI artifact S3 storage requires SUPABASE_S3_ENDPOINT and access credentials."
+            )
+        raise ProjectArtifactStorageError("CLI artifact storage is not configured.")
+
+    def _validate_size(self, content: bytes) -> None:
+        if len(content) > int(self.config["max_bytes"]):
+            raise ProjectArtifactStorageError(
+                f"Project artifact exceeds the {self.config['max_bytes']} byte size limit."
+            )
+
+    def _supabase_bucket(self):
+        supabase_url = config.optional("SUPABASE_URL") or config.optional("NEXT_PUBLIC_SUPABASE_URL")
+        service_key = config.optional("SUPABASE_SERVICE_ROLE_KEY") or config.optional("SUPABASE_SECRET_KEY")
+        if not supabase_url or not service_key:
+            raise ProjectArtifactStorageError(
+                "CLI artifact storage requires SUPABASE_URL plus SUPABASE_SERVICE_ROLE_KEY or SUPABASE_SECRET_KEY."
+            )
+        try:
+            from supabase import create_client
+        except ImportError as exc:
+            raise ProjectArtifactStorageError(
+                "Supabase client is not installed. Run pip install -r apps/api/requirements.txt."
+            ) from exc
+        return create_client(supabase_url, service_key).storage.from_(self.config["bucket"])
+
+    def _s3_client(self):
+        try:
+            import boto3
+            from botocore.config import Config
+        except ImportError as exc:
+            raise ProjectArtifactStorageError("boto3 is required for S3-compatible artifact storage.") from exc
+        endpoint = config.optional("SUPABASE_S3_ENDPOINT")
+        access_key = config.optional("SUPABASE_S3_ACCESS_KEY_ID") or config.optional("AWS_ACCESS_KEY_ID")
+        secret_key = config.optional("SUPABASE_S3_SECRET_ACCESS_KEY") or config.optional("AWS_SECRET_ACCESS_KEY")
+        return boto3.client(
+            "s3",
+            endpoint_url=endpoint,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            region_name=config.optional("SUPABASE_S3_REGION") or config.optional("AWS_REGION") or "us-east-1",
+            config=Config(signature_version="s3v4", s3={"addressing_style": "path"}),
+        )
+
+    def put(self, project_id: str, sha256: str, content: bytes, media_type: str) -> StoredProjectArtifact:
+        self._require_enabled()
+        self._validate_size(content)
+        normalized_sha256 = str(sha256 or "").strip().lower()
+        key = project_artifact_storage_key(project_id, normalized_sha256)
+        actual_sha256 = hashlib.sha256(content).hexdigest()
+        if actual_sha256 != normalized_sha256:
+            raise ProjectArtifactStorageError(
+                f"Project artifact content does not match its declared SHA-256 hash: {normalized_sha256}."
+            )
+        try:
+            normalized_media_type = normalize_artifact_media_type(media_type)
+        except ValueError as exc:
+            raise ProjectArtifactStorageError("Project artifact media type is invalid.") from exc
+        backend = self.config["backend"]
+        if backend == "local":
+            target = Path(self.config["directory"]) / Path(*key.split("/"))
+            target.parent.mkdir(parents=True, exist_ok=True)
+            temporary = target.with_suffix(f"{target.suffix}.tmp")
+            temporary.write_bytes(content)
+            temporary.replace(target)
+        elif backend == "supabase":
+            bucket = self._supabase_bucket()
+            options = {
+                "content-type": normalized_media_type,
+                "cache-control": "31536000",
+                "upsert": "true",
+            }
+            try:
+                bucket.upload(key, content, file_options=options)
+            except Exception:
+                # A retry may target an object that the first request created.
+                try:
+                    bucket.update(key, content, file_options=options)
+                except Exception as update_exc:
+                    raise ProjectArtifactStorageError("Project artifact storage upload failed.") from update_exc
+        else:
+            try:
+                self._s3_client().put_object(
+                    Bucket=self.config["bucket"],
+                    Key=key,
+                    Body=content,
+                    ContentType=normalized_media_type,
+                )
+            except Exception as exc:
+                raise ProjectArtifactStorageError("Project artifact storage upload failed.") from exc
+        return StoredProjectArtifact(project_id, normalized_sha256, normalized_media_type, len(content))
+
+    def get(self, project_id: str, sha256: str, media_type: str) -> StoredProjectArtifact:
+        self._require_enabled()
+        normalized_sha256 = str(sha256 or "").strip().lower()
+        key = project_artifact_storage_key(project_id, normalized_sha256)
+        try:
+            normalized_media_type = normalize_artifact_media_type(media_type)
+        except ValueError as exc:
+            raise ProjectArtifactStorageError("Project artifact media type is invalid.") from exc
+        backend = self.config["backend"]
+        if backend == "local":
+            content = (Path(self.config["directory"]) / Path(*key.split("/"))).read_bytes()
+        elif backend == "supabase":
+            try:
+                content = bytes(self._supabase_bucket().download(key))
+            except FileNotFoundError:
+                raise
+            except Exception as exc:
+                raise ProjectArtifactStorageError("Project artifact storage download failed.") from exc
+        else:
+            try:
+                content = self._s3_client().get_object(Bucket=self.config["bucket"], Key=key)["Body"].read()
+            except Exception as exc:
+                raise ProjectArtifactStorageError("Project artifact storage download failed.") from exc
+        self._validate_size(content)
+        return StoredProjectArtifact(project_id, normalized_sha256, normalized_media_type, len(content), content)
+
+    def delete_project(self, project_id: str) -> int:
+        """Delete all objects for a project; used by privacy purge workers."""
+        self._require_enabled()
+        project_text = str(project_id or "").strip()
+        if not project_text:
+            raise ValueError("Project artifact deletion requires a project_id.")
+        scope = hashlib.sha256(project_text.encode("utf-8")).hexdigest()
+        prefix = f"projects/{scope}/artifacts/"
+        backend = self.config["backend"]
+        if backend == "local":
+            root = Path(self.config["directory"]) / Path(*prefix.split("/")[:-1])
+            if not root.exists():
+                return 0
+            count = sum(1 for item in root.iterdir() if item.is_file())
+            for item in root.iterdir():
+                if item.is_file():
+                    item.unlink()
+            return count
+        if backend == "supabase":
+            bucket = self._supabase_bucket()
+            items: list[dict[str, Any]] = []
+            offset = 0
+            while True:
+                page = bucket.list(prefix.removesuffix("/"), {"limit": 1000, "offset": offset}) or []
+                items.extend(item for item in page if isinstance(item, dict))
+                if len(page) < 1000:
+                    break
+                offset += 1000
+            keys = [f"{prefix}{item['name']}" for item in items if item.get("name")]
+            for start in range(0, len(keys), 1000):
+                bucket.remove(keys[start : start + 1000])
+            return len(keys)
+        client = self._s3_client()
+        paginator = client.get_paginator("list_objects_v2")
+        keys = [
+            item["Key"]
+            for page in paginator.paginate(Bucket=self.config["bucket"], Prefix=prefix)
+            for item in page.get("Contents") or []
+            if item.get("Key")
+        ]
+        for start in range(0, len(keys), 1000):
+            client.delete_objects(
+                Bucket=self.config["bucket"],
+                Delete={"Objects": [{"Key": key} for key in keys[start : start + 1000]], "Quiet": True},
+            )
+        return len(keys)
+
+
+__all__ = [
+    "DEFAULT_PROJECT_ARTIFACT_BUCKET",
+    "ProjectArtifactStorage",
+    "ProjectArtifactStorageError",
+    "StoredProjectArtifact",
+    "get_project_artifact_storage_config",
+    "project_artifact_storage_key",
+]

--- a/forma_core/workspaces/projects/manifest.py
+++ b/forma_core/workspaces/projects/manifest.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from copy import deepcopy
 import json
+import mimetypes
 from pathlib import Path
+import re
 from typing import Any, Mapping
 from uuid import uuid4
 
@@ -13,6 +15,22 @@ from pydantic import BaseModel, ConfigDict, Field
 
 PROJECT_MANIFEST_FORMAT = "forma-project"
 PROJECT_MANIFEST_VERSION = 1
+_SHA256_PATTERN = re.compile(r"^[0-9a-fA-F]{64}$")
+_MEDIA_TYPE_PATTERN = re.compile(r"^[a-z0-9][a-z0-9!#$&^_.+-]*/[a-z0-9][a-z0-9!#$&^_.+-]*$")
+_NON_PATH_KEYS = frozenset(
+    {
+        "filename",
+        "name",
+        "title",
+        "description",
+        "label",
+        "format",
+        "source",
+        "url",
+        "download_url",
+        "source_url",
+    }
+)
 _SECRET_FIELD_MARKERS = (
     "api_key",
     "apikey",
@@ -21,6 +39,135 @@ _SECRET_FIELD_MARKERS = (
     "secret",
     "token",
 )
+
+
+def normalize_artifact_path(value: object) -> str:
+    """Return a safe, portable project-relative artifact path."""
+    raw = str(value or "").strip().replace("\\", "/")
+    if not raw:
+        raise ValueError("Artifact path must not be empty.")
+    if (
+        "\x00" in raw
+        or "://" in raw
+        or raw.startswith("/")
+        or re.match(r"^[A-Za-z][A-Za-z0-9+.-]*:", raw)
+    ):
+        raise ValueError(f"Artifact path must be project-relative: {value!r}")
+
+    parts = []
+    for part in raw.split("/"):
+        if part in {"", "."}:
+            continue
+        if part == "..":
+            raise ValueError(f"Artifact path may not escape the project directory: {value!r}")
+        parts.append(part)
+    if not parts:
+        raise ValueError("Artifact path must identify a file.")
+    return "/".join(parts)
+
+
+def normalize_artifact_media_type(value: object) -> str:
+    """Normalize and validate an artifact media type without parameters."""
+    media_type = str(value or "").split(";", 1)[0].strip().lower()
+    if not media_type or not _MEDIA_TYPE_PATTERN.fullmatch(media_type):
+        raise ValueError(f"Invalid artifact media type: {value!r}")
+    return media_type
+
+
+def infer_artifact_media_type(path: str) -> str:
+    """Infer a stable media type for common CAD files and ordinary documents."""
+    suffix = Path(path).suffix.lower()
+    if suffix in {".step", ".stp"}:
+        return "model/step"
+    if suffix == ".stl":
+        return "model/stl"
+    if suffix == ".3mf":
+        return "model/3mf"
+    return mimetypes.guess_type(path)[0] or "application/octet-stream"
+
+
+def validate_artifact_references(
+    artifacts: object,
+    *,
+    require_integrity: bool = True,
+) -> list[dict[str, Any]]:
+    """Normalize artifact declarations and reject unsafe or ambiguous entries."""
+    if artifacts is None:
+        return []
+    if not isinstance(artifacts, list):
+        raise ValueError("Project artifacts must be a list.")
+
+    normalized: list[dict[str, Any]] = []
+    seen_paths: set[str] = set()
+    for index, item in enumerate(artifacts):
+        if isinstance(item, BaseModel):
+            record = item.model_dump(mode="json")
+        elif isinstance(item, Mapping):
+            record = dict(item)
+        else:
+            raise ValueError(f"Project artifact {index + 1} must be an object.")
+        path = normalize_artifact_path(record.get("path"))
+        lower_path = path.lower()
+        if lower_path == "forma-project.json" or lower_path == ".forma" or lower_path.startswith(".forma/"):
+            raise ValueError(f"Project artifact path is reserved: {path}")
+        path_key = path.casefold()
+        if path_key in seen_paths:
+            raise ValueError(f"Project artifact path is duplicated: {path}")
+        seen_paths.add(path_key)
+        record["path"] = path
+
+        raw_sha256 = record.get("sha256")
+        if raw_sha256 is None or not str(raw_sha256).strip():
+            if require_integrity:
+                raise ValueError(f"Project artifact {path} must declare a SHA-256 hash.")
+        else:
+            sha256 = str(raw_sha256).strip().lower()
+            if not _SHA256_PATTERN.fullmatch(sha256):
+                raise ValueError(f"Project artifact {path} has an invalid SHA-256 hash.")
+            record["sha256"] = sha256
+
+        raw_media_type = record.get("media_type")
+        if raw_media_type is None or not str(raw_media_type).strip():
+            if require_integrity:
+                raise ValueError(f"Project artifact {path} must declare a media type.")
+        else:
+            record["media_type"] = normalize_artifact_media_type(raw_media_type)
+
+        if "size_bytes" in record and record["size_bytes"] is not None:
+            size = record["size_bytes"]
+            if isinstance(size, bool) or not isinstance(size, int) or size < 0:
+                raise ValueError(f"Project artifact {path} has an invalid size_bytes value.")
+        normalized.append(record)
+    return normalized
+
+
+def rewrite_artifact_paths(value: Any, replacements: Mapping[str, str], *, _key: str | None = None) -> Any:
+    """Rewrite known project-file references while preserving display filenames."""
+    if isinstance(value, Mapping):
+        return {
+            str(key): rewrite_artifact_paths(item, replacements, _key=str(key))
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [rewrite_artifact_paths(item, replacements, _key=_key) for item in value]
+    if isinstance(value, tuple):
+        return [rewrite_artifact_paths(item, replacements, _key=_key) for item in value]
+    if not isinstance(value, str) or (_key and _key.strip().lower() in _NON_PATH_KEYS):
+        return deepcopy(value)
+
+    candidates = (value, value.replace("\\", "/"))
+    for candidate in candidates:
+        replacement = replacements.get(candidate)
+        if replacement is not None:
+            return replacement
+        suffix_matches: list[tuple[int, str]] = []
+        for source, source_replacement in replacements.items():
+            normalized_source = str(source).replace("\\", "/").strip("/")
+            if normalized_source and candidate.rstrip("/").endswith(f"/{normalized_source}"):
+                suffix_matches.append((len(normalized_source), source_replacement))
+        if suffix_matches:
+            return max(suffix_matches, key=lambda match: match[0])[1]
+    return value
 
 
 def _is_secret_field(name: object) -> bool:
@@ -51,6 +198,7 @@ class ProjectArtifactReference(BaseModel):
     path: str
     sha256: str | None = None
     media_type: str | None = None
+    size_bytes: int | None = Field(default=None, ge=0)
 
 
 class ProjectManifest(BaseModel):
@@ -71,7 +219,9 @@ class ProjectManifest(BaseModel):
     def from_document(cls, document: Mapping[str, Any]) -> "ProjectManifest":
         """Accept both the canonical wrapper and legacy raw HardwareIR JSON."""
         raw = dict(document)
-        nested = raw.get("project_ir") or raw.get("hardware_ir")
+        nested = raw.get("project_ir")
+        if not isinstance(nested, Mapping):
+            nested = raw.get("hardware_ir")
         project_ir = dict(nested) if isinstance(nested, Mapping) else raw
         metadata = project_ir.get("assembly_metadata")
         metadata = metadata if isinstance(metadata, Mapping) else {}
@@ -100,10 +250,7 @@ class ProjectManifest(BaseModel):
 
     def upload_payload(self) -> dict[str, Any]:
         """Build the only payload shape that may cross the cloud boundary."""
-        payload = self.model_dump(mode="json")
-        payload["project_ir"] = redact_project_secrets(payload["project_ir"])
-        payload["artifacts"] = redact_project_secrets(payload["artifacts"])
-        return payload
+        return redact_project_secrets(self.model_dump(mode="json"))
 
 
 def load_project_manifest(path: str | Path) -> ProjectManifest:
@@ -132,7 +279,12 @@ __all__ = [
     "PROJECT_MANIFEST_VERSION",
     "ProjectArtifactReference",
     "ProjectManifest",
+    "infer_artifact_media_type",
     "load_project_manifest",
+    "normalize_artifact_media_type",
+    "normalize_artifact_path",
     "redact_project_secrets",
+    "rewrite_artifact_paths",
+    "validate_artifact_references",
     "write_project_manifest",
 ]

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -128,6 +128,11 @@ file_size_limit = "50MiB"
 public = true
 file_size_limit = "50MiB"
 
+# Private files transferred by the forma-oss CLI project sync commands.
+[storage.buckets.cli-project-artifacts]
+public = false
+file_size_limit = "50MiB"
+
 # Allow connections via S3 compatible clients
 [storage.s3_protocol]
 enabled = true

--- a/supabase/migrations/20260831000100_cli_project_artifact_storage.sql
+++ b/supabase/migrations/20260831000100_cli_project_artifact_storage.sql
@@ -1,0 +1,7 @@
+-- Private object storage for files referenced by CLI project revisions.
+
+insert into storage.buckets (id, name, public, file_size_limit)
+values ('cli-project-artifacts', 'cli-project-artifacts', false, 52428800)
+on conflict (id) do update
+set public = excluded.public,
+    file_size_limit = excluded.file_size_limit;

--- a/tests/api/test_cli_project_artifacts.py
+++ b/tests/api/test_cli_project_artifacts.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from apps.api import cli_projects_api
+from apps.api.auth import UserContext
+from forma_core.persistence.project_artifacts import ProjectArtifactStorage, project_artifact_storage_key
+
+
+def _user(owner: str = "user-a") -> UserContext:
+    return UserContext(
+        provider="clerk",
+        subject=owner,
+        owner_user_id=owner,
+        is_authenticated=True,
+        is_admin=False,
+        claims={"sub": owner},
+    )
+
+
+def _request(content: bytes, media_type: str) -> Request:
+    sent = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal sent
+        if sent:
+            return {"type": "http.disconnect"}
+        sent = True
+        return {"type": "http.request", "body": content, "more_body": False}
+
+    return Request(
+        {
+            "type": "http",
+            "method": "PUT",
+            "path": "/cli/projects/project-a/revisions/revision-1/artifacts",
+            "headers": [
+                (b"content-type", media_type.encode("ascii")),
+                (b"content-length", str(len(content)).encode("ascii")),
+            ],
+            "query_string": b"",
+            "server": ("testserver", 80),
+            "client": ("testclient", 50000),
+        },
+        receive,
+    )
+
+
+class CliProjectArtifactApiTests(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.content = b"native cad bytes"
+        self.sha256 = hashlib.sha256(self.content).hexdigest()
+        self.revision = {
+            "revision_id": "revision-1",
+            "project_id": "project-a",
+            "revision": 1,
+            "parent_revision_id": None,
+            "manifest": {
+                "format": "forma-project",
+                "project_id": "project-a",
+                "project_ir": {"cad_model": {"path": "assembly.step"}},
+                "artifacts": [
+                    {
+                        "path": "assembly.step",
+                        "sha256": self.sha256,
+                        "media_type": "model/step",
+                        "size_bytes": len(self.content),
+                    }
+                ],
+            },
+        }
+
+    def _storage(self, directory: str) -> ProjectArtifactStorage:
+        return ProjectArtifactStorage(
+            {
+                "enabled": True,
+                "backend": "local",
+                "directory": Path(directory),
+                "bucket": "unused",
+                "max_bytes": 1024,
+            }
+        )
+
+    async def test_upload_and_download_are_owner_scoped_and_integrity_checked(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            storage = self._storage(directory)
+            with (
+                patch.object(cli_projects_api, "get_cli_project_revision", return_value=self.revision),
+                patch.object(cli_projects_api, "ProjectArtifactStorage", return_value=storage),
+            ):
+                uploaded = await cli_projects_api.upload_cli_project_artifact(
+                    "project-a",
+                    "revision-1",
+                    self.sha256.upper(),
+                    _request(self.content, "model/step"),
+                    _user(),
+                )
+                downloaded = await cli_projects_api.download_cli_project_artifact(
+                    "project-a",
+                    "revision-1",
+                    self.sha256,
+                    _user(),
+                )
+                object_path = Path(directory) / Path(*project_artifact_storage_key("project-a", self.sha256).split("/"))
+                object_path.write_bytes(b"corrupt")
+                with self.assertRaisesRegex(HTTPException, "integrity check"):
+                    await cli_projects_api.download_cli_project_artifact(
+                        "project-a",
+                        "revision-1",
+                        self.sha256,
+                        _user(),
+                    )
+
+        self.assertEqual("uploaded", uploaded["status"])
+        self.assertEqual(self.sha256, uploaded["sha256"])
+        self.assertEqual(self.content, downloaded.body)
+        self.assertEqual("model/step", downloaded.headers["content-type"])
+        self.assertEqual(self.sha256, downloaded.headers["x-forma-artifact-sha256"])
+
+    async def test_upload_rejects_bad_bytes_and_wrong_media_type(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            storage = self._storage(directory)
+            with (
+                patch.object(cli_projects_api, "get_cli_project_revision", return_value=self.revision),
+                patch.object(cli_projects_api, "ProjectArtifactStorage", return_value=storage),
+            ):
+                with self.assertRaisesRegex(HTTPException, "hash mismatch"):
+                    await cli_projects_api.upload_cli_project_artifact(
+                        "project-a",
+                        "revision-1",
+                        self.sha256,
+                        _request(b"tampered", "model/step"),
+                        _user(),
+                    )
+                with self.assertRaisesRegex(HTTPException, "media type mismatch"):
+                    await cli_projects_api.upload_cli_project_artifact(
+                        "project-a",
+                        "revision-1",
+                        self.sha256,
+                        _request(self.content, "application/octet-stream"),
+                        _user(),
+                    )
+
+    async def test_artifact_endpoints_hide_unowned_revisions(self) -> None:
+        with patch.object(cli_projects_api, "get_cli_project_revision", return_value=None):
+            with self.assertRaisesRegex(HTTPException, "not found or not authorized") as raised:
+                await cli_projects_api.download_cli_project_artifact(
+                    "project-a",
+                    "revision-1",
+                    self.sha256,
+                    _user("user-b"),
+                )
+        self.assertEqual(404, raised.exception.status_code)
+
+    async def test_push_rejects_artifact_without_integrity_metadata(self) -> None:
+        request = cli_projects_api.ProjectPushRequest(
+            manifest={
+                "format": "forma-project",
+                "project_id": "project-a",
+                "project_ir": {},
+                "artifacts": [{"path": "assembly.step", "media_type": "model/step"}],
+            }
+        )
+        with self.assertRaisesRegex(HTTPException, "SHA-256") as raised:
+            await cli_projects_api.push_cli_project(request, _user())
+        self.assertEqual(400, raised.exception.status_code)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integrations/test_project_artifacts.py
+++ b/tests/integrations/test_project_artifacts.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+from forma_core.persistence.project_artifacts import (
+    ProjectArtifactStorage,
+    ProjectArtifactStorageError,
+    project_artifact_storage_key,
+)
+from forma_core.workspaces.projects.manifest import validate_artifact_references
+
+
+class ProjectArtifactStorageTests(unittest.TestCase):
+    def test_local_storage_round_trip_is_project_scoped(self) -> None:
+        content = b"private project artifact"
+        sha256 = hashlib.sha256(content).hexdigest()
+        with tempfile.TemporaryDirectory() as directory:
+            storage = ProjectArtifactStorage(
+                {
+                    "enabled": True,
+                    "backend": "local",
+                    "directory": Path(directory),
+                    "bucket": "unused",
+                    "max_bytes": 1024,
+                }
+            )
+
+            stored = storage.put("project-a", sha256, content, "application/octet-stream")
+            restored = storage.get("project-a", sha256, "application/octet-stream")
+
+            self.assertEqual(content, restored.content)
+            self.assertTrue((Path(directory) / Path(*project_artifact_storage_key("project-a", sha256).split("/"))).is_file())
+            with self.assertRaises(FileNotFoundError):
+                storage.get("project-b", sha256, "application/octet-stream")
+            self.assertEqual(sha256, stored.sha256)
+            with self.assertRaisesRegex(ProjectArtifactStorageError, "does not match"):
+                storage.put("project-a", "0" * 64, content, "application/octet-stream")
+            self.assertEqual(1, storage.delete_project("project-a"))
+            with self.assertRaises(FileNotFoundError):
+                storage.get("project-a", sha256, "application/octet-stream")
+            self.assertEqual(0, storage.delete_project("project-a"))
+
+    def test_artifact_declarations_require_integrity_and_reject_traversal(self) -> None:
+        with self.assertRaisesRegex(ValueError, "SHA-256"):
+            validate_artifact_references([{"path": "assembly.step", "media_type": "model/step"}])
+        with self.assertRaisesRegex(ValueError, "escape"):
+            validate_artifact_references(
+                [{"path": "../secret.txt", "sha256": "0" * 64, "media_type": "text/plain"}]
+            )
+        with self.assertRaisesRegex(ValueError, "duplicated"):
+            validate_artifact_references(
+                [
+                    {"path": "Assembly.step", "sha256": "0" * 64, "media_type": "model/step"},
+                    {"path": "assembly.step", "sha256": "1" * 64, "media_type": "model/step"},
+                ]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tooling/test_oss_cli.py
+++ b/tests/tooling/test_oss_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import io
 import json
 from pathlib import Path
@@ -9,12 +10,13 @@ from contextlib import redirect_stderr, redirect_stdout
 from unittest.mock import patch
 
 from forma_cli.app import build_parser, cmd_projects_pull, cmd_projects_push, cmd_render
+from forma_cli.config import load_linkage
 from forma_cli.credentials import CredentialStore
-from forma_cli.local import build_project, import_project, init_project
+from forma_cli.local import LocalProjectError, build_project, import_project, init_project
 from forma_cli.metadata_api import project_metadata
-from forma_cli.sdk import CloudProjectRevision, FormaAPIClient
+from forma_cli.sdk import CloudProjectRevision, FormaAPIClient, ProjectArtifactDownload, TokenSet
 from forma_core.database import get_generated_project, init_db, save_generated_project
-from forma_core.workspaces.projects.manifest import ProjectManifest, write_project_manifest
+from forma_core.workspaces.projects.manifest import ProjectArtifactReference, ProjectManifest, write_project_manifest
 
 
 class FakeKeyring:
@@ -43,6 +45,21 @@ class Response:
 
     def read(self) -> bytes:
         return json.dumps(self.payload).encode("utf-8")
+
+
+class BinaryResponse:
+    def __init__(self, content: bytes, headers: dict[str, str]) -> None:
+        self.content = content
+        self.headers = headers
+
+    def __enter__(self) -> "BinaryResponse":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self.content
 
 
 class OssCliTests(unittest.TestCase):
@@ -74,6 +91,7 @@ class OssCliTests(unittest.TestCase):
                 "assembly_metadata": {"api_key": "do-not-upload", "safe": "yes"},
                 "nested": {"authorization": "Bearer secret", "safe": "yes"},
             },
+            extra_token="top-level-secret",
         )
 
         payload = manifest.upload_payload()
@@ -81,6 +99,7 @@ class OssCliTests(unittest.TestCase):
         serialized = json.dumps(payload)
         self.assertNotIn("do-not-upload", serialized)
         self.assertNotIn("Bearer secret", serialized)
+        self.assertNotIn("top-level-secret", serialized)
         self.assertEqual("yes", payload["project_ir"]["assembly_metadata"]["safe"])
 
     def test_local_manifest_writer_does_not_persist_provider_secrets(self) -> None:
@@ -268,6 +287,42 @@ class OssCliTests(unittest.TestCase):
         self.assertEqual("access", tokens.access_token)
         self.assertEqual("refresh", client._saved_tokens().refresh_token)
 
+    def test_sdk_transfers_binary_project_artifacts_with_integrity_headers(self) -> None:
+        keyring = FakeKeyring()
+        client = FormaAPIClient(
+            base_url="https://api.example.test",
+            credential_store=CredentialStore(keyring_backend=keyring),
+        )
+        client._save_tokens(
+            TokenSet(access_token="access", refresh_token="refresh", expires_in=3600)
+        )
+        content = b"native cad bytes"
+        sha256 = hashlib.sha256(content).hexdigest()
+        with patch(
+            "forma_cli.sdk.urlopen",
+            side_effect=[
+                Response({"status": "uploaded", "sha256": sha256}),
+                BinaryResponse(
+                    content,
+                    {
+                        "Content-Type": "model/step",
+                        "X-Forma-Artifact-SHA256": sha256,
+                        "X-Forma-Artifact-Size": str(len(content)),
+                    },
+                ),
+            ],
+        ) as urlopen:
+            uploaded = client.upload_project_artifact("project/a", "revision-1", sha256, content, "model/step")
+            downloaded = client.download_project_artifact("project/a", "revision-1", sha256)
+
+        upload_request = urlopen.call_args_list[0].args[0]
+        self.assertEqual(content, upload_request.data)
+        self.assertEqual("model/step", upload_request.get_header("Content-type"))
+        self.assertEqual("uploaded", uploaded["status"])
+        self.assertEqual(content, downloaded.content)
+        self.assertEqual(sha256, downloaded.sha256)
+        self.assertEqual(len(content), downloaded.size_bytes)
+
     def test_projects_pull_writes_typed_remote_manifest(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             init_project(temp_dir)
@@ -324,6 +379,189 @@ class OssCliTests(unittest.TestCase):
                 payload["project_url"],
             )
             self.assertIn("This will upload", stderr.getvalue())
+
+    def test_projects_push_uploads_referenced_files_and_records_integrity(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            manifest = init_project(root, title="Portable project")
+            assembly = b"ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n"
+            (root / "assembly.step").write_bytes(assembly)
+            source_manifest = ProjectManifest(
+                project_id=manifest.project_id,
+                title="Portable project",
+                project_ir={
+                    "cad_model": {
+                        "path": str(root / "assembly.step"),
+                        "filename": "assembly.step",
+                    }
+                },
+                artifacts=[ProjectArtifactReference(path="assembly.step", media_type="model/step")],
+            )
+            write_project_manifest(root / "forma-project.json", source_manifest)
+            revision = CloudProjectRevision(
+                revision_id="revision-1",
+                project_id=manifest.project_id,
+                revision=1,
+                manifest={},
+            )
+            client = FormaAPIClient(
+                base_url="https://api.example.test",
+                credential_store=CredentialStore(keyring_backend=FakeKeyring()),
+            )
+            uploaded: list[tuple[str, bytes, str]] = []
+            client.push_project = lambda _manifest, parent_revision_id=None: revision  # type: ignore[method-assign]
+            client.upload_project_artifact = lambda _project_id, _revision_id, sha256, content, media_type: (  # type: ignore[method-assign]
+                uploaded.append((sha256, content, media_type))
+                or {
+                    "status": "uploaded",
+                    "sha256": sha256,
+                    "media_type": media_type,
+                    "size_bytes": len(content),
+                }
+            )
+            args = type("Args", (), {"path": temp_dir, "yes": True, "json": True, "api_url": None})()
+            stdout = io.StringIO()
+            with patch("forma_cli.app.FormaAPIClient", return_value=client), redirect_stdout(stdout):
+                self.assertEqual(0, cmd_projects_push(args))
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual("uploaded", payload["artifacts"][0]["status"])
+            self.assertEqual(assembly, uploaded[0][1])
+            self.assertEqual("model/step", uploaded[0][2])
+            self.assertEqual(
+                "assembly.step",
+                json.loads((root / "forma-project.json").read_text(encoding="utf-8"))["artifacts"][0]["path"],
+            )
+            self.assertEqual(
+                "assembly.step",
+                json.loads((root / "forma-project.json").read_text(encoding="utf-8"))["project_ir"]["cad_model"]["path"],
+            )
+            linkage = load_linkage(root)
+            self.assertEqual(
+                {"assembly.step": hashlib.sha256(assembly).hexdigest()},
+                json.loads(linkage["artifact_digests"]),
+            )
+
+    def test_projects_pull_restores_files_and_rewrites_cad_paths(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            init_project(root)
+            content = b"native cad bytes"
+            sha256 = hashlib.sha256(content).hexdigest()
+            remote_manifest = {
+                "format": "forma-project",
+                "project_id": "project-1",
+                "title": "Remote CAD",
+                "project_ir": {
+                    "cad_model": {"path": "assembly.step", "filename": "assembly.step"}
+                },
+                "artifacts": [
+                    {
+                        "path": "assembly.step",
+                        "sha256": sha256,
+                        "media_type": "model/step",
+                        "size_bytes": len(content),
+                    }
+                ],
+            }
+            revision = CloudProjectRevision(
+                revision_id="revision-1",
+                project_id="project-1",
+                revision=1,
+                manifest=remote_manifest,
+            )
+            client = FormaAPIClient(
+                base_url="https://api.example.test",
+                credential_store=CredentialStore(keyring_backend=FakeKeyring()),
+            )
+            client.pull_project = lambda _project_id, _revision_id=None: revision  # type: ignore[method-assign]
+            client.download_project_artifact = lambda *_args: ProjectArtifactDownload(  # type: ignore[method-assign]
+                content=content,
+                content_type="model/step",
+                sha256=sha256,
+                size_bytes=len(content),
+            )
+            args = type("Args", (), {
+                "path": temp_dir,
+                "project_id": "project-1",
+                "revision_id": None,
+                "json": True,
+                "api_url": None,
+            })()
+            stdout = io.StringIO()
+            with patch("forma_cli.app.FormaAPIClient", return_value=client), redirect_stdout(stdout):
+                self.assertEqual(0, cmd_projects_pull(args))
+
+            self.assertEqual(content, (root / "assembly.step").read_bytes())
+            saved = json.loads((root / "forma-project.json").read_text(encoding="utf-8"))
+            self.assertEqual(str((root / "assembly.step").resolve()), saved["project_ir"]["cad_model"]["path"])
+            self.assertEqual("assembly.step", saved["project_ir"]["cad_model"]["filename"])
+            self.assertEqual("restored", json.loads(stdout.getvalue())["artifacts"][0]["status"])
+
+            stdout = io.StringIO()
+            with patch("forma_cli.app.FormaAPIClient", return_value=client), redirect_stdout(stdout):
+                self.assertEqual(0, cmd_projects_pull(args))
+            self.assertEqual("already_present", json.loads(stdout.getvalue())["artifacts"][0]["status"])
+
+    def test_projects_pull_refuses_to_overwrite_a_changed_artifact(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            init_project(root)
+            original = b"original"
+            original_sha256 = hashlib.sha256(original).hexdigest()
+            remote = ProjectManifest(
+                project_id="project-1",
+                title="Remote",
+                project_ir={"cad_model": {"path": "assembly.step"}},
+                artifacts=[
+                    ProjectArtifactReference(
+                        path="assembly.step",
+                        sha256=original_sha256,
+                        media_type="model/step",
+                        size_bytes=len(original),
+                    )
+                ],
+            )
+            write_project_manifest(root / "forma-project.json", remote)
+            # Simulate a previously pulled revision and then a local edit.
+            from forma_cli.config import save_linkage
+
+            save_linkage(
+                root,
+                {
+                    "version": 1,
+                    "project_id": "project-1",
+                    "remote_project_id": "project-1",
+                    "revision_id": "revision-1",
+                    "manifest_digest": hashlib.sha256(
+                        json.dumps(remote.upload_payload(), sort_keys=True, separators=(",", ":")).encode()
+                    ).hexdigest(),
+                    "artifact_digests": json.dumps({"assembly.step": original_sha256}),
+                },
+            )
+            (root / "assembly.step").write_bytes(b"local edit")
+            revision = CloudProjectRevision(
+                revision_id="revision-1",
+                project_id="project-1",
+                revision=1,
+                manifest=remote.upload_payload(),
+            )
+            client = FormaAPIClient(
+                base_url="https://api.example.test",
+                credential_store=CredentialStore(keyring_backend=FakeKeyring()),
+            )
+            client.pull_project = lambda _project_id, _revision_id=None: revision  # type: ignore[method-assign]
+            args = type("Args", (), {
+                "path": temp_dir,
+                "project_id": "project-1",
+                "revision_id": None,
+                "json": False,
+                "api_url": None,
+            })()
+            with patch("forma_cli.app.FormaAPIClient", return_value=client):
+                with self.assertRaisesRegex(LocalProjectError, "refusing to overwrite local changes"):
+                    cmd_projects_pull(args)
+            self.assertEqual(b"local edit", (root / "assembly.step").read_bytes())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Upload referenced STEP, STL, image, and other project files during \\orma-oss projects push\\.
- Restore and verify artifacts during pull with portable CAD path rewriting and dirty-tree protection.
- Add authenticated binary API/SDK transfer support, private storage configuration, and purge cleanup.
- Add manifest validation, storage migration, documentation, and focused tests.

Closes #361

## Tests
- \\python -m unittest tests.api.test_cli_project_artifacts tests.api.test_project_access tests.api.test_project_deletion_auth tests.tooling.test_oss_cli tests.tooling.test_opencode_setup tests.integrations.test_project_artifacts -v\\ (52 passed)
- \\python -m compileall -q apps/api forma_cli forma_core tests\\`n- \\git diff --check\\`n
The repository-wide suite was also attempted; remaining failures are unrelated Windows SQLite file-lock and provider-environment issues.