### PR TITLE
fix: preserve inline project images

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1766,7 +1766,14 @@ def _project_summary_response(
     sequence = hydrated_metadata.get("product_visual_sequence")
     first_sequence_image = None
     if isinstance(sequence, list):
-        first_sequence_image = next((item for item in sequence if isinstance(item, dict) and item.get("url")), None)
+        first_sequence_image = next(
+            (
+                item
+                for item in sequence
+                if isinstance(item, dict) and (item.get("url") or item.get("data"))
+            ),
+            None,
+        )
     product_image_url = (
         (first_sequence_image.get("url") if isinstance(first_sequence_image, dict) else None)
         or hydrated_metadata.get("product_case_image_url")
@@ -1777,6 +1784,9 @@ def _project_summary_response(
         or hydrated_metadata.get("product_case_image_content_type")
         or hydrated_metadata.get("product_image_content_type")
     )
+    product_image_data = hydrated_metadata.get("product_image_data")
+    if not product_image_data and isinstance(first_sequence_image, dict):
+        product_image_data = first_sequence_image.get("data")
     stored_creator_display = metadata.get("creator_display") or metadata.get("creator_username")
     creator_display = (
         stored_creator_display.strip()
@@ -1805,8 +1815,9 @@ def _project_summary_response(
         "save_count": 0,
         "remix_count": 0,
         "saved": False,
-        "has_product_image": bool(product_image_url or hydrated_metadata.get("product_image_data")),
+        "has_product_image": bool(product_image_url or product_image_data),
         "product_image_url": product_image_url,
+        "product_image_data": product_image_data,
         "product_image_content_type": product_image_content_type,
         "product_image_model": hydrated_metadata.get("product_image_model") or hydrated_metadata.get("image_output_model"),
         "product_visual_sequence": sequence if isinstance(sequence, list) else [],

--- a/tests/api/test_project_summary.py
+++ b/tests/api/test_project_summary.py
@@ -31,6 +31,7 @@ class ProjectSummaryTests(unittest.TestCase):
                 "components": [],
                 "assembly_metadata": {
                     "product_image_url": "https://storage.example.test/product.png",
+                    "product_image_data": "inline-image-data",
                 },
             },
         )
@@ -42,6 +43,34 @@ class ProjectSummaryTests(unittest.TestCase):
 
         hydrate.assert_not_called()
         self.assertEqual("https://storage.example.test/product.png", summary["product_image_url"])
+        self.assertEqual("inline-image-data", summary["product_image_data"])
+
+    def test_project_summary_promotes_visual_sequence_data_for_gallery_cards(self) -> None:
+        project = SimpleNamespace(
+            project_id="fd54de37-2fbb-485a-92e4-8bfaf4a2f08c",
+            chat_id="chat_123",
+            title="Low Voltage Desk Lamp",
+            prompt="desk lamp",
+            created_at="2026-07-21T14:08:00Z",
+            owner_user_id="user_123",
+            hardware_ir={
+                "components": [],
+                "assembly_metadata": {
+                    "product_visual_sequence": [
+                        {"view_id": "case", "data": "inline-image-data"},
+                    ],
+                },
+            },
+        )
+
+        with patch.object(main, "creator_display_name", return_value="isayahc"), patch.object(
+            main, "hydrate_image_storage_metadata"
+        ) as hydrate:
+            summary = main._project_summary_response(project, hydrate_storage=False)
+
+        hydrate.assert_not_called()
+        self.assertTrue(summary["has_product_image"])
+        self.assertEqual("inline-image-data", summary["product_image_data"])
 
     def test_project_summary_includes_hydrated_product_image(self) -> None:
         project = SimpleNamespace(


### PR DESCRIPTION
## Summary

- Fixes the image regression observed after #375.
- Promotes existing product_visual_sequence[*].data into the top-level product_image_data field consumed by the GUI.
- Treats data-only visual sequence entries as valid previews.
- Keeps signed URL behavior unchanged.

## Evidence

Production project-list responses contained inline image data but no top-level image URL/data. The GUI only renders image_url, product_image_url, or product_image_data, so those cards appeared without images.

## Verification

- Focused project API suite: 30 passed
- Python compilation: passed
- git diff --check: passed
- Related issue: #374