### PR TITLE
refactor: type project API contracts

### DIFF
--- a/apps/api/cli_projects_api.py
+++ b/apps/api/cli_projects_api.py
@@ -24,6 +24,7 @@ from forma_core.workspaces.projects.manifest import (
     normalize_artifact_media_type,
     validate_artifact_references,
 )
+from forma_core.workspaces.projects.models import ProjectIdentityResponse
 
 
 router = APIRouter(prefix="/cli/projects", tags=["cli"])
@@ -42,7 +43,11 @@ def _owner(user: UserContext) -> str:
 
 @router.get("")
 async def list_cli_projects_endpoint(user: UserContext = Depends(require_user_context)) -> dict[str, object]:
-    return {"items": list_project_identities(_owner(user))}
+    items = [
+        ProjectIdentityResponse.model_validate(identity).model_dump(mode="json", exclude_unset=True)
+        for identity in list_project_identities(_owner(user))
+    ]
+    return {"items": items}
 
 
 @router.post("/push")

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -117,7 +117,7 @@ from forma_core.workspaces.chats.models import Chat, ChatUpsertRequest, ProjectC
 from forma_core.workspaces.projects.models import (
     ClarifyingQuestionsRequest, ClarifyingQuestionsResponse, ComponentInstance,
     ConnectionNet, GenerateProjectRequest, HardwareIR, IterateProjectRequest,
-    ProjectContributionConsentRequest, ProjectUpdateRequest, ValidationIssue, ValidationReport, VideoSelfCorrectRequest,
+    ProjectContributionConsentRequest, ProjectDetail, ProjectIdentityResponse, ProjectUpdateRequest, ProjectSummary, ValidationIssue, ValidationReport, VideoSelfCorrectRequest,
 )
 from forma_core.workspaces.projects import ProjectStateError
 from forma_core.workspaces.projects.manifest import ProjectManifest
@@ -1805,7 +1805,7 @@ def _project_summary_response(
     current_user_id: Optional[str] = None,
     *,
     hydrate_storage: bool = True,
-) -> Dict[str, Any]:
+) -> ProjectSummary:
     owner_user_id = _project_owner_user_id(project)
     can_chat = bool(current_user_id and owner_user_id == current_user_id)
     hardware_ir = getattr(project, "hardware_ir", None) if isinstance(getattr(project, "hardware_ir", None), dict) else {}
@@ -1853,32 +1853,32 @@ def _project_summary_response(
         and stored_creator_image_url.strip().startswith(("http://", "https://"))
         else None
     )
-    return {
-        "project_id": project.project_id,
-        "creation_channel": getattr(project, "creation_channel", "hosted"),
-        "chat_id": getattr(project, "chat_id", None) if can_chat else None,
-        "title": project.title,
-        "prompt": project.prompt,
-        "created_at": project.created_at,
-        "visibility": _project_visibility(project),
-        "can_chat": can_chat,
-        "creator_display": creator_display,
-        "creator_username": creator_display,
-        "creator_image_url": creator_image_url,
-        "parts_count": len(components) if isinstance(components, list) else 0,
-        "save_count": 0,
-        "remix_count": 0,
-        "saved": False,
-        "has_product_image": bool(product_image_url or product_image_data),
-        "product_image_url": product_image_url,
-        "product_image_data": product_image_data,
-        "product_image_content_type": product_image_content_type,
-        "product_image_model": hydrated_metadata.get("product_image_model") or hydrated_metadata.get("image_output_model"),
-        "product_visual_sequence": sequence if isinstance(sequence, list) else [],
-        "image_output_status": hydrated_metadata.get("image_output_status"),
-        "generation_status": metadata.get("generation_status", "succeeded"),
-        "project_readiness": metadata.get("project_readiness", "complete"),
-    }
+    return ProjectSummary(
+        project_id=project.project_id,
+        creation_channel=getattr(project, "creation_channel", "hosted"),
+        chat_id=getattr(project, "chat_id", None) if can_chat else None,
+        title=project.title,
+        prompt=project.prompt,
+        created_at=project.created_at,
+        visibility=_project_visibility(project),
+        can_chat=can_chat,
+        creator_display=creator_display,
+        creator_username=creator_display,
+        creator_image_url=creator_image_url,
+        parts_count=len(components) if isinstance(components, list) else 0,
+        save_count=0,
+        remix_count=0,
+        saved=False,
+        has_product_image=bool(product_image_url or product_image_data),
+        product_image_url=product_image_url,
+        product_image_data=product_image_data,
+        product_image_content_type=product_image_content_type,
+        product_image_model=hydrated_metadata.get("product_image_model") or hydrated_metadata.get("image_output_model"),
+        product_visual_sequence=sequence if isinstance(sequence, list) else [],
+        image_output_status=hydrated_metadata.get("image_output_status"),
+        generation_status=metadata.get("generation_status", "succeeded"),
+        project_readiness=metadata.get("project_readiness", "complete"),
+    )
 
 
 def _canonical_project_summary_response(
@@ -1887,7 +1887,7 @@ def _canonical_project_summary_response(
     *,
     owner_user_id: str,
     hydrate_storage: bool = True,
-) -> Dict[str, Any]:
+) -> ProjectSummary:
     """Adapt canonical project state to the established gallery response."""
 
     state = revision.state
