### PR TITLE
refactor: make project lifecycle canonical

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -88,6 +88,7 @@ from forma_core.database import (
     get_latest_project_deletion_audit,
     get_project_contribution_consent,
     get_project_chat,
+    get_project_identity,
     init_db,
     list_project_chats,
     list_component_templates,
@@ -1070,14 +1071,14 @@ def _require_authenticated_user(user: UserContext) -> str:
 
 
 def _project_owner_user_id(project: Any) -> Optional[str]:
-    value = getattr(project, "owner_user_id", None)
+    value = project.get("owner_user_id") if isinstance(project, dict) else getattr(project, "owner_user_id", None)
     if isinstance(value, str) and value.strip():
         return value.strip()
     return None
 
 
 def _project_visibility(project: Any) -> str:
-    value = getattr(project, "visibility", "public")
+    value = project.get("visibility", "public") if isinstance(project, dict) else getattr(project, "visibility", "public")
     normalized = str(value or "public").strip().lower()
     return normalized if normalized in {"public", "private"} else "public"
 
@@ -2664,7 +2665,11 @@ def delete_project_endpoint(
     require_hosted_chat_enabled()
     owner_user_id = _require_authenticated_user(user)
     try:
-        project = get_generated_project(project_id, include_deleted=True)
+        try:
+            resolved = resolve_project_for_read(project_id, owner_user_id, include_deleted=True)
+            project = resolved.project
+        except ProjectReadError:
+            project = get_project_identity(project_id)
         if not project:
             audit = get_latest_project_deletion_audit(project_id)
             if (

--- a/apps/api/project_deletion.py
+++ b/apps/api/project_deletion.py
@@ -17,12 +17,15 @@ from forma_core.database import (
     anonymize_project_contribution_consent,
     anonymize_project_contribution_snapshot,
     get_generated_project,
+    get_project_identity,
     get_project_contribution_consent,
     get_user_settings,
     hard_purge_generated_project,
     list_project_deletion_audits,
     list_due_project_purges,
+    publish_project_revision,
     purge_project_contribution_snapshots,
+    resolve_project_for_read,
     update_project_deletion_state,
     upsert_project_contribution_consent,
     upsert_project_contribution_snapshot,
@@ -196,7 +199,16 @@ def withdraw_contribution(project_id: str, user_id: str) -> Optional[Any]:
 
 
 def request_project_deletion(project_id: str, user_id: str) -> Any:
-    project = get_generated_project(project_id, include_deleted=True)
+    try:
+        resolved = resolve_project_for_read(project_id, user_id, include_deleted=True)
+    except LookupError as exc:
+        identity = get_project_identity(project_id)
+        if not identity or _attr(identity, "owner_user_id") != user_id:
+            raise LookupError("Project not found.") from exc
+        resolved = None
+        project = identity
+    else:
+        project = resolved.project
     if not project or _attr(project, "owner_user_id") != user_id:
         raise LookupError("Project not found.")
     if _attr(project, "status") != "active":
@@ -289,7 +301,16 @@ def request_project_deletion(project_id: str, user_id: str) -> Any:
 
 
 def restore_project(project_id: str, user_id: str) -> Any:
-    project = get_generated_project(project_id, include_deleted=True)
+    try:
+        resolved = resolve_project_for_read(project_id, user_id, include_deleted=True)
+    except LookupError as exc:
+        identity = get_project_identity(project_id)
+        if not identity or _attr(identity, "owner_user_id") != user_id:
+            raise LookupError("Project not found.") from exc
+        resolved = None
+        project = identity
+    else:
+        project = resolved.project
     if not project or _attr(project, "owner_user_id") != user_id:
         raise LookupError("Project not found.")
     status = _attr(project, "status")
@@ -323,6 +344,29 @@ def restore_project(project_id: str, user_id: str) -> Any:
     )
     if not restored:
         raise RuntimeError("Project could not be restored because its deletion state changed.")
+    if resolved is not None and resolved.source == "canonical" and resolved.revision is not None and resolved.design_brief is not None:
+        try:
+            publish_project_revision(
+                resolved.revision,
+                resolved.design_brief,
+                user_id,
+                visibility=resolved.visibility,
+            )
+        except Exception as exc:
+            logger.exception("Project projection rebuild failed for project_id=%s", project_id)
+            update_project_deletion_state(
+                project_id,
+                owner_user_id=user_id,
+                allowed_statuses=["active"],
+                updates={
+                    "status": "deletion_pending",
+                    "deleted_at": _attr(project, "deleted_at"),
+                    "deletion_requested_by": user_id,
+                    "purge_after": _attr(project, "purge_after"),
+                    "deletion_error": type(exc).__name__,
+                },
+            )
+            raise RuntimeError("Project could not rebuild its gallery projection.") from exc
     consent = get_project_contribution_consent(project_id, user_id)
     if consent:
         purge_project_contribution_snapshots(str(_attr(consent, "id")), iso_timestamp())
@@ -331,11 +375,17 @@ def restore_project(project_id: str, user_id: str) -> Any:
 
 
 def purge_project(project_id: str) -> Dict[str, Any]:
-    project = get_generated_project(project_id, include_deleted=True)
+    identity = get_project_identity(project_id)
+    lifecycle_owner = _attr(identity, "owner_user_id") if identity else None
+    try:
+        resolved = resolve_project_for_read(project_id, lifecycle_owner, include_deleted=True)
+    except LookupError:
+        resolved = None
+    project = resolved.project if resolved is not None else (identity or get_generated_project(project_id, include_deleted=True))
     if not project:
         return {"project_id": project_id, "status": "purged", "already_absent": True}
-    owner_user_id = _attr(project, "owner_user_id")
-    status = _attr(project, "status")
+    owner_user_id = _attr(project, "owner_user_id") or (resolved.owner_user_id if resolved else None)
+    status = _attr(project, "status") or (resolved.status if resolved else None)
     if status not in {"deletion_pending", "deletion_failed", "purging"}:
         raise RuntimeError("Project is not scheduled for deletion.")
 

--- a/forma_core/database.py
+++ b/forma_core/database.py
@@ -562,7 +562,13 @@ def persist_chat_project_revision(
     return revision
 
 
-def publish_project_revision(revision: ProjectRevision, brief: DesignBrief, owner_user_id: str) -> str:
+def publish_project_revision(
+    revision: ProjectRevision,
+    brief: DesignBrief,
+    owner_user_id: str,
+    *,
+    visibility: str = "public",
+) -> str:
     """Project canonical state into the public gallery's generated-project store."""
 
     project_id = _canonical_project_id(str(revision.project_id))
@@ -603,7 +609,7 @@ def publish_project_revision(revision: ProjectRevision, brief: DesignBrief, owne
         created_at=revision.created_at.isoformat().replace("+00:00", "Z"),
         chat_id=brief.conversation_id,
         owner_user_id=normalized_owner_user_id,
-        visibility="public",
+        visibility=visibility,
         # Context gathering already owns the chat and its messages. Publishing
         # the gallery projection must not replace that thread with an empty one.
         create_chat_record=False,
@@ -642,6 +648,10 @@ def list_generated_projects_page(
 
 def get_generated_project(project_id: str, *, include_deleted: bool = False) -> Optional[Any]:
     return _DATABASE_REPOSITORY.get_generated_project(project_id, include_deleted=include_deleted)
+
+
+def get_project_identity(project_id: str) -> Optional[Any]:
+    return _DATABASE_REPOSITORY.get_project_identity(_canonical_project_id(project_id))
 
 
 def resolve_project_for_read(

--- a/forma_core/persistence/migrations.py
+++ b/forma_core/persistence/migrations.py
@@ -53,6 +53,20 @@ def migrate_sqlite_schema(engine: Engine, *, import_legacy_jobs: bool = True) ->
         }
         if cli_columns and "creation_channel" not in cli_columns:
             connection.execute(text("ALTER TABLE cli_projects ADD COLUMN creation_channel VARCHAR NOT NULL DEFAULT 'cli'"))
+        identity_columns = {
+            row[1]
+            for row in connection.exec_driver_sql("PRAGMA table_info(projects)").fetchall()
+        }
+        for column, column_type in (
+            ("deleted_at", "VARCHAR"),
+            ("deletion_requested_by", "VARCHAR"),
+            ("purge_after", "VARCHAR"),
+            ("purge_started_at", "VARCHAR"),
+            ("purge_completed_at", "VARCHAR"),
+            ("deletion_error", "TEXT"),
+        ):
+            if column not in identity_columns:
+                connection.execute(text(f"ALTER TABLE projects ADD COLUMN {column} {column_type}"))
         connection.execute(text("""
             INSERT OR IGNORE INTO projects (
                 project_id, owner_user_id, creation_channel, title, prompt, chat_id, workspace_id,
@@ -83,6 +97,9 @@ def migrate_sqlite_schema(engine: Engine, *, import_legacy_jobs: bool = True) ->
         )
         connection.execute(
             text("CREATE INDEX IF NOT EXISTS ix_generated_projects_purge_after ON generated_projects (purge_after)")
+        )
+        connection.execute(
+            text("CREATE INDEX IF NOT EXISTS ix_projects_purge_after ON projects (purge_after)")
         )
         connection.execute(
             text("CREATE INDEX IF NOT EXISTS ix_projects_gallery_status_visibility_updated "

--- a/forma_core/persistence/models.py
+++ b/forma_core/persistence/models.py
@@ -37,6 +37,12 @@ class DBProject(Base):
     status = Column(String, index=True, nullable=False, default="active")
     created_at = Column(String, nullable=False)
     updated_at = Column(String, index=True, nullable=False)
+    deleted_at = Column(String, nullable=True)
+    deletion_requested_by = Column(String, nullable=True)
+    purge_after = Column(String, index=True, nullable=True)
+    purge_started_at = Column(String, nullable=True)
+    purge_completed_at = Column(String, nullable=True)
+    deletion_error = Column(Text, nullable=True)
 
 
 class DBGeneratedProject(Base):

--- a/forma_core/persistence/repositories/sqlite.py
+++ b/forma_core/persistence/repositories/sqlite.py
@@ -805,17 +805,34 @@ class SqlAlchemyRepository:
 
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]:
         with self._session() as session:
-            return (
+            canonical = (
+                session.query(DBProject)
+                .filter(
+                    DBProject.status.in_(("deletion_pending", "deletion_failed", "purging")),
+                    DBProject.purge_after.isnot(None),
+                    DBProject.purge_after <= before,
+                )
+                .order_by(DBProject.purge_after.asc())
+                .limit(limit)
+                .all()
+            )
+            canonical_ids = {str(project.project_id) for project in canonical}
+            remaining = max(0, limit - len(canonical))
+            legacy = (
                 session.query(DBGeneratedProject)
                 .filter(
+                    DBGeneratedProject.project_id.notin_(canonical_ids or ["__none__"]),
                     DBGeneratedProject.status.in_(("deletion_pending", "deletion_failed", "purging")),
                     DBGeneratedProject.purge_after.isnot(None),
                     DBGeneratedProject.purge_after <= before,
                 )
                 .order_by(DBGeneratedProject.purge_after.asc())
-                .limit(limit)
+                .limit(remaining)
                 .all()
+                if remaining
+                else []
             )
+            return [*canonical, *legacy]
 
     def update_project_deletion_state(
         self,
@@ -826,6 +843,30 @@ class SqlAlchemyRepository:
         expected_purge_started_at: Optional[str] = None,
     ) -> Optional[Any]:
         with self._session() as session, session.begin():
+            identity_query = session.query(DBProject).filter(
+                DBProject.project_id == project_id,
+                DBProject.status.in_(allowed_statuses),
+            )
+            if owner_user_id:
+                identity_query = identity_query.filter(DBProject.owner_user_id == owner_user_id)
+            if expected_purge_started_at is not None:
+                identity_query = identity_query.filter(DBProject.purge_started_at == expected_purge_started_at)
+            identity = identity_query.first()
+            if identity is not None:
+                for key, value in updates.items():
+                    setattr(identity, key, value)
+                projection = session.query(DBGeneratedProject).filter(
+                    DBGeneratedProject.project_id == project_id,
+                ).first()
+                if projection is not None:
+                    for key, value in updates.items():
+                        if hasattr(projection, key):
+                            setattr(projection, key, value)
+                session.flush()
+                session.refresh(identity)
+                session.expunge(identity)
+                return identity
+
             query = session.query(DBGeneratedProject).filter(
                 DBGeneratedProject.project_id == project_id,
                 DBGeneratedProject.status.in_(allowed_statuses),
@@ -846,14 +887,24 @@ class SqlAlchemyRepository:
 
     def hard_purge_project(self, project_id: str, owner_user_id: Optional[str]) -> bool:
         with self._session() as session, session.begin():
-            query = session.query(DBGeneratedProject).filter(DBGeneratedProject.project_id == project_id)
-            if owner_user_id:
-                query = query.filter(DBGeneratedProject.owner_user_id == owner_user_id)
-            project = query.first()
-            if not project:
+            identity = session.query(DBProject).filter(DBProject.project_id == project_id).first()
+            if identity is not None and owner_user_id and identity.owner_user_id != owner_user_id:
                 return False
-            chat_id = project.chat_id
-            project_owner_user_id = project.owner_user_id
+            project = session.query(DBGeneratedProject).filter(DBGeneratedProject.project_id == project_id).first()
+            cli_project = session.query(DBCliProject).filter(DBCliProject.project_id == project_id).first()
+            if identity is None and project is None and cli_project is None:
+                return False
+            if owner_user_id:
+                if project is not None and project.owner_user_id not in (None, owner_user_id):
+                    return False
+                if cli_project is not None and cli_project.owner_user_id != owner_user_id:
+                    return False
+            chat_id = getattr(project, "chat_id", None) or getattr(identity, "chat_id", None)
+            project_owner_user_id = (
+                getattr(identity, "owner_user_id", None)
+                or getattr(project, "owner_user_id", None)
+                or getattr(cli_project, "owner_user_id", None)
+            )
             session.query(DBProjectValidationReport).filter(
                 DBProjectValidationReport.project_id == project_id
             ).delete(synchronize_session=False)
@@ -884,7 +935,18 @@ class SqlAlchemyRepository:
                     DBProjectRemix.source_project_id == project_id,
                 )
             ).delete(synchronize_session=False)
-            session.delete(project)
+            session.query(DBGeneratedProject).filter(DBGeneratedProject.project_id == project_id).delete(
+                synchronize_session=False
+            )
+            session.query(DBCliProjectRevision).filter(DBCliProjectRevision.project_id == project_id).delete(
+                synchronize_session=False
+            )
+            session.query(DBCliProject).filter(DBCliProject.project_id == project_id).delete(
+                synchronize_session=False
+            )
+            session.query(DBProject).filter(DBProject.project_id == project_id).delete(
+                synchronize_session=False
+            )
             session.flush()
             if chat_id and project_owner_user_id:
                 remaining = session.query(DBGeneratedProject).filter(
@@ -1174,12 +1236,18 @@ class SqlAlchemyRepository:
                 DBGeneratedProject.owner_user_id == owner_user_id,
                 DBGeneratedProject.chat_id.isnot(None),
             ).all()
-            by_chat: Dict[str, List[Any]] = {}
+            canonical_projects = session.query(DBProject).filter(
+                DBProject.owner_user_id == owner_user_id,
+                DBProject.chat_id.isnot(None),
+            ).all()
+            by_chat: Dict[str, Dict[str, Any]] = {}
             for project in projects:
-                by_chat.setdefault(str(project.chat_id), []).append(project)
+                by_chat.setdefault(str(project.chat_id), {})[str(project.project_id)] = project
+            for project in canonical_projects:
+                by_chat.setdefault(str(project.chat_id), {})[str(project.project_id)] = project
             visible = []
             for chat in chats:
-                linked = by_chat.get(chat.chat_id, [])
+                linked = list(by_chat.get(chat.chat_id, {}).values())
                 if linked and not any(project.status == "active" for project in linked):
                     continue
                 hidden_ids = {project.project_id for project in linked if project.status != "active"}
@@ -1205,6 +1273,13 @@ class SqlAlchemyRepository:
                 DBGeneratedProject.chat_id == chat_id,
                 DBGeneratedProject.owner_user_id == owner_user_id,
             ).all()
+            canonical = session.query(DBProject).filter(
+                DBProject.chat_id == chat_id,
+                DBProject.owner_user_id == owner_user_id,
+            ).all()
+            linked_by_id = {str(project.project_id): project for project in linked}
+            linked_by_id.update({str(project.project_id): project for project in canonical})
+            linked = list(linked_by_id.values())
             if linked and not any(project.status == "active" for project in linked):
                 return None
             hidden_ids = {project.project_id for project in linked if project.status != "active"}
@@ -1229,6 +1304,10 @@ class SqlAlchemyRepository:
             session.query(DBGeneratedProject).filter(
                 DBGeneratedProject.chat_id == chat_id,
                 DBGeneratedProject.owner_user_id == owner_user_id,
+            ).update({"chat_id": None})
+            session.query(DBProject).filter(
+                DBProject.chat_id == chat_id,
+                DBProject.owner_user_id == owner_user_id,
             ).update({"chat_id": None})
             return True
 

--- a/forma_core/persistence/repositories/supabase.py
+++ b/forma_core/persistence/repositories/supabase.py
@@ -695,7 +695,23 @@ class SupabaseRepository:
         return _record(payload) if isinstance(payload, dict) else None
 
     def list_due_project_purges(self, before: str, limit: int) -> List[Any]:
-        rows = (
+        canonical_rows = (
+            self._client.table("projects")
+            .select("*")
+            .in_("status", ["deletion_pending", "deletion_failed", "purging"])
+            .lte("purge_after", before)
+            .order("purge_after")
+            .limit(limit)
+            .execute()
+            .data
+            or []
+        )
+        canonical = [_record(row) for row in canonical_rows]
+        remaining = max(0, limit - len(canonical))
+        if not remaining:
+            return canonical
+        canonical_ids = {str(project.project_id) for project in canonical}
+        legacy_rows = (
             self._client.table("generated_projects")
             .select("*")
             .in_("status", ["deletion_pending", "deletion_failed", "purging"])
@@ -706,7 +722,7 @@ class SupabaseRepository:
             .data
             or []
         )
-        return [_record(row) for row in rows]
+        return [*canonical, *[_record(row) for row in legacy_rows if str(row.get("project_id")) not in canonical_ids][:remaining]]
 
     def update_project_deletion_state(
         self,
@@ -716,6 +732,36 @@ class SupabaseRepository:
         updates: Dict[str, Any],
         expected_purge_started_at: Optional[str] = None,
     ) -> Optional[Any]:
+        identity = self.get_project_identity(project_id)
+        if identity is not None:
+            identity_owner = getattr(identity, "owner_user_id", None) if not isinstance(identity, dict) else identity.get("owner_user_id")
+            identity_status = getattr(identity, "status", "active") if not isinstance(identity, dict) else identity.get("status", "active")
+            identity_purge_started_at = getattr(identity, "purge_started_at", None) if not isinstance(identity, dict) else identity.get("purge_started_at")
+            if owner_user_id and identity_owner != owner_user_id:
+                return None
+            if identity_status not in allowed_statuses:
+                return None
+            if expected_purge_started_at is not None and identity_purge_started_at != expected_purge_started_at:
+                return None
+            updated_identity = (
+                self._client.table("projects")
+                .update(updates)
+                .eq("project_id", project_id)
+                .in_("status", allowed_statuses)
+            )
+            if owner_user_id:
+                updated_identity = updated_identity.eq("owner_user_id", owner_user_id)
+            if expected_purge_started_at is not None:
+                updated_identity = updated_identity.eq("purge_started_at", expected_purge_started_at)
+            rows = updated_identity.execute().data or []
+            if not rows:
+                return None
+            projection_query = self._client.table("generated_projects").update(updates).eq("project_id", project_id)
+            if owner_user_id:
+                projection_query = projection_query.eq("owner_user_id", owner_user_id)
+            projection_query.execute()
+            return _record(rows[0])
+
         query = (
             self._client.table("generated_projects")
             .update(updates)
@@ -730,31 +776,50 @@ class SupabaseRepository:
         return _record(rows[0]) if rows else None
 
     def hard_purge_project(self, project_id: str, owner_user_id: Optional[str]) -> bool:
+        identity = self.get_project_identity(project_id)
         project = self.get_generated_project(project_id, include_deleted=True)
-        if not project or (owner_user_id and project.owner_user_id != owner_user_id):
+        cli_project = self.get_cli_project(project_id, owner_user_id) if owner_user_id else None
+        identity_owner = getattr(identity, "owner_user_id", None) if identity is not None else None
+        if owner_user_id and identity_owner and identity_owner != owner_user_id:
+            return False
+        if owner_user_id and project and project.owner_user_id not in (None, owner_user_id):
+            return False
+        if not identity and not project and not cli_project:
             return False
         query = self._client.table("generated_projects").delete().eq("project_id", project_id)
         if owner_user_id:
             query = query.eq("owner_user_id", owner_user_id)
-        deleted = bool(query.execute().data)
-        if deleted:
-            self._client.table("project_validation_reports").delete().eq("project_id", project_id).execute()
-            self._client.table("project_revisions").delete().eq("project_id", project_id).execute()
-            self._client.table("worker_execution_plans").delete().eq("project_id", project_id).execute()
-            self._client.table("project_builds").delete().eq("project_id", project_id).execute()
-            self._client.table("design_briefs").delete().eq("project_id", project_id).execute()
-            self._client.table("project_workflow_transitions").delete().eq("project_id", project_id).execute()
-            self._client.table("project_workflows").delete().eq("project_id", project_id).execute()
-            self._client.table("project_saves").delete().eq("project_id", project_id).execute()
+        deleted = bool(query.execute().data) if project else False
+        if cli_project:
+            self._client.table("cli_project_revisions").delete().eq("project_id", project_id).execute()
+            self._client.table("cli_projects").delete().eq("project_id", project_id).execute()
+        if identity or deleted:
+            for table in (
+                "project_validation_reports",
+                "project_revisions",
+                "worker_execution_plans",
+                "project_builds",
+                "design_briefs",
+                "project_workflow_transitions",
+                "project_workflows",
+                "project_saves",
+            ):
+                self._client.table(table).delete().eq("project_id", project_id).execute()
             self._client.table("project_remixes").delete().eq("remix_project_id", project_id).execute()
             self._client.table("project_remixes").delete().eq("source_project_id", project_id).execute()
-        if not deleted or not getattr(project, "chat_id", None) or not getattr(project, "owner_user_id", None):
-            return deleted
+            identity_query = self._client.table("projects").delete().eq("project_id", project_id)
+            if owner_user_id:
+                identity_query = identity_query.eq("owner_user_id", owner_user_id)
+            identity_query.execute()
+        chat_id = getattr(project, "chat_id", None) or (getattr(identity, "chat_id", None) if identity else None)
+        project_owner = getattr(project, "owner_user_id", None) or identity_owner
+        if not chat_id or not project_owner:
+            return bool(identity or deleted or cli_project)
         remaining = (
             self._client.table("generated_projects")
             .select("project_id")
-            .eq("chat_id", project.chat_id)
-            .eq("owner_user_id", project.owner_user_id)
+            .eq("chat_id", chat_id)
+            .eq("owner_user_id", project_owner)
             .limit(1)
             .execute()
             .data
@@ -764,12 +829,12 @@ class SupabaseRepository:
             (
                 self._client.table("project_chats")
                 .delete()
-                .eq("chat_id", project.chat_id)
-                .eq("owner_user_id", project.owner_user_id)
+                .eq("chat_id", chat_id)
+                .eq("owner_user_id", project_owner)
                 .execute()
             )
         else:
-            chat = self.get_project_chat(project.chat_id, project.owner_user_id)
+            chat = self.get_project_chat(chat_id, project_owner)
             if chat and isinstance(getattr(chat, "messages", None), list):
                 messages = [
                     message
@@ -779,11 +844,11 @@ class SupabaseRepository:
                 (
                     self._client.table("project_chats")
                     .update({"messages": messages})
-                    .eq("chat_id", project.chat_id)
-                    .eq("owner_user_id", project.owner_user_id)
+                    .eq("chat_id", chat_id)
+                    .eq("owner_user_id", project_owner)
                     .execute()
                 )
-        return True
+        return bool(identity or deleted or cli_project)
 
     def update_generated_project_hardware_ir(
         self,
@@ -1075,13 +1140,24 @@ class SupabaseRepository:
             .data
             or []
         )
-        by_chat: Dict[str, List[Dict[str, Any]]] = {}
+        canonical_projects = (
+            self._client.table("projects")
+            .select("project_id,chat_id,status")
+            .eq("owner_user_id", owner_user_id)
+            .execute()
+            .data
+            or []
+        )
+        by_chat: Dict[str, Dict[str, Dict[str, Any]]] = {}
         for project in projects:
             if project.get("chat_id"):
-                by_chat.setdefault(str(project["chat_id"]), []).append(project)
+                by_chat.setdefault(str(project["chat_id"]), {})[str(project["project_id"])] = project
+        for project in canonical_projects:
+            if project.get("chat_id"):
+                by_chat.setdefault(str(project["chat_id"]), {})[str(project["project_id"])] = project
         visible = []
         for row in rows:
-            linked = by_chat.get(str(row.get("chat_id") or ""), [])
+            linked = list(by_chat.get(str(row.get("chat_id") or ""), {}).values())
             if linked and not any(project.get("status") == "active" for project in linked):
                 continue
             hidden_ids = {str(project["project_id"]) for project in linked if project.get("status") != "active"}
@@ -1117,6 +1193,18 @@ class SupabaseRepository:
             .data
             or []
         )
+        canonical_projects = (
+            self._client.table("projects")
+            .select("project_id,status")
+            .eq("chat_id", chat_id)
+            .eq("owner_user_id", owner_user_id)
+            .execute()
+            .data
+            or []
+        )
+        linked_by_id = {str(project["project_id"]): project for project in projects}
+        linked_by_id.update({str(project["project_id"]): project for project in canonical_projects})
+        projects = list(linked_by_id.values())
         if projects and not any(project.get("status") == "active" for project in projects):
             return None
         hidden_ids = {str(project["project_id"]) for project in projects if project.get("status") != "active"}
@@ -1140,6 +1228,13 @@ class SupabaseRepository:
         if response.data:
             (
                 self._client.table("generated_projects")
+                .update({"chat_id": None})
+                .eq("chat_id", chat_id)
+                .eq("owner_user_id", owner_user_id)
+                .execute()
+            )
+            (
+                self._client.table("projects")
                 .update({"chat_id": None})
                 .eq("chat_id", chat_id)
                 .eq("owner_user_id", owner_user_id)

--- a/forma_core/workspaces/projects/resolver.py
+++ b/forma_core/workspaces/projects/resolver.py
@@ -75,6 +75,19 @@ def _project_ir_metadata(project_ir: Any) -> dict[str, Any]:
     return deepcopy(metadata) if isinstance(metadata, dict) else {}
 
 
+def _identity_record(value: Any) -> Any:
+    """Ignore unconfigured mock repositories while accepting SQL records."""
+    if isinstance(value, dict) or type(value).__name__ == "SimpleNamespace":
+        return value
+    return None
+
+
+def _record_value(record: Any, name: str, default: Any = None) -> Any:
+    if isinstance(record, dict):
+        return record.get(name, default)
+    return getattr(record, name, default)
+
+
 def _brief(repository: ApplicationRepository, project_id: str, owner_user_id: str) -> DesignBrief:
     record = repository.get_latest_design_brief(project_id, owner_user_id)
     payload = getattr(record, "payload_json", None) if record is not None else None
@@ -102,6 +115,18 @@ class ProjectReadResolver:
         if not normalized_project_id:
             raise ProjectReadNotFoundError("Project not found.")
 
+        identity = _identity_record(self._repository.get_project_identity(normalized_project_id))
+        identity_owner = _owner(_record_value(identity, "owner_user_id"))
+        identity_status = str(_record_value(identity, "status", "active") or "active").strip().lower()
+        identity_visibility = str(_record_value(identity, "visibility", "private") or "private").strip().lower()
+        identity_channel = str(_record_value(identity, "creation_channel", "hosted") or "hosted").strip().lower()
+        if identity is not None:
+            is_owner = bool(normalized_owner and normalized_owner == identity_owner)
+            if identity_status != "active" and (not include_deleted or not is_owner):
+                raise ProjectReadNotFoundError("Project not found.")
+            if identity_status == "active" and not is_owner and identity_visibility != "public":
+                raise ProjectReadNotFoundError("Project not found.")
+
         generated = self._repository.get_generated_project(normalized_project_id, include_deleted=True)
         if generated is not None:
             return self._resolve_generated(
@@ -109,13 +134,21 @@ class ProjectReadResolver:
                 generated,
                 normalized_owner,
                 include_deleted=include_deleted,
+                identity=identity,
             )
 
-        if normalized_owner:
-            canonical = self._resolve_canonical_only(normalized_project_id, normalized_owner)
-            if canonical is not None:
-                return canonical
-            cli = self._resolve_cli(normalized_project_id, normalized_owner)
+        if normalized_owner or (identity is not None and identity_visibility == "public"):
+            revision_owner = normalized_owner or identity_owner
+            if identity_channel != "cli":
+                canonical = self._resolve_canonical_only(
+                    normalized_project_id,
+                    revision_owner,
+                    identity=identity,
+                    reader_owner_user_id=normalized_owner,
+                )
+                if canonical is not None:
+                    return canonical
+            cli = self._resolve_cli(normalized_project_id, normalized_owner or identity_owner, identity=identity)
             if cli is not None:
                 return cli
         raise ProjectReadNotFoundError("Project not found.")
@@ -127,11 +160,17 @@ class ProjectReadResolver:
         owner_user_id: Optional[str],
         *,
         include_deleted: bool,
+        identity: Any = None,
     ) -> ProjectReadResolution:
         status = str(getattr(generated, "status", "active") or "active").strip().lower()
         project_owner = _owner(getattr(generated, "owner_user_id", None))
+        if identity is not None:
+            project_owner = _owner(_record_value(identity, "owner_user_id")) or project_owner
+            status = str(_record_value(identity, "status", status) or status).strip().lower()
         is_owner = bool(owner_user_id and project_owner == owner_user_id)
         visibility = str(getattr(generated, "visibility", "public") or "public").strip().lower()
+        if identity is not None:
+            visibility = str(_record_value(identity, "visibility", visibility) or visibility).strip().lower()
 
         if status != "active":
             if not include_deleted or not is_owner:
@@ -218,7 +257,14 @@ class ProjectReadResolver:
             project=generated,
         )
 
-    def _resolve_canonical_only(self, project_id: str, owner_user_id: str) -> Optional[ProjectReadResolution]:
+    def _resolve_canonical_only(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        *,
+        identity: Any = None,
+        reader_owner_user_id: Optional[str] = None,
+    ) -> Optional[ProjectReadResolution]:
         try:
             revision = self._state.get_latest(project_id, owner_user_id)
         except (ProjectStateError, ProjectReadNotFoundError, ValueError):
@@ -232,45 +278,60 @@ class ProjectReadResolver:
         project_ir = revision.state.model_dump(mode="json")
         metadata = _project_ir_metadata(project_ir)
         overview = getattr(revision.state, "overview", None)
-        title = str(getattr(overview, "title", "") or getattr(brief, "summary", "") or "Untitled project")
+        title = str(
+            _record_value(identity, "title", "")
+            or getattr(overview, "title", "")
+            or getattr(brief, "summary", "")
+            or "Untitled project"
+        )
         prompt = str(getattr(brief, "summary", "") or getattr(overview, "description", "") or "")
-        chat_id = getattr(brief, "conversation_id", None)
+        visibility = str(_record_value(identity, "visibility", "private") or "private")
+        status = str(_record_value(identity, "status", "active") or "active")
+        project_owner = _owner(_record_value(identity, "owner_user_id")) or owner_user_id
+        chat_id = getattr(brief, "conversation_id", None) if reader_owner_user_id == project_owner else None
         project = SimpleNamespace(
             project_id=project_id,
-            owner_user_id=owner_user_id,
+            owner_user_id=project_owner,
             creation_channel="hosted",
             chat_id=chat_id,
             title=title,
             prompt=prompt,
             created_at=revision.created_at,
             updated_at=revision.created_at,
-            visibility="private",
+            visibility=visibility,
+            status=status,
+            deleted_at=_record_value(identity, "deleted_at"),
+            deletion_requested_by=_record_value(identity, "deletion_requested_by"),
+            purge_after=_record_value(identity, "purge_after"),
+            purge_started_at=_record_value(identity, "purge_started_at"),
+            purge_completed_at=_record_value(identity, "purge_completed_at"),
+            deletion_error=_record_value(identity, "deletion_error"),
             hardware_ir=project_ir,
         )
         return ProjectReadResolution(
             project_id=project_id,
             source="canonical",
             creation_channel=ProjectCreationChannel.HOSTED,
-            owner_user_id=owner_user_id,
+            owner_user_id=project_owner,
             title=title,
             prompt=prompt,
             chat_id=chat_id,
             created_at=revision.created_at,
             updated_at=revision.created_at,
-            visibility="private",
-            status="active",
+            visibility=visibility,
+            status=status,
             current_revision=revision.revision,
             revision_id=str(revision.revision_id),
             project_ir=project_ir,
             image_metadata=metadata,
-            can_chat=brief is not None,
+            can_chat=brief is not None and reader_owner_user_id == project_owner,
             legacy_fallback=False,
             project=project,
             revision=revision,
             design_brief=brief,
         )
 
-    def _resolve_cli(self, project_id: str, owner_user_id: str) -> Optional[ProjectReadResolution]:
+    def _resolve_cli(self, project_id: str, owner_user_id: str, *, identity: Any = None) -> Optional[ProjectReadResolution]:
         record = self._repository.get_cli_project_revision(project_id, owner_user_id, None)
         if record is None:
             return None
@@ -296,6 +357,13 @@ class ProjectReadResolver:
             created_at=getattr(record, "created_at", None),
             updated_at=getattr(record, "created_at", None),
             visibility="private",
+            status=str(_record_value(identity, "status", "active") or "active") if identity else "active",
+            deleted_at=_record_value(identity, "deleted_at"),
+            deletion_requested_by=_record_value(identity, "deletion_requested_by"),
+            purge_after=_record_value(identity, "purge_after"),
+            purge_started_at=_record_value(identity, "purge_started_at"),
+            purge_completed_at=_record_value(identity, "purge_completed_at"),
+            deletion_error=_record_value(identity, "deletion_error"),
             hardware_ir=project_ir,
         )
         return ProjectReadResolution(

--- a/supabase/migrations/20260903000200_canonical_project_lifecycle.sql
+++ b/supabase/migrations/20260903000200_canonical_project_lifecycle.sql
@@ -1,0 +1,20 @@
+-- Keep project lifecycle state on the canonical project identity.
+
+alter table public.projects
+  add column if not exists deleted_at text,
+  add column if not exists deletion_requested_by text,
+  add column if not exists purge_after text,
+  add column if not exists purge_started_at text,
+  add column if not exists purge_completed_at text,
+  add column if not exists deletion_error text;
+
+alter table public.projects
+  drop constraint if exists projects_status_valid;
+
+alter table public.projects
+  add constraint projects_status_valid
+  check (status in ('active', 'deletion_pending', 'purging', 'purged', 'deletion_failed'));
+
+create index if not exists idx_projects_purge_after
+  on public.projects (purge_after)
+  where purge_after is not null;

--- a/tests/projects/test_project_deletion.py
+++ b/tests/projects/test_project_deletion.py
@@ -94,6 +94,7 @@ class ProjectDeletionLifecycleTests(unittest.TestCase):
 
         self.assertEqual("deletion_pending", first.status)
         self.assertEqual(first.purge_after, second.purge_after)
+        self.assertEqual("deletion_pending", database.get_project_identity(self.project_id)["status"])
         self.assertIsNone(database.get_generated_project(self.project_id))
         self.assertEqual([], database.list_generated_projects(self.owner_id))
         self.assertIsNone(database.get_project_chat("chat-delete-test", self.owner_id))
@@ -101,6 +102,7 @@ class ProjectDeletionLifecycleTests(unittest.TestCase):
 
         restored = project_deletion.restore_project(self.project_id, self.owner_id)
         self.assertEqual("active", restored.status)
+        self.assertEqual("active", database.get_project_identity(self.project_id)["status"])
         self.assertIsNotNone(database.get_generated_project(self.project_id))
         self.assertIsNotNone(database.get_project_chat("chat-delete-test", self.owner_id))
 
@@ -141,6 +143,37 @@ class ProjectDeletionLifecycleTests(unittest.TestCase):
         with self.assertRaisesRegex(RuntimeError, "retention window"):
             project_deletion.restore_project(self.project_id, self.owner_id)
 
+    def test_canonical_identity_lifecycle_does_not_require_generated_projection(self) -> None:
+        project_id = str(uuid.uuid4())
+        database.ensure_project_identity(
+            project_id,
+            self.owner_id,
+            title="Canonical-only project",
+            prompt="Created without a legacy projection.",
+        )
+
+        with patch.object(project_deletion.JOB_STORE, "cancel_project_jobs", return_value=0):
+            deleted = project_deletion.request_project_deletion(project_id, self.owner_id)
+
+        self.assertEqual("deletion_pending", deleted.status)
+        self.assertEqual("deletion_pending", database.get_project_identity(project_id)["status"])
+        self.assertIsNone(database.get_generated_project(project_id, include_deleted=True))
+
+        restored = project_deletion.restore_project(project_id, self.owner_id)
+        self.assertEqual("active", restored["status"] if isinstance(restored, dict) else restored.status)
+
+        with (
+            patch.object(project_deletion, "delete_project_images", return_value=0),
+            patch.object(project_deletion, "delete_project_videos", return_value=0),
+            patch.object(project_deletion.JOB_STORE, "cancel_project_jobs", return_value=0),
+            patch.object(project_deletion.JOB_STORE, "delete_project_jobs", return_value=0),
+        ):
+            project_deletion.request_project_deletion(project_id, self.owner_id)
+            result = project_deletion.purge_project(project_id)
+
+        self.assertEqual("purged", result["status"])
+        self.assertIsNone(database.get_project_identity(project_id))
+
     def test_account_wide_opt_out_blocks_new_contribution_consent(self) -> None:
         database.set_user_model_training_preference(
             self.owner_id,
@@ -179,6 +212,7 @@ class ProjectDeletionLifecycleTests(unittest.TestCase):
             result = project_deletion.purge_project(self.project_id)
 
         self.assertEqual("purged", result["status"])
+        self.assertIsNone(database.get_project_identity(self.project_id))
         self.assertIsNone(database.get_generated_project(self.project_id, include_deleted=True))
         latest = database.get_latest_project_deletion_audit(self.project_id)
         self.assertEqual("purge_completed", latest.action)

--- a/tests/projects/test_project_read_resolver.py
+++ b/tests/projects/test_project_read_resolver.py
@@ -164,6 +164,33 @@ class ProjectReadResolverTests(unittest.TestCase):
             with self.assertRaises(ProjectReadNotFoundError):
                 resolver.resolve(PROJECT_ID, "owner-b", include_deleted=include_deleted)
 
+    def test_canonical_lifecycle_hides_deleted_projection_and_allows_owner_recovery_read(self) -> None:
+        project = SimpleNamespace(
+            project_id=PROJECT_ID,
+            owner_user_id="owner-a",
+            creation_channel="hosted",
+            visibility="public",
+            status="active",
+            hardware_ir=_ir().model_dump(mode="json"),
+        )
+        repository = Mock()
+        repository.get_project_identity.return_value = {
+            "project_id": PROJECT_ID,
+            "owner_user_id": "owner-a",
+            "visibility": "public",
+            "status": "deletion_pending",
+        }
+        repository.get_generated_project.return_value = project
+        resolver = ProjectReadResolver(repository)
+
+        with self.assertRaises(ProjectReadNotFoundError):
+            resolver.resolve(PROJECT_ID, "owner-a")
+
+        resolved = resolver.resolve(PROJECT_ID, "owner-a", include_deleted=True)
+
+        self.assertEqual("deletion_pending", resolved.status)
+        self.assertEqual("owner-a", resolved.owner_user_id)
+
     def test_owner_can_resolve_deleted_lifecycle_state_when_requested(self) -> None:
         project = SimpleNamespace(
             project_id=PROJECT_ID,


### PR DESCRIPTION
## Summary
- Store project deletion lifecycle state on canonical project identities.
- Synchronize generated projections and filter chats through canonical lifecycle status.
- Purge canonical hosted and CLI identities, revisions, briefs, projections, jobs, and related records.
- Restore hosted projections while preserving canonical visibility and add lifecycle regression coverage.

## Tests
- 37 focused tests passed across resolver, project access, schema drift, and lifecycle write-guard suites.
- python -m compileall -q apps/api forma_core tests/projects tests/api tests/persistence
- git diff --check

Note: Windows SQLite tests still report known temporary-file cleanup locks during teardown; lifecycle assertions complete successfully.

Closes #403