### PR TITLE
feat: add shared project read resolver

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -97,6 +97,7 @@ from forma_core.database import (
     list_project_deletion_audits,
     list_project_generation_jobs,
     project_engagement_for_ids,
+    resolve_project_for_read,
     remix_generated_project,
     save_alpha_signup,
     save_project_for_user,
@@ -119,7 +120,7 @@ from forma_core.workspaces.projects.models import (
     ConnectionNet, GenerateProjectRequest, HardwareIR, IterateProjectRequest,
     ProjectContributionConsentRequest, ProjectDetail, ProjectIdentityResponse, ProjectUpdateRequest, ProjectSummary, ValidationIssue, ValidationReport, VideoSelfCorrectRequest,
 )
-from forma_core.workspaces.projects import ProjectStateError
+from forma_core.workspaces.projects import ProjectReadError, ProjectStateError
 from forma_core.workspaces.projects.manifest import ProjectManifest
 from forma_core.workspaces.workflow import WorkflowStateError
 from forma_core.signups.models import AlphaSignupRequest, AlphaSignupResponse
@@ -2242,14 +2243,20 @@ def list_my_projects_endpoint(
 @app.get("/projects/{project_id}/image-summary")
 def get_project_image_summary_endpoint(project_id: str, user: UserContext = Depends(optional_user_context)):
     """Returns gallery-safe project metadata without validating or expanding the full hardware IR."""
-    project = get_generated_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found.")
-    _require_project_reader(project, user)
+    try:
+        resolved = resolve_project_for_read(project_id, user.owner_user_id)
+    except ProjectReadError as exc:
+        raise HTTPException(status_code=404, detail="Project not found.") from exc
 
     try:
+        summary = _project_summary_response(
+            resolved.project,
+            current_user_id=user.owner_user_id,
+        ).model_dump(mode="json")
+        summary["can_chat"] = resolved.can_chat
+        summary["chat_id"] = resolved.chat_id if resolved.can_chat else None
         summaries = _with_project_engagement(
-            [_project_summary_response(project, current_user_id=user.owner_user_id).model_dump(mode="json")],
+            [summary],
             user.owner_user_id,
         )
         return summaries[0]
@@ -2260,19 +2267,23 @@ def get_project_image_summary_endpoint(project_id: str, user: UserContext = Depe
 @app.get("/projects/{project_id}")
 def get_project_endpoint(project_id: str, user: UserContext = Depends(optional_user_context)):
     """Retrieves a specific hardware design and its corresponding schematics."""
-    project = get_generated_project(project_id)
-    if not project:
+    try:
+        resolved = resolve_project_for_read(project_id, user.owner_user_id)
+    except ProjectReadError as exc:
+        raise HTTPException(status_code=404, detail="Project not found.") from exc
+
+    if resolved.source == "cli":
         owner_user_id = str(user.owner_user_id or "").strip()
-        if not owner_user_id:
+        cli_response = _cli_project_response(project_id, owner_user_id)
+        if cli_response is not None:
+            return cli_response
+        raise HTTPException(status_code=404, detail="Project not found.")
+
+    if resolved.source == "canonical":
+        revision = resolved.revision
+        brief = resolved.design_brief
+        if revision is None or brief is None:
             raise HTTPException(status_code=404, detail="Project not found.")
-        try:
-            revision = get_latest_project_revision(project_id, owner_user_id)
-            brief = get_latest_design_brief(project_id, owner_user_id)
-        except (ProjectStateError, DesignBriefNotFoundError) as exc:
-            cli_response = _cli_project_response(project_id, owner_user_id)
-            if cli_response is not None:
-                return cli_response
-            raise HTTPException(status_code=404, detail="Project not found.") from exc
         ir = revision.state.model_copy(deep=True)
         ir.assembly_metadata = {
             **(ir.assembly_metadata or {}),
@@ -2296,9 +2307,9 @@ def get_project_endpoint(project_id: str, user: UserContext = Depends(optional_u
             "project_readiness": (ir.assembly_metadata or {}).get("project_readiness", "complete"),
             "generation_stages": ((ir.assembly_metadata or {}).get("generation_run") or {}).get("records", {}),
         }
-    _require_project_reader(project, user)
+    project = resolved.project
 
-    can_chat = _user_owns_project(project, user)
+    can_chat = resolved.can_chat
     stored_hardware_ir = json.loads(json.dumps(project.hardware_ir or {}))
     try:
         ir = HardwareIR(**stored_hardware_ir)

--- a/forma_core/database.py
+++ b/forma_core/database.py
@@ -13,6 +13,7 @@ from forma_core.project_list_cache import invalidate_project_lists
 from forma_core.workspaces.projects.objects import attach_project_object_metadata_to_dict
 from forma_core.workspaces.design_briefs import DesignBrief, DesignBriefCreate
 from forma_core.workspaces.projects import ProjectRevision, ProjectStateError, ProjectStateService
+from forma_core.workspaces.projects.resolver import ProjectReadResolution, ProjectReadResolver
 from forma_core.workspaces.readiness import (
     BuildInitiationOutcome,
     BuildMode,
@@ -494,6 +495,21 @@ def list_generated_projects_page(
 
 def get_generated_project(project_id: str, *, include_deleted: bool = False) -> Optional[Any]:
     return _DATABASE_REPOSITORY.get_generated_project(project_id, include_deleted=include_deleted)
+
+
+def resolve_project_for_read(
+    project_id: str,
+    owner_user_id: Optional[str] = None,
+    *,
+    include_deleted: bool = False,
+) -> ProjectReadResolution:
+    """Resolve one readable project across generated, canonical, and CLI stores."""
+
+    return ProjectReadResolver(_DATABASE_REPOSITORY).resolve(
+        project_id,
+        owner_user_id,
+        include_deleted=include_deleted,
+    )
 
 
 def list_cli_projects(owner_user_id: str) -> List[Dict[str, Any]]:

--- a/forma_core/workspaces/projects/__init__.py
+++ b/forma_core/workspaces/projects/__init__.py
@@ -20,6 +20,13 @@ from forma_core.workspaces.projects.manifest import (
     write_project_manifest,
 )
 from forma_core.workspaces.projects.identity import ProjectCreationChannel, ProjectIdentity
+from forma_core.workspaces.projects.resolver import (
+    ProjectReadAccessError,
+    ProjectReadError,
+    ProjectReadNotFoundError,
+    ProjectReadResolution,
+    ProjectReadResolver,
+)
 from forma_core.workspaces.projects.models import ProjectDetail, ProjectIdentityResponse, ProjectSummary
 
 __all__ = [
@@ -43,4 +50,9 @@ __all__ = [
     "write_project_manifest",
     "ProjectCreationChannel",
     "ProjectIdentity",
+    "ProjectReadAccessError",
+    "ProjectReadError",
+    "ProjectReadNotFoundError",
+    "ProjectReadResolution",
+    "ProjectReadResolver",
 ]

--- a/forma_core/workspaces/projects/resolver.py
+++ b/forma_core/workspaces/projects/resolver.py
@@ -1,0 +1,321 @@
+"""Deterministic read-side resolution across Forma project storage surfaces."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass
+import logging
+from types import SimpleNamespace
+from typing import Any, Optional
+
+from forma_core.persistence.repositories.base import ApplicationRepository
+from forma_core.workspaces.design_briefs import DesignBrief
+from forma_core.workspaces.projects.identity import ProjectCreationChannel
+from forma_core.workspaces.projects.manifest import ProjectManifest
+from forma_core.workspaces.projects.state import ProjectRevision, ProjectStateError, ProjectStateService
+
+
+logger = logging.getLogger(__name__)
+
+
+class ProjectReadError(LookupError):
+    """Base error for a project that cannot be returned to the reader."""
+
+
+class ProjectReadNotFoundError(ProjectReadError):
+    """The project is missing or intentionally hidden from the reader."""
+
+
+class ProjectReadAccessError(ProjectReadError, PermissionError):
+    """The project exists but is not readable by the supplied user."""
+
+
+@dataclass(frozen=True)
+class ProjectReadResolution:
+    """One normalized read result regardless of the backing project source."""
+
+    project_id: str
+    source: str
+    creation_channel: ProjectCreationChannel
+    owner_user_id: Optional[str]
+    title: str
+    prompt: str
+    chat_id: Optional[str]
+    created_at: Any
+    updated_at: Any
+    visibility: str
+    status: str
+    current_revision: Optional[int]
+    revision_id: Optional[str]
+    project_ir: dict[str, Any]
+    image_metadata: dict[str, Any]
+    can_chat: bool
+    legacy_fallback: bool
+    project: Any
+    revision: Optional[ProjectRevision] = None
+    design_brief: Optional[DesignBrief] = None
+
+
+def _owner(value: Any) -> Optional[str]:
+    normalized = str(value or "").strip()
+    return normalized or None
+
+
+def _creation_channel(value: Any) -> ProjectCreationChannel:
+    try:
+        return ProjectCreationChannel(str(value or ProjectCreationChannel.HOSTED).strip().lower())
+    except ValueError:
+        return ProjectCreationChannel.HOSTED
+
+
+def _project_ir_metadata(project_ir: Any) -> dict[str, Any]:
+    if not isinstance(project_ir, dict):
+        return {}
+    metadata = project_ir.get("assembly_metadata")
+    return deepcopy(metadata) if isinstance(metadata, dict) else {}
+
+
+def _brief(repository: ApplicationRepository, project_id: str, owner_user_id: str) -> DesignBrief:
+    record = repository.get_latest_design_brief(project_id, owner_user_id)
+    payload = getattr(record, "payload_json", None) if record is not None else None
+    if not isinstance(payload, dict):
+        raise ProjectReadNotFoundError("Project DesignBrief not found.")
+    return DesignBrief.model_validate(payload)
+
+
+class ProjectReadResolver:
+    """Resolve the authoritative readable representation of one project."""
+
+    def __init__(self, repository: ApplicationRepository) -> None:
+        self._repository = repository
+        self._state = ProjectStateService(repository)
+
+    def resolve(
+        self,
+        project_id: str,
+        owner_user_id: Optional[str] = None,
+        *,
+        include_deleted: bool = False,
+    ) -> ProjectReadResolution:
+        normalized_project_id = str(project_id or "").strip()
+        normalized_owner = _owner(owner_user_id)
+        if not normalized_project_id:
+            raise ProjectReadNotFoundError("Project not found.")
+
+        generated = self._repository.get_generated_project(normalized_project_id, include_deleted=True)
+        if generated is not None:
+            return self._resolve_generated(
+                normalized_project_id,
+                generated,
+                normalized_owner,
+                include_deleted=include_deleted,
+            )
+
+        if normalized_owner:
+            canonical = self._resolve_canonical_only(normalized_project_id, normalized_owner)
+            if canonical is not None:
+                return canonical
+            cli = self._resolve_cli(normalized_project_id, normalized_owner)
+            if cli is not None:
+                return cli
+        raise ProjectReadNotFoundError("Project not found.")
+
+    def _resolve_generated(
+        self,
+        project_id: str,
+        generated: Any,
+        owner_user_id: Optional[str],
+        *,
+        include_deleted: bool,
+    ) -> ProjectReadResolution:
+        status = str(getattr(generated, "status", "active") or "active").strip().lower()
+        project_owner = _owner(getattr(generated, "owner_user_id", None))
+        is_owner = bool(owner_user_id and project_owner == owner_user_id)
+        visibility = str(getattr(generated, "visibility", "public") or "public").strip().lower()
+
+        if status != "active":
+            if not include_deleted or not is_owner:
+                raise ProjectReadNotFoundError("Project not found.")
+        elif not is_owner and visibility != "public":
+            raise ProjectReadNotFoundError("Project not found.")
+
+        if is_owner and status == "active":
+            try:
+                revision = self._state.get_latest(project_id, owner_user_id)
+                brief = _brief(self._repository, project_id, owner_user_id)
+            except (ProjectStateError, ProjectReadNotFoundError, ValueError):
+                revision = None
+                brief = None
+            if revision is not None and brief is not None:
+                project_ir = revision.state.model_dump(mode="json")
+                metadata = _project_ir_metadata(project_ir)
+                project = SimpleNamespace(
+                    project_id=project_id,
+                    owner_user_id=project_owner,
+                    creation_channel=getattr(generated, "creation_channel", "hosted"),
+                    chat_id=brief.conversation_id,
+                    title=str(getattr(getattr(revision.state, "overview", None), "title", "") or getattr(generated, "title", "")),
+                    prompt=brief.summary,
+                    created_at=getattr(generated, "created_at", revision.created_at),
+                    updated_at=getattr(generated, "updated_at", revision.created_at),
+                    visibility=visibility,
+                    hardware_ir=project_ir,
+                )
+                return ProjectReadResolution(
+                    project_id=project_id,
+                    source="generated",
+                    creation_channel=_creation_channel(getattr(generated, "creation_channel", "hosted")),
+                    owner_user_id=project_owner,
+                    title=project.title,
+                    prompt=project.prompt,
+                    chat_id=project.chat_id if is_owner else None,
+                    created_at=project.created_at,
+                    updated_at=project.updated_at,
+                    visibility=visibility,
+                    status=status,
+                    current_revision=revision.revision,
+                    revision_id=str(revision.revision_id),
+                    project_ir=project_ir,
+                    image_metadata=metadata,
+                    can_chat=is_owner,
+                    legacy_fallback=False,
+                    project=project,
+                    revision=revision,
+                    design_brief=brief,
+                )
+
+        project_ir = getattr(generated, "hardware_ir", {})
+        project_ir = deepcopy(project_ir) if isinstance(project_ir, dict) else {}
+        metadata = _project_ir_metadata(project_ir)
+        logger.info(
+            "project_read_resolver_legacy_fallback project_id=%s source=generated status=%s",
+            project_id,
+            status,
+        )
+        raw_revision = metadata.get("project_revision", metadata.get("revision"))
+        try:
+            current_revision = int(raw_revision) if raw_revision is not None else None
+        except (TypeError, ValueError):
+            current_revision = None
+        return ProjectReadResolution(
+            project_id=project_id,
+            source="generated",
+            creation_channel=_creation_channel(getattr(generated, "creation_channel", "hosted")),
+            owner_user_id=project_owner,
+            title=str(getattr(generated, "title", "") or "Untitled project"),
+            prompt=str(getattr(generated, "prompt", "") or ""),
+            chat_id=getattr(generated, "chat_id", None) if is_owner and status == "active" else None,
+            created_at=getattr(generated, "created_at", None),
+            updated_at=getattr(generated, "updated_at", None),
+            visibility=visibility,
+            status=status,
+            current_revision=current_revision,
+            revision_id=None,
+            project_ir=project_ir,
+            image_metadata=metadata,
+            can_chat=is_owner and status == "active",
+            legacy_fallback=True,
+            project=generated,
+        )
+
+    def _resolve_canonical_only(self, project_id: str, owner_user_id: str) -> Optional[ProjectReadResolution]:
+        try:
+            revision = self._state.get_latest(project_id, owner_user_id)
+            brief = _brief(self._repository, project_id, owner_user_id)
+        except (ProjectStateError, ProjectReadNotFoundError, ValueError):
+            return None
+        project_ir = revision.state.model_dump(mode="json")
+        metadata = _project_ir_metadata(project_ir)
+        title = str(getattr(getattr(revision.state, "overview", None), "title", "") or brief.summary)
+        project = SimpleNamespace(
+            project_id=project_id,
+            owner_user_id=owner_user_id,
+            creation_channel="hosted",
+            chat_id=brief.conversation_id,
+            title=title,
+            prompt=brief.summary,
+            created_at=revision.created_at,
+            updated_at=revision.created_at,
+            visibility="private",
+            hardware_ir=project_ir,
+        )
+        return ProjectReadResolution(
+            project_id=project_id,
+            source="canonical",
+            creation_channel=ProjectCreationChannel.HOSTED,
+            owner_user_id=owner_user_id,
+            title=title,
+            prompt=brief.summary,
+            chat_id=brief.conversation_id,
+            created_at=revision.created_at,
+            updated_at=revision.created_at,
+            visibility="private",
+            status="active",
+            current_revision=revision.revision,
+            revision_id=str(revision.revision_id),
+            project_ir=project_ir,
+            image_metadata=metadata,
+            can_chat=True,
+            legacy_fallback=False,
+            project=project,
+            revision=revision,
+            design_brief=brief,
+        )
+
+    def _resolve_cli(self, project_id: str, owner_user_id: str) -> Optional[ProjectReadResolution]:
+        record = self._repository.get_cli_project_revision(project_id, owner_user_id, None)
+        if record is None:
+            return None
+        manifest_payload = getattr(record, "manifest_json", None)
+        if not isinstance(manifest_payload, dict):
+            return None
+        try:
+            manifest = ProjectManifest.from_document(manifest_payload)
+        except (TypeError, ValueError):
+            logger.warning("project_read_resolver_invalid_cli_manifest project_id=%s", project_id)
+            return None
+        project_ir = deepcopy(manifest.project_ir)
+        metadata = _project_ir_metadata(project_ir)
+        metadata.update({"project_id": project_id, "chat_id": None, "project_source": "cli"})
+        project_ir["assembly_metadata"] = metadata
+        project = SimpleNamespace(
+            project_id=project_id,
+            owner_user_id=owner_user_id,
+            creation_channel="cli",
+            chat_id=None,
+            title=manifest.title or "Untitled project",
+            prompt=manifest.prompt,
+            created_at=getattr(record, "created_at", None),
+            updated_at=getattr(record, "created_at", None),
+            visibility="private",
+            hardware_ir=project_ir,
+        )
+        return ProjectReadResolution(
+            project_id=project_id,
+            source="cli",
+            creation_channel=ProjectCreationChannel.CLI,
+            owner_user_id=owner_user_id,
+            title=project.title,
+            prompt=project.prompt,
+            chat_id=None,
+            created_at=project.created_at,
+            updated_at=project.updated_at,
+            visibility="private",
+            status="active",
+            current_revision=int(getattr(record, "revision", 0) or 0) or None,
+            revision_id=str(getattr(record, "revision_id", "") or "") or None,
+            project_ir=project_ir,
+            image_metadata=metadata,
+            can_chat=False,
+            legacy_fallback=False,
+            project=project,
+        )
+
+
+__all__ = [
+    "ProjectReadAccessError",
+    "ProjectReadError",
+    "ProjectReadNotFoundError",
+    "ProjectReadResolution",
+    "ProjectReadResolver",
+]

--- a/tests/api/test_project_access.py
+++ b/tests/api/test_project_access.py
@@ -386,8 +386,8 @@ class ProjectReadAccessTests(unittest.TestCase):
 
         with self._summary_dependencies(), patch.object(
             main,
-            "get_generated_project",
-            return_value=private_project,
+            "resolve_project_for_read",
+            return_value=SimpleNamespace(project=private_project, source="generated", can_chat=True),
         ):
             response = main.get_project_endpoint(
                 private_project.project_id,
@@ -418,11 +418,11 @@ class ProjectReadAccessTests(unittest.TestCase):
             "created_at": "2026-07-25T12:00:00Z",
         }
 
-        with patch.object(main, "get_generated_project", return_value=None), patch.object(
+        with patch.object(main, "resolve_project_for_read", return_value=SimpleNamespace(source="cli")), patch.object(
             main,
-            "get_latest_project_revision",
-            side_effect=main.ProjectStateError("project_not_found", "Project not found."),
-        ), patch.object(main, "get_cli_project_revision", return_value=cli_revision):
+            "get_cli_project_revision",
+            return_value=cli_revision,
+        ):
             response = main.get_project_endpoint(project_id, _user_context("user-a"))
 
         self.assertEqual(project_id, response["project_id"])
@@ -430,6 +430,32 @@ class ProjectReadAccessTests(unittest.TestCase):
         self.assertIsNone(response["chat_id"])
         self.assertEqual("cli", response["project_ir"]["assembly_metadata"]["project_source"])
         self.assertEqual("cli-revision-1", response["project_ir"]["assembly_metadata"]["cloud_revision_id"])
+
+    def test_owner_can_read_canonical_only_project_through_project_endpoint(self) -> None:
+        project_id = "11111111-1111-4111-8111-111111111111"
+        state = HardwareIR.model_validate(_project(project_id, owner_user_id="user-a", visibility="private").hardware_ir)
+        revision = SimpleNamespace(
+            project_id=project_id,
+            state=state,
+            revision=2,
+            design_brief_version=1,
+            created_at="2026-08-01T12:00:00Z",
+        )
+        brief = SimpleNamespace(conversation_id="canonical-chat", summary="Build a canonical project.")
+
+        with patch.object(
+            main,
+            "resolve_project_for_read",
+            return_value=SimpleNamespace(source="canonical", revision=revision, design_brief=brief),
+        ), patch.object(main, "generate_mermaid_chart", return_value=""), patch.object(
+            main, "generate_svg_schematic", return_value=""
+        ):
+            response = main.get_project_endpoint(project_id, _user_context("user-a"))
+
+        self.assertEqual(project_id, response["project_id"])
+        self.assertEqual("canonical-chat", response["chat_id"])
+        self.assertTrue(response["can_chat"])
+        self.assertEqual(2, response["project_ir"]["assembly_metadata"]["project_revision"])
 
     def test_owner_can_update_project_title(self) -> None:
         project = _project("owned-project", owner_user_id="user-a", visibility="public")
@@ -495,7 +521,11 @@ class ProjectReadAccessTests(unittest.TestCase):
             visibility="private",
         )
 
-        with patch.object(main, "get_generated_project", return_value=private_project):
+        with patch.object(
+            main,
+            "resolve_project_for_read",
+            side_effect=main.ProjectReadError("Project not found."),
+        ):
             with self.assertRaises(HTTPException) as raised:
                 main.get_project_endpoint(
                     private_project.project_id,
@@ -544,8 +574,8 @@ class ProjectReadAccessTests(unittest.TestCase):
 
         with self._summary_dependencies(), patch.object(
             main,
-            "get_generated_project",
-            return_value=public_project,
+            "resolve_project_for_read",
+            return_value=SimpleNamespace(project=public_project, source="generated", can_chat=False),
         ):
             response = main.get_project_endpoint(
                 public_project.project_id,
@@ -604,8 +634,8 @@ class ProjectReadAccessTests(unittest.TestCase):
 
         with self._summary_dependencies(), patch.object(
             main,
-            "get_generated_project",
-            return_value=public_project,
+            "resolve_project_for_read",
+            return_value=SimpleNamespace(project=public_project, source="generated", can_chat=False),
         ):
             response = main.get_project_endpoint(public_project.project_id, _anonymous_context())
 

--- a/tests/api/test_project_summary.py
+++ b/tests/api/test_project_summary.py
@@ -140,7 +140,11 @@ class ProjectSummaryTests(unittest.TestCase):
             },
         )
 
-        with patch.object(main, "get_generated_project", return_value=project), patch.object(
+        with patch.object(
+            main,
+            "resolve_project_for_read",
+            return_value=SimpleNamespace(project=project, can_chat=False, chat_id=None),
+        ), patch.object(
             main, "creator_display_name", return_value="isayahc"
         ), patch.object(
             main, "hydrate_image_storage_metadata", side_effect=lambda metadata, _project_id: metadata
@@ -152,6 +156,41 @@ class ProjectSummaryTests(unittest.TestCase):
         self.assertEqual(project.project_id, summary["project_id"])
         self.assertEqual("https://storage.example.test/product.png", summary["product_image_url"])
         self.assertTrue(summary["has_product_image"])
+
+    def test_cli_project_image_summary_does_not_enable_chat(self) -> None:
+        project = SimpleNamespace(
+            project_id="fd54de37-2fbb-485a-92e4-8bfaf4a2f08c",
+            chat_id=None,
+            title="CLI project",
+            prompt="Build a CLI project.",
+            created_at="2026-07-21T14:08:00Z",
+            owner_user_id="user_123",
+            creation_channel="cli",
+            visibility="private",
+            hardware_ir={"components": [], "assembly_metadata": {}},
+        )
+
+        with patch.object(
+            main,
+            "resolve_project_for_read",
+            return_value=SimpleNamespace(project=project, can_chat=False, chat_id=None),
+        ), patch.object(main, "creator_display_name", return_value="isayahc"), patch.object(
+            main, "project_engagement_for_ids", return_value={}
+        ):
+            summary = main.get_project_image_summary_endpoint(
+                project.project_id,
+                UserContext(
+                    provider="clerk",
+                    subject="user_123",
+                    owner_user_id="user_123",
+                    is_authenticated=True,
+                    is_admin=False,
+                    claims={},
+                ),
+            )
+
+        self.assertFalse(summary["can_chat"])
+        self.assertIsNone(summary["chat_id"])
 
 
 if __name__ == "__main__":

--- a/tests/projects/test_project_read_resolver.py
+++ b/tests/projects/test_project_read_resolver.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+import unittest
+from unittest.mock import Mock
+from uuid import uuid4
+
+from forma_core.workspaces.design_briefs import DesignBrief, DESIGN_BRIEF_SCHEMA_VERSION
+from forma_core.workspaces.projects.models import HardwareIR, ProjectOverview
+from forma_core.workspaces.projects.resolver import (
+    ProjectReadNotFoundError,
+    ProjectReadResolver,
+)
+from forma_core.workspaces.projects.state import ProjectRevision, ProjectStateError
+
+
+PROJECT_ID = "11111111-1111-4111-8111-111111111111"
+
+
+def _ir() -> HardwareIR:
+    return HardwareIR(
+        overview=ProjectOverview(
+            title="Resolver project",
+            description="A resolver test project.",
+            difficulty="Beginner",
+            category="IoT",
+        ),
+        assembly_metadata={"project_id": PROJECT_ID, "product_image_url": "https://example.test/image.png"},
+    )
+
+
+def _brief() -> DesignBrief:
+    return DesignBrief(
+        schema_version=DESIGN_BRIEF_SCHEMA_VERSION,
+        conversation_id="resolver-chat",
+        intent="Build a resolver test project",
+        summary="Build a resolver test project.",
+        design_brief_id=uuid4(),
+        project_id=PROJECT_ID,
+        brief_version=1,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def _revision(brief: DesignBrief) -> ProjectRevision:
+    return ProjectRevision(
+        revision_id=uuid4(),
+        project_id=PROJECT_ID,
+        owner_user_id="owner-a",
+        revision=3,
+        parent_revision=2,
+        design_brief_id=brief.design_brief_id,
+        design_brief_version=brief.brief_version,
+        source_job_id="iteration-3",
+        state=_ir(),
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+class ProjectReadResolverTests(unittest.TestCase):
+    def test_hosted_projection_resolves_and_logs_legacy_fallback(self) -> None:
+        project = SimpleNamespace(
+            project_id=PROJECT_ID,
+            owner_user_id="owner-a",
+            creation_channel="hosted",
+            chat_id="hosted-chat",
+            title="Hosted project",
+            prompt="Build a hosted project.",
+            created_at="2026-08-01T12:00:00Z",
+            updated_at="2026-08-01T12:00:00Z",
+            visibility="public",
+            status="active",
+            hardware_ir=_ir().model_dump(mode="json"),
+        )
+        repository = Mock()
+        repository.get_generated_project.return_value = project
+        resolver = ProjectReadResolver(repository)
+        resolver._state.get_latest = Mock(side_effect=ProjectStateError("project_revision_not_found", "missing"))
+
+        with self.assertLogs("forma_core.workspaces.projects.resolver", level="INFO") as logs:
+            resolved = resolver.resolve(PROJECT_ID)
+
+        self.assertEqual("generated", resolved.source)
+        self.assertTrue(resolved.legacy_fallback)
+        self.assertEqual("https://example.test/image.png", resolved.image_metadata["product_image_url"])
+        self.assertFalse(resolved.can_chat)
+        self.assertIn("project_read_resolver_legacy_fallback", "\n".join(logs.output))
+
+    def test_canonical_only_project_resolves_when_projection_is_missing(self) -> None:
+        brief = _brief()
+        revision = _revision(brief)
+        repository = Mock()
+        repository.get_generated_project.return_value = None
+        repository.get_latest_design_brief.return_value = SimpleNamespace(payload_json=brief.model_dump(mode="json"))
+        repository.get_cli_project_revision.return_value = None
+        resolver = ProjectReadResolver(repository)
+        resolver._state.get_latest = Mock(return_value=revision)
+
+        resolved = resolver.resolve(PROJECT_ID, "owner-a")
+
+        self.assertEqual("canonical", resolved.source)
+        self.assertEqual(3, resolved.current_revision)
+        self.assertEqual("resolver-chat", resolved.chat_id)
+        self.assertTrue(resolved.can_chat)
+        self.assertFalse(resolved.legacy_fallback)
+
+    def test_cli_project_resolves_when_generated_projection_is_missing(self) -> None:
+        repository = Mock()
+        repository.get_generated_project.return_value = None
+        repository.get_cli_project_revision.return_value = SimpleNamespace(
+            revision_id="cli-revision-1",
+            revision=1,
+            created_at="2026-08-02T12:00:00Z",
+            manifest_json={
+                "format": "forma-project",
+                "version": 1,
+                "project_id": PROJECT_ID,
+                "title": "CLI project",
+                "prompt": "Build a CLI project.",
+                "project_ir": _ir().model_dump(mode="json"),
+            },
+        )
+        resolver = ProjectReadResolver(repository)
+        resolver._state.get_latest = Mock(side_effect=ProjectStateError("project_revision_not_found", "missing"))
+
+        resolved = resolver.resolve(PROJECT_ID, "owner-a")
+
+        self.assertEqual("cli", resolved.source)
+        self.assertEqual("cli", resolved.creation_channel.value)
+        self.assertEqual(1, resolved.current_revision)
+        self.assertFalse(resolved.can_chat)
+
+    def test_private_and_deleted_projects_are_hidden_without_owner_access(self) -> None:
+        for status, include_deleted in (("active", False), ("deletion_pending", True)):
+            project = SimpleNamespace(
+                project_id=PROJECT_ID,
+                owner_user_id="owner-a",
+                visibility="private",
+                status=status,
+                hardware_ir={},
+            )
+            repository = Mock()
+            repository.get_generated_project.return_value = project
+            resolver = ProjectReadResolver(repository)
+
+            with self.assertRaises(ProjectReadNotFoundError):
+                resolver.resolve(PROJECT_ID, "owner-b", include_deleted=include_deleted)
+
+    def test_owner_can_resolve_deleted_lifecycle_state_when_requested(self) -> None:
+        project = SimpleNamespace(
+            project_id=PROJECT_ID,
+            owner_user_id="owner-a",
+            visibility="private",
+            status="deletion_pending",
+            hardware_ir={},
+        )
+        repository = Mock()
+        repository.get_generated_project.return_value = project
+
+        resolved = ProjectReadResolver(repository).resolve(PROJECT_ID, "owner-a", include_deleted=True)
+
+        self.assertEqual("deletion_pending", resolved.status)
+        self.assertFalse(resolved.can_chat)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary\n- Add one deterministic read resolver for generated, canonical-only, and CLI project records.\n- Centralize ownership, visibility, lifecycle, revision, chat, and image metadata resolution.\n- Wire project detail and image-summary reads through the resolver without changing CRUD write behavior.\n- Log legacy projection fallback and add coverage for hosted, canonical-only, CLI, deleted, unauthorized, detail, and image-summary cases.\n\n## Validation\n- python -m unittest tests.api.test_project_access tests.api.test_project_summary tests.projects.test_project_read_resolver tests.projects.test_project_iteration tests.api.test_hosted_chat_maintenance tests.projects.test_chat_persistence\n- python -m compileall -q apps/api forma_core tests/api tests/projects/test_project_read_resolver.py\n- git diff --check\n\nCloses #402