### PR TITLE
fix: make project image summaries canonical-aware

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1822,12 +1822,20 @@ def _project_summary_response(
     *,
     hydrate_storage: bool = True,
     include_inline_images: bool = True,
+    image_metadata: Optional[Dict[str, Any]] = None,
 ) -> ProjectSummary:
     owner_user_id = _project_owner_user_id(project)
     can_chat = bool(current_user_id and owner_user_id == current_user_id)
     hardware_ir = getattr(project, "hardware_ir", None) if isinstance(getattr(project, "hardware_ir", None), dict) else {}
     components = hardware_ir.get("components") if isinstance(hardware_ir, dict) else []
-    metadata = hardware_ir.get("assembly_metadata") if isinstance(hardware_ir, dict) and isinstance(hardware_ir.get("assembly_metadata"), dict) else {}
+    project_metadata = (
+        hardware_ir.get("assembly_metadata")
+        if isinstance(hardware_ir, dict) and isinstance(hardware_ir.get("assembly_metadata"), dict)
+        else {}
+    )
+    # Resolved metadata is authoritative for cross-store project reads. The
+    # legacy project payload remains the fallback for callers without a resolver.
+    metadata = image_metadata if isinstance(image_metadata, dict) else project_metadata
     hydrated_metadata = (
         hydrate_image_storage_metadata(metadata, project.project_id)
         if metadata and hydrate_storage
@@ -2428,6 +2436,7 @@ def get_project_image_summary_endpoint(project_id: str, user: UserContext = Depe
         summary = _project_summary_response(
             resolved.project,
             current_user_id=user.owner_user_id,
+            image_metadata=getattr(resolved, "image_metadata", None),
         ).model_dump(mode="json")
         summary["can_chat"] = resolved.can_chat
         summary["chat_id"] = resolved.chat_id if resolved.can_chat else None

--- a/forma_core/workspaces/projects/resolver.py
+++ b/forma_core/workspaces/projects/resolver.py
@@ -221,19 +221,27 @@ class ProjectReadResolver:
     def _resolve_canonical_only(self, project_id: str, owner_user_id: str) -> Optional[ProjectReadResolution]:
         try:
             revision = self._state.get_latest(project_id, owner_user_id)
-            brief = _brief(self._repository, project_id, owner_user_id)
         except (ProjectStateError, ProjectReadNotFoundError, ValueError):
             return None
+        try:
+            brief = _brief(self._repository, project_id, owner_user_id)
+        except (ProjectReadNotFoundError, ValueError):
+            # A revision is sufficient for image-summary reads; design briefs are
+            # optional context and should not make a valid project look missing.
+            brief = None
         project_ir = revision.state.model_dump(mode="json")
         metadata = _project_ir_metadata(project_ir)
-        title = str(getattr(getattr(revision.state, "overview", None), "title", "") or brief.summary)
+        overview = getattr(revision.state, "overview", None)
+        title = str(getattr(overview, "title", "") or getattr(brief, "summary", "") or "Untitled project")
+        prompt = str(getattr(brief, "summary", "") or getattr(overview, "description", "") or "")
+        chat_id = getattr(brief, "conversation_id", None)
         project = SimpleNamespace(
             project_id=project_id,
             owner_user_id=owner_user_id,
             creation_channel="hosted",
-            chat_id=brief.conversation_id,
+            chat_id=chat_id,
             title=title,
-            prompt=brief.summary,
+            prompt=prompt,
             created_at=revision.created_at,
             updated_at=revision.created_at,
             visibility="private",
@@ -245,8 +253,8 @@ class ProjectReadResolver:
             creation_channel=ProjectCreationChannel.HOSTED,
             owner_user_id=owner_user_id,
             title=title,
-            prompt=brief.summary,
-            chat_id=brief.conversation_id,
+            prompt=prompt,
+            chat_id=chat_id,
             created_at=revision.created_at,
             updated_at=revision.created_at,
             visibility="private",
@@ -255,7 +263,7 @@ class ProjectReadResolver:
             revision_id=str(revision.revision_id),
             project_ir=project_ir,
             image_metadata=metadata,
-            can_chat=True,
+            can_chat=brief is not None,
             legacy_fallback=False,
             project=project,
             revision=revision,

--- a/tests/api/test_project_summary.py
+++ b/tests/api/test_project_summary.py
@@ -192,6 +192,63 @@ class ProjectSummaryTests(unittest.TestCase):
         self.assertFalse(summary["can_chat"])
         self.assertIsNone(summary["chat_id"])
 
+    def test_project_image_summary_uses_resolver_image_metadata(self) -> None:
+        project = SimpleNamespace(
+            project_id="canonical-only-project",
+            chat_id=None,
+            title="Canonical project",
+            prompt="Build a canonical project.",
+            created_at="2026-08-01T12:00:00Z",
+            owner_user_id="user_123",
+            hardware_ir={"components": [], "assembly_metadata": {}},
+        )
+
+        with patch.object(
+            main,
+            "resolve_project_for_read",
+            return_value=SimpleNamespace(
+                project=project,
+                image_metadata={"product_image_url": "https://storage.example.test/canonical.png"},
+                can_chat=False,
+                chat_id=None,
+            ),
+        ), patch.object(main, "creator_display_name", return_value="isayahc"), patch.object(
+            main, "project_engagement_for_ids", return_value={}
+        ):
+            summary = main.get_project_image_summary_endpoint(project.project_id, ANONYMOUS_USER)
+
+        self.assertTrue(summary["has_product_image"])
+        self.assertEqual("https://storage.example.test/canonical.png", summary["product_image_url"])
+
+    def test_project_image_summary_reports_missing_storage_without_404(self) -> None:
+        project = SimpleNamespace(
+            project_id="canonical-missing-image",
+            chat_id=None,
+            title="Canonical project without image",
+            prompt="Build a canonical project.",
+            created_at="2026-08-01T12:00:00Z",
+            owner_user_id="user_123",
+            hardware_ir={"components": [], "assembly_metadata": {}},
+        )
+
+        with patch.object(
+            main,
+            "resolve_project_for_read",
+            return_value=SimpleNamespace(
+                project=project,
+                image_metadata={"product_image_s3_key": "images/missing/product.png"},
+                can_chat=False,
+                chat_id=None,
+            ),
+        ), patch.object(main, "hydrate_image_storage_metadata", return_value={}), patch.object(
+            main, "creator_display_name", return_value="isayahc"
+        ), patch.object(main, "project_engagement_for_ids", return_value={}):
+            summary = main.get_project_image_summary_endpoint(project.project_id, ANONYMOUS_USER)
+
+        self.assertFalse(summary["has_product_image"])
+        self.assertIsNone(summary["product_image_url"])
+        self.assertIsNone(summary["product_image_data"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/projects/test_project_read_resolver.py
+++ b/tests/projects/test_project_read_resolver.py
@@ -105,6 +105,23 @@ class ProjectReadResolverTests(unittest.TestCase):
         self.assertTrue(resolved.can_chat)
         self.assertFalse(resolved.legacy_fallback)
 
+    def test_canonical_revision_resolves_without_design_brief(self) -> None:
+        revision = _revision(_brief())
+        repository = Mock()
+        repository.get_generated_project.return_value = None
+        repository.get_latest_design_brief.return_value = None
+        repository.get_cli_project_revision.return_value = None
+        resolver = ProjectReadResolver(repository)
+        resolver._state.get_latest = Mock(return_value=revision)
+
+        resolved = resolver.resolve(PROJECT_ID, "owner-a")
+
+        self.assertEqual("canonical", resolved.source)
+        self.assertEqual("Resolver project", resolved.title)
+        self.assertEqual("A resolver test project.", resolved.prompt)
+        self.assertIsNone(resolved.chat_id)
+        self.assertFalse(resolved.can_chat)
+
     def test_cli_project_resolves_when_generated_projection_is_missing(self) -> None:
         repository = Mock()
         repository.get_generated_project.return_value = None


### PR DESCRIPTION
## Summary
- Route image-summary responses through resolver-normalized image metadata.
- Keep canonical revisions readable when optional design briefs are absent.
- Return missing-image metadata instead of treating valid projects as missing.

## Tests
- python -m unittest tests.api.test_project_summary tests.api.test_project_access tests.projects.test_project_read_resolver -v
- python -m compileall -q apps/api forma_core tests/api tests/projects

Closes #400