### PR TITLE
fix: keep hosted chat maintenance on chat pages

### DIFF
--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -7098,12 +7098,6 @@ function ProjectDetailWorkspace({
         </div>
       </header>
 
-      {readOnly && (
-        <div className="px-3 pt-3 sm:px-4">
-          <HostedChatMaintenance compact />
-        </div>
-      )}
-
       <section className="min-h-0 min-w-0 flex-1 overflow-hidden bg-[var(--forma-page)]" aria-label="Project workspace">
         <ProjectWorkspacePanel
           projectId={projectId}


### PR DESCRIPTION
## Summary

- Remove the hosted-chat maintenance panel from project detail views.
- Keep the existing read-only maintenance block on chat views.
- Preserve project detail as a focused read-only viewing surface.

## Verification

- 
pm run lint passes with 10 pre-existing @next/next/no-img-element warnings.
- 
px next build passes.
- Playwright desktop (1440x900) and mobile (390x844) checks confirm the maintenance message is absent from project detail.
- Before/after screenshots captured locally in .playwright-mcp/:
  - issue-378-before-desktop.png`n  - issue-378-before-mobile.png`n  - issue-378-after-desktop.png`n  - issue-378-after-mobile.png`n- Local screenshot run had expected API 404s because the frontend was run without the backend.

Closes #378