@@ -1918,7 +1918,7 @@ def _project_owner_digest(owner_user_id: Optional[str]) -> Optional[str]:
 
 def _public_project_cache_record(project: Any) -> Dict[str, Any]:
     """Build one shared gallery record with non-response ownership hints."""
-    summary = _project_summary_response(project, current_user_id=None, hydrate_storage=False)
+    summary = _project_summary_response(project, current_user_id=None, hydrate_storage=False).model_dump(mode="json")
     summary[_CACHE_OWNER_DIGEST_FIELD] = _project_owner_digest(_project_owner_user_id(project))
     summary[_CACHE_OWNER_CHAT_FIELD] = getattr(project, "chat_id", None)
     return summary
@@ -1952,6 +1952,10 @@ def _with_project_engagement(
     current_user_id: Optional[str],
 ) -> List[Dict[str, Any]]:
     """Attach live save/remix counts and the current user's save state."""
+    records = [
+        record.model_dump(mode="json") if isinstance(record, ProjectSummary) else record
+        for record in records
+    ]
     if not records:
         return records
     project_ids = [str(record.get("project_id") or "") for record in records]
@@ -2016,7 +2020,7 @@ def _without_downloadable_project_assets(hardware_ir: Dict[str, Any]) -> Dict[st
     return sanitized
 
 
-def _cli_project_response(project_id: str, owner_user_id: str) -> Optional[Dict[str, Any]]:
+def _cli_project_response(project_id: str, owner_user_id: str) -> Optional[ProjectDetail]:
     """Adapt an authenticated CLI revision to the web project's response shape."""
     revision = get_cli_project_revision(project_id, owner_user_id)
     if revision is None:
@@ -2057,37 +2061,34 @@ def _cli_project_response(project_id: str, owner_user_id: str) -> Optional[Dict[
         # Keep older CLI manifests inspectable even if they predate HardwareIR.
         pass
 
-    return {
-        "project_id": str(revision["project_id"]),
-        "creation_channel": "cli",
-        "chat_id": None,
-        "title": title,
-        "prompt": manifest.prompt,
-        "created_at": revision.get("created_at"),
-        "visibility": "private",
-        "can_chat": False,
-        "creator_display": creator_display_name(owner_user_id),
-        "creator_username": creator_display_name(owner_user_id),
-        "creator_image_url": None,
-        "parts_count": len(components),
-        "has_product_image": bool(product_image_url or product_image_data),
-        "product_image_url": product_image_url,
-        "product_image_data": product_image_data,
-        "product_visual_sequence": metadata.get("product_visual_sequence") or [],
-        "project_ir": project_ir,
-        "project_object": project_object,
-        "mermaid_code": mermaid_code,
-        "svg_schematic": svg_schematic,
-        "generation_status": metadata.get("generation_status", "succeeded"),
-        "project_readiness": metadata.get("project_readiness", "complete"),
-        "generation_stages": (metadata.get("generation_run") or {}).get("records", {}),
-    }
+    return ProjectDetail(
+        project_id=str(revision["project_id"]),
+        creation_channel="cli",
+        title=title,
+        prompt=manifest.prompt,
+        created_at=revision.get("created_at"),
+        visibility="private",
+        creator_display=creator_display_name(owner_user_id),
+        creator_username=creator_display_name(owner_user_id),
+        parts_count=len(components),
+        has_product_image=bool(product_image_url or product_image_data),
+        product_image_url=product_image_url,
+        product_image_data=product_image_data,
+        product_visual_sequence=metadata.get("product_visual_sequence") or [],
+        project_ir=project_ir,
+        project_object=project_object,
+        mermaid_code=mermaid_code,
+        svg_schematic=svg_schematic,
+        generation_status=metadata.get("generation_status", "succeeded"),
+        project_readiness=metadata.get("project_readiness", "complete"),
+        generation_stages=(metadata.get("generation_run") or {}).get("records", {}),
+    )
 
 
-def _list_project_identities(owner_user_id: str) -> List[Dict[str, Any]]:
+def _list_project_identities(owner_user_id: str) -> List[ProjectIdentityResponse]:
     """Read the shared identity table, tolerating pre-migration local stores."""
     try:
-        return list_project_identities(owner_user_id)
+        return [ProjectIdentityResponse.model_validate(record) for record in list_project_identities(owner_user_id)]
     except Exception as exc:
         if "no such table" in str(exc).lower() and "projects" in str(exc).lower():
             return []
@@ -2157,11 +2158,11 @@ def list_my_projects_endpoint(
                 if identity.get("creation_channel") == "cli":
                     project = _cli_project_response(project_id, owner_user_id)
                     if project is not None:
-                        response.append(project)
+                        response.append(project.model_dump(mode="json"))
                     continue
                 project = get_generated_project(project_id)
                 if project is not None:
-                    response.append(_project_summary_response(project, current_user_id=owner_user_id))
+                    response.append(_project_summary_response(project, current_user_id=owner_user_id).model_dump(mode="json"))
                     continue
                 try:
                     revision = get_latest_project_revision(project_id, owner_user_id)
@@ -2172,7 +2173,7 @@ def list_my_projects_endpoint(
                     revision,
                     brief,
                     owner_user_id=owner_user_id,
-                ))
+                ).model_dump(mode="json"))
             return _with_project_engagement(response, owner_user_id)
         if limit is not None:
             projects, total = list_generated_projects_page(
@@ -2181,11 +2182,11 @@ def list_my_projects_endpoint(
                 offset=offset,
             )
             items = [
-                _project_summary_response(
-                    project,
-                    current_user_id=owner_user_id,
-                    hydrate_storage=False,
-                )
+                    _project_summary_response(
+                        project,
+                        current_user_id=owner_user_id,
+                        hydrate_storage=False,
+                    ).model_dump(mode="json")
                 for project in projects
             ]
             return {
@@ -2200,7 +2201,7 @@ def list_my_projects_endpoint(
             return _with_project_engagement(cached, owner_user_id)
         projects = list_generated_projects(owner_user_id=owner_user_id)
         response = [
-            _project_summary_response(project, current_user_id=owner_user_id)
+                _project_summary_response(project, current_user_id=owner_user_id).model_dump(mode="json")
             for project in projects
         ]
         legacy_project_ids = {str(project.project_id) for project in projects}
@@ -2227,7 +2228,7 @@ def list_my_projects_endpoint(
                     brief,
                     owner_user_id=owner_user_id,
                     hydrate_storage=False,
-                )
+                ).model_dump(mode="json")
             )
         response.sort(key=lambda item: str(item.get("created_at") or ""), reverse=True)
         response = jsonable_encoder(response)
@@ -2247,7 +2248,7 @@ def get_project_image_summary_endpoint(project_id: str, user: UserContext = Depe
 
     try:
         summaries = _with_project_engagement(
-            [_project_summary_response(project, current_user_id=user.owner_user_id)],
+            [_project_summary_response(project, current_user_id=user.owner_user_id).model_dump(mode="json")],
             user.owner_user_id,
         )
         return summaries[0]

--- a/forma_cli/sdk.py
+++ b/forma_cli/sdk.py
@@ -64,9 +64,13 @@ class CloudProjectSummary(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     project_id: str
+    owner_user_id: str | None = None
     workspace_id: str | None = None
     creation_channel: str = "cli"
     title: str = ""
+    prompt: str = ""
+    visibility: str = "private"
+    status: str = "active"
     revision_id: str | None = None
     revision: int | None = None
     parent_revision_id: str | None = None

--- a/forma_core/workspaces/projects/__init__.py
+++ b/forma_core/workspaces/projects/__init__.py
@@ -20,6 +20,7 @@ from forma_core.workspaces.projects.manifest import (
     write_project_manifest,
 )
 from forma_core.workspaces.projects.identity import ProjectCreationChannel, ProjectIdentity
+from forma_core.workspaces.projects.models import ProjectDetail, ProjectIdentityResponse, ProjectSummary
 
 __all__ = [
     "PROJECT_REVISION_SCHEMA_VERSION",
@@ -30,6 +31,9 @@ __all__ = [
     "ProjectStateError",
     "ProjectStateService",
     "ProjectSystem",
+    "ProjectSummary",
+    "ProjectDetail",
+    "ProjectIdentityResponse",
     "PROJECT_MANIFEST_FORMAT",
     "PROJECT_MANIFEST_VERSION",
     "ProjectArtifactReference",

--- a/forma_core/workspaces/projects/models.py
+++ b/forma_core/workspaces/projects/models.py
@@ -1,5 +1,6 @@
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from typing import List, Optional, Dict, Any, Iterable, Mapping
+from datetime import datetime
 import re
 
 # ==========================================
@@ -618,12 +619,82 @@ class Project(BaseModel):
     """Durable design artifact contained by a workspace."""
 
     project_id: str
+    owner_user_id: str | None = None
     chat_id: str | None = None
     title: str
     prompt: str
     hardware_ir: HardwareIR | Dict[str, Any]
     created_at: str
+    updated_at: str | None = None
+    creation_channel: str = "hosted"
     visibility: str = "public"
+
+
+class ProjectSummary(BaseModel):
+    """Common gallery contract returned for every project creation channel."""
+
+    project_id: str
+    creation_channel: str
+    chat_id: str | None = None
+    title: str
+    prompt: str = ""
+    created_at: str | None = None
+    updated_at: str | None = None
+    visibility: str = "private"
+    can_chat: bool = False
+    creator_display: str = "unknown"
+    creator_username: str | None = None
+    creator_image_url: str | None = None
+    parts_count: int = 0
+    save_count: int = 0
+    remix_count: int = 0
+    saved: bool = False
+    has_product_image: bool = False
+    product_image_url: str | None = None
+    product_image_data: str | None = None
+    product_image_content_type: str | None = None
+    product_image_model: str | None = None
+    product_visual_sequence: list[dict[str, Any]] = Field(default_factory=list)
+    image_output_status: str | None = None
+    generation_status: str = "succeeded"
+    project_readiness: str = "complete"
+
+    model_config = ConfigDict(extra="allow")
+
+    def __getitem__(self, key: str) -> Any:
+        """Allow existing response assertions to inspect typed contracts by key."""
+        return getattr(self, key)
+
+
+class ProjectIdentityResponse(BaseModel):
+    """Stable identity projection shared by hosted and CLI project listings."""
+
+    model_config = ConfigDict(from_attributes=True, extra="ignore")
+
+    project_id: str
+    owner_user_id: str | None = None
+    creation_channel: str = "hosted"
+    title: str = ""
+    prompt: str = ""
+    chat_id: str | None = None
+    workspace_id: str | None = None
+    visibility: str = "private"
+    status: str = "active"
+    created_at: str | datetime | None = None
+    updated_at: str | datetime | None = None
+
+    def __getitem__(self, key: str) -> Any:
+        return getattr(self, key)
+
+
+class ProjectDetail(ProjectSummary):
+    """Extended project contract used by authenticated detail views."""
+
+    project_ir: dict[str, Any] | HardwareIR | None = None
+    project_object: dict[str, Any] | None = None
+    mermaid_code: str | None = None
+    svg_schematic: str | None = None
+    generation_stages: dict[str, Any] = Field(default_factory=dict)
 
 # ==========================================
 # 3. API Requests & Response Models

--- a/packages/forma-gui/package-lock.json
+++ b/packages/forma-gui/package-lock.json
@@ -1,0 +1,92 @@
+{
+  "name": "@isayahc/forma-gui",
+  "version": "0.1.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@isayahc/forma-gui",
+      "version": "0.1.1",
+      "devDependencies": {
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "typescript": "^5.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.2.0 <20",
+        "react-dom": ">=18.2.0 <20"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-fMPwH9v7r/pp43yUd2/Mbiex5KouJwwR3dzHkhLREUC6764VyDsqxhAxv6OFEYR1RhjOyD1naqba8ECDBe7ZQg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/packages/forma-gui/src/contracts.ts
+++ b/packages/forma-gui/src/contracts.ts
@@ -2,6 +2,7 @@ export type JsonObject = Record<string, unknown>;
 
 export type FormaProjectSummary = {
   project_id: string;
+  creation_channel?: "hosted" | "cli";
   title: string;
   description?: string | null;
   prompt?: string | null;
@@ -113,11 +114,13 @@ export type FormaHardwareProject = {
 
 export type FormaProjectResponse = {
   project_id?: string;
+  creation_channel?: "hosted" | "cli";
   chat_id?: string;
   title?: string;
   prompt?: string;
   status?: string | null;
   generation_status?: string | null;
+  project_readiness?: string | null;
   readiness?: string | null;
   stage?: string | null;
   created_at?: string;

--- a/tests/api/test_user_integrations_api.py
+++ b/tests/api/test_user_integrations_api.py
@@ -16,7 +16,7 @@ from apps.api.user_integrations_api import (
     _store_for_context,
     image_model_test_available,
     router,
-    test_image_model,
+    test_image_model as run_image_model_test,
     update_user_integration,
 )
 from forma_core.user_integrations import SupabaseUserIntegrationStore, SupabaseWorkspaceIntegrationStore
@@ -172,7 +172,7 @@ class UserIntegrationsApiAuthTests(unittest.TestCase):
         ), patch("apps.api.user_integrations_api.apply_user_integrations_to_environment"), patch(
             "apps.api.user_integrations_api.build_image_provider", return_value=provider
         ):
-            response = test_image_model(request, HOSTED_CONTEXT)
+            response = run_image_model_test(request, HOSTED_CONTEXT)
 
         self.assertTrue(response["ok"])
         self.assertEqual("test render", provider.prompt)
@@ -183,7 +183,7 @@ class UserIntegrationsApiAuthTests(unittest.TestCase):
         request = ImageModelTestRequest(provider="gmi", model="seedream-5.0-pro", prompt="test render")
         with patch.dict(os.environ, {"VERCEL": "1", "VERCEL_ENV": "production"}, clear=True):
             with self.assertRaises(HTTPException) as raised:
-                test_image_model(request, HOSTED_CONTEXT)
+                run_image_model_test(request, HOSTED_CONTEXT)
 
         self.assertEqual(404, raised.exception.status_code)
 


### PR DESCRIPTION
## Summary
- add shared typed project identity, summary, and detail contracts
- route hosted and CLI project serializers through Pydantic models
- align CLI and GUI project contracts with creation-channel metadata
- prevent pytest from collecting the imported image-model route as a test

## Validation
- python -m pytest tests/api -q -> 144 passed
- 
pm test in packages/forma-gui -> 5 passed
- TypeScript build passes
- full repository pytest reached 602 passed but encountered unrelated Windows SQLite file-lock cleanup failures in worker/persistence tests

Closes #386