### PR TITLE
perf: paginate my projects gallery

### DIFF
--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -2947,7 +2947,11 @@ export function FormaWorkspace({
     setMyProjectHistoryLoaded(false);
     setMyProjectHistoryError(null);
     try {
-      const res = await fetch(`${API_URL}/my/projects`, {
+      const params = new URLSearchParams({
+        limit: String(PROJECT_GALLERY_PAGE_SIZE),
+        offset: String(Math.max(0, page) * PROJECT_GALLERY_PAGE_SIZE),
+      });
+      const res = await fetch(`${API_URL}/my/projects?${params.toString()}`, {
         headers: await generationRequestHeaders(),
       });
       if (myProjectHistoryRequestIdRef.current !== requestId) return;
@@ -5498,6 +5502,9 @@ export function FormaWorkspace({
                   return item ? handleRemixProject(item) : undefined;
                 } : undefined}
                 onVisibleProjectIdsChange={handleVisibleProjectGalleryIdsChange}
+                totalItems={myProjectHistoryTotal}
+                currentPage={myProjectHistoryPage}
+                onPageChange={handleMyProjectHistoryPageChange}
                 error={myProjectHistoryError}
               />
           ) : homeView === "jobs" ? (


### PR DESCRIPTION
## Summary
- Request only one page of My Projects from /api/my/projects using the existing bounded API path.
- Wire total count and page controls into the My Projects browser.
- Avoid loading every owned project and hydrating every project image during the initial gallery load.

## Related latency findings
- Related to #389, which measured roughly 18.8 MB compressed for six gallery projects; payload reduction and authenticated measurement remain follow-up work.
- Production cold starts initialize and probe many Supabase tables before serving requests.
- Image metadata hydration still produces repeated Supabase Storage 400 responses for missing paths; the endpoint can still return 200, but this adds noise and latency.
- The API no-limit identity fallback still performs sequential per-project lookups for callers that do not use pagination; this PR removes that path from the My Projects UI but does not redesign the fallback.

## Validation
- python -m unittest tests.api.test_project_access -q (23 passed)
- npm run lint (passed)
- npx tsc --noEmit (passed)
- npm run build (passed)
- git diff --check origin/main...HEAD (passed)

Refs #389