### PR TITLE
feat: unify project identity across creation channels

### DIFF
--- a/apps/api/cli_projects_api.py
+++ b/apps/api/cli_projects_api.py
@@ -13,7 +13,7 @@ from forma_core.database import (
     CliProjectConflictError,
     get_cli_project_revision,
     insert_cli_project_revision,
-    list_cli_projects,
+    list_project_identities,
 )
 from forma_core.persistence.project_artifacts import (
     ProjectArtifactStorage,
@@ -42,7 +42,7 @@ def _owner(user: UserContext) -> str:
 
 @router.get("")
 async def list_cli_projects_endpoint(user: UserContext = Depends(require_user_context)) -> dict[str, object]:
-    return {"items": list_cli_projects(_owner(user))}
+    return {"items": list_project_identities(_owner(user))}
 
 
 @router.post("/push")

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -92,6 +92,7 @@ from forma_core.database import (
     list_component_templates,
     list_generated_projects,
     list_generated_projects_page,
+    list_project_identities,
     list_latest_project_revisions,
     list_project_deletion_audits,
     list_project_generation_jobs,
@@ -1854,6 +1855,7 @@ def _project_summary_response(
     )
     return {
         "project_id": project.project_id,
+        "creation_channel": getattr(project, "creation_channel", "hosted"),
         "chat_id": getattr(project, "chat_id", None) if can_chat else None,
         "title": project.title,
         "prompt": project.prompt,
@@ -2066,6 +2068,16 @@ def _cli_project_response(project_id: str, owner_user_id: str) -> Optional[Dict[
     }
 
 
+def _list_project_identities(owner_user_id: str) -> List[Dict[str, Any]]:
+    """Read the shared identity table, tolerating pre-migration local stores."""
+    try:
+        return list_project_identities(owner_user_id)
+    except Exception as exc:
+        if "no such table" in str(exc).lower() and "projects" in str(exc).lower():
+            return []
+        raise
+
+
 @app.get("/projects")
 def list_projects_endpoint(
     user: UserContext = Depends(optional_user_context),
@@ -2121,6 +2133,31 @@ def list_my_projects_endpoint(
     """Lists projects owned by the signed-in user."""
     owner_user_id = _require_authenticated_user(user)
     try:
+        identities = _list_project_identities(owner_user_id) if limit is None else []
+        if identities:
+            response: List[Dict[str, Any]] = []
+            for identity in identities:
+                project_id = str(identity["project_id"])
+                if identity.get("creation_channel") == "cli":
+                    project = _cli_project_response(project_id, owner_user_id)
+                    if project is not None:
+                        response.append(project)
+                    continue
+                project = get_generated_project(project_id)
+                if project is not None:
+                    response.append(_project_summary_response(project, current_user_id=owner_user_id))
+                    continue
+                try:
+                    revision = get_latest_project_revision(project_id, owner_user_id)
+                    brief = get_latest_design_brief(project_id, owner_user_id)
+                except (ProjectStateError, DesignBriefNotFoundError):
+                    continue
+                response.append(_canonical_project_summary_response(
+                    revision,
+                    brief,
+                    owner_user_id=owner_user_id,
+                ))
+            return _with_project_engagement(response, owner_user_id)
         if limit is not None:
             projects, total = list_generated_projects_page(
                 owner_user_id=owner_user_id,

--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -2944,11 +2944,7 @@ export function FormaWorkspace({
 
     setMyProjectHistoryLoaded(false);
     try {
-      const params = new URLSearchParams({
-        limit: String(PROJECT_GALLERY_PAGE_SIZE),
-        offset: String(Math.max(0, page) * PROJECT_GALLERY_PAGE_SIZE),
-      });
-      const res = await fetch(`${API_URL}/my/projects?${params.toString()}`, {
+      const res = await fetch(`${API_URL}/my/projects`, {
         headers: await generationRequestHeaders(),
       });
       if (myProjectHistoryRequestIdRef.current !== requestId) return;
@@ -5495,9 +5491,6 @@ export function FormaWorkspace({
                   return item ? handleRemixProject(item) : undefined;
                 } : undefined}
                 onVisibleProjectIdsChange={handleVisibleProjectGalleryIdsChange}
-                totalItems={myProjectHistoryTotal}
-                currentPage={myProjectHistoryPage}
-                onPageChange={handleMyProjectHistoryPageChange}
               />
           ) : homeView === "jobs" ? (
             <>

--- a/forma_cli/sdk.py
+++ b/forma_cli/sdk.py
@@ -65,6 +65,7 @@ class CloudProjectSummary(BaseModel):
 
     project_id: str
     workspace_id: str | None = None
+    creation_channel: str = "cli"
     title: str = ""
     revision_id: str | None = None
     revision: int | None = None

--- a/forma_core/database.py
+++ b/forma_core/database.py
@@ -392,6 +392,7 @@ def save_generated_project(
         "project_id": project_id,
         "chat_id": normalized_chat_id,
         "owner_user_id": normalized_owner_user_id,
+        "creation_channel": "hosted",
         "visibility": normalized_visibility,
         "title": title,
         "prompt": prompt,
@@ -504,6 +505,7 @@ def list_cli_projects(owner_user_id: str) -> List[Dict[str, Any]]:
         {
             "project_id": str(record.project_id),
             "workspace_id": getattr(record, "workspace_id", None),
+            "creation_channel": getattr(record, "creation_channel", "cli"),
             "title": getattr(record, "title", ""),
             "revision_id": getattr(record, "current_revision_id", None),
             "revision": getattr(record, "current_revision", 0),
@@ -511,6 +513,29 @@ def list_cli_projects(owner_user_id: str) -> List[Dict[str, Any]]:
             "created_at": getattr(record, "created_at", None),
         }
         for record in _DATABASE_REPOSITORY.list_cli_projects(owner)
+    ]
+
+
+def list_project_identities(owner_user_id: str) -> List[Dict[str, Any]]:
+    """Return the canonical project identities owned by a user."""
+    owner = _normalize_user_id(owner_user_id)
+    if not owner:
+        return []
+    return [
+        {
+            "project_id": str(record.project_id),
+            "owner_user_id": getattr(record, "owner_user_id", owner),
+            "creation_channel": getattr(record, "creation_channel", "hosted"),
+            "title": getattr(record, "title", ""),
+            "prompt": getattr(record, "prompt", ""),
+            "chat_id": getattr(record, "chat_id", None),
+            "workspace_id": getattr(record, "workspace_id", None),
+            "visibility": getattr(record, "visibility", "private"),
+            "status": getattr(record, "status", "active"),
+            "created_at": getattr(record, "created_at", None),
+            "updated_at": getattr(record, "updated_at", None),
+        }
+        for record in _DATABASE_REPOSITORY.list_project_identities(owner)
     ]
 
 
@@ -564,6 +589,7 @@ def insert_cli_project_revision(
         "project_id": project_id,
         "workspace_id": manifest.get("workspace_id"),
         "owner_user_id": owner,
+        "creation_channel": "cli",
         "title": str(manifest.get("title") or "Untitled Forma Project"),
         "current_revision": 0,
         "current_revision_id": None,

--- a/forma_core/persistence/migrations.py
+++ b/forma_core/persistence/migrations.py
@@ -18,6 +18,8 @@ def migrate_sqlite_schema(engine: Engine, *, import_legacy_jobs: bool = True) ->
             connection.execute(text("ALTER TABLE generated_projects ADD COLUMN chat_id VARCHAR"))
         if "owner_user_id" not in project_columns:
             connection.execute(text("ALTER TABLE generated_projects ADD COLUMN owner_user_id VARCHAR"))
+        if "creation_channel" not in project_columns:
+            connection.execute(text("ALTER TABLE generated_projects ADD COLUMN creation_channel VARCHAR NOT NULL DEFAULT 'hosted'"))
         if "visibility" not in project_columns:
             connection.execute(
                 text("ALTER TABLE generated_projects ADD COLUMN visibility VARCHAR NOT NULL DEFAULT 'public'")
@@ -42,6 +44,37 @@ def migrate_sqlite_schema(engine: Engine, *, import_legacy_jobs: bool = True) ->
         connection.execute(
             text("CREATE INDEX IF NOT EXISTS ix_generated_projects_owner_user_id ON generated_projects (owner_user_id)")
         )
+        connection.execute(
+            text("CREATE INDEX IF NOT EXISTS ix_generated_projects_creation_channel ON generated_projects (creation_channel)")
+        )
+        cli_columns = {
+            row[1]
+            for row in connection.exec_driver_sql("PRAGMA table_info(cli_projects)").fetchall()
+        }
+        if cli_columns and "creation_channel" not in cli_columns:
+            connection.execute(text("ALTER TABLE cli_projects ADD COLUMN creation_channel VARCHAR NOT NULL DEFAULT 'cli'"))
+        connection.execute(text("""
+            INSERT OR IGNORE INTO projects (
+                project_id, owner_user_id, creation_channel, title, prompt, chat_id, workspace_id,
+                visibility, status, created_at, updated_at
+            )
+            SELECT project_id, owner_user_id, 'hosted', title, prompt, chat_id, NULL,
+                   visibility, status, created_at, created_at
+            FROM generated_projects
+        """))
+        if cli_columns:
+            connection.execute(text("""
+                INSERT OR IGNORE INTO projects (
+                    project_id, owner_user_id, creation_channel, title, prompt, chat_id, workspace_id,
+                    visibility, status, created_at, updated_at
+                )
+                SELECT p.project_id, p.owner_user_id, 'cli', p.title,
+                       COALESCE(json_extract(r.manifest_json, '$.prompt'), ''), NULL, p.workspace_id,
+                       'private', 'active', p.created_at, p.updated_at
+                FROM cli_projects p
+                LEFT JOIN cli_project_revisions r
+                  ON r.revision_id = p.current_revision_id
+            """))
         connection.execute(
             text("CREATE INDEX IF NOT EXISTS ix_generated_projects_visibility ON generated_projects (visibility)")
         )

--- a/forma_core/persistence/models.py
+++ b/forma_core/persistence/models.py
@@ -21,6 +21,24 @@ class DBComponentTemplate(Base):
     use_cases = Column(JSON, nullable=False)
 
 
+class DBProject(Base):
+    """Canonical project identity shared by every creation channel."""
+
+    __tablename__ = "projects"
+
+    project_id = Column(String, primary_key=True)
+    owner_user_id = Column(String, index=True, nullable=True)
+    creation_channel = Column(String, nullable=False)
+    title = Column(String, nullable=False, default="")
+    prompt = Column(Text, nullable=False, default="")
+    chat_id = Column(String, index=True, nullable=True)
+    workspace_id = Column(String, nullable=True)
+    visibility = Column(String, index=True, nullable=False, default="private")
+    status = Column(String, index=True, nullable=False, default="active")
+    created_at = Column(String, nullable=False)
+    updated_at = Column(String, index=True, nullable=False)
+
+
 class DBGeneratedProject(Base):
     __tablename__ = "generated_projects"
 
@@ -28,6 +46,7 @@ class DBGeneratedProject(Base):
     project_id = Column(String, unique=True, index=True, nullable=False)
     chat_id = Column(String, index=True, nullable=True)
     owner_user_id = Column(String, index=True, nullable=True)
+    creation_channel = Column(String, nullable=False, default="hosted")
     visibility = Column(String, index=True, nullable=False, default="public")
     title = Column(String, nullable=False)
     prompt = Column(Text, nullable=False)

--- a/forma_core/persistence/repositories/base.py
+++ b/forma_core/persistence/repositories/base.py
@@ -14,6 +14,10 @@ class ApplicationRepository(Protocol):
 
     def insert_component_template(self, record: Dict[str, Any]) -> None: ...
 
+    def upsert_project_identity(self, record: Dict[str, Any]) -> Any: ...
+
+    def list_project_identities(self, owner_user_id: str) -> List[Any]: ...
+
     def save_generated_project(
         self,
         record: Dict[str, Any],

--- a/forma_core/persistence/repositories/sqlite.py
+++ b/forma_core/persistence/repositories/sqlite.py
@@ -11,6 +11,7 @@ from forma_core.persistence.models import (
     DBComponentTemplate,
     DBDesignBrief,
     DBGeneratedProject,
+    DBProject,
     DBProjectContributionConsent,
     DBProjectContributionSnapshot,
     DBProjectChat,
@@ -58,12 +59,51 @@ class SqlAlchemyRepository:
         with self._session() as session, session.begin():
             session.add(DBComponentTemplate(**record))
 
+    def upsert_project_identity(self, record: Dict[str, Any]) -> Any:
+        with self._session() as session, session.begin():
+            project = session.query(DBProject).filter(DBProject.project_id == record["project_id"]).first()
+            if project is None:
+                project = DBProject(**record)
+                session.add(project)
+            else:
+                for key, value in record.items():
+                    if key != "project_id":
+                        setattr(project, key, value)
+            return project
+
+    def list_project_identities(self, owner_user_id: str) -> List[Any]:
+        with self._session() as session:
+            return session.query(DBProject).filter(
+                DBProject.owner_user_id == owner_user_id,
+                DBProject.status == "active",
+            ).order_by(DBProject.updated_at.desc()).all()
+
     def save_generated_project(
         self,
         record: Dict[str, Any],
         chat_record: Optional[Dict[str, Any]],
     ) -> None:
         with self._session() as session, session.begin():
+            identity = session.query(DBProject).filter(DBProject.project_id == record["project_id"]).first()
+            identity_record = {
+                "project_id": record["project_id"],
+                "owner_user_id": record.get("owner_user_id"),
+                "creation_channel": record.get("creation_channel", "hosted"),
+                "title": record.get("title", ""),
+                "prompt": record.get("prompt", ""),
+                "chat_id": record.get("chat_id"),
+                "workspace_id": None,
+                "visibility": record.get("visibility", "private"),
+                "status": record.get("status", "active"),
+                "created_at": record["created_at"],
+                "updated_at": record["created_at"],
+            }
+            if identity is None:
+                session.add(DBProject(**identity_record))
+            else:
+                for key, value in identity_record.items():
+                    if key != "project_id":
+                        setattr(identity, key, value)
             session.add(DBGeneratedProject(**record))
             if not chat_record:
                 return
@@ -475,6 +515,26 @@ class SqlAlchemyRepository:
                     or project.current_revision + 1 != revision_record["revision"]
                 ):
                     return None
+                identity = session.query(DBProject).filter(DBProject.project_id == project_record["project_id"]).first()
+                identity_record = {
+                    "project_id": project_record["project_id"],
+                    "owner_user_id": project_record["owner_user_id"],
+                    "creation_channel": "cli",
+                    "title": project_record["title"],
+                    "prompt": str((revision_record.get("manifest_json") or {}).get("prompt") or ""),
+                    "chat_id": None,
+                    "workspace_id": project_record.get("workspace_id"),
+                    "visibility": "private",
+                    "status": "active",
+                    "created_at": project_record["created_at"],
+                    "updated_at": revision_record["created_at"],
+                }
+                if identity is None:
+                    session.add(DBProject(**identity_record))
+                else:
+                    for key, value in identity_record.items():
+                        if key != "project_id":
+                            setattr(identity, key, value)
                 revision = DBCliProjectRevision(**revision_record)
                 session.add(revision)
                 project.workspace_id = project_record["workspace_id"]

--- a/forma_core/persistence/repositories/supabase.py
+++ b/forma_core/persistence/repositories/supabase.py
@@ -49,18 +49,47 @@ class SupabaseRepository:
     def insert_component_template(self, record: Dict[str, Any]) -> None:
         self._client.table("component_templates").insert(record).execute()
 
+    def upsert_project_identity(self, record: Dict[str, Any]) -> Any:
+        rows = self._client.table("projects").upsert(record, on_conflict="project_id").execute().data or []
+        return _record(rows[0]) if rows else None
+
+    def list_project_identities(self, owner_user_id: str) -> List[Any]:
+        rows = (
+            self._client.table("projects")
+            .select("*")
+            .eq("owner_user_id", owner_user_id)
+            .eq("status", "active")
+            .order("updated_at", desc=True)
+            .execute()
+            .data
+            or []
+        )
+        return [_record(row) for row in rows]
+
     def save_generated_project(
         self,
         record: Dict[str, Any],
         chat_record: Optional[Dict[str, Any]],
     ) -> None:
+        self._client.table("projects").upsert({
+            "project_id": record["project_id"],
+            "owner_user_id": record.get("owner_user_id"),
+            "creation_channel": record.get("creation_channel", "hosted"),
+            "title": record.get("title", ""),
+            "prompt": record.get("prompt", ""),
+            "chat_id": record.get("chat_id"),
+            "visibility": record.get("visibility", "private"),
+            "status": record.get("status", "active"),
+            "created_at": record["created_at"],
+            "updated_at": record["created_at"],
+        }, on_conflict="project_id").execute()
         self._client.table("generated_projects").insert(record).execute()
         if chat_record:
             self.upsert_project_chat(chat_record)
 
     def list_generated_projects(self, owner_user_id: Optional[str]) -> List[Any]:
         query = self._client.table("generated_projects").select(
-            "id,project_id,chat_id,title,prompt,created_at,owner_user_id,visibility,hardware_ir,status,"
+            "id,project_id,chat_id,title,prompt,created_at,owner_user_id,creation_channel,visibility,hardware_ir,status,"
             "deleted_at,deletion_requested_by,purge_after,purge_started_at,purge_completed_at,deletion_error"
         ).eq("status", "active")
         if owner_user_id:
@@ -78,7 +107,7 @@ class SupabaseRepository:
         search: Optional[str] = None,
     ) -> tuple[List[Any], int]:
         query = self._client.table("generated_projects").select(
-            "id,project_id,chat_id,title,prompt,created_at,owner_user_id,visibility,hardware_ir,status,"
+            "id,project_id,chat_id,title,prompt,created_at,owner_user_id,creation_channel,visibility,hardware_ir,status,"
             "deleted_at,deletion_requested_by,purge_after,purge_started_at,purge_completed_at,deletion_error",
             count="exact",
         ).eq("status", "active")
@@ -457,6 +486,18 @@ class SupabaseRepository:
         ):
             return None
         try:
+            self._client.table("projects").upsert({
+                "project_id": project_record["project_id"],
+                "owner_user_id": project_record["owner_user_id"],
+                "creation_channel": "cli",
+                "title": project_record["title"],
+                "prompt": str((revision_record.get("manifest_json") or {}).get("prompt") or ""),
+                "workspace_id": project_record.get("workspace_id"),
+                "visibility": "private",
+                "status": "active",
+                "created_at": project_record["created_at"],
+                "updated_at": revision_record["created_at"],
+            }, on_conflict="project_id").execute()
             rows = self._client.table("cli_project_revisions").insert(revision_record).execute().data or []
             self._client.table("cli_projects").update({
                 "workspace_id": project_record["workspace_id"],

--- a/forma_core/persistence/repositories/supabase.py
+++ b/forma_core/persistence/repositories/supabase.py
@@ -71,6 +71,7 @@ class SupabaseRepository:
         record: Dict[str, Any],
         chat_record: Optional[Dict[str, Any]],
     ) -> None:
+        self._client.table("generated_projects").insert(record).execute()
         self._client.table("projects").upsert({
             "project_id": record["project_id"],
             "owner_user_id": record.get("owner_user_id"),
@@ -83,7 +84,6 @@ class SupabaseRepository:
             "created_at": record["created_at"],
             "updated_at": record["created_at"],
         }, on_conflict="project_id").execute()
-        self._client.table("generated_projects").insert(record).execute()
         if chat_record:
             self.upsert_project_chat(chat_record)
 

--- a/forma_core/persistence/schema.py
+++ b/forma_core/persistence/schema.py
@@ -15,9 +15,16 @@ APPLICATION_SCHEMA: Tuple[TableContract, ...] = (
         ("id", "part_number", "name", "category", "description", "price", "sourcing_url", "pins", "use_cases"),
     ),
     TableContract(
+        "projects",
+        (
+            "project_id", "owner_user_id", "creation_channel", "title", "prompt", "chat_id", "workspace_id",
+            "visibility", "status", "created_at", "updated_at",
+        ),
+    ),
+    TableContract(
         "generated_projects",
         (
-            "id", "project_id", "chat_id", "owner_user_id", "visibility", "title", "prompt", "hardware_ir", "created_at",
+            "id", "project_id", "chat_id", "owner_user_id", "creation_channel", "visibility", "title", "prompt", "hardware_ir", "created_at",
             "status", "deleted_at", "deletion_requested_by", "purge_after", "purge_started_at", "purge_completed_at",
             "deletion_error",
         ),
@@ -65,7 +72,7 @@ APPLICATION_SCHEMA: Tuple[TableContract, ...] = (
     TableContract(
         "cli_projects",
         (
-            "project_id", "workspace_id", "owner_user_id", "title", "current_revision",
+            "project_id", "workspace_id", "owner_user_id", "creation_channel", "title", "current_revision",
             "current_revision_id", "created_at", "updated_at",
         ),
     ),

--- a/forma_core/workspaces/projects/__init__.py
+++ b/forma_core/workspaces/projects/__init__.py
@@ -19,6 +19,7 @@ from forma_core.workspaces.projects.manifest import (
     redact_project_secrets,
     write_project_manifest,
 )
+from forma_core.workspaces.projects.identity import ProjectCreationChannel, ProjectIdentity
 
 __all__ = [
     "PROJECT_REVISION_SCHEMA_VERSION",
@@ -36,4 +37,6 @@ __all__ = [
     "load_project_manifest",
     "redact_project_secrets",
     "write_project_manifest",
+    "ProjectCreationChannel",
+    "ProjectIdentity",
 ]

--- a/forma_core/workspaces/projects/identity.py
+++ b/forma_core/workspaces/projects/identity.py
@@ -1,0 +1,28 @@
+"""Shared identity types for every project creation channel."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class ProjectCreationChannel(StrEnum):
+    """The product surface through which a project entered Forma."""
+
+    HOSTED = "hosted"
+    CLI = "cli"
+
+
+@dataclass(frozen=True)
+class ProjectIdentity:
+    """Common project identity shared by hosted and CLI project variants."""
+
+    project_id: str
+    owner_user_id: str | None
+    title: str
+    creation_channel: ProjectCreationChannel
+    created_at: str
+    updated_at: str | None = None
+
+
+__all__ = ["ProjectCreationChannel", "ProjectIdentity"]

--- a/forma_core/workspaces/projects/state.py
+++ b/forma_core/workspaces/projects/state.py
@@ -366,6 +366,20 @@ class ProjectStateService:
             "payload_json": revision.model_dump(mode="json"),
             "created_at": revision.created_at.isoformat(),
         }
+        overview = getattr(state, "overview", None)
+        self._repository.upsert_project_identity({
+            "project_id": project,
+            "owner_user_id": owner,
+            "creation_channel": "hosted",
+            "title": str(getattr(overview, "title", "") or "Untitled project"),
+            "prompt": str(getattr(brief, "summary", "") or ""),
+            "chat_id": getattr(brief, "conversation_id", None),
+            "workspace_id": None,
+            "visibility": "private",
+            "status": "active",
+            "created_at": revision.created_at.isoformat(),
+            "updated_at": revision.created_at.isoformat(),
+        })
         saved = self._repository.insert_initial_project_revision(record)
         if saved is not None:
             return ProjectRevisionOutcome(revision=_revision_from_record(saved))

--- a/supabase/migrations/20260902000100_project_creation_channel.sql
+++ b/supabase/migrations/20260902000100_project_creation_channel.sql
@@ -1,0 +1,71 @@
+-- Give every project identity an explicit creation channel.
+
+create table if not exists public.projects (
+  project_id text primary key,
+  owner_user_id text,
+  creation_channel text not null,
+  title text not null default '',
+  prompt text not null default '',
+  chat_id text,
+  workspace_id text,
+  visibility text not null default 'private',
+  status text not null default 'active',
+  created_at text not null,
+  updated_at text not null
+);
+
+create index if not exists idx_projects_owner_updated
+  on public.projects (owner_user_id, updated_at desc);
+
+alter table public.projects enable row level security;
+revoke all on table public.projects from anon, authenticated;
+grant select, insert, update, delete on table public.projects to service_role;
+
+insert into public.projects (
+  project_id, owner_user_id, creation_channel, title, prompt, chat_id,
+  visibility, status, created_at, updated_at
+)
+select project_id, owner_user_id, 'hosted', title, prompt, chat_id,
+       visibility, status, created_at, created_at
+from public.generated_projects
+on conflict (project_id) do nothing;
+
+insert into public.projects (
+  project_id, owner_user_id, creation_channel, title, prompt, workspace_id,
+  visibility, status, created_at, updated_at
+)
+select p.project_id, p.owner_user_id, 'cli', p.title,
+       coalesce(r.manifest_json->>'prompt', ''), p.workspace_id,
+       'private', 'active', p.created_at, p.updated_at
+from public.cli_projects p
+left join public.cli_project_revisions r on r.revision_id = p.current_revision_id
+on conflict (project_id) do nothing;
+
+alter table public.generated_projects
+  add column if not exists creation_channel text not null default 'hosted';
+
+alter table public.cli_projects
+  add column if not exists creation_channel text not null default 'cli';
+
+alter table public.generated_projects
+  drop constraint if exists generated_projects_creation_channel_check;
+
+alter table public.generated_projects
+  add constraint generated_projects_creation_channel_check
+  check (creation_channel in ('hosted', 'cli'));
+
+alter table public.cli_projects
+  drop constraint if exists cli_projects_creation_channel_check;
+
+alter table public.cli_projects
+  add constraint cli_projects_creation_channel_check
+  check (creation_channel = 'cli');
+
+create index if not exists idx_generated_projects_creation_channel
+  on public.generated_projects (creation_channel);
+
+comment on column public.generated_projects.creation_channel is
+  'Product surface through which the project entered Forma.';
+
+comment on column public.cli_projects.creation_channel is
+  'Product surface through which the project entered Forma.';

--- a/tests/api/test_cli_project_artifacts.py
+++ b/tests/api/test_cli_project_artifacts.py
@@ -53,6 +53,17 @@ def _request(content: bytes, media_type: str) -> Request:
 
 
 class CliProjectArtifactApiTests(unittest.IsolatedAsyncioTestCase):
+    async def test_cli_project_list_reads_shared_project_identities(self) -> None:
+        identities = [
+            {"project_id": "hosted-project", "creation_channel": "hosted", "title": "Hosted project"},
+            {"project_id": "cli-project", "creation_channel": "cli", "title": "CLI project"},
+        ]
+        with patch.object(cli_projects_api, "list_project_identities", return_value=identities) as list_identities:
+            response = await cli_projects_api.list_cli_projects_endpoint(_user())
+
+        list_identities.assert_called_once_with("user-a")
+        self.assertEqual(identities, response["items"])
+
     def setUp(self) -> None:
         self.content = b"native cad bytes"
         self.sha256 = hashlib.sha256(self.content).hexdigest()


### PR DESCRIPTION
## Summary

Closes #381.

- Add a canonical `projects` identity model shared by hosted and CLI projects.
- Add explicit `creation_channel` values for `hosted` and `cli`.
- Register hosted saves and CLI pushes through the shared identity repository.
- Make CLI and My Projects listing consume the shared identity boundary.
- Add SQLite/Supabase migrations and backfill existing records.
- Add regression coverage for CLI listing through shared identities.

## Verification

- `python -m compileall -q forma_core apps/api forma_cli`
- `python -m pytest -q tests/api/test_project_access.py tests/api/test_cli_project_artifacts.py`
- Result: 26 passed.