### PR TITLE
fix: replace workspace image tags

### DIFF
--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -2,6 +2,7 @@
 
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import dynamic from "next/dynamic";
+import Image from "next/image";
 import { usePathname, useRouter } from "next/navigation";
 import {
   generationLlmImageSupport,
@@ -6675,7 +6676,14 @@ function VideoPanel({
                         aria-pressed={selected}
                       >
                         <div className="relative h-20 overflow-hidden rounded-md bg-[var(--forma-surface-muted)]">
-                          <img src={candidate.src} alt={candidate.label} className="h-full w-full object-cover" />
+                          <Image
+                            src={candidate.src}
+                            alt={candidate.label}
+                            width={1}
+                            height={1}
+                            unoptimized
+                            className="h-full w-full object-cover"
+                          />
                           <span className={`absolute right-2 top-2 flex h-5 w-5 items-center justify-center rounded-md border text-[10px] font-medium ${
                             selected
                               ? "border-[rgb(var(--forma-cyan-rgb))] bg-[rgb(var(--forma-cyan-rgb))] text-[var(--forma-page)]"
@@ -6745,8 +6753,14 @@ function VideoPanel({
             {mode === "video-to-video" && sourceVideoPreview ? (
               <video src={sourceVideoPreview} controls preload="metadata" className="h-full w-full object-contain" />
             ) : imagePreview ? (
-              // eslint-disable-next-line @next/next/no-img-element
-              <img src={imagePreview} alt="Video source preview" className="h-full w-full object-contain" />
+              <Image
+                src={imagePreview}
+                alt="Video source preview"
+                width={1}
+                height={1}
+                unoptimized
+                className="h-full w-full object-contain"
+              />
             ) : (
               <div className="flex h-full items-center justify-center text-[11px] font-medium uppercase tracking-[0.14em] text-[var(--forma-text-muted)]">
                 No source

--- a/apps/web/app/forma-workspace/conversation-message-list.tsx
+++ b/apps/web/app/forma-workspace/conversation-message-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ReactNode } from "react";
+import Image from "next/image";
 import {
   AlertTriangle,
   ArrowRight,
@@ -149,9 +150,12 @@ export default function ConversationMessageList({
             </button>
           )}
           {message.imagePreview && (
-            <img
+            <Image
               src={message.imagePreview}
               alt="Hardware reference thumbnail"
+              width={144}
+              height={96}
+              unoptimized
               className="mt-3 h-24 w-36 rounded-lg border border-white/10 object-cover"
             />
           )}

--- a/apps/web/app/forma-workspace/home-chat-view.tsx
+++ b/apps/web/app/forma-workspace/home-chat-view.tsx
@@ -3,6 +3,7 @@
 import type { ChangeEventHandler, ClipboardEventHandler, FormEventHandler, ReactNode, RefObject } from "react";
 import { useEffect, useRef } from "react";
 import Link from "next/link";
+import Image from "next/image";
 import {
   AlertTriangle,
   ArrowRight,
@@ -260,9 +261,12 @@ export default function HomeChatView({
             <input ref={imageInputRef} type="file" accept="image/*" onChange={onImageChange} className="hidden" />
             {selectedImage && (
               <div className="mb-2 flex items-start gap-2 rounded-xl border border-[var(--forma-border)] bg-[var(--forma-surface-muted)] p-1.5 pr-2">
-                <img
+                <Image
                   src={selectedImage}
                   alt="Attached prompt image"
+                  width={64}
+                  height={64}
+                  unoptimized
                   className="h-16 w-16 shrink-0 rounded-lg object-cover"
                 />
                 <div className="min-w-0 flex-1 py-0.5">

--- a/apps/web/app/forma-workspace/project-detail-panels.tsx
+++ b/apps/web/app/forma-workspace/project-detail-panels.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import dynamic from "next/dynamic";
+import Image from "next/image";
 import {
   AlertTriangle,
   Battery,
@@ -96,9 +97,12 @@ export function OverviewPanel({
         {showProductImage && (
           <div className="relative overflow-hidden rounded-xl border border-[var(--forma-border)] bg-[var(--forma-surface-muted)]">
             {activeImage ? (
-              <img
+              <Image
                 src={activeImage.src}
                 alt={activeImage.label}
+                width={1}
+                height={1}
+                unoptimized
                 onError={() => setImageIndex((current) => current + 1)}
                 className="h-[280px] w-full object-cover object-center sm:h-[380px]"
               />
@@ -126,7 +130,14 @@ export function OverviewPanel({
                     : "border-[var(--forma-border)] bg-[var(--forma-surface)] text-[var(--forma-text-muted)] hover:border-[var(--forma-text-muted)] hover:text-[var(--forma-text-strong)]"
                 }`}
               >
-                <img src={candidate.src} alt={candidate.label} className="h-20 w-full rounded-md bg-[var(--forma-surface-muted)] object-cover" />
+                <Image
+                  src={candidate.src}
+                  alt={candidate.label}
+                  width={1}
+                  height={1}
+                  unoptimized
+                  className="h-20 w-full rounded-md bg-[var(--forma-surface-muted)] object-cover"
+                />
                 <div className="mt-2 truncate text-[10px] font-medium">{candidate.label}</div>
               </button>
             ))}
@@ -139,10 +150,13 @@ export function OverviewPanel({
             <p className="mt-1 text-xs leading-5 text-[var(--forma-text-secondary)]">The image you shared for this project.</p>
             <div className={`mt-3 grid gap-2 ${referenceImages.length > 1 ? "sm:grid-cols-2" : ""}`}>
               {referenceImages.map((candidate) => (
-                <img
+                <Image
                   key={candidate.src}
                   src={candidate.src}
                   alt={candidate.label}
+                  width={1}
+                  height={1}
+                  unoptimized
                   className="h-44 w-full rounded-lg bg-[var(--forma-surface-muted)] object-cover object-center sm:h-52"
                 />
               ))}

--- a/apps/web/app/forma-workspace/project-gallery.tsx
+++ b/apps/web/app/forma-workspace/project-gallery.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useMemo, useState } from "react";
+import Image from "next/image";
 import {
   ArrowLeft,
   ArrowRight,
@@ -373,9 +374,12 @@ function ProjectImageLoadingPanel() {
 
 function ProjectGalleryPlaceholderThumb() {
   return (
-    <img
+    <Image
       src="/project-placeholder.jpg"
       alt=""
+      width={1}
+      height={1}
+      unoptimized
       className="h-full w-full object-cover transition duration-300 group-hover:scale-[1.015]"
     />
   );
@@ -506,9 +510,12 @@ function ProjectGalleryCard({
     >
       <div className="aspect-square overflow-hidden border-b border-white/5 bg-[#0f1117] sm:aspect-[4/3]">
         {item.image && !imageFailed ? (
-          <img
+          <Image
             src={item.image.src}
             alt={`${item.title} preview`}
+            width={1}
+            height={1}
+            unoptimized
             className="h-full w-full object-contain p-2 transition duration-300 group-hover:scale-[1.015] sm:object-cover sm:p-0"
             onError={() => setImageFailed(true)}
           />
@@ -557,9 +564,12 @@ function ProjectGalleryCard({
         <div className="flex min-w-0 items-center justify-between gap-3">
           <div className="flex min-w-0 items-center gap-2 text-xs font-medium text-zinc-500">
             {item.creatorImageUrl ? (
-              <img
+              <Image
                 src={item.creatorImageUrl}
                 alt=""
+                width={20}
+                height={20}
+                unoptimized
                 className="h-5 w-5 shrink-0 rounded-full border border-white/10 object-cover"
               />
             ) : (

--- a/apps/web/components/provider-mark.tsx
+++ b/apps/web/components/provider-mark.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 export type ProviderMarkId =
   | "anthropic"
   | "baseten"
@@ -52,9 +54,11 @@ export function ProviderMark({
 }) {
   if (!isProviderMarkId(id)) return null;
   return (
-    <img
+    <Image
       src={`/provider-marks/${id}.svg`}
       alt=""
+      width={20}
+      height={20}
       className={className}
       draggable={false}
     />


### PR DESCRIPTION
## Summary
- replace reported workspace and provider `<img>` elements with `next/image`
- preserve dimensions and styling for previews, gallery images, and provider marks
- use `unoptimized` for runtime and data/blob image sources that cannot rely on configured remote hosts

## Validation
- `npx eslint app/forma-workspace.tsx app/forma-workspace/conversation-message-list.tsx app/forma-workspace/home-chat-view.tsx app/forma-workspace/project-detail-panels.tsx app/forma-workspace/project-gallery.tsx components/provider-mark.tsx`
- `npx tsc --noEmit`