### PR TITLE
fix: render resolved project gallery images

### DIFF
--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -406,7 +406,7 @@ function formaBrowserProjectFromGalleryItem(item: ProjectGalleryItem): FormaProj
     remix_count: item.remixCount,
     saved: item.saved,
     can_chat: item.canChat,
-    image_url: item.image ? previewableImageSrc(item.image) : null,
+    image_url: item.image ? previewableImageSrc(item.image.src) : null,
   };
 }
 


### PR DESCRIPTION
## Summary

- Fixes the remaining image rendering regression from #374.
- Passes the resolved candidate source string to previewableImageSrc instead of the candidate object.
- This restores rendering for both inline data images and signed remote image URLs.

## Reproduction

A headless Chromium check against https://caid-technologies.us/projects reproduced six project cards with no <img> elements, even though /api/projects?limit=6&offset=0 returned valid image data.

## Verification

- Headless production browser: reproduced blank cards before fix.
- Production API: first image decoded as valid PNG, 913,606 bytes.
- 
px tsc --noEmit: passed.
- 
pm run lint -- --no-cache: passed with 10 existing @next/next/no-img-element warnings.
- Related issue: #374