### PR TITLE
refactor: persist CLI pushes canonically

### DIFF
--- a/forma_core/database.py
+++ b/forma_core/database.py
@@ -705,6 +705,8 @@ def list_project_identities(owner_user_id: str) -> List[Dict[str, Any]]:
             "workspace_id": getattr(record, "workspace_id", None),
             "visibility": getattr(record, "visibility", "private"),
             "status": getattr(record, "status", "active"),
+            "current_revision": getattr(record, "current_revision", 0),
+            "current_revision_id": getattr(record, "current_revision_id", None),
             "created_at": getattr(record, "created_at", None),
             "updated_at": getattr(record, "updated_at", None),
         }

--- a/forma_core/persistence/migrations.py
+++ b/forma_core/persistence/migrations.py
@@ -58,6 +58,8 @@ def migrate_sqlite_schema(engine: Engine, *, import_legacy_jobs: bool = True) ->
             for row in connection.exec_driver_sql("PRAGMA table_info(projects)").fetchall()
         }
         for column, column_type in (
+            ("current_revision", "INTEGER NOT NULL DEFAULT 0"),
+            ("current_revision_id", "VARCHAR"),
             ("deleted_at", "VARCHAR"),
             ("deletion_requested_by", "VARCHAR"),
             ("purge_after", "VARCHAR"),

--- a/forma_core/persistence/models.py
+++ b/forma_core/persistence/models.py
@@ -35,6 +35,8 @@ class DBProject(Base):
     workspace_id = Column(String, nullable=True)
     visibility = Column(String, index=True, nullable=False, default="private")
     status = Column(String, index=True, nullable=False, default="active")
+    current_revision = Column(Integer, nullable=False, default=0)
+    current_revision_id = Column(String, nullable=True)
     created_at = Column(String, nullable=False)
     updated_at = Column(String, index=True, nullable=False)
     deleted_at = Column(String, nullable=True)

--- a/forma_core/persistence/repositories/sqlite.py
+++ b/forma_core/persistence/repositories/sqlite.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
@@ -31,6 +32,10 @@ from forma_core.persistence.models import (
     DBWorkerExecutionPlan,
     DBUserSettings,
 )
+from forma_core.workspaces.projects.manifest import build_canonical_revision_record
+
+
+logger = logging.getLogger(__name__)
 
 
 class SqlAlchemyRepository:
@@ -585,6 +590,11 @@ class SqlAlchemyRepository:
     ) -> Optional[Any]:
         try:
             with self._session() as session, session.begin():
+                identity = session.query(DBProject).filter(
+                    DBProject.project_id == project_record["project_id"],
+                ).first()
+                if identity is not None and identity.status != "active":
+                    return None
                 project = session.query(DBCliProject).filter(
                     DBCliProject.project_id == project_record["project_id"],
                 ).first()
@@ -599,7 +609,6 @@ class SqlAlchemyRepository:
                     or project.current_revision + 1 != revision_record["revision"]
                 ):
                     return None
-                identity = session.query(DBProject).filter(DBProject.project_id == project_record["project_id"]).first()
                 identity_record = {
                     "project_id": project_record["project_id"],
                     "owner_user_id": project_record["owner_user_id"],
@@ -610,6 +619,8 @@ class SqlAlchemyRepository:
                     "workspace_id": project_record.get("workspace_id"),
                     "visibility": "private",
                     "status": "active",
+                    "current_revision": revision_record["revision"],
+                    "current_revision_id": revision_record["revision_id"],
                     "created_at": project_record["created_at"],
                     "updated_at": revision_record["created_at"],
                 }
@@ -621,6 +632,14 @@ class SqlAlchemyRepository:
                             setattr(identity, key, value)
                 revision = DBCliProjectRevision(**revision_record)
                 session.add(revision)
+                canonical_revision = build_canonical_revision_record(project_record, revision_record)
+                if canonical_revision is not None:
+                    session.add(DBProjectRevision(**canonical_revision))
+                else:
+                    logger.info(
+                        "cli_project_canonical_revision_skipped project_id=%s reason=legacy_identifier_or_invalid_ir",
+                        project_record["project_id"],
+                    )
                 project.workspace_id = project_record["workspace_id"]
                 project.title = project_record["title"]
                 project.current_revision = revision_record["revision"]

--- a/forma_core/persistence/repositories/supabase.py
+++ b/forma_core/persistence/repositories/supabase.py
@@ -1,8 +1,13 @@
 from __future__ import annotations
 
 from collections import Counter
+import logging
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
+
+from forma_core.workspaces.projects.manifest import build_canonical_revision_record
+
+logger = logging.getLogger(__name__)
 
 
 def _record(row: Dict[str, Any]) -> SimpleNamespace:
@@ -535,17 +540,83 @@ class SupabaseRepository:
         revision_record: Dict[str, Any],
         expected_revision_id: Optional[str],
     ) -> Optional[Any]:
+        identity = self.get_project_identity(project_record["project_id"])
+        if identity is not None and getattr(identity, "status", "active") != "active":
+            logger.warning(
+                "cli_project_push_rejected_lifecycle project_id=%s status=%s",
+                project_record["project_id"],
+                getattr(identity, "status", None),
+            )
+            return None
         project = self.get_cli_project(project_record["project_id"], project_record["owner_user_id"])
+        latest = self.get_cli_project_revision(project_record["project_id"], project_record["owner_user_id"])
+        if (
+            latest is not None
+            and getattr(latest, "revision", None) == revision_record["revision"]
+            and getattr(latest, "parent_revision_id", None) == expected_revision_id
+            and getattr(latest, "manifest_json", None) == revision_record.get("manifest_json")
+        ):
+            try:
+                logger.info("cli_project_push_recovered project_id=%s revision_id=%s", project_record["project_id"], latest.revision_id)
+                self._ensure_canonical_cli_revision(
+                    project_record,
+                    {
+                        "revision_id": latest.revision_id,
+                        "revision": latest.revision,
+                        "manifest_json": latest.manifest_json,
+                        "created_at": latest.created_at,
+                    },
+                )
+                self._client.table("projects").upsert({
+                    "project_id": project_record["project_id"],
+                    "owner_user_id": project_record["owner_user_id"],
+                    "creation_channel": "cli",
+                    "title": project_record["title"],
+                    "prompt": str((revision_record.get("manifest_json") or {}).get("prompt") or ""),
+                    "workspace_id": project_record.get("workspace_id"),
+                    "visibility": "private",
+                    "status": "active",
+                    "current_revision": latest.revision,
+                    "current_revision_id": latest.revision_id,
+                    "created_at": project_record["created_at"],
+                    "updated_at": latest.created_at,
+                }, on_conflict="project_id").execute()
+                project_updates = {
+                    "workspace_id": project_record["workspace_id"],
+                    "title": project_record["title"],
+                    "current_revision": latest.revision,
+                    "current_revision_id": latest.revision_id,
+                    "updated_at": latest.created_at,
+                }
+                if project is None:
+                    self._client.table("cli_projects").insert({
+                        **project_record,
+                        **project_updates,
+                    }).execute()
+                else:
+                    self._client.table("cli_projects").update(project_updates).eq(
+                        "project_id", project_record["project_id"]
+                    ).eq("owner_user_id", project_record["owner_user_id"]).execute()
+            except Exception:
+                logger.exception("cli_project_push_recovery_failed project_id=%s revision_id=%s", project_record["project_id"], latest.revision_id)
+                return None
+            return latest
         if project is None:
             if expected_revision_id is not None:
                 return None
-            self._client.table("cli_projects").insert(project_record).execute()
+            try:
+                self._client.table("cli_projects").insert(project_record).execute()
+            except Exception:
+                logger.exception("cli_project_push_compatibility_create_failed project_id=%s", project_record["project_id"])
+                return None
         elif (
             getattr(project, "current_revision_id", None) != expected_revision_id
             or int(getattr(project, "current_revision", 0)) + 1 != revision_record["revision"]
         ):
             return None
         try:
+            rows = self._client.table("cli_project_revisions").insert(revision_record).execute().data or []
+            self._ensure_canonical_cli_revision(project_record, revision_record)
             self._client.table("projects").upsert({
                 "project_id": project_record["project_id"],
                 "owner_user_id": project_record["owner_user_id"],
@@ -555,10 +626,11 @@ class SupabaseRepository:
                 "workspace_id": project_record.get("workspace_id"),
                 "visibility": "private",
                 "status": "active",
+                "current_revision": revision_record["revision"],
+                "current_revision_id": revision_record["revision_id"],
                 "created_at": project_record["created_at"],
                 "updated_at": revision_record["created_at"],
             }, on_conflict="project_id").execute()
-            rows = self._client.table("cli_project_revisions").insert(revision_record).execute().data or []
             self._client.table("cli_projects").update({
                 "workspace_id": project_record["workspace_id"],
                 "title": project_record["title"],
@@ -569,8 +641,34 @@ class SupabaseRepository:
                 "owner_user_id", project_record["owner_user_id"]
             ).execute()
         except Exception:
+            logger.exception("cli_project_push_partial_write project_id=%s revision_id=%s", project_record["project_id"], revision_record["revision_id"])
             return None
         return _record(rows[0]) if rows else None
+
+    def _ensure_canonical_cli_revision(
+        self,
+        project_record: Dict[str, Any],
+        revision_record: Dict[str, Any],
+    ) -> None:
+        canonical = build_canonical_revision_record(project_record, revision_record)
+        if canonical is None:
+            logger.info(
+                "cli_project_canonical_revision_skipped project_id=%s reason=legacy_identifier_or_invalid_ir",
+                project_record["project_id"],
+            )
+            return
+        existing = (
+            self._client.table("project_revisions")
+            .select("id")
+            .eq("project_id", canonical["project_id"])
+            .eq("revision", canonical["revision"])
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        if not existing:
+            self._client.table("project_revisions").insert(canonical).execute()
 
     def get_cli_device_authorization(self, device_code_hash: Optional[str] = None, user_code_hash: Optional[str] = None) -> Optional[Any]:
         query = self._client.table("cli_device_authorizations").select("*")

--- a/forma_core/workspaces/projects/manifest.py
+++ b/forma_core/workspaces/projects/manifest.py
@@ -8,7 +8,7 @@ import mimetypes
 from pathlib import Path
 import re
 from typing import Any, Mapping
-from uuid import uuid4
+from uuid import NAMESPACE_URL, UUID, uuid4, uuid5
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -253,6 +253,73 @@ class ProjectManifest(BaseModel):
         return redact_project_secrets(self.model_dump(mode="json"))
 
 
+def build_canonical_revision_record(
+    project_record: Mapping[str, Any],
+    revision_record: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Build a unified revision when a CLI identifier and IR are canonicalizable."""
+    try:
+        project_id = UUID(str(project_record["project_id"]).strip())
+        revision_id = UUID(str(revision_record["revision_id"]).strip())
+    except (KeyError, TypeError, ValueError, AttributeError):
+        return None
+
+    manifest = revision_record.get("manifest_json")
+    if not isinstance(manifest, Mapping):
+        return None
+    try:
+        from forma_core.workspaces.projects.models import HardwareIR
+        from forma_core.workspaces.projects.state import ProjectRevision
+
+        state = HardwareIR.model_validate(manifest.get("project_ir") or {})
+        artifacts = []
+        for item in validate_artifact_references(manifest.get("artifacts"), require_integrity=False):
+            path = str(item["path"])
+            artifact = {
+                "artifact_id": str(item.get("sha256") or path),
+                "kind": "file",
+                "uri": path,
+                "media_type": item.get("media_type"),
+                "checksum": item.get("sha256"),
+                "metadata": {"size_bytes": item.get("size_bytes")} if item.get("size_bytes") is not None else {},
+            }
+            artifacts.append(artifact)
+        payload = {
+            "schema_version": "1.0",
+            "revision_id": str(revision_id),
+            "project_id": str(project_id),
+            "owner_user_id": str(project_record["owner_user_id"]),
+            "revision": int(revision_record["revision"]),
+            "parent_revision": max(1, int(revision_record["revision"]) - 1)
+            if int(revision_record["revision"]) > 1
+            else None,
+            "design_brief_id": str(uuid5(NAMESPACE_URL, f"forma-cli-brief:{project_id}")),
+            "design_brief_version": 1,
+            "source_job_id": f"cli:{revision_id}",
+            "created_at": revision_record["created_at"],
+            "state": state.model_dump(mode="json"),
+            "components": [item.model_dump(mode="json") for item in state.components],
+            "systems": [],
+            "artifacts": artifacts,
+            "assumptions": [],
+        }
+        ProjectRevision.model_validate(payload)
+    except (KeyError, TypeError, ValueError):
+        return None
+    return {
+        "id": str(revision_id),
+        "project_id": str(project_id),
+        "owner_user_id": str(project_record["owner_user_id"]),
+        "revision": int(revision_record["revision"]),
+        "parent_revision": payload["parent_revision"],
+        "design_brief_id": payload["design_brief_id"],
+        "design_brief_version": 1,
+        "source_job_id": payload["source_job_id"],
+        "payload_json": payload,
+        "created_at": revision_record["created_at"],
+    }
+
+
 def load_project_manifest(path: str | Path) -> ProjectManifest:
     project_path = Path(path)
     with project_path.open(encoding="utf-8") as file:
@@ -279,6 +346,7 @@ __all__ = [
     "PROJECT_MANIFEST_VERSION",
     "ProjectArtifactReference",
     "ProjectManifest",
+    "build_canonical_revision_record",
     "infer_artifact_media_type",
     "load_project_manifest",
     "normalize_artifact_media_type",

--- a/forma_core/workspaces/projects/models.py
+++ b/forma_core/workspaces/projects/models.py
@@ -680,6 +680,8 @@ class ProjectIdentityResponse(BaseModel):
     workspace_id: str | None = None
     visibility: str = "private"
     status: str = "active"
+    current_revision: int = 0
+    current_revision_id: str | None = None
     created_at: str | datetime | None = None
     updated_at: str | datetime | None = None
 

--- a/supabase/migrations/20260903000300_cli_canonical_revision_pointer.sql
+++ b/supabase/migrations/20260903000300_cli_canonical_revision_pointer.sql
@@ -1,0 +1,5 @@
+-- Keep the canonical identity's current revision pointer in sync with CLI pushes.
+
+alter table public.projects
+  add column if not exists current_revision integer not null default 0,
+  add column if not exists current_revision_id text;

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -462,6 +462,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 )
 
                 project = repository.get_cli_project("cli-summary", "user-a")
+                identity = repository.get_project_identity("cli-summary")
             finally:
                 assert provider.engine is not None
                 provider.engine.dispose()
@@ -470,6 +471,54 @@ class PersistenceArchitectureTests(unittest.TestCase):
         self.assertEqual("workspace-b", project.workspace_id)
         self.assertEqual("Updated title", project.title)
         self.assertEqual(2, project.current_revision)
+        self.assertEqual(2, identity["current_revision"])
+        self.assertEqual("cli-summary-r2", identity["current_revision_id"])
+
+    def test_uuid_cli_revision_is_also_written_to_canonical_revision_store(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            provider = create_sqlite_provider(
+                source="test primary",
+                url=f"sqlite:///{Path(directory) / 'forma.db'}",
+                import_legacy_jobs=False,
+            )
+            assert provider.session_factory is not None
+            provider.initialize()
+            repository = SqlAlchemyRepository(provider.session_factory)
+            project_id = str(uuid.uuid4())
+            revision_id = str(uuid.uuid4())
+            try:
+                saved = repository.insert_cli_project_revision(
+                    {
+                        "project_id": project_id,
+                        "workspace_id": None,
+                        "owner_user_id": "user-a",
+                        "title": "Canonical CLI project",
+                        "current_revision": 0,
+                        "current_revision_id": None,
+                        "created_at": "2026-08-31T12:00:00Z",
+                        "updated_at": "2026-08-31T12:00:00Z",
+                    },
+                    {
+                        "revision_id": revision_id,
+                        "project_id": project_id,
+                        "owner_user_id": "user-a",
+                        "revision": 1,
+                        "parent_revision_id": None,
+                        "manifest_json": {
+                            "project_id": project_id,
+                            "project_ir": {},
+                        },
+                        "created_at": "2026-08-31T12:00:00Z",
+                    },
+                    None,
+                )
+                canonical = repository.get_latest_project_revision(project_id, "user-a")
+            finally:
+                provider.engine.dispose()
+
+        self.assertIsNotNone(saved)
+        self.assertIsNotNone(canonical)
+        self.assertEqual(revision_id, str(canonical.id))
 
     def test_sqlite_repository_pages_filtered_projects_before_loading_records(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary\n- write UUID-addressable CLI pushes to the canonical projects and project_revisions stores\n- keep legacy CLI projections and non-UUID identifiers compatible\n- synchronize current revision pointers and recover partial Supabase writes\n- add SQLite/Supabase schema and persistence coverage\n\nCloses #396\n\n## Tests\n- python -m unittest tests.persistence.test_persistence.PersistenceArchitectureTests.test_cli_revision_push_updates_project_summary_metadata tests.persistence.test_persistence.PersistenceArchitectureTests.test_uuid_cli_revision_is_also_written_to_canonical_revision_store tests.persistence.test_persistence.PersistenceArchitectureTests.test_legacy_project_iteration_bootstraps_one_canonical_revision_then_appends tests.api.test_cli_project_artifacts -v\n- python -m unittest tests.projects.test_project_read_resolver tests.persistence.test_database_schema_drift -v\n- python -m compileall -q apps/api forma_core tests/api tests/projects tests/persistence\n- git diff --check