### PR TITLE
fix: avoid storage hydration in project lists

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1747,13 +1747,22 @@ async def a2a_mcp_endpoint(payload: Any = Body(...), _user: UserContext = Depend
     return response
 
 
-def _project_summary_response(project: Any, current_user_id: Optional[str] = None) -> Dict[str, Any]:
+def _project_summary_response(
+    project: Any,
+    current_user_id: Optional[str] = None,
+    *,
+    hydrate_storage: bool = True,
+) -> Dict[str, Any]:
     owner_user_id = _project_owner_user_id(project)
     can_chat = bool(current_user_id and owner_user_id == current_user_id)
     hardware_ir = getattr(project, "hardware_ir", None) if isinstance(getattr(project, "hardware_ir", None), dict) else {}
     components = hardware_ir.get("components") if isinstance(hardware_ir, dict) else []
     metadata = hardware_ir.get("assembly_metadata") if isinstance(hardware_ir, dict) and isinstance(hardware_ir.get("assembly_metadata"), dict) else {}
-    hydrated_metadata = hydrate_image_storage_metadata(metadata, project.project_id) if metadata else {}
+    hydrated_metadata = (
+        hydrate_image_storage_metadata(metadata, project.project_id)
+        if metadata and hydrate_storage
+        else metadata
+    )
     sequence = hydrated_metadata.get("product_visual_sequence")
     first_sequence_image = None
     if isinstance(sequence, list):
@@ -1812,6 +1821,7 @@ def _canonical_project_summary_response(
     brief: Any,
     *,
     owner_user_id: str,
+    hydrate_storage: bool = True,
 ) -> Dict[str, Any]:
     """Adapt canonical project state to the established gallery response."""
 
@@ -1828,7 +1838,11 @@ def _canonical_project_summary_response(
         created_at=revision.created_at,
         hardware_ir=state.model_dump(mode="json"),
     )
-    return _project_summary_response(project, current_user_id=owner_user_id)
+    return _project_summary_response(
+        project,
+        current_user_id=owner_user_id,
+        hydrate_storage=hydrate_storage,
+    )
 
 
 def _project_owner_digest(owner_user_id: Optional[str]) -> Optional[str]:
@@ -1839,7 +1853,7 @@ def _project_owner_digest(owner_user_id: Optional[str]) -> Optional[str]:
 
 def _public_project_cache_record(project: Any) -> Dict[str, Any]:
     """Build one shared gallery record with non-response ownership hints."""
-    summary = _project_summary_response(project, current_user_id=None)
+    summary = _project_summary_response(project, current_user_id=None, hydrate_storage=False)
     summary[_CACHE_OWNER_DIGEST_FIELD] = _project_owner_digest(_project_owner_user_id(project))
     summary[_CACHE_OWNER_CHAT_FIELD] = getattr(project, "chat_id", None)
     return summary
@@ -2051,7 +2065,11 @@ def list_my_projects_endpoint(
                 offset=offset,
             )
             items = [
-                _project_summary_response(project, current_user_id=owner_user_id)
+                _project_summary_response(
+                    project,
+                    current_user_id=owner_user_id,
+                    hydrate_storage=False,
+                )
                 for project in projects
             ]
             return {
@@ -2092,6 +2110,7 @@ def list_my_projects_endpoint(
                     revision,
                     brief,
                     owner_user_id=owner_user_id,
+                    hydrate_storage=False,
                 )
             )
         response.sort(key=lambda item: str(item.get("created_at") or ""), reverse=True)

--- a/tests/api/test_project_summary.py
+++ b/tests/api/test_project_summary.py
@@ -19,6 +19,30 @@ ANONYMOUS_USER = UserContext(
 
 
 class ProjectSummaryTests(unittest.TestCase):
+    def test_project_summary_can_skip_storage_hydration(self) -> None:
+        project = SimpleNamespace(
+            project_id="fd54de37-2fbb-485a-92e4-8bfaf4a2f08c",
+            chat_id="chat_123",
+            title="Low Voltage Desk Lamp",
+            prompt="desk lamp",
+            created_at="2026-07-21T14:08:00Z",
+            owner_user_id="user_123",
+            hardware_ir={
+                "components": [],
+                "assembly_metadata": {
+                    "product_image_url": "https://storage.example.test/product.png",
+                },
+            },
+        )
+
+        with patch.object(main, "creator_display_name", return_value="isayahc"), patch.object(
+            main, "hydrate_image_storage_metadata"
+        ) as hydrate:
+            summary = main._project_summary_response(project, hydrate_storage=False)
+
+        hydrate.assert_not_called()
+        self.assertEqual("https://storage.example.test/product.png", summary["product_image_url"])
+
     def test_project_summary_includes_hydrated_product_image(self) -> None:
         project = SimpleNamespace(
             project_id="fd54de37-2fbb-485a-92e4-8bfaf4a2f08c",


### PR DESCRIPTION
## Summary

- Fixes #374.
- Prevents public and owner project-list summaries from synchronously discovering/signing Supabase Storage images.
- Preserves hydration for project detail and image-summary responses.
- Adds regression coverage proving summary generation can skip Storage hydration.

## Verification

- python -m pytest tests/api/test_project_access.py tests/api/test_project_summary.py tests/api/test_project_engagement.py -> 29 passed
- python -m compileall -q apps/api/main.py tests/api/test_project_summary.py -> passed
- git diff --check -> passed
- Full suite: 570 passed, 2 skipped, 98 failed in Windows/Python 3.13 due existing SQLite WinError 32 file-lock cleanup failures and unrelated environment issues.