### PR TITLE
fix: handle project list failures

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -2154,8 +2154,8 @@ def list_my_projects_endpoint(
         if identities:
             response: List[Dict[str, Any]] = []
             for identity in identities:
-                project_id = str(identity["project_id"])
-                if identity.get("creation_channel") == "cli":
+                project_id = str(identity.project_id)
+                if identity.creation_channel == "cli":
                     project = _cli_project_response(project_id, owner_user_id)
                     if project is not None:
                         response.append(project.model_dump(mode="json"))
@@ -2234,8 +2234,9 @@ def list_my_projects_endpoint(
         response = jsonable_encoder(response)
         cache_project_list("mine", owner_user_id, response, generation)
         return _with_project_engagement(response, owner_user_id)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    except Exception as exc:
+        logger.exception("My project list failed for owner_user_id=%s", owner_user_id)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 
 @app.get("/projects/{project_id}/image-summary")

--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -1729,6 +1729,7 @@ export function FormaWorkspace({
   const [myProjectHistoryTotal, setMyProjectHistoryTotal] = useState(0);
   const [projectHistoryLoaded, setProjectHistoryLoaded] = useState(false);
   const [myProjectHistoryLoaded, setMyProjectHistoryLoaded] = useState(false);
+  const [myProjectHistoryError, setMyProjectHistoryError] = useState<Error | null>(null);
   const [projectSearchInput, setProjectSearchInput] = useState("");
   const [projectSearchQuery, setProjectSearchQuery] = useState("");
   const [localChatItems, setLocalChatItems] = useState<ChatListItem[]>([]);
@@ -2938,11 +2939,13 @@ export function FormaWorkspace({
     if (authRequired && !isSignedIn) {
       setMyProjectHistory([]);
       setMyProjectHistoryTotal(0);
+      setMyProjectHistoryError(new Error("Sign in to view your projects."));
       setMyProjectHistoryLoaded(true);
       return;
     }
 
     setMyProjectHistoryLoaded(false);
+    setMyProjectHistoryError(null);
     try {
       const res = await fetch(`${API_URL}/my/projects`, {
         headers: await generationRequestHeaders(),
@@ -2953,15 +2956,19 @@ export function FormaWorkspace({
         if (myProjectHistoryRequestIdRef.current !== requestId) return;
         setMyProjectHistory(result.items);
         setMyProjectHistoryTotal(result.total);
+        setMyProjectHistoryError(null);
         setAuthSecurityError(false);
       } else if (isAuthOrSecurityHttpStatus(res.status)) {
         if (isSignedIn) setAuthSecurityError(true);
         setMyProjectHistory([]);
         setMyProjectHistoryTotal(0);
+        setMyProjectHistoryError(new Error("Sign in to view your projects."));
       } else {
         throw new Error(await readApiErrorMessage(res));
       }
     } catch (e) {
+      if (myProjectHistoryRequestIdRef.current !== requestId) return;
+      setMyProjectHistoryError(e instanceof Error ? e : new Error("Projects could not be loaded."));
       console.error("Error fetching my project history", e);
     } finally {
       if (myProjectHistoryRequestIdRef.current === requestId) setMyProjectHistoryLoaded(true);
@@ -5491,6 +5498,7 @@ export function FormaWorkspace({
                   return item ? handleRemixProject(item) : undefined;
                 } : undefined}
                 onVisibleProjectIdsChange={handleVisibleProjectGalleryIdsChange}
+                error={myProjectHistoryError}
               />
           ) : homeView === "jobs" ? (
             <>

--- a/tests/api/test_project_access.py
+++ b/tests/api/test_project_access.py
@@ -259,6 +259,53 @@ class ProjectReadAccessTests(unittest.TestCase):
         self.assertTrue(response[0]["can_chat"])
         self.assertTrue(response[0]["has_product_image"])
 
+    def test_owner_list_handles_typed_project_identity_records(self) -> None:
+        project = _project(
+            "identity-project",
+            owner_user_id="user-a",
+            visibility="private",
+        )
+        identity = SimpleNamespace(
+            project_id=project.project_id,
+            owner_user_id="user-a",
+            creation_channel="hosted",
+            title=project.title,
+            prompt=project.prompt,
+            chat_id=project.chat_id,
+            visibility=project.visibility,
+            status="active",
+        )
+
+        with self._summary_dependencies(), patch.object(
+            main,
+            "list_project_identities",
+            return_value=[identity],
+        ), patch.object(main, "get_generated_project", return_value=project):
+            response = main.list_my_projects_endpoint(_user_context("user-a"))
+
+        self.assertEqual([project.project_id], [item["project_id"] for item in response])
+        self.assertTrue(response[0]["can_chat"])
+
+    def test_owner_list_logs_and_returns_http_error_on_failure(self) -> None:
+        with patch.object(main, "list_project_identities", return_value=[]), patch.object(
+            main,
+            "get_cached_project_list",
+            return_value=(None, None),
+        ), patch.object(
+            main,
+            "list_generated_projects",
+            side_effect=RuntimeError("database unavailable"),
+        ), patch.object(main.logger, "exception") as log_exception:
+            with self.assertRaises(HTTPException) as raised:
+                main.list_my_projects_endpoint(_user_context("user-a"))
+
+        self.assertEqual(500, raised.exception.status_code)
+        self.assertEqual("database unavailable", raised.exception.detail)
+        log_exception.assert_called_once_with(
+            "My project list failed for owner_user_id=%s",
+            "user-a",
+        )
+
     def test_owner_list_uses_bounded_projection_page(self) -> None:
         page_projects = [
             _project("private-project-7", owner_user_id="user-a", visibility="private"),


### PR DESCRIPTION
## Summary
- Fix typed project identity access in /api/my/projects.
- Log project-list exceptions with the owner context and preserve the HTTP 500 response.
- Show authenticated project-list failures in the workspace instead of silently rendering an empty list.
- Add regression coverage for identity records and backend failures.

Fixes #392

## Validation
- python -m unittest tests.api.test_project_access -q (23 passed)
- 
pm run lint (passed)
- 
px tsc --noEmit (passed)
- 
pm run build (passed)
- Full Python suite ran 697 tests but has unrelated environment/configuration failures.