### PR TITLE
feat: append chat project revisions

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -2717,6 +2717,18 @@ def iterate_project_endpoint(
         project_chat_id = getattr(project, "chat_id", None)
         project_created_at = project.created_at
         can_chat = _user_owns_project(project, user)
+        if save_owner_user_id:
+            try:
+                canonical_revision = get_latest_project_revision(project_id, save_owner_user_id)
+                canonical_brief = get_latest_design_brief(project_id, save_owner_user_id)
+            except (ProjectStateError, DesignBriefNotFoundError):
+                canonical_revision = None
+                canonical_brief = None
+            else:
+                current_ir = canonical_revision.state
+                project_prompt = canonical_brief.summary
+                project_chat_id = canonical_brief.conversation_id
+                project_created_at = canonical_revision.created_at
     else:
         save_owner_user_id = _require_authenticated_user(user)
         try:
@@ -2747,15 +2759,14 @@ def iterate_project_endpoint(
         )
         revised_ir.assembly_metadata = hydrate_image_storage_metadata(revised_ir.assembly_metadata, project_id)
         if request.save:
-            if canonical_revision is not None:
-                persisted_revision = append_project_revision(
-                    project_id,
-                    save_owner_user_id,
-                    revised_ir,
-                    source_job_id=f"iteration-{uuid4().hex}",
-                )
-                revised_ir = persisted_revision.state
-            else:
+            persisted_revision = append_project_revision(
+                project_id,
+                save_owner_user_id,
+                revised_ir,
+                source_job_id=f"iteration-{request.idempotency_key or uuid4().hex}",
+            )
+            revised_ir = persisted_revision.state
+            if project is not None:
                 saved = update_generated_project_hardware_ir(
                     project_id,
                     revised_ir.model_dump(mode="json"),
@@ -2783,6 +2794,11 @@ def iterate_project_endpoint(
         raise HTTPException(
             status_code=400,
             detail=runtime_safe_error_message(str(e), provider=request.provider, model=request.model),
+        ) from e
+    except ProjectStateError as e:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT if e.retryable or e.code.endswith("conflict") else 404,
+            detail=e.as_dict(),
         ) from e
     except LLMProviderConfigError as e:
         raise HTTPException(
@@ -2928,6 +2944,13 @@ def video_self_correct_project_endpoint(
         )
         revised_ir.assembly_metadata = hydrate_image_storage_metadata(revised_ir.assembly_metadata, project.project_id)
         if request.save:
+            persisted_revision = append_project_revision(
+                project.project_id,
+                owner_user_id,
+                revised_ir,
+                source_job_id=f"video-correction-{request.idempotency_key or uuid4().hex}",
+            )
+            revised_ir = persisted_revision.state
             saved = update_generated_project_hardware_ir(project.project_id, revised_ir.model_dump(mode="json"), owner_user_id=owner_user_id)
             if not saved:
                 raise HTTPException(status_code=404, detail="Project not found.")

--- a/forma_core/database.py
+++ b/forma_core/database.py
@@ -980,7 +980,59 @@ def append_project_revision(
     from forma_core.workspaces.projects.models import HardwareIR
 
     service = ProjectStateService(_DATABASE_REPOSITORY)
-    parent = service.get_latest(project_id, owner_user_id)
+    try:
+        parent = service.get_latest(project_id, owner_user_id)
+    except ProjectStateError as exc:
+        if exc.code != "project_revision_not_found":
+            raise
+
+        # Legacy generated_projects rows have no immutable history. Migrate the
+        # current projection once before appending the requested iteration.
+        legacy = get_generated_project(project_id, include_deleted=True)
+        if legacy is None or getattr(legacy, "status", "active") != "active":
+            raise
+        if str(getattr(legacy, "owner_user_id", "") or "").strip() != str(owner_user_id or "").strip():
+            raise ProjectStateError("project_revision_not_found", "Project revision not found.")
+
+        project_uuid = _canonical_project_id(project_id)
+        try:
+            brief = get_latest_design_brief(project_id, owner_user_id)
+        except DesignBriefNotFoundError:
+            prompt = str(getattr(legacy, "prompt", "") or "").strip()
+            title = str(getattr(legacy, "title", "") or "").strip()
+            brief = create_design_brief_version(
+                project_uuid,
+                owner_user_id,
+                DesignBriefCreate(
+                    schema_version="1.0",
+                    conversation_id=str(getattr(legacy, "chat_id", "") or "").strip()
+                    or f"project-{project_uuid}",
+                    intent=prompt or title or "Update an existing hardware project.",
+                    summary=prompt or title or "Update an existing hardware project.",
+                ),
+            )
+
+        baseline = HardwareIR.model_validate(getattr(legacy, "hardware_ir", {}))
+        baseline.assembly_metadata = {
+            **(baseline.assembly_metadata or {}),
+            "project_id": str(project_uuid),
+            "revision": 1,
+        }
+        baseline_draft = build_generation_draft(brief, baseline)
+        try:
+            service.create_initial_revision(
+                baseline_draft,
+                project_id=project_uuid,
+                owner_user_id=owner_user_id,
+                design_brief_id=brief.design_brief_id,
+                design_brief_version=brief.brief_version,
+                source_job_id=f"legacy-migration-{project_uuid}",
+            )
+        except ProjectStateError as migration_exc:
+            if migration_exc.code != "initial_project_revision_exists":
+                raise
+        parent = service.get_latest(project_id, owner_user_id)
+
     brief = service.get_frozen_design_brief(
         project_id,
         owner_user_id,

--- a/forma_core/workspaces/projects/models.py
+++ b/forma_core/workspaces/projects/models.py
@@ -882,6 +882,10 @@ class IterateProjectRequest(BaseModel):
         description="Optional runtime model override for the iteration.",
     )
     save: bool = Field(True, description="When true, persist the revised HardwareIR over the existing project record.")
+    idempotency_key: Optional[str] = Field(
+        None,
+        description="Optional stable key used to replay a saved iteration without creating another revision.",
+    )
 
     @field_validator("instruction", mode="before")
     @classmethod
@@ -890,7 +894,7 @@ class IterateProjectRequest(BaseModel):
             return value.strip()
         return value
 
-    @field_validator("namespace", "provider", "model", mode="before")
+    @field_validator("namespace", "provider", "model", "idempotency_key", mode="before")
     @classmethod
     def strip_optional_iteration_selector(cls, value: Any) -> Any:
         if isinstance(value, str):
@@ -922,6 +926,10 @@ class VideoSelfCorrectRequest(BaseModel):
         description="Optional Fireworks review model override. Defaults to kimi-k2p6 frame review unless native video deployment routing is configured.",
     )
     save: bool = Field(True, description="When true, persist the revised HardwareIR over the existing project record.")
+    idempotency_key: Optional[str] = Field(
+        None,
+        description="Optional stable key used to replay a saved correction without creating another revision.",
+    )
 
     @field_validator("video_url", mode="before")
     @classmethod
@@ -930,7 +938,7 @@ class VideoSelfCorrectRequest(BaseModel):
             return value.strip()
         return value
 
-    @field_validator("video_key", "namespace", "provider", "model", "review_model", mode="before")
+    @field_validator("video_key", "namespace", "provider", "model", "review_model", "idempotency_key", mode="before")
     @classmethod
     def strip_optional_video_review_selector(cls, value: Any) -> Any:
         if isinstance(value, str):

--- a/forma_core/workspaces/projects/state.py
+++ b/forma_core/workspaces/projects/state.py
@@ -367,13 +367,15 @@ class ProjectStateService:
             "created_at": revision.created_at.isoformat(),
         }
         overview = getattr(state, "overview", None)
+        brief_payload = getattr(brief_record, "payload_json", None)
+        brief_payload = brief_payload if isinstance(brief_payload, dict) else {}
         self._repository.upsert_project_identity({
             "project_id": project,
             "owner_user_id": owner,
             "creation_channel": "hosted",
             "title": str(getattr(overview, "title", "") or "Untitled project"),
-            "prompt": str(getattr(brief, "summary", "") or ""),
-            "chat_id": getattr(brief, "conversation_id", None),
+            "prompt": str(brief_payload.get("summary") or ""),
+            "chat_id": brief_payload.get("conversation_id"),
             "workspace_id": None,
             "visibility": "private",
             "status": "active",

--- a/tests/api/test_project_access.py
+++ b/tests/api/test_project_access.py
@@ -17,6 +17,7 @@ from forma_core.workspaces.projects.models import (
     FunctionalRequirements,
     GenerateProjectRequest,
     HardwareIR,
+    IterateProjectRequest,
     MechanicalNotes,
     MechanicalSource,
     ProjectOverview,
@@ -718,6 +719,47 @@ class ProjectGenerationAccessTests(unittest.TestCase):
         self.assertTrue(response["can_chat"])
         self.assertEqual("generated-project", response["project_id"])
         self.assertEqual("generated-chat", response["chat_id"])
+
+
+class ProjectIterationAccessTests(unittest.TestCase):
+    def test_saved_legacy_iteration_appends_revision_and_refreshes_projection(self) -> None:
+        project_id = "11111111-1111-4111-8111-111111111111"
+        project = _project(project_id, owner_user_id="user-a", visibility="private")
+        current = HardwareIR.model_validate(project.hardware_ir)
+        revised = current.model_copy(deep=True)
+        revised.assembly_metadata["revision"] = 2
+        revised.assembly_metadata["last_iteration"] = "enclosure"
+        persisted = SimpleNamespace(state=revised)
+
+        iterator = MagicMock()
+        iterator.iterate_project.return_value = revised
+        with (
+            patch.object(main, "require_hosted_chat_enabled"),
+            patch.object(main, "_apply_user_integrations"),
+            patch.object(main, "get_generated_project", return_value=project),
+            patch.object(main, "get_latest_project_revision", side_effect=main.ProjectStateError("project_revision_not_found", "not found")),
+            patch.object(main, "ensure_project_action_allowed"),
+            patch.object(main, "ProjectIterator", return_value=iterator),
+            patch.object(main, "hydrate_image_storage_metadata", side_effect=lambda metadata, _project_id: metadata),
+            patch.object(main, "append_project_revision", return_value=persisted) as append_revision,
+            patch.object(main, "update_generated_project_hardware_ir", return_value=True) as update_projection,
+            patch.object(main, "generate_mermaid_chart", return_value=""),
+            patch.object(main, "generate_svg_schematic", return_value=""),
+        ):
+            response = main.iterate_project_endpoint(
+                project_id,
+                IterateProjectRequest(instruction="Add an enclosure", idempotency_key="chat-message-1"),
+                _user_context("user-a"),
+            )
+
+        append_revision.assert_called_once_with(
+            project_id,
+            "user-a",
+            revised,
+            source_job_id="iteration-chat-message-1",
+        )
+        update_projection.assert_called_once()
+        self.assertEqual(2, response["project_ir"]["assembly_metadata"]["revision"])
 
 
 if __name__ == "__main__":

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -72,6 +72,66 @@ class PersistenceArchitectureTests(unittest.TestCase):
         self.assertEqual("conversation-publication", saved["chat_id"])
         self.assertEqual("conversation-publication", saved["hardware_ir"]["assembly_metadata"]["chat_id"])
 
+    def test_legacy_project_iteration_bootstraps_one_canonical_revision_then_appends(self) -> None:
+        project_id = str(uuid.uuid4())
+        state = HardwareIR(
+            overview=ProjectOverview(
+                title="Legacy Sensor",
+                description="A legacy sensor.",
+                difficulty="Beginner",
+                category="Sensors",
+            ),
+            assembly_metadata={"project_id": project_id},
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            provider = create_sqlite_provider(
+                source="test legacy migration",
+                url=f"sqlite:///{Path(directory) / 'forma.db'}",
+                import_legacy_jobs=False,
+            )
+            assert provider.session_factory is not None
+            provider.initialize()
+            repository = SqlAlchemyRepository(provider.session_factory)
+            original_repository = database._DATABASE_REPOSITORY
+            try:
+                database._DATABASE_REPOSITORY = repository
+                database.save_generated_project(
+                    project_id=project_id,
+                    title="Legacy Sensor",
+                    prompt="Build a legacy sensor.",
+                    hardware_ir=state.model_dump(mode="json"),
+                    created_at="2026-08-08T12:00:00Z",
+                    chat_id="legacy-chat",
+                    owner_user_id="legacy-owner",
+                    visibility="private",
+                )
+
+                revised = state.model_copy(deep=True)
+                revised.overview.description = "Revised legacy sensor."
+                first = database.append_project_revision(
+                    project_id,
+                    "legacy-owner",
+                    revised,
+                    source_job_id="iteration-legacy-1",
+                )
+                replay = database.append_project_revision(
+                    project_id,
+                    "legacy-owner",
+                    revised,
+                    source_job_id="iteration-legacy-1",
+                )
+                latest = database.get_latest_project_revision(project_id, "legacy-owner")
+                briefs = database.list_design_brief_versions(project_id, "legacy-owner")
+            finally:
+                database._DATABASE_REPOSITORY = original_repository
+                provider.engine.dispose()
+
+        self.assertEqual(2, first.revision)
+        self.assertEqual(1, first.parent_revision)
+        self.assertEqual(first.revision_id, replay.revision_id)
+        self.assertEqual(2, latest.revision)
+        self.assertEqual(1, len(briefs))
+
     def test_supabase_provider_checks_complete_schema_contract(self) -> None:
         client = _SchemaClient()
         provider = SupabaseProvider(source="test", url="https://example.supabase.co", client=client)


### PR DESCRIPTION
## Summary\n- Route saved chat iterations through canonical immutable project revisions.\n- Bootstrap legacy generated_projects rows with a one-time canonical baseline and DesignBrief.\n- Refresh compatibility projections and support stable idempotency keys for iterations and video corrections.\n- Fix initial revision identity metadata and add regression coverage.\n\n## Validation\n- python -m unittest tests.api.test_project_access tests.projects.test_project_iteration tests.api.test_hosted_chat_maintenance tests.projects.test_chat_persistence\n- python -m unittest tests.persistence.test_persistence.PersistenceArchitectureTests.test_legacy_project_iteration_bootstraps_one_canonical_revision_then_appends\n- python -m compileall -q apps/api forma_core tests/api/test_project_access.py tests/persistence/test_persistence.py\n\nCloses #401\nRelated: #405