### PR TITLE
refactor: make project galleries canonical

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -92,7 +92,8 @@ from forma_core.database import (
     list_project_chats,
     list_component_templates,
     list_generated_projects,
-    list_generated_projects_page,
+    list_project_gallery_inventory,
+    list_project_gallery_inventory_page,
     list_project_identities,
     list_latest_project_revisions,
     list_project_deletion_audits,
@@ -123,7 +124,7 @@ from forma_core.workspaces.projects.models import (
     ConnectionNet, GenerateProjectRequest, HardwareIR, IterateProjectRequest,
     ProjectContributionConsentRequest, ProjectDetail, ProjectIdentityResponse, ProjectUpdateRequest, ProjectSummary, ValidationIssue, ValidationReport, VideoSelfCorrectRequest,
 )
-from forma_core.workspaces.projects import ProjectReadError, ProjectStateError
+from forma_core.workspaces.projects import ProjectReadError, ProjectRevision, ProjectStateError
 from forma_core.workspaces.projects.manifest import ProjectManifest
 from forma_core.workspaces.workflow import WorkflowStateError
 from forma_core.signups.models import AlphaSignupRequest, AlphaSignupResponse
@@ -1820,6 +1821,7 @@ def _project_summary_response(
     current_user_id: Optional[str] = None,
     *,
     hydrate_storage: bool = True,
+    include_inline_images: bool = True,
 ) -> ProjectSummary:
     owner_user_id = _project_owner_user_id(project)
     can_chat = bool(current_user_id and owner_user_id == current_user_id)
@@ -1855,6 +1857,14 @@ def _project_summary_response(
     product_image_data = hydrated_metadata.get("product_image_data")
     if not product_image_data and isinstance(first_sequence_image, dict):
         product_image_data = first_sequence_image.get("data")
+    has_product_image = bool(product_image_url or product_image_data)
+    if not include_inline_images:
+        product_image_data = None
+        sequence = [
+            {key: value for key, value in item.items() if key not in {"data", "image_data"}}
+            for item in sequence[:12]
+            if isinstance(item, dict)
+        ] if isinstance(sequence, list) else []
     stored_creator_display = metadata.get("creator_display") or metadata.get("creator_username")
     creator_display = (
         stored_creator_display.strip()
@@ -1884,7 +1894,7 @@ def _project_summary_response(
         save_count=0,
         remix_count=0,
         saved=False,
-        has_product_image=bool(product_image_url or product_image_data),
+        has_product_image=has_product_image,
         product_image_url=product_image_url,
         product_image_data=product_image_data,
         product_image_content_type=product_image_content_type,
@@ -1925,6 +1935,134 @@ def _canonical_project_summary_response(
     )
 
 
+def _json_object(value: Any) -> Dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except (TypeError, ValueError):
+            return {}
+        return decoded if isinstance(decoded, dict) else {}
+    return {}
+
+
+def _gallery_inventory_summary(record: Any, *, current_user_id: Optional[str]) -> Optional[ProjectSummary]:
+    """Adapt one inventory row without loading chat or DesignBrief history."""
+    source_value = str(getattr(record, "source", "") or "").strip().lower()
+    source = source_value or ("legacy" if hasattr(record, "hardware_ir") else "canonical")
+    project_id = str(getattr(record, "project_id", "") or "").strip()
+    if not project_id:
+        return None
+    if source == "legacy":
+        legacy_hardware_ir = _json_object(getattr(record, "legacy_hardware_ir", None))
+        legacy_project = None
+        if legacy_hardware_ir:
+            legacy_project = types.SimpleNamespace(
+                project_id=project_id,
+                owner_user_id=getattr(record, "owner_user_id", None),
+                creation_channel=getattr(record, "creation_channel", "hosted"),
+                chat_id=getattr(record, "chat_id", None),
+                visibility=getattr(record, "visibility", "public"),
+                title=getattr(record, "title", ""),
+                prompt=getattr(record, "prompt", ""),
+                created_at=getattr(record, "created_at", None),
+                updated_at=getattr(record, "updated_at", None),
+                hardware_ir=legacy_hardware_ir,
+            )
+        elif hasattr(record, "hardware_ir"):
+            legacy_project = record
+        if legacy_project is None:
+            legacy_project = get_generated_project(project_id, include_deleted=False)
+        if legacy_project is None:
+            return None
+        project = types.SimpleNamespace(
+            project_id=project_id,
+            owner_user_id=getattr(legacy_project, "owner_user_id", getattr(record, "owner_user_id", None)),
+            creation_channel=getattr(legacy_project, "creation_channel", getattr(record, "creation_channel", "hosted")),
+            chat_id=getattr(legacy_project, "chat_id", getattr(record, "chat_id", None)),
+            visibility=getattr(legacy_project, "visibility", getattr(record, "visibility", "public")),
+            title=getattr(legacy_project, "title", getattr(record, "title", "")),
+            prompt=getattr(legacy_project, "prompt", getattr(record, "prompt", "")),
+            created_at=getattr(legacy_project, "created_at", getattr(record, "created_at", None)),
+            updated_at=getattr(legacy_project, "updated_at", getattr(record, "updated_at", None)),
+            hardware_ir=getattr(legacy_project, "hardware_ir", {}),
+        )
+        return _project_summary_response(
+            project,
+            current_user_id=current_user_id,
+            hydrate_storage=False,
+            include_inline_images=False,
+        )
+
+    identity = {
+        "project_id": project_id,
+        "owner_user_id": getattr(record, "owner_user_id", None),
+        "creation_channel": getattr(record, "creation_channel", "hosted"),
+        "chat_id": getattr(record, "chat_id", None),
+        "visibility": getattr(record, "visibility", "private"),
+        "title": getattr(record, "title", ""),
+        "prompt": getattr(record, "prompt", ""),
+        "created_at": getattr(record, "created_at", None),
+        "updated_at": getattr(record, "updated_at", None),
+    }
+    if str(identity["creation_channel"]).strip().lower() == "cli":
+        try:
+            manifest = ProjectManifest.from_document(_json_object(getattr(record, "revision_payload_json", None)))
+        except (TypeError, ValueError):
+            logger.warning("Skipping invalid CLI project in gallery inventory: project_id=%s", project_id)
+            return None
+        project = types.SimpleNamespace(**identity, hardware_ir=manifest.project_ir)
+        return _project_summary_response(
+            project,
+            current_user_id=current_user_id,
+            hydrate_storage=False,
+            include_inline_images=False,
+        )
+
+    try:
+        revision = ProjectRevision.model_validate(_json_object(getattr(record, "revision_payload_json", None)))
+    except (TypeError, ValueError):
+        logger.warning("Skipping invalid canonical project in gallery inventory: project_id=%s", project_id)
+        return None
+    project_ir = revision.state.model_dump(mode="json")
+    metadata = project_ir.get("assembly_metadata")
+    metadata = dict(metadata) if isinstance(metadata, dict) else {}
+    metadata.update({
+        "project_id": project_id,
+        "project_revision": revision.revision,
+        "canonical_revision_id": str(revision.revision_id),
+    })
+    project_ir["assembly_metadata"] = metadata
+    overview = getattr(revision.state, "overview", None)
+    identity["title"] = str(getattr(overview, "title", "") or identity["title"] or "Untitled project")
+    project = types.SimpleNamespace(
+        **identity,
+        hardware_ir=project_ir,
+    )
+    return _project_summary_response(
+        project,
+        current_user_id=current_user_id,
+        hydrate_storage=False,
+        include_inline_images=False,
+    )
+
+
+def _gallery_inventory_cache_record(record: Any) -> Optional[Dict[str, Any]]:
+    summary = _gallery_inventory_summary(record, current_user_id=None)
+    if summary is None:
+        return None
+    cached = summary.model_dump(mode="json")
+    cached[_CACHE_OWNER_DIGEST_FIELD] = _project_owner_digest(getattr(record, "owner_user_id", None))
+    cached[_CACHE_OWNER_CHAT_FIELD] = getattr(record, "chat_id", None)
+    return cached
+
+
+def _log_gallery_legacy_fallback(endpoint: str, records: List[Any]) -> None:
+    count = sum(1 for record in records if str(getattr(record, "source", "") or "").lower() == "legacy")
+    logger.info("project_gallery_legacy_fallback endpoint=%s count=%d", endpoint, count)
+
+
 def _project_owner_digest(owner_user_id: Optional[str]) -> Optional[str]:
     if not isinstance(owner_user_id, str) or not owner_user_id.strip():
         return None
@@ -1933,7 +2071,12 @@ def _project_owner_digest(owner_user_id: Optional[str]) -> Optional[str]:
 
 def _public_project_cache_record(project: Any) -> Dict[str, Any]:
     """Build one shared gallery record with non-response ownership hints."""
-    summary = _project_summary_response(project, current_user_id=None, hydrate_storage=False).model_dump(mode="json")
+    summary = _project_summary_response(
+        project,
+        current_user_id=None,
+        hydrate_storage=False,
+        include_inline_images=False,
+    ).model_dump(mode="json")
     summary[_CACHE_OWNER_DIGEST_FIELD] = _project_owner_digest(_project_owner_user_id(project))
     summary[_CACHE_OWNER_CHAT_FIELD] = getattr(project, "chat_id", None)
     return summary
@@ -2120,13 +2263,19 @@ def list_projects_endpoint(
     """Lists public compiled hardware projects."""
     try:
         if limit is not None:
-            projects, total = list_generated_projects_page(
+            projects, total = list_project_gallery_inventory_page(
+                owner_user_id=None,
                 visibility="public",
                 limit=limit,
                 offset=offset,
                 search=q,
             )
-            items = [_public_project_cache_record(project) for project in projects]
+            _log_gallery_legacy_fallback("public", projects)
+            items = [
+                cached
+                for project in projects
+                if (cached := _gallery_inventory_cache_record(project)) is not None
+            ]
             return {
                 "items": _with_project_engagement(
                     _personalize_public_project_records(items, user.owner_user_id),
@@ -2143,10 +2292,15 @@ def list_projects_endpoint(
                 _personalize_public_project_records(cached, user.owner_user_id),
                 user.owner_user_id,
             )
-        projects = [project for project in list_generated_projects() if _project_visibility(project) == "public"]
+        projects = list_project_gallery_inventory(visibility="public")
         cache_records = jsonable_encoder(
-            [_public_project_cache_record(project) for project in projects]
+            [
+                cached
+                for project in projects
+                if (cached := _gallery_inventory_cache_record(project)) is not None
+            ]
         )
+        _log_gallery_legacy_fallback("public", projects)
         cache_project_list("public", None, cache_records, generation)
         return _with_project_engagement(
             _personalize_public_project_records(cache_records, user.owner_user_id),
@@ -2165,7 +2319,27 @@ def list_my_projects_endpoint(
     """Lists projects owned by the signed-in user."""
     owner_user_id = _require_authenticated_user(user)
     try:
-        identities = _list_project_identities(owner_user_id) if limit is None else []
+        if limit is not None:
+            projects, total = list_project_gallery_inventory_page(
+                owner_user_id=owner_user_id,
+                visibility=None,
+                limit=limit,
+                offset=offset,
+            )
+            _log_gallery_legacy_fallback("mine", projects)
+            items = [
+                summary.model_dump(mode="json")
+                for project in projects
+                if (summary := _gallery_inventory_summary(project, current_user_id=owner_user_id)) is not None
+            ]
+            return {
+                "items": _with_project_engagement(items, owner_user_id),
+                "total": total,
+                "limit": max(1, min(int(limit), 50)),
+                "offset": max(0, int(offset)),
+                "has_more": max(0, int(offset)) + len(items) < total,
+            }
+        identities = _list_project_identities(owner_user_id)
         if identities:
             response: List[Dict[str, Any]] = []
             for identity in identities:
@@ -2177,7 +2351,13 @@ def list_my_projects_endpoint(
                     continue
                 project = get_generated_project(project_id)
                 if project is not None:
-                    response.append(_project_summary_response(project, current_user_id=owner_user_id).model_dump(mode="json"))
+                    response.append(
+                        _project_summary_response(
+                            project,
+                            current_user_id=owner_user_id,
+                            include_inline_images=False,
+                        ).model_dump(mode="json")
+                    )
                     continue
                 try:
                     revision = get_latest_project_revision(project_id, owner_user_id)
@@ -2188,35 +2368,19 @@ def list_my_projects_endpoint(
                     revision,
                     brief,
                     owner_user_id=owner_user_id,
+                    hydrate_storage=False,
                 ).model_dump(mode="json"))
             return _with_project_engagement(response, owner_user_id)
-        if limit is not None:
-            projects, total = list_generated_projects_page(
-                owner_user_id=owner_user_id,
-                limit=limit,
-                offset=offset,
-            )
-            items = [
-                    _project_summary_response(
-                        project,
-                        current_user_id=owner_user_id,
-                        hydrate_storage=False,
-                    ).model_dump(mode="json")
-                for project in projects
-            ]
-            return {
-                "items": _with_project_engagement(items, owner_user_id),
-                "total": total,
-                "limit": max(1, min(int(limit), 50)),
-                "offset": max(0, int(offset)),
-                "has_more": max(0, int(offset)) + len(items) < total,
-            }
         cached, generation = get_cached_project_list("mine", owner_user_id)
         if cached is not None:
             return _with_project_engagement(cached, owner_user_id)
         projects = list_generated_projects(owner_user_id=owner_user_id)
         response = [
-                _project_summary_response(project, current_user_id=owner_user_id).model_dump(mode="json")
+            _project_summary_response(
+                project,
+                current_user_id=owner_user_id,
+                include_inline_images=False,
+            ).model_dump(mode="json")
             for project in projects
         ]
         legacy_project_ids = {str(project.project_id) for project in projects}
@@ -2226,8 +2390,6 @@ def list_my_projects_endpoint(
                 continue
             legacy_record = get_generated_project(project_id, include_deleted=True)
             if legacy_record is not None:
-                # A soft-deleted legacy projection must not be resurrected by
-                # its retained canonical revisions during the recovery window.
                 continue
             try:
                 brief = get_latest_design_brief(project_id, owner_user_id)

--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -3163,10 +3163,7 @@ export function FormaWorkspace({
     const visibleProjectIds = new Set(visibleProjectGalleryIds);
     if (!visibleProjectIds.size) return;
 
-    const imageProjects = mergeProjectRecords(
-      mergeProjectRecords(projectHistory, myProjectHistory),
-      projectRecordsFromChatItems(chatListItems)
-    ).filter((project: any) => {
+    const imageProjects = mergeProjectRecords(projectHistory, myProjectHistory).filter((project: any) => {
       const projectId = project?.project_id ? String(project.project_id) : "";
       return projectId && visibleProjectIds.has(projectId);
     });
@@ -6009,26 +6006,6 @@ function mergeProjectRecords(primary: any[], secondary: any[]): any[] {
 
 function sameStringList(left: string[], right: string[]): boolean {
   return left.length === right.length && left.every((value, index) => value === right[index]);
-}
-
-function projectRecordsFromChatItems(chatItems: ChatListItem[]): any[] {
-  return chatItems
-    .filter((item) => item.projectId)
-    .map((item) => ({
-      project_id: item.projectId,
-      chat_id: item.chatId,
-      title: item.title || "Untitled project",
-      prompt: item.title || "",
-      created_at: item.createdAt || chatTimestamp(),
-      can_chat: true,
-      creator_display: "unknown",
-      creator_username: "unknown",
-      creator_image_url: null,
-      parts_count: 0,
-      save_count: 0,
-      remix_count: 0,
-      saved: false,
-    }));
 }
 
 function WorkspaceChromeIdentity({

--- a/forma_core/database.py
+++ b/forma_core/database.py
@@ -702,6 +702,50 @@ def list_project_identities(owner_user_id: str) -> List[Dict[str, Any]]:
     ]
 
 
+def list_project_gallery_inventory_page(
+    owner_user_id: Optional[str] = None,
+    *,
+    visibility: Optional[str] = None,
+    limit: int = 6,
+    offset: int = 0,
+    search: Optional[str] = None,
+) -> tuple[List[Any], int]:
+    """Return a bounded page of canonical identities and current revisions."""
+    owner = _normalize_user_id(owner_user_id)
+    normalized_visibility = str(visibility or "").strip().lower() or None
+    if normalized_visibility not in {None, "public", "private"}:
+        raise ValueError("visibility must be public or private.")
+    normalized_limit = max(1, min(int(limit), 50))
+    normalized_offset = max(0, int(offset))
+    normalized_search = " ".join(str(search or "").split())[:100] or None
+    return _DATABASE_REPOSITORY.list_project_gallery_inventory_page(
+        owner,
+        visibility=normalized_visibility,
+        limit=normalized_limit,
+        offset=normalized_offset,
+        search=normalized_search,
+    )
+
+
+def list_project_gallery_inventory(
+    owner_user_id: Optional[str] = None,
+    *,
+    visibility: Optional[str] = None,
+    search: Optional[str] = None,
+) -> List[Any]:
+    """Return the compatibility no-limit gallery inventory from the same source."""
+    owner = _normalize_user_id(owner_user_id)
+    normalized_visibility = str(visibility or "").strip().lower() or None
+    if normalized_visibility not in {None, "public", "private"}:
+        raise ValueError("visibility must be public or private.")
+    normalized_search = " ".join(str(search or "").split())[:100] or None
+    return _DATABASE_REPOSITORY.list_project_gallery_inventory(
+        owner,
+        visibility=normalized_visibility,
+        search=normalized_search,
+    )
+
+
 def get_cli_project_revision(
     project_id: str,
     owner_user_id: str,

--- a/forma_core/persistence/migrations.py
+++ b/forma_core/persistence/migrations.py
@@ -84,5 +84,85 @@ def migrate_sqlite_schema(engine: Engine, *, import_legacy_jobs: bool = True) ->
         connection.execute(
             text("CREATE INDEX IF NOT EXISTS ix_generated_projects_purge_after ON generated_projects (purge_after)")
         )
+        connection.execute(
+            text("CREATE INDEX IF NOT EXISTS ix_projects_gallery_status_visibility_updated "
+                 "ON projects (status, visibility, updated_at DESC)")
+        )
+        connection.execute(
+            text("CREATE INDEX IF NOT EXISTS ix_project_revisions_project_revision "
+                 "ON project_revisions (project_id, revision DESC)")
+        )
+        connection.exec_driver_sql("DROP VIEW IF EXISTS project_gallery_inventory")
+        connection.exec_driver_sql(
+            """
+            CREATE VIEW project_gallery_inventory AS
+            WITH hosted_latest AS (
+                SELECT r.*
+                FROM project_revisions r
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM project_revisions newer
+                    WHERE newer.project_id = r.project_id
+                      AND newer.revision > r.revision
+                )
+            ), cli_latest AS (
+                SELECT r.*
+                FROM cli_project_revisions r
+                WHERE NOT EXISTS (
+                    SELECT 1
+                    FROM cli_project_revisions newer
+                    WHERE newer.project_id = r.project_id
+                      AND newer.revision > r.revision
+                )
+            )
+            SELECT
+                p.project_id, p.owner_user_id, p.creation_channel, p.title, p.prompt, p.chat_id,
+                p.workspace_id, p.visibility, p.status, p.created_at,
+                coalesce(r.created_at, p.updated_at) AS updated_at,
+                'canonical' AS source, r.id AS revision_id, r.revision,
+                r.payload_json AS revision_payload_json, r.created_at AS revision_created_at,
+                NULL AS legacy_hardware_ir, NULL AS legacy_id
+            FROM projects p
+            JOIN hosted_latest r ON r.project_id = p.project_id
+                                     AND r.owner_user_id = p.owner_user_id
+            WHERE p.creation_channel <> 'cli'
+            UNION ALL
+            SELECT
+                p.project_id, p.owner_user_id, p.creation_channel, p.title, p.prompt, p.chat_id,
+                p.workspace_id, p.visibility, p.status, p.created_at,
+                coalesce(r.created_at, p.updated_at) AS updated_at,
+                'canonical' AS source, r.revision_id, r.revision,
+                r.manifest_json AS revision_payload_json, r.created_at AS revision_created_at,
+                NULL AS legacy_hardware_ir, NULL AS legacy_id
+            FROM projects p
+            JOIN cli_projects cp ON cp.project_id = p.project_id
+                                    AND cp.owner_user_id = p.owner_user_id
+            JOIN cli_latest r ON r.project_id = cp.project_id
+                               AND r.owner_user_id = cp.owner_user_id
+            WHERE p.creation_channel = 'cli'
+              AND (cp.current_revision_id IS NULL OR r.revision_id = cp.current_revision_id)
+            UNION ALL
+            SELECT
+                g.project_id, g.owner_user_id, g.creation_channel, g.title, g.prompt, g.chat_id,
+                NULL AS workspace_id, g.visibility, g.status, g.created_at, g.created_at,
+                'legacy' AS source, NULL AS revision_id, NULL AS revision,
+                NULL AS revision_payload_json, NULL AS revision_created_at,
+                NULL AS legacy_hardware_ir, g.id AS legacy_id
+            FROM generated_projects g
+            WHERE g.status = 'active'
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM project_revisions r
+                  WHERE r.project_id = g.project_id
+                    AND r.owner_user_id = g.owner_user_id
+              )
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM cli_project_revisions r
+                  WHERE r.project_id = g.project_id
+                    AND r.owner_user_id = g.owner_user_id
+              )
+            """
+        )
 
     migrate_job_schema(engine, import_legacy_jobs=import_legacy_jobs)

--- a/forma_core/persistence/repositories/base.py
+++ b/forma_core/persistence/repositories/base.py
@@ -20,6 +20,24 @@ class ApplicationRepository(Protocol):
 
     def list_project_identities(self, owner_user_id: str) -> List[Any]: ...
 
+    def list_project_gallery_inventory_page(
+        self,
+        owner_user_id: Optional[str],
+        *,
+        visibility: Optional[str],
+        limit: int,
+        offset: int,
+        search: Optional[str] = None,
+    ) -> tuple[List[Any], int]: ...
+
+    def list_project_gallery_inventory(
+        self,
+        owner_user_id: Optional[str],
+        *,
+        visibility: Optional[str],
+        search: Optional[str] = None,
+    ) -> List[Any]: ...
+
     def save_generated_project(
         self,
         record: Dict[str, Any],

--- a/forma_core/persistence/repositories/sqlite.py
+++ b/forma_core/persistence/repositories/sqlite.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 
@@ -85,6 +86,81 @@ class SqlAlchemyRepository:
                 DBProject.owner_user_id == owner_user_id,
                 DBProject.status == "active",
             ).order_by(DBProject.updated_at.desc()).all()
+
+    def list_project_gallery_inventory_page(
+        self,
+        owner_user_id: Optional[str],
+        *,
+        visibility: Optional[str],
+        limit: int,
+        offset: int,
+        search: Optional[str] = None,
+    ) -> tuple[List[Any], int]:
+        """Read one bounded, privacy-filtered canonical gallery page."""
+        filters = ["status = :status"]
+        parameters: Dict[str, Any] = {
+            "status": "active",
+            "limit": max(1, int(limit)),
+            "offset": max(0, int(offset)),
+        }
+        if owner_user_id:
+            filters.append("owner_user_id = :owner_user_id")
+            parameters["owner_user_id"] = owner_user_id
+        if visibility:
+            filters.append("visibility = :visibility")
+            parameters["visibility"] = visibility
+        if search:
+            filters.append("(lower(title) like lower(:search) or lower(prompt) like lower(:search))")
+            parameters["search"] = f"%{search}%"
+        where = " AND ".join(filters)
+        with self._session() as session:
+            total = session.execute(
+                text(f"SELECT COUNT(*) FROM project_gallery_inventory WHERE {where}"),
+                parameters,
+            ).scalar_one()
+            rows = session.execute(
+                text(
+                    "SELECT project_id, owner_user_id, creation_channel, title, prompt, chat_id, "
+                    "workspace_id, visibility, status, created_at, updated_at, source, revision_id, "
+                    "revision, revision_payload_json, revision_created_at, legacy_hardware_ir, legacy_id "
+                    f"FROM project_gallery_inventory WHERE {where} "
+                    "ORDER BY updated_at DESC, project_id DESC LIMIT :limit OFFSET :offset"
+                ),
+                parameters,
+            ).mappings().all()
+            return [SimpleNamespace(**dict(row)) for row in rows], int(total or 0)
+
+    def list_project_gallery_inventory(
+        self,
+        owner_user_id: Optional[str],
+        *,
+        visibility: Optional[str],
+        search: Optional[str] = None,
+    ) -> List[Any]:
+        filters = ["status = :status"]
+        parameters: Dict[str, Any] = {"status": "active"}
+        if owner_user_id:
+            filters.append("owner_user_id = :owner_user_id")
+            parameters["owner_user_id"] = owner_user_id
+        if visibility:
+            filters.append("visibility = :visibility")
+            parameters["visibility"] = visibility
+        if search:
+            filters.append("(lower(title) like lower(:search) or lower(prompt) like lower(:search))")
+            parameters["search"] = f"%{search}%"
+        where = " AND ".join(filters)
+        with self._session() as session:
+            rows = session.execute(
+                text(
+                    "SELECT project_id, owner_user_id, creation_channel, title, prompt, chat_id, "
+                    "workspace_id, visibility, status, created_at, updated_at, source, revision_id, "
+                    "revision, revision_payload_json, revision_created_at, legacy_hardware_ir, legacy_id "
+                    f"FROM project_gallery_inventory WHERE {where} "
+                    "ORDER BY updated_at DESC, project_id DESC"
+                ),
+                parameters,
+            ).mappings().all()
+            return [SimpleNamespace(**dict(row)) for row in rows]
 
     def save_generated_project(
         self,

--- a/forma_core/persistence/repositories/supabase.py
+++ b/forma_core/persistence/repositories/supabase.py
@@ -70,6 +70,62 @@ class SupabaseRepository:
         )
         return [_record(row) for row in rows]
 
+    def list_project_gallery_inventory_page(
+        self,
+        owner_user_id: Optional[str],
+        *,
+        visibility: Optional[str],
+        limit: int,
+        offset: int,
+        search: Optional[str] = None,
+    ) -> tuple[List[Any], int]:
+        """Read one bounded page from the canonical gallery inventory view."""
+        query = self._client.table("project_gallery_inventory").select(
+            "project_id,owner_user_id,creation_channel,title,prompt,chat_id,workspace_id,visibility,status,"
+            "created_at,updated_at,source,revision_id,revision,revision_payload_json,revision_created_at,"
+            "legacy_hardware_ir,legacy_id",
+            count="exact",
+        ).eq("status", "active")
+        if owner_user_id:
+            query = query.eq("owner_user_id", owner_user_id)
+        if visibility:
+            query = query.eq("visibility", visibility)
+        if search:
+            pattern = _postgrest_ilike_pattern(search)
+            query = query.or_(f"title.ilike.{pattern},prompt.ilike.{pattern}")
+        response = (
+            query.order("updated_at", desc=True)
+            .order("project_id", desc=True)
+            .range(max(0, int(offset)), max(0, int(offset)) + max(1, int(limit)) - 1)
+            .execute()
+        )
+        rows = response.data or []
+        response_count = getattr(response, "count", None)
+        total = response_count if isinstance(response_count, int) else len(rows)
+        return [_record(row) for row in rows], total
+
+    def list_project_gallery_inventory(
+        self,
+        owner_user_id: Optional[str],
+        *,
+        visibility: Optional[str],
+        search: Optional[str] = None,
+    ) -> List[Any]:
+        query = self._client.table("project_gallery_inventory").select(
+            "project_id,owner_user_id,creation_channel,title,prompt,chat_id,workspace_id,visibility,status,"
+            "created_at,updated_at,source,revision_id,revision,revision_payload_json,revision_created_at,"
+            "legacy_hardware_ir,legacy_id"
+        ).eq("status", "active")
+        if owner_user_id:
+            query = query.eq("owner_user_id", owner_user_id)
+        if visibility:
+            query = query.eq("visibility", visibility)
+        if search:
+            pattern = _postgrest_ilike_pattern(search)
+            query = query.or_(f"title.ilike.{pattern},prompt.ilike.{pattern}")
+        rows = query.order("updated_at", desc=True).order("project_id", desc=True).execute().data or []
+        return [_record(row) for row in rows]
+
     def save_generated_project(
         self,
         record: Dict[str, Any],

--- a/forma_core/persistence/schema.py
+++ b/forma_core/persistence/schema.py
@@ -22,6 +22,14 @@ APPLICATION_SCHEMA: Tuple[TableContract, ...] = (
         ),
     ),
     TableContract(
+        "project_gallery_inventory",
+        (
+            "project_id", "owner_user_id", "creation_channel", "title", "prompt", "chat_id", "workspace_id",
+            "visibility", "status", "created_at", "updated_at", "source", "revision_id", "revision",
+            "revision_payload_json", "revision_created_at", "legacy_hardware_ir", "legacy_id",
+        ),
+    ),
+    TableContract(
         "generated_projects",
         (
             "id", "project_id", "chat_id", "owner_user_id", "creation_channel", "visibility", "title", "prompt", "hardware_ir", "created_at",

--- a/supabase/migrations/20260903000100_canonical_gallery_inventory.sql
+++ b/supabase/migrations/20260903000100_canonical_gallery_inventory.sql
@@ -1,0 +1,120 @@
+-- Bounded gallery read surface. Canonical identities win over legacy projections.
+
+create index if not exists idx_projects_gallery_status_visibility_updated
+  on public.projects (status, visibility, updated_at desc);
+
+create index if not exists idx_project_revisions_project_revision
+  on public.project_revisions (project_id, revision desc);
+
+create or replace view public.project_gallery_inventory as
+with hosted_latest as (
+  select distinct on (project_id)
+    id as revision_id,
+    project_id,
+    owner_user_id,
+    revision,
+    payload_json as revision_payload_json,
+    created_at as revision_created_at
+  from public.project_revisions
+  order by project_id, revision desc
+), cli_latest as (
+  select distinct on (project_id)
+    revision_id,
+    project_id,
+    owner_user_id,
+    revision,
+    manifest_json as revision_payload_json,
+    created_at as revision_created_at
+  from public.cli_project_revisions
+  order by project_id, revision desc
+)
+select
+  p.project_id,
+  p.owner_user_id,
+  p.creation_channel,
+  p.title,
+  p.prompt,
+  p.chat_id,
+  p.workspace_id,
+  p.visibility,
+  p.status,
+  p.created_at,
+  coalesce(r.revision_created_at, p.updated_at) as updated_at,
+  'canonical'::text as source,
+  r.revision_id,
+  r.revision,
+  r.revision_payload_json,
+  r.revision_created_at,
+  null::jsonb as legacy_hardware_ir,
+  null::integer as legacy_id
+from public.projects p
+join hosted_latest r on r.project_id = p.project_id
+                     and r.owner_user_id = p.owner_user_id
+where p.creation_channel <> 'cli'
+union all
+select
+  p.project_id,
+  p.owner_user_id,
+  p.creation_channel,
+  p.title,
+  p.prompt,
+  p.chat_id,
+  p.workspace_id,
+  p.visibility,
+  p.status,
+  p.created_at,
+  coalesce(r.revision_created_at, p.updated_at) as updated_at,
+  'canonical'::text as source,
+  r.revision_id,
+  r.revision,
+  r.revision_payload_json,
+  r.revision_created_at,
+  null::jsonb as legacy_hardware_ir,
+  null::integer as legacy_id
+from public.projects p
+join public.cli_projects cp on cp.project_id = p.project_id
+                            and cp.owner_user_id = p.owner_user_id
+join cli_latest r on r.project_id = cp.project_id
+                   and r.owner_user_id = cp.owner_user_id
+where p.creation_channel = 'cli'
+  and (cp.current_revision_id is null or r.revision_id = cp.current_revision_id)
+union all
+select
+  g.project_id,
+  g.owner_user_id,
+  g.creation_channel,
+  g.title,
+  g.prompt,
+  g.chat_id,
+  null::text as workspace_id,
+  g.visibility,
+  g.status,
+  g.created_at,
+  g.created_at as updated_at,
+  'legacy'::text as source,
+  null::text as revision_id,
+  null::integer as revision,
+  null::jsonb as revision_payload_json,
+  null::text as revision_created_at,
+  null::jsonb as legacy_hardware_ir,
+  g.id as legacy_id
+from public.generated_projects g
+where g.status = 'active'
+  and not exists (
+    select 1
+    from public.project_revisions r
+    where r.project_id = g.project_id
+      and r.owner_user_id = g.owner_user_id
+  )
+  and not exists (
+    select 1
+    from public.cli_project_revisions r
+    where r.project_id = g.project_id
+      and r.owner_user_id = g.owner_user_id
+  );
+
+revoke all on public.project_gallery_inventory from anon, authenticated;
+grant select on public.project_gallery_inventory to service_role;
+
+comment on view public.project_gallery_inventory is
+  'Canonical gallery inventory with current revisions and active legacy fallback rows only when no identity exists.';

--- a/tests/api/test_project_access.py
+++ b/tests/api/test_project_access.py
@@ -80,6 +80,43 @@ def _project(
     )
 
 
+def _legacy_inventory(project: SimpleNamespace) -> SimpleNamespace:
+    return SimpleNamespace(
+        source="legacy",
+        legacy_id=1,
+        legacy_hardware_ir=project.hardware_ir,
+        project_id=project.project_id,
+        owner_user_id=project.owner_user_id,
+        creation_channel=project.creation_channel if hasattr(project, "creation_channel") else "hosted",
+        chat_id=project.chat_id,
+        visibility=project.visibility,
+        title=project.title,
+        prompt=project.prompt,
+        created_at=project.created_at,
+        updated_at=project.created_at,
+    )
+
+
+def _canonical_revision_payload(project_id: str, state: HardwareIR, revision: int = 1) -> dict:
+    return {
+        "schema_version": "1.0",
+        "state": state.model_dump(mode="json"),
+        "components": [],
+        "systems": [],
+        "artifacts": [],
+        "assumptions": [],
+        "revision_id": f"22222222-2222-4222-8222-{revision:012d}",
+        "project_id": project_id,
+        "owner_user_id": "user-a",
+        "revision": revision,
+        "parent_revision": revision - 1 if revision > 1 else None,
+        "design_brief_id": "33333333-3333-4333-8333-333333333333",
+        "design_brief_version": 1,
+        "source_job_id": f"gallery-job-{revision}",
+        "created_at": "2026-08-07T12:00:00Z",
+    }
+
+
 class LocalProjectIdentityTests(unittest.IsolatedAsyncioTestCase):
     async def test_local_user_context_owns_local_dev_user_projects(self) -> None:
         with patch.dict(os.environ, {"FORMA_AUTH_MODE": "local"}, clear=False):
@@ -122,8 +159,8 @@ class ProjectReadAccessTests(unittest.TestCase):
 
         with self._summary_dependencies(), patch.object(
             main,
-            "list_generated_projects",
-            return_value=[private_project, public_project],
+            "list_project_gallery_inventory",
+            return_value=[public_project],
         ):
             response = main.list_projects_endpoint(_user_context("user-a"))
 
@@ -139,12 +176,12 @@ class ProjectReadAccessTests(unittest.TestCase):
 
         with self._summary_dependencies(), patch.object(
             main,
-            "list_generated_projects_page",
-            return_value=(page_projects, 14),
+            "list_project_gallery_inventory_page",
+            return_value=([_legacy_inventory(project) for project in page_projects], 14),
         ) as list_page, patch.object(main, "list_generated_projects") as list_all:
             response = main.list_projects_endpoint(_user_context("user-a"), limit=2, offset=6)
 
-        list_page.assert_called_once_with(visibility="public", limit=2, offset=6, search=None)
+        list_page.assert_called_once_with(owner_user_id=None, visibility="public", limit=2, offset=6, search=None)
         list_all.assert_not_called()
         self.assertEqual(14, response["total"])
         self.assertEqual(2, response["limit"])
@@ -160,7 +197,7 @@ class ProjectReadAccessTests(unittest.TestCase):
     def test_public_list_passes_search_to_the_paginated_query(self) -> None:
         with self._summary_dependencies(), patch.object(
             main,
-            "list_generated_projects_page",
+            "list_project_gallery_inventory_page",
             return_value=([], 0),
         ) as list_page:
             response = main.list_projects_endpoint(
@@ -171,6 +208,7 @@ class ProjectReadAccessTests(unittest.TestCase):
             )
 
         list_page.assert_called_once_with(
+            owner_user_id=None,
             visibility="public",
             limit=6,
             offset=0,
@@ -315,12 +353,12 @@ class ProjectReadAccessTests(unittest.TestCase):
 
         with self._summary_dependencies(), patch.object(
             main,
-            "list_generated_projects_page",
-            return_value=(page_projects, 9),
+            "list_project_gallery_inventory_page",
+            return_value=([_legacy_inventory(project) for project in page_projects], 9),
         ) as list_page, patch.object(main, "list_latest_project_revisions") as list_revisions:
             response = main.list_my_projects_endpoint(_user_context("user-a"), limit=2, offset=6)
 
-        list_page.assert_called_once_with(owner_user_id="user-a", limit=2, offset=6)
+        list_page.assert_called_once_with(owner_user_id="user-a", visibility=None, limit=2, offset=6)
         list_revisions.assert_not_called()
         self.assertEqual(9, response["total"])
         self.assertEqual(2, response["limit"])
@@ -330,6 +368,91 @@ class ProjectReadAccessTests(unittest.TestCase):
             ["private-project-7", "private-project-8"],
             [item["project_id"] for item in response["items"]],
         )
+
+    def test_public_paginated_list_uses_current_canonical_revision_without_brief_or_legacy_reads(self) -> None:
+        project_id = "11111111-1111-4111-8111-111111111111"
+        state = HardwareIR(
+            overview=ProjectOverview(
+                title="Current canonical title",
+                description="Current state",
+                difficulty="Beginner",
+                category="Automation",
+            ),
+            assembly_metadata={"project_id": project_id},
+        )
+        revision = SimpleNamespace(
+            source="canonical",
+            project_id=project_id,
+            owner_user_id="user-a",
+            creation_channel="hosted",
+            title="Stale identity title",
+            prompt="Canonical prompt",
+            chat_id="canonical-chat",
+            visibility="public",
+            created_at="2026-08-07T12:00:00Z",
+            updated_at="2026-08-07T12:01:00Z",
+            revision_payload_json=_canonical_revision_payload(project_id, state, revision=2),
+            revision_id="revision-2",
+            revision=2,
+        )
+
+        with self._summary_dependencies(), patch.object(
+            main,
+            "list_project_gallery_inventory_page",
+            return_value=([revision], 1),
+        ) as list_page, patch.object(main, "get_latest_design_brief") as get_brief, patch.object(
+            main, "get_generated_project"
+        ) as get_legacy, patch.object(main.logger, "info") as log_info:
+            response = main.list_projects_endpoint(_anonymous_context(), limit=1, offset=0)
+
+        list_page.assert_called_once()
+        get_brief.assert_not_called()
+        get_legacy.assert_not_called()
+        log_info.assert_any_call("project_gallery_legacy_fallback endpoint=%s count=%d", "public", 0)
+        self.assertEqual("Current canonical title", response["items"][0]["title"])
+        self.assertIsNone(response["items"][0]["chat_id"])
+        self.assertFalse(response["items"][0]["can_chat"])
+
+    def test_my_paginated_list_uses_identity_and_legacy_fallback_rows_without_chat_history(self) -> None:
+        canonical_id = "11111111-1111-4111-8111-111111111111"
+        state = HardwareIR(
+            overview=ProjectOverview(
+                title="Canonical project",
+                description="Canonical state",
+                difficulty="Beginner",
+                category="Automation",
+            ),
+            assembly_metadata={"project_id": canonical_id},
+        )
+        canonical = SimpleNamespace(
+            source="canonical",
+            project_id=canonical_id,
+            owner_user_id="user-a",
+            creation_channel="hosted",
+            title="Canonical project",
+            prompt="Canonical prompt",
+            chat_id="canonical-chat",
+            visibility="private",
+            created_at="2026-08-07T12:00:00Z",
+            updated_at="2026-08-07T12:00:00Z",
+            revision_payload_json=_canonical_revision_payload(canonical_id, state),
+            revision_id="revision-1",
+            revision=1,
+        )
+        legacy = _legacy_inventory(_project("legacy-id", owner_user_id="user-a", visibility="private"))
+
+        with self._summary_dependencies(), patch.object(
+            main,
+            "list_project_gallery_inventory_page",
+            return_value=([canonical, legacy], 2),
+        ) as list_page, patch.object(main, "get_latest_design_brief") as get_brief:
+            response = main.list_my_projects_endpoint(_user_context("user-a"), limit=2)
+
+        list_page.assert_called_once_with(
+            owner_user_id="user-a", visibility=None, limit=2, offset=0
+        )
+        get_brief.assert_not_called()
+        self.assertEqual([canonical_id, "legacy-id"], [item["project_id"] for item in response["items"]])
 
     def test_owner_list_deduplicates_legacy_and_canonical_project_records(self) -> None:
         project_id = "legacy-and-canonical"

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -11,7 +11,7 @@ from unittest.mock import patch
 from forma_core.jobs.store import JobMetadataStore
 from forma_core import database
 from forma_core.persistence import APPLICATION_SCHEMA
-from forma_core.persistence.models import DBGeneratedProject, DBProjectRevision
+from forma_core.persistence.models import DBGeneratedProject, DBProject, DBProjectRevision
 from forma_core.jobs.migrations import import_legacy_job_database
 from forma_core.persistence.providers import SupabaseProvider, create_sqlite_provider
 from forma_core.persistence.repositories import SqlAlchemyRepository, SupabaseRepository
@@ -294,6 +294,130 @@ class PersistenceArchitectureTests(unittest.TestCase):
             [(revision.project_id, revision.revision) for revision in revisions],
         )
 
+    def test_sqlite_gallery_inventory_prefers_identity_and_current_revision_with_legacy_fallback(self) -> None:
+        canonical_id = str(uuid.uuid4())
+        legacy_id = str(uuid.uuid4())
+        deleted_id = str(uuid.uuid4())
+        state = HardwareIR(
+            overview=ProjectOverview(
+                title="Current canonical title",
+                description="Canonical state",
+                difficulty="Beginner",
+                category="Automation",
+            ),
+            assembly_metadata={"project_id": canonical_id},
+        )
+
+        def revision_record(revision: int) -> DBProjectRevision:
+            return DBProjectRevision(
+                id=f"gallery-revision-{revision}",
+                project_id=canonical_id,
+                owner_user_id="user-a",
+                revision=revision,
+                parent_revision=revision - 1 if revision > 1 else None,
+                design_brief_id="brief-gallery",
+                design_brief_version=1,
+                source_job_id=f"gallery-job-{revision}",
+                payload_json={
+                    "schema_version": "1.0",
+                    "state": state.model_dump(mode="json"),
+                    "components": [],
+                    "systems": [],
+                    "artifacts": [],
+                    "assumptions": [],
+                    "revision_id": str(uuid.uuid4()),
+                    "project_id": canonical_id,
+                    "owner_user_id": "user-a",
+                    "revision": revision,
+                    "parent_revision": revision - 1 if revision > 1 else None,
+                    "design_brief_id": str(uuid.uuid4()),
+                    "design_brief_version": 1,
+                    "source_job_id": f"gallery-job-{revision}",
+                    "created_at": f"2026-08-0{revision}T12:00:00Z",
+                },
+                created_at=f"2026-08-0{revision}T12:00:00Z",
+            )
+
+        with tempfile.TemporaryDirectory() as directory:
+            provider = create_sqlite_provider(
+                source="test gallery inventory",
+                url=f"sqlite:///{Path(directory) / 'forma.db'}",
+                import_legacy_jobs=False,
+            )
+            assert provider.session_factory is not None
+            provider.initialize()
+            repository = SqlAlchemyRepository(provider.session_factory)
+            with provider.session_factory() as session, session.begin():
+                session.add_all([
+                    DBProject(
+                        project_id=canonical_id,
+                        owner_user_id="user-a",
+                        creation_channel="hosted",
+                        title="Identity title",
+                        prompt="Canonical prompt",
+                        chat_id="canonical-chat",
+                        visibility="public",
+                        status="active",
+                        created_at="2026-08-01T12:00:00Z",
+                        updated_at="2026-08-02T12:00:00Z",
+                    ),
+                    DBProject(
+                        project_id=deleted_id,
+                        owner_user_id="user-a",
+                        creation_channel="hosted",
+                        title="Deleted project",
+                        prompt="Deleted",
+                        visibility="public",
+                        status="pending_purge",
+                        created_at="2026-08-01T12:00:00Z",
+                        updated_at="2026-08-03T12:00:00Z",
+                    ),
+                    revision_record(1),
+                    revision_record(2),
+                    DBGeneratedProject(
+                        project_id=canonical_id,
+                        owner_user_id="user-a",
+                        visibility="public",
+                        title="Stale generated projection",
+                        prompt="Stale",
+                        hardware_ir={"assembly_metadata": {"project_id": canonical_id}},
+                        created_at="2026-08-04T12:00:00Z",
+                        status="active",
+                    ),
+                    DBGeneratedProject(
+                        project_id=legacy_id,
+                        owner_user_id="user-a",
+                        visibility="public",
+                        title="Legacy fallback",
+                        prompt="Legacy",
+                        hardware_ir={"assembly_metadata": {"project_id": legacy_id}},
+                        created_at="2026-08-05T12:00:00Z",
+                        status="active",
+                    ),
+                    DBProject(
+                        project_id=legacy_id,
+                        owner_user_id="user-a",
+                        creation_channel="hosted",
+                        title="Legacy identity",
+                        prompt="Legacy identity prompt",
+                        visibility="public",
+                        status="active",
+                        created_at="2026-08-05T12:00:00Z",
+                        updated_at="2026-08-05T12:00:00Z",
+                    ),
+                ])
+
+            rows, total = repository.list_project_gallery_inventory_page(
+                "user-a", visibility="public", limit=10, offset=0
+            )
+            provider.engine.dispose()
+
+        self.assertEqual(2, total)
+        self.assertEqual(["legacy", "canonical"], [row.source for row in rows])
+        canonical = next(row for row in rows if row.project_id == canonical_id)
+        self.assertEqual(2, canonical.revision)
+        self.assertEqual("Identity title", canonical.title)
+
     def test_cli_revision_push_updates_project_summary_metadata(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             provider = create_sqlite_provider(
@@ -455,6 +579,21 @@ class PersistenceArchitectureTests(unittest.TestCase):
         self.assertIn(("status", "active"), client.query.filters)
         self.assertIn(("owner_user_id", "user-a"), client.query.filters)
         self.assertIn(("visibility", "public"), client.query.filters)
+
+    def test_supabase_gallery_inventory_requests_an_exact_bounded_page(self) -> None:
+        client = _GalleryInventoryClient()
+        repository = SupabaseRepository(client)
+
+        rows, total = repository.list_project_gallery_inventory_page(
+            "user-a", visibility=None, limit=6, offset=12
+        )
+
+        self.assertEqual(37, total)
+        self.assertEqual(["project-13", "project-14"], [row.project_id for row in rows])
+        self.assertEqual("exact", client.query.count_mode)
+        self.assertEqual((12, 17), client.query.requested_range)
+        self.assertIn(("status", "active"), client.query.filters)
+        self.assertIn(("owner_user_id", "user-a"), client.query.filters)
 
     def test_supabase_repository_searches_titles_and_prompts(self) -> None:
         client = _ProjectPageClient()
@@ -715,6 +854,15 @@ class _ProjectPageClient:
 
     def table(self, table: str) -> _ProjectPageQuery:
         assert table == "generated_projects"
+        return self.query
+
+
+class _GalleryInventoryClient:
+    def __init__(self) -> None:
+        self.query = _ProjectPageQuery()
+
+    def table(self, table: str) -> _ProjectPageQuery:
+        assert table == "project_gallery_inventory"
         return self.query
 
 


### PR DESCRIPTION
## Summary
- Make public and owner gallery inventory come from canonical project identities and current revisions.
- Keep active generated-project rows as a measured fallback only when canonical revisions are unavailable.
- Add bounded SQLite/Supabase inventory views and pagination support.
- Keep gallery summaries lightweight and remove chat-derived phantom image inventory.
- Add backend, persistence, migration, and gallery regression coverage.

## Verification
- 31 targeted Python tests passed.
- Frontend ESLint passed.
- TypeScript check passed.
- Next.js production build passed.

Closes #399