### PR TITLE
fix: expose project creation channel in web details

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -2054,6 +2054,7 @@ def _cli_project_response(project_id: str, owner_user_id: str) -> Optional[Dict[
 
     return {
         "project_id": str(revision["project_id"]),
+        "creation_channel": "cli",
         "chat_id": None,
         "prompt": manifest.prompt,
         "created_at": revision.get("created_at"),


### PR DESCRIPTION
## Summary

Follow-up to #384.

The merged project identity implementation correctly returns `creation_channel` from the CLI listing, but the web project-detail response omitted it for CLI-created projects. This adds `creation_channel: cli` so hosted and CLI project responses expose the same identity metadata.

## Verification

- `python -m compileall -q apps/api/main.py`
- `python -m pytest -q tests/api/test_project_access.py tests/api/test_cli_project_artifacts.py`
- Result: 26 passed.