### PR TITLE
refactor: retire legacy project persistence

### DIFF
--- a/apps/api/a2a.py
+++ b/apps/api/a2a.py
@@ -30,11 +30,12 @@ from forma_core.agents.workflows import (
 from forma_core.agents.orchestrator import HardwarePipelineOrchestrator
 from forma_core.database import (
     ensure_project_action_allowed,
+    get_latest_project_revision,
+    get_project_identity,
     persist_chat_project_revision,
-    get_generated_project,
-    save_generated_project,
-    update_generated_project_metadata,
-    update_generated_project_hardware_ir,
+    persist_legacy_project_projection,
+    refresh_legacy_project_projection,
+    resolve_project_for_read,
 )
 from forma_core.images import build_image_provider, build_project_visual_spec, get_image_output_debug_config
 from apps.api.auth_mode import clerk_auth_required
@@ -863,9 +864,13 @@ def _persist_updated_project_ir(
     if not project_id:
         return
 
+    if owner_user_id:
+        # Authenticated generation is committed canonically by the caller.
+        return
+
     try:
         hardware_ir = ir.model_dump()
-        updated = update_generated_project_hardware_ir(
+        updated = refresh_legacy_project_projection(
             project_id,
             hardware_ir,
             owner_user_id=owner_user_id,
@@ -879,7 +884,7 @@ def _persist_updated_project_ir(
             or "Untitled Forma Project"
         )
         created_at = metadata.get("created_at") if isinstance(metadata.get("created_at"), str) else _utc_now()
-        save_generated_project(
+        persist_legacy_project_projection(
             project_id=project_id,
             title=title,
             prompt=(prompt_text or metadata.get("source_prompt") or "").strip(),
@@ -960,12 +965,17 @@ def build_generation_response(
             raise ValueError("Named generation-stage retry is not supported by this workflow.")
         if not project_id:
             raise ValueError("project_id is required when retry_stage is provided.")
-        existing_project = get_generated_project(project_id)
-        if existing_project is None:
+        if not owner_user_id:
+            raise ValueError("owner_user_id is required when retry_stage is provided.")
+        try:
+            existing_revision = get_latest_project_revision(project_id, owner_user_id)
+        except Exception as exc:
+            raise ValueError("The project containing the failed generation stage was not found.") from exc
+        if existing_revision is None:
             raise ValueError("The project containing the failed generation stage was not found.")
-        if owner_user_id and str(getattr(existing_project, "owner_user_id", "") or "") != str(owner_user_id):
+        if str(getattr(existing_revision, "owner_user_id", "") or "") != str(owner_user_id):
             raise ValueError("The failed generation stage is not owned by the requesting user.")
-        existing_ir = getattr(existing_project, "hardware_ir", None)
+        existing_ir = existing_revision.state
         if hasattr(existing_ir, "model_dump"):
             existing_ir = existing_ir.model_dump(mode="json")
         existing_ir = existing_ir if isinstance(existing_ir, dict) else {}
@@ -1077,6 +1087,7 @@ def build_generation_response(
                     "retry_stage_replay": retry_stage_replay,
                     "cad_required": cad_required,
                 },
+                persist_project=False,
             )
             ensure_agent_pipeline_active()
             ir.assembly_metadata = {
@@ -1213,7 +1224,13 @@ async def call_forma_action(
         data_sources = normalize_generation_data_sources(payload.get("data_sources") or [])
         past_job_context = None
         if PAST_JOBS_DATA_SOURCE in data_sources:
-            past_job_context = await PastJobContextSource(JOB_STORE, get_generated_project).retrieve(
+            def load_project_for_context(context_project_id: str) -> Any:
+                try:
+                    return resolve_project_for_read(context_project_id, owner_user_id).project
+                except Exception:
+                    return None
+
+            past_job_context = await PastJobContextSource(JOB_STORE, load_project_for_context).retrieve(
                 str(payload.get("prompt") or ""),
                 owner_user_id=owner_user_id if isinstance(owner_user_id, str) else None,
                 limit=int(payload.get("past_jobs_limit") or 3),
@@ -2260,18 +2277,19 @@ def _persist_mcp_compile(
         raise ValueError("project_id must be a UUID when supplied.") from exc
 
     owner_user_id = _context_owner_user_id(user_context)
-    existing = get_generated_project(project_id, include_deleted=True)
+    existing = get_project_identity(project_id)
     if existing is not None:
-        if getattr(existing, "status", "active") != "active":
+        if existing.get("status", "active") != "active":
             raise ValueError("A deleted compiled project cannot be restored by recompiling.")
-        existing_owner = str(getattr(existing, "owner_user_id", "") or "").strip()
+        existing_owner = str(existing.get("owner_user_id") or "").strip()
         if not owner_user_id or existing_owner != owner_user_id:
             raise ValueError("An existing compiled project can only be updated by its owner.")
-        chat_id = str(getattr(existing, "chat_id", "") or "").strip() or None
-        existing_ir = getattr(existing, "hardware_ir", {})
+        chat_id = str(existing.get("chat_id") or "").strip() or None
+        existing_revision = get_latest_project_revision(project_id, owner_user_id)
+        existing_ir = existing_revision.state.model_dump(mode="json") if existing_revision is not None else {}
         existing_metadata = existing_ir.get("assembly_metadata", {}) if isinstance(existing_ir, dict) else {}
         revision = int(existing_metadata.get("compile_revision") or 1) + 1
-        created_at = str(getattr(existing, "created_at", "") or _utc_now())
+        created_at = str(existing.get("created_at") or _utc_now())
     else:
         chat_id = str(uuid.uuid4()) if owner_user_id else None
         revision = 1
@@ -2281,7 +2299,7 @@ def _persist_mcp_compile(
     prompt = str(arguments.get("prompt") or metadata.get("source_prompt") or title).strip()
     visibility = str(
         arguments.get("visibility")
-        or (getattr(existing, "visibility", None) if existing is not None else None)
+        or (existing.get("visibility") if isinstance(existing, dict) else None)
         or "public"
     ).strip().lower()
     if visibility not in {"public", "private"}:
@@ -2301,22 +2319,29 @@ def _persist_mcp_compile(
     }
     hardware_ir = project.model_dump(mode="json")
     if existing is not None:
-        if not update_generated_project_hardware_ir(
+        if not owner_user_id:
+            raise ValueError("An authenticated owner is required to update a compiled project.")
+        persist_chat_project_revision(
             project_id,
-            hardware_ir,
-            owner_user_id=owner_user_id,
-        ):
-            raise RuntimeError("Could not update the persisted compiled project.")
-        if not update_generated_project_metadata(
-            project_id,
-            owner_user_id=owner_user_id,
-            title=title,
+            owner_user_id,
+            project,
+            source_job_id=f"compile-{uuid.uuid4().hex}",
             prompt=prompt,
+            chat_id=chat_id,
             visibility=visibility,
-        ):
-            raise RuntimeError("Could not update the compiled project metadata.")
+        )
+    elif owner_user_id:
+        persist_chat_project_revision(
+            project_id,
+            owner_user_id,
+            project,
+            source_job_id=f"compile-{uuid.uuid4().hex}",
+            prompt=prompt,
+            chat_id=chat_id,
+            visibility=visibility,
+        )
     else:
-        save_generated_project(
+        persist_legacy_project_projection(
             project_id=project_id,
             title=title,
             prompt=prompt,

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -77,12 +77,9 @@ from forma_core.database import (
     DesignBriefAccessError,
     DesignBriefNotFoundError,
     count_component_templates,
-    delete_generated_project,
     delete_project_chat,
     ensure_project_action_allowed,
-    get_cli_project_revision,
     get_database_config,
-    get_generated_project,
     get_latest_design_brief,
     get_latest_project_revision,
     get_latest_project_deletion_audit,
@@ -92,14 +89,16 @@ from forma_core.database import (
     init_db,
     list_project_chats,
     list_component_templates,
-    list_generated_projects,
     list_project_gallery_inventory,
     list_project_gallery_inventory_page,
     list_project_identities,
     list_latest_project_revisions,
+    update_project_deletion_state,
+    update_project_identity,
     list_project_deletion_audits,
     list_project_generation_jobs,
     project_engagement_for_ids,
+    refresh_legacy_project_projection,
     ensure_chat_project,
     persist_chat_project_revision,
     resolve_project_for_read,
@@ -107,8 +106,7 @@ from forma_core.database import (
     save_alpha_signup,
     save_project_for_user,
     unsave_project_for_user,
-    update_generated_project_metadata,
-    update_generated_project_hardware_ir,
+    publish_project_revision,
     upsert_project_chat,
 )
 from forma_core.project_list_cache import (
@@ -463,17 +461,27 @@ def _delete_cancelled_generation_projects(job_id: str, job: Optional[Dict[str, A
     if not owner_user_id:
         return
     deleted_chats: List[tuple[str, str]] = []
-    for project in list_generated_projects(owner_user_id=owner_user_id):
-        hardware_ir = getattr(project, "hardware_ir", None)
-        project_id = getattr(project, "project_id", None)
+    for revision in list_latest_project_revisions(owner_user_id):
+        project_id = str(revision.project_id)
+        hardware_ir = revision.state.model_dump(mode="json")
         if not isinstance(hardware_ir, dict) or not isinstance(project_id, str):
             continue
         metadata = hardware_ir.get("assembly_metadata")
         if not isinstance(metadata, dict) or metadata.get("frontend_job_id") != job_id:
             continue
-        if delete_generated_project(project_id, owner_user_id):
-            chat_id = getattr(project, "chat_id", None)
-            title = getattr(project, "title", None)
+        deleted = update_project_deletion_state(
+            project_id,
+            owner_user_id=owner_user_id,
+            allowed_statuses=["active"],
+            updates={
+                "status": "deletion_pending",
+                "deleted_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "deletion_requested_by": owner_user_id,
+            },
+        )
+        if deleted:
+            chat_id = getattr(deleted, "chat_id", None)
+            title = getattr(deleted, "title", None)
             if isinstance(chat_id, str) and isinstance(title, str):
                 deleted_chats.append((chat_id, title))
             logger.info("Removed project %s created after cancelled job %s.", project_id, job_id)
@@ -730,9 +738,10 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
     message_id = f"msg_{uuid4().hex}"
     correlation_id = new_error_correlation_id()
     if request.source_project_id:
-        source_project = get_generated_project(request.source_project_id)
-        if not source_project:
-            raise HTTPException(status_code=404, detail="Source project not found.")
+        try:
+            source_project = resolve_project_for_read(request.source_project_id, owner_user_id).project
+        except ProjectReadError as exc:
+            raise HTTPException(status_code=404, detail="Source project not found.") from exc
         _require_project_chat_owner(source_project, user)
     payload = {
         "prompt": request.prompt,
@@ -767,7 +776,13 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
     try:
         past_job_context = None
         if PAST_JOBS_DATA_SOURCE in request.data_sources:
-            past_job_context = await PastJobContextSource(JOB_STORE, get_generated_project).retrieve(
+            def load_project_for_context(project_id: str) -> Any:
+                try:
+                    return resolve_project_for_read(project_id, owner_user_id).project
+                except ProjectReadError:
+                    return None
+
+            past_job_context = await PastJobContextSource(JOB_STORE, load_project_for_context).retrieve(
                 request.prompt,
                 owner_user_id=owner_user_id,
                 limit=request.past_jobs_limit,
@@ -815,11 +830,6 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
         response = _attach_generation_timing_metadata(response, job)
         metadata = (response.get("project_ir", {}).get("assembly_metadata") or {})
         project_id = metadata.get("project_id")
-        if project_id and isinstance(response.get("project_ir"), dict):
-            try:
-                update_generated_project_hardware_ir(project_id, response["project_ir"])
-            except Exception:
-                logger.warning("Failed to persist generation timing metadata for project_id=%s", project_id, exc_info=debug_mode_enabled())
         return {
             **response,
             "project_id": project_id,
@@ -1113,6 +1123,26 @@ def _require_project_owner(project: Any, user: UserContext) -> str:
     return user_id
 
 
+def _resolve_project_owner(project_id: str, user: UserContext, *, include_deleted: bool = False) -> Any:
+    """Resolve project state through the canonical read boundary before access checks."""
+    try:
+        resolved = resolve_project_for_read(project_id, user.owner_user_id, include_deleted=include_deleted)
+    except ProjectReadError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found.") from exc
+    _require_project_owner(resolved.project, user)
+    return resolved.project
+
+
+def _resolve_project_reader(project_id: str, user: UserContext, *, include_deleted: bool = False) -> Any:
+    """Resolve one project through the canonical boundary for read access."""
+    try:
+        resolved = resolve_project_for_read(project_id, user.owner_user_id, include_deleted=include_deleted)
+    except ProjectReadError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Project not found.") from exc
+    _require_project_reader(resolved.project, user)
+    return resolved.project
+
+
 def _require_project_chat_owner(project: Any, user: UserContext) -> str:
     user_id = _require_authenticated_user(user)
     owner_user_id = _project_owner_user_id(project)
@@ -1217,10 +1247,7 @@ def list_video_models_endpoint():
 def list_project_videos_endpoint(project_id: str, user: UserContext = Depends(require_user_context)):
     """Lists videos saved for one project from configured backend storage."""
     project_id = _require_non_empty(project_id, "projectId is required.")
-    project = get_generated_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found.")
-    _require_project_owner(project, user)
+    project = _resolve_project_owner(project_id, user)
     try:
         videos = list_project_videos(project_id)
         return {
@@ -1237,10 +1264,7 @@ def create_image_to_video_endpoint(request: VideoImageToVideoRequest, user: User
     """Queues a backend-only GMI Cloud image-to-video generation request."""
     require_hosted_chat_enabled()
     project_id = _require_non_empty(request.projectId, "projectId is required.")
-    project = get_generated_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found.")
-    _require_project_owner(project, user)
+    project = _resolve_project_owner(project_id, user)
     image = _require_non_empty(request.image, "image is required.")
     prompt = _require_non_empty(request.prompt, "prompt is required.")
     model = _normalize_video_model(request.model, VIDEO_MODE_IMAGE_TO_VIDEO)
@@ -1297,10 +1321,7 @@ def create_video_to_video_endpoint(request: VideoToVideoRequest, user: UserConte
     """Queues a backend-only GMI Cloud video-to-video generation request."""
     require_hosted_chat_enabled()
     project_id = _require_non_empty(request.projectId, "projectId is required.")
-    project = get_generated_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found.")
-    _require_project_owner(project, user)
+    project = _resolve_project_owner(project_id, user)
     video = _require_non_empty(request.video, "video is required.")
     prompt = _require_non_empty(request.prompt, "prompt is required.")
     model = _normalize_video_model(request.model, VIDEO_MODE_VIDEO_TO_VIDEO)
@@ -1366,10 +1387,7 @@ def get_image_to_video_status_endpoint(
     """Polls GMI Cloud for a project-scoped video request and stores completed videos in S3."""
     request_id = _require_non_empty(request_id, "requestId is required.")
     project_id = _require_non_empty(projectId, "projectId is required.")
-    project = get_generated_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found.")
-    _require_project_owner(project, user)
+    project = _resolve_project_owner(project_id, user)
     normalized_mode = normalize_video_mode(mode)
     model = _normalize_video_model(model, normalized_mode)
     aspect_ratio = _normalize_video_request_aspect_ratio(aspectRatio) if aspectRatio else None
@@ -1982,8 +2000,6 @@ def _gallery_inventory_summary(record: Any, *, current_user_id: Optional[str]) -
         elif hasattr(record, "hardware_ir"):
             legacy_project = record
         if legacy_project is None:
-            legacy_project = get_generated_project(project_id, include_deleted=False)
-        if legacy_project is None:
             return None
         project = types.SimpleNamespace(
             project_id=project_id,
@@ -2188,30 +2204,32 @@ def _without_downloadable_project_assets(hardware_ir: Dict[str, Any]) -> Dict[st
 
 
 def _cli_project_response(project_id: str, owner_user_id: str) -> Optional[ProjectDetail]:
-    """Adapt an authenticated CLI revision to the web project's response shape."""
-    revision = get_cli_project_revision(project_id, owner_user_id)
-    if revision is None:
+    """Adapt an authenticated CLI resolution to the web project's response shape."""
+    try:
+        resolved = resolve_project_for_read(project_id, owner_user_id)
+    except ProjectReadError:
+        return None
+    if resolved.source != "cli":
         return None
 
-    manifest = ProjectManifest.from_document(revision.get("manifest") or {})
-    project_ir = json.loads(json.dumps(manifest.project_ir))
+    project_ir = json.loads(json.dumps(resolved.project_ir))
     metadata = project_ir.get("assembly_metadata")
     metadata = dict(metadata) if isinstance(metadata, dict) else {}
     metadata.update(
         {
-            "project_id": str(revision["project_id"]),
+            "project_id": str(resolved.project_id),
             "chat_id": None,
             "can_chat": False,
-            "project_revision": revision.get("revision"),
-            "cloud_revision_id": revision.get("revision_id"),
-            "source_prompt": manifest.prompt,
+            "project_revision": resolved.current_revision,
+            "cloud_revision_id": resolved.revision_id,
+            "source_prompt": resolved.prompt,
             "project_source": "cli",
         }
     )
     project_ir["assembly_metadata"] = metadata
     overview = project_ir.get("overview") if isinstance(project_ir.get("overview"), dict) else {}
     components = project_ir.get("components") if isinstance(project_ir.get("components"), list) else []
-    title = str(manifest.title or overview.get("title") or "Untitled project")
+    title = str(resolved.title or overview.get("title") or "Untitled project")
     product_image_url = metadata.get("product_image_url") or metadata.get("product_case_image_url")
     product_image_data = metadata.get("product_image_data")
 
@@ -2229,11 +2247,11 @@ def _cli_project_response(project_id: str, owner_user_id: str) -> Optional[Proje
         pass
 
     return ProjectDetail(
-        project_id=str(revision["project_id"]),
+        project_id=str(resolved.project_id),
         creation_channel="cli",
         title=title,
-        prompt=manifest.prompt,
-        created_at=revision.get("created_at"),
+        prompt=resolved.prompt,
+        created_at=resolved.created_at,
         visibility="private",
         creator_display=creator_display_name(owner_user_id),
         creator_username=creator_display_name(owner_user_id),
@@ -2351,6 +2369,7 @@ def list_my_projects_endpoint(
         identities = _list_project_identities(owner_user_id)
         if identities:
             response: List[Dict[str, Any]] = []
+            fallback_projects: Optional[dict[str, Any]] = None
             for identity in identities:
                 project_id = str(identity.project_id)
                 if identity.creation_channel == "cli":
@@ -2358,20 +2377,23 @@ def list_my_projects_endpoint(
                     if project is not None:
                         response.append(project.model_dump(mode="json"))
                     continue
-                project = get_generated_project(project_id)
-                if project is not None:
-                    response.append(
-                        _project_summary_response(
-                            project,
-                            current_user_id=owner_user_id,
-                            include_inline_images=False,
-                        ).model_dump(mode="json")
-                    )
-                    continue
                 try:
                     revision = get_latest_project_revision(project_id, owner_user_id)
                     brief = get_latest_design_brief(project_id, owner_user_id)
                 except (ProjectStateError, DesignBriefNotFoundError):
+                    if fallback_projects is None:
+                        fallback_rows, _ = list_project_gallery_inventory_page(
+                            owner_user_id=owner_user_id,
+                            visibility=None,
+                            limit=50,
+                            offset=0,
+                        )
+                        fallback_projects = {str(row.project_id): row for row in fallback_rows}
+                    fallback = fallback_projects.get(project_id)
+                    if fallback is not None:
+                        summary = _gallery_inventory_summary(fallback, current_user_id=owner_user_id)
+                        if summary is not None:
+                            response.append(summary.model_dump(mode="json"))
                     continue
                 response.append(_canonical_project_summary_response(
                     revision,
@@ -2383,39 +2405,18 @@ def list_my_projects_endpoint(
         cached, generation = get_cached_project_list("mine", owner_user_id)
         if cached is not None:
             return _with_project_engagement(cached, owner_user_id)
-        projects = list_generated_projects(owner_user_id=owner_user_id)
-        response = [
-            _project_summary_response(
-                project,
-                current_user_id=owner_user_id,
-                include_inline_images=False,
-            ).model_dump(mode="json")
-            for project in projects
-        ]
-        legacy_project_ids = {str(project.project_id) for project in projects}
-        for revision in list_latest_project_revisions(owner_user_id):
-            project_id = str(revision.project_id)
-            if project_id in legacy_project_ids:
-                continue
-            legacy_record = get_generated_project(project_id, include_deleted=True)
-            if legacy_record is not None:
-                continue
-            try:
-                brief = get_latest_design_brief(project_id, owner_user_id)
-            except DesignBriefNotFoundError:
-                logger.warning(
-                    "Skipping canonical project without a design brief in owner listing: project_id=%s",
-                    project_id,
-                )
-                continue
-            response.append(
-                _canonical_project_summary_response(
-                    revision,
-                    brief,
-                    owner_user_id=owner_user_id,
-                    hydrate_storage=False,
-                ).model_dump(mode="json")
-            )
+        projects, total = list_project_gallery_inventory_page(
+            owner_user_id=owner_user_id,
+            visibility=None,
+            limit=50,
+            offset=0,
+        )
+        response = []
+        for project in projects:
+            summary = _gallery_inventory_summary(project, current_user_id=owner_user_id)
+            if summary is not None:
+                response.append(summary.model_dump(mode="json"))
+        response = _with_project_engagement(response, owner_user_id)
         response.sort(key=lambda item: str(item.get("created_at") or ""), reverse=True)
         response = jsonable_encoder(response)
         cache_project_list("mine", owner_user_id, response, generation)
@@ -2583,11 +2584,9 @@ def update_project_endpoint(
 ):
     """Updates owner-managed project metadata, including public/private visibility."""
     require_hosted_chat_enabled()
-    project = get_generated_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found.")
-    owner_user_id = _require_project_owner(project, user)
-    saved = update_generated_project_metadata(
+    project = _resolve_project_owner(project_id, user)
+    owner_user_id = user.owner_user_id
+    saved = update_project_identity(
         project.project_id,
         owner_user_id=owner_user_id,
         title=request.title,
@@ -2602,10 +2601,7 @@ def update_project_endpoint(
 @app.post("/projects/{project_id}/save")
 def save_project_endpoint(project_id: str, user: UserContext = Depends(require_user_context)):
     """Save a readable project for the signed-in user."""
-    project = get_generated_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found.")
-    _require_project_reader(project, user)
+    project = _resolve_project_reader(project_id, user)
     owner_user_id = _require_authenticated_user(user)
     try:
         return {"ok": True, "project_id": project.project_id, **save_project_for_user(project.project_id, owner_user_id)}
@@ -2616,10 +2612,7 @@ def save_project_endpoint(project_id: str, user: UserContext = Depends(require_u
 @app.delete("/projects/{project_id}/save")
 def unsave_project_endpoint(project_id: str, user: UserContext = Depends(require_user_context)):
     """Remove a previously saved project for the signed-in user."""
-    project = get_generated_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found.")
-    _require_project_reader(project, user)
+    project = _resolve_project_reader(project_id, user)
     owner_user_id = _require_authenticated_user(user)
     try:
         return {"ok": True, "project_id": project.project_id, **unsave_project_for_user(project.project_id, owner_user_id)}
@@ -2631,10 +2624,7 @@ def unsave_project_endpoint(project_id: str, user: UserContext = Depends(require
 def remix_project_endpoint(project_id: str, user: UserContext = Depends(require_user_context)):
     """Copy a readable project into a new owned project the signed-in user can edit."""
     require_hosted_chat_enabled()
-    project = get_generated_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found.")
-    _require_project_reader(project, user)
+    project = _resolve_project_reader(project_id, user)
     owner_user_id = _require_authenticated_user(user)
     try:
         remixed = remix_generated_project(project.project_id, owner_user_id)
@@ -2725,12 +2715,11 @@ def get_project_contribution_consent_endpoint(
 ):
     owner_user_id = _require_authenticated_user(user)
     try:
-        project = get_generated_project(project_id, include_deleted=True)
+        project = _resolve_project_owner(project_id, user, include_deleted=True)
+    except HTTPException:
+        raise
     except ValueError:
-        project = None
-    if not project:
         raise HTTPException(status_code=404, detail="Project not found.")
-    _require_project_owner(project, user)
     consent = get_project_contribution_consent(project_id, owner_user_id)
     return {
         "project_id": project_id,
@@ -2779,12 +2768,11 @@ def withdraw_project_contribution_consent_endpoint(
 ):
     owner_user_id = _require_authenticated_user(user)
     try:
-        project = get_generated_project(project_id, include_deleted=True)
+        project = _resolve_project_owner(project_id, user, include_deleted=True)
+    except HTTPException:
+        raise
     except ValueError:
-        project = None
-    if not project:
         raise HTTPException(status_code=404, detail="Project not found.")
-    _require_project_owner(project, user)
     withdrawn = withdraw_contribution(project_id, owner_user_id)
     return {"ok": True, "project_id": project_id, "granted": False, "withdrawn": bool(withdrawn)}
 
@@ -2880,10 +2868,7 @@ def delete_chat_endpoint(chat_id: str, user: UserContext = Depends(require_user_
 def generate_project_video_prompt_endpoint(project_id: str, user: UserContext = Depends(optional_user_context)):
     """Builds an image-to-video prompt from Forma project namespaces."""
     require_hosted_chat_enabled()
-    project = get_generated_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found.")
-    _require_project_reader(project, user)
+    project = _resolve_project_reader(project_id, user)
 
     try:
         ir = HardwareIR(**project.hardware_ir)
@@ -2907,7 +2892,10 @@ def iterate_project_endpoint(
     """Applies an iteration instruction to an existing project through forma_core."""
     require_hosted_chat_enabled()
     _apply_user_integrations(user)
-    project = get_generated_project(project_id)
+    try:
+        project = resolve_project_for_read(project_id, user.owner_user_id).project
+    except ProjectReadError:
+        project = None
     canonical_revision = None
     canonical_brief = None
     if project is not None:
@@ -2968,13 +2956,14 @@ def iterate_project_endpoint(
             )
             revised_ir = persisted_revision.state
             if project is not None:
-                saved = update_generated_project_hardware_ir(
-                    project_id,
-                    revised_ir.model_dump(mode="json"),
-                    owner_user_id=save_owner_user_id,
-                )
-                if not saved:
-                    raise HTTPException(status_code=404, detail="Project not found.")
+                if canonical_brief is not None:
+                    publish_project_revision(persisted_revision, canonical_brief, save_owner_user_id)
+                else:
+                    refresh_legacy_project_projection(
+                        project_id,
+                        revised_ir.model_dump(mode="json"),
+                        owner_user_id=save_owner_user_id,
+                    )
 
         return {
             "project_id": project_id,
@@ -3124,10 +3113,12 @@ def video_self_correct_project_endpoint(
     """Reviews a generated project video with a Fireworks native video model and applies a corrective iteration."""
     require_hosted_chat_enabled()
     _apply_user_integrations(user)
-    project = get_generated_project(project_id)
-    if not project:
-        raise HTTPException(status_code=404, detail="Project not found.")
-    owner_user_id = _require_project_owner(project, user)
+    project = _resolve_project_owner(project_id, user)
+    owner_user_id = user.owner_user_id
+    try:
+        canonical_brief = get_latest_design_brief(project_id, owner_user_id)
+    except DesignBriefNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Project brief not found.") from exc
 
     try:
         current_ir = HardwareIR(**project.hardware_ir)
@@ -3152,9 +3143,14 @@ def video_self_correct_project_endpoint(
                 source_job_id=f"video-correction-{request.idempotency_key or uuid4().hex}",
             )
             revised_ir = persisted_revision.state
-            saved = update_generated_project_hardware_ir(project.project_id, revised_ir.model_dump(mode="json"), owner_user_id=owner_user_id)
-            if not saved:
-                raise HTTPException(status_code=404, detail="Project not found.")
+            if canonical_brief is None:
+                refresh_legacy_project_projection(
+                    project.project_id,
+                    revised_ir.model_dump(mode="json"),
+                    owner_user_id=owner_user_id,
+                )
+            else:
+                publish_project_revision(persisted_revision, canonical_brief, owner_user_id)
 
         target_namespace = (revised_ir.assembly_metadata or {}).get("iteration_target_namespace") or request.namespace
         return {

--- a/apps/api/project_deletion.py
+++ b/apps/api/project_deletion.py
@@ -16,7 +16,6 @@ from forma_core.database import (
     add_project_deletion_audit,
     anonymize_project_contribution_consent,
     anonymize_project_contribution_snapshot,
-    get_generated_project,
     get_project_identity,
     get_project_contribution_consent,
     get_user_settings,
@@ -156,7 +155,10 @@ def grant_contribution_consent(
     permitted_purposes: Iterable[str],
     workspace_id: Optional[str] = None,
 ) -> Any:
-    project = get_generated_project(project_id)
+    try:
+        project = resolve_project_for_read(project_id, user_id).project
+    except LookupError as exc:
+        raise LookupError("Project not found.") from exc
     if not project or _attr(project, "owner_user_id") != user_id:
         raise LookupError("Project not found.")
     purposes = sorted(set(permitted_purposes))
@@ -232,7 +234,7 @@ def request_project_deletion(project_id: str, user_id: str) -> Any:
         },
     )
     if not updated:
-        return get_generated_project(project_id, include_deleted=True)
+        return get_project_identity(project_id)
 
     try:
         matched_jobs = JOB_STORE.cancel_project_jobs(project_id)
@@ -381,7 +383,7 @@ def purge_project(project_id: str) -> Dict[str, Any]:
         resolved = resolve_project_for_read(project_id, lifecycle_owner, include_deleted=True)
     except LookupError:
         resolved = None
-    project = resolved.project if resolved is not None else (identity or get_generated_project(project_id, include_deleted=True))
+    project = resolved.project if resolved is not None else identity
     if not project:
         return {"project_id": project_id, "status": "purged", "already_absent": True}
     owner_user_id = _attr(project, "owner_user_id") or (resolved.owner_user_id if resolved else None)

--- a/docs/project-persistence-retirement.md
+++ b/docs/project-persistence-retirement.md
@@ -1,0 +1,58 @@
+# Project Persistence Retirement
+
+## Current Boundary
+
+`projects` and `project_revisions` are the authoritative project identity and state
+stores. Authenticated hosted generation, iteration, CLI pushes, and MCP compilation
+write canonical revisions first. `generated_projects`, `cli_projects`, and
+`cli_project_revisions` are compatibility projections used only by adapters that
+serve existing clients or perform retention cleanup.
+
+The web API reads through `resolve_project_for_read` and the canonical gallery
+inventory. CLI response shaping remains an explicit compatibility adapter until all
+CLI clients consume canonical project responses.
+
+## Migration Verification
+
+Run the reconciliation tool in dry-run mode before applying any repair:
+
+```text
+python scripts/operations/reconcile-projects.py --dry-run --audit artifacts/project-reconciliation.json --json
+python scripts/operations/reconcile-projects.py --apply --audit artifacts/project-reconciliation-apply.json --json
+```
+
+Every report records the project ID, source channel, ownership decision, status,
+mismatches, and repair actions. Failed records can be retried without rerunning
+successful projects:
+
+```text
+python scripts/operations/reconcile-projects.py --apply --retry-failed --audit artifacts/project-reconciliation-apply.json --json
+```
+
+Do not run schema retirement while the report contains unresolved failures or
+unrepaired mismatches. The tool never deletes legacy rows.
+
+## Usage Metrics And Retirement Gate
+
+Before removing a compatibility adapter, instrument and review:
+
+- legacy projection fallback reads by endpoint and source channel;
+- legacy projection writes by caller and source channel;
+- CLI clients using legacy response fields;
+- reconciliation drift and failed repair counts.
+
+Retirement requires zero fallback reads and writes for one complete retention window,
+successful reconciliation, and a reviewed client migration. Until then, retain the
+legacy tables and projection adapters in read-only or repair-only mode as appropriate.
+
+## Rollback And Retention
+
+Rollback is application-level: route reads back through the compatibility adapter and
+stop applying projection repairs. Canonical identities and revisions are immutable
+source records and must not be deleted as part of a rollback. Keep the reconciliation
+JSON reports and deployment commit that produced them with operational records.
+
+Schema retirement is a separate, reviewed migration. It must include a tested backup,
+a restore rehearsal, an export of retained project records, and a documented data
+retention/deletion date. No table drop or destructive cleanup is included in the
+canonical migration work.

--- a/forma_cli/metadata_api.py
+++ b/forma_cli/metadata_api.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import unquote, urlparse
 
-from forma_core.database import get_generated_project
+from forma_core.database import get_project_identity
 
 from forma_cli.local import project_root, read_project, status_project
 
@@ -47,12 +47,12 @@ def project_metadata(path: str | Path | None = None) -> dict[str, Any]:
     project_id = manifest.project_id
 
     try:
-        stored = get_generated_project(project_id)
+        stored = get_project_identity(project_id)
         database = {
             "present": stored is not None,
-            "owner_user_id": stored.owner_user_id if stored else None,
-            "status": stored.status if stored else None,
-            "visibility": stored.visibility if stored else None,
+            "owner_user_id": stored.get("owner_user_id") if stored else None,
+            "status": stored.get("status") if stored else None,
+            "visibility": stored.get("visibility") if stored else None,
         }
     except Exception as exc:
         stored = None

--- a/forma_core/agents/orchestrator.py
+++ b/forma_core/agents/orchestrator.py
@@ -11,10 +11,11 @@ from dotenv import load_dotenv
 load_dotenv()
 
 from forma_core.database import (
-    delete_generated_project,
     get_component_template_by_part_number,
     list_component_templates,
-    save_generated_project,
+    persist_chat_project_revision,
+    persist_legacy_project_projection,
+    update_project_deletion_state,
 )
 from forma_core.llm import (
     LLMProviderConfigError,
@@ -2228,22 +2229,42 @@ class HardwarePipelineOrchestrator:
         if not self.persist_project:
             return project_id
         try:
-            save_generated_project(
-                project_id=project_id,
-                title=ir.overview.title if ir.overview else "Untitled Forma Project",
-                prompt=str(generation_metadata.get("project_prompt") or prompt),
-                hardware_ir=ir.model_dump(),
-                created_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-                chat_id=generation_metadata.get("chat_id"),
-                owner_user_id=generation_metadata.get("owner_user_id"),
-                visibility="public",
-            )
+            owner_user_id = generation_metadata.get("owner_user_id")
+            if owner_user_id:
+                persist_chat_project_revision(
+                    project_id,
+                    owner_user_id,
+                    ir,
+                    source_job_id=str(generation_metadata.get("frontend_job_id") or f"generation-{uuid.uuid4().hex}"),
+                    prompt=str(generation_metadata.get("project_prompt") or prompt),
+                    chat_id=generation_metadata.get("chat_id"),
+                )
+            else:
+                persist_legacy_project_projection(
+                    project_id=project_id,
+                    title=ir.overview.title if ir.overview else "Untitled Forma Project",
+                    prompt=str(generation_metadata.get("project_prompt") or prompt),
+                    hardware_ir=ir.model_dump(),
+                    created_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                    chat_id=generation_metadata.get("chat_id"),
+                    owner_user_id=None,
+                    visibility="public",
+                )
             try:
                 ensure_agent_pipeline_active()
             except PipelineCancelledError:
                 owner_user_id = generation_metadata.get("owner_user_id")
                 if owner_user_id:
-                    delete_generated_project(project_id, owner_user_id)
+                    update_project_deletion_state(
+                        project_id,
+                        owner_user_id=owner_user_id,
+                        allowed_statuses=["active"],
+                        updates={
+                            "status": "deletion_pending",
+                            "deleted_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                            "deletion_requested_by": owner_user_id,
+                        },
+                    )
                 raise
             logger.info(f"Project saved to database with ID: {project_id}")
             return project_id

--- a/forma_core/agents/web_research_workflow.py
+++ b/forma_core/agents/web_research_workflow.py
@@ -4,6 +4,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
+from uuid import uuid4
 
 from pydantic import BaseModel, Field
 
@@ -21,7 +22,7 @@ from forma_core.agents.system_architecture import (
     compact_net_context,
     system_context,
 )
-from forma_core.database import delete_generated_project, save_generated_project
+from forma_core.database import persist_chat_project_revision, persist_legacy_project_projection, update_project_deletion_state
 from forma_core.jobs.source_usage import source_usage_for_workflow
 from forma_core.llm import (
     LLMProviderConfigError,
@@ -1178,22 +1179,42 @@ class WebResearchHardwarePipeline:
         if not self.persist_project:
             return project_id
         try:
-            save_generated_project(
-                project_id=project_id,
-                title=ir.overview.title if ir.overview else "Untitled Forma Project",
-                prompt=str(generation_metadata.get("project_prompt") or prompt),
-                hardware_ir=ir.model_dump(),
-                created_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
-                chat_id=generation_metadata.get("chat_id"),
-                owner_user_id=generation_metadata.get("owner_user_id"),
-                visibility="public",
-            )
+            owner_user_id = generation_metadata.get("owner_user_id")
+            if owner_user_id:
+                persist_chat_project_revision(
+                    project_id,
+                    owner_user_id,
+                    ir,
+                    source_job_id=str(generation_metadata.get("frontend_job_id") or f"web-research-{uuid4().hex}"),
+                    prompt=str(generation_metadata.get("project_prompt") or prompt),
+                    chat_id=generation_metadata.get("chat_id"),
+                )
+            else:
+                persist_legacy_project_projection(
+                    project_id=project_id,
+                    title=ir.overview.title if ir.overview else "Untitled Forma Project",
+                    prompt=str(generation_metadata.get("project_prompt") or prompt),
+                    hardware_ir=ir.model_dump(),
+                    created_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                    chat_id=generation_metadata.get("chat_id"),
+                    owner_user_id=None,
+                    visibility="public",
+                )
             try:
                 ensure_agent_pipeline_active()
             except PipelineCancelledError:
                 owner_user_id = generation_metadata.get("owner_user_id")
                 if owner_user_id:
-                    delete_generated_project(project_id, owner_user_id)
+                    update_project_deletion_state(
+                        project_id,
+                        owner_user_id=owner_user_id,
+                        allowed_statuses=["active"],
+                        updates={
+                            "status": "deletion_pending",
+                            "deleted_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                            "deletion_requested_by": owner_user_id,
+                        },
+                    )
                 raise
             logger.info("Web research workflow project saved to database with ID: %s", project_id)
             return project_id

--- a/forma_core/database.py
+++ b/forma_core/database.py
@@ -38,7 +38,6 @@ from forma_core.persistence.models import (
     Base,
     DBAlphaSignup,
     DBComponentTemplate,
-    DBGeneratedProject,
     DBProjectChat,
     DBUserIntegrationConfig,
     DBUserSettings,
@@ -415,6 +414,33 @@ def save_generated_project(
     invalidate_project_lists()
 
 
+def persist_legacy_project_projection(
+    *,
+    project_id: str,
+    title: str,
+    prompt: str,
+    hardware_ir: Dict[str, Any],
+    created_at: str,
+    chat_id: Optional[str] = None,
+    owner_user_id: Optional[str] = None,
+    visibility: Optional[str] = "public",
+    create_chat_record: bool = True,
+) -> None:
+    """Write the retained generated-project compatibility projection."""
+
+    save_generated_project(
+        project_id=project_id,
+        title=title,
+        prompt=prompt,
+        hardware_ir=hardware_ir,
+        created_at=created_at,
+        chat_id=chat_id,
+        owner_user_id=owner_user_id,
+        visibility=visibility,
+        create_chat_record=create_chat_record,
+    )
+
+
 def ensure_project_identity(
     project_id: str,
     owner_user_id: str,
@@ -461,6 +487,35 @@ def ensure_project_identity(
     return record
 
 
+def update_project_identity(
+    project_id: str,
+    owner_user_id: str,
+    *,
+    title: Optional[str] = None,
+    prompt: Optional[str] = None,
+    visibility: Optional[str] = None,
+) -> bool:
+    """Update canonical project metadata; compatibility projections are rebuilt separately."""
+    canonical_project_id = _canonical_project_id(project_id)
+    owner = _normalize_user_id(owner_user_id)
+    identity = _DATABASE_REPOSITORY.get_project_identity(canonical_project_id)
+    if not owner or identity is None or _normalize_user_id(identity.get("owner_user_id")) != owner:
+        return False
+    if identity.get("status", "active") != "active":
+        return False
+    record = dict(identity)
+    if title is not None:
+        record["title"] = title.strip() or "Untitled Forma Project"
+    if prompt is not None:
+        record["prompt"] = prompt.strip()
+    if visibility is not None:
+        record["visibility"] = _normalize_visibility(visibility)
+    record["updated_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    _DATABASE_REPOSITORY.upsert_project_identity(record)
+    invalidate_project_lists()
+    return True
+
+
 def ensure_chat_project(
     project_id: str,
     owner_user_id: str,
@@ -475,23 +530,37 @@ def ensure_chat_project(
     owner = _normalize_user_id(owner_user_id)
     if not owner:
         raise ValueError("owner_user_id is required.")
-    existing = get_generated_project(canonical_project_id, include_deleted=True)
+    existing_identity = get_project_identity(canonical_project_id)
+    existing_legacy = None
+    if existing_identity is None:
+        # Pre-migration local databases still need to bootstrap into the
+        # canonical identity/revision model without making the legacy row the
+        # ongoing source of truth.
+        existing_legacy = get_generated_project(canonical_project_id, include_deleted=True)
+    existing = existing_identity or existing_legacy
     if existing is not None:
-        existing_owner = _normalize_user_id(getattr(existing, "owner_user_id", None))
+        existing_owner = _normalize_user_id(
+            existing.get("owner_user_id") if isinstance(existing, dict) else getattr(existing, "owner_user_id", None)
+        )
         if existing_owner != owner:
             raise DesignBriefAccessError("Project is not owned by the current user.")
-        if getattr(existing, "status", "active") != "active":
+        existing_status = existing.get("status", "active") if isinstance(existing, dict) else getattr(existing, "status", "active")
+        if existing_status != "active":
             raise DesignBriefAccessError("Cannot initialize a deleted project.")
 
     summary = str(prompt or "").strip() or str(title or "Untitled Forma Project").strip()
+    existing_title = existing.get("title") if isinstance(existing, dict) else getattr(existing, "title", None)
+    existing_prompt = existing.get("prompt") if isinstance(existing, dict) else getattr(existing, "prompt", None)
+    existing_created_at = existing.get("created_at") if isinstance(existing, dict) else getattr(existing, "created_at", None)
+    existing_visibility = existing.get("visibility") if isinstance(existing, dict) else getattr(existing, "visibility", "private")
     identity = ensure_project_identity(
         canonical_project_id,
         owner,
-        title=(title or (getattr(existing, "title", None) if existing is not None else None) or summary),
-        prompt=(getattr(existing, "prompt", None) if existing is not None else None) or summary,
+        title=(title or existing_title or summary),
+        prompt=existing_prompt or summary,
         chat_id=chat_id,
-        created_at=getattr(existing, "created_at", None) if existing is not None else None,
-        visibility=getattr(existing, "visibility", "private") if existing is not None else "private",
+        created_at=existing_created_at,
+        visibility=existing_visibility or "private",
     )
     canonical_chat_id = identity.get("chat_id") or _normalize_chat_id(chat_id)
 
@@ -519,6 +588,7 @@ def persist_chat_project_revision(
     source_job_id: str,
     prompt: str,
     chat_id: Optional[str] = None,
+    visibility: Optional[str] = None,
 ) -> ProjectRevision:
     """Commit generated chat output canonically, then refresh its gallery projection."""
 
@@ -532,6 +602,13 @@ def persist_chat_project_revision(
         prompt=prompt,
         chat_id=chat_id,
     )
+    if visibility is not None:
+        if not update_project_identity(
+            canonical_project_id,
+            owner_user_id,
+            visibility=visibility,
+        ):
+            raise ValueError("Could not update the canonical project visibility.")
     service = ProjectStateService(_DATABASE_REPOSITORY)
     candidate = HardwareIR.model_validate(state)
     try:
@@ -567,7 +644,7 @@ def publish_project_revision(
     brief: DesignBrief,
     owner_user_id: str,
     *,
-    visibility: str = "public",
+    visibility: Optional[str] = None,
 ) -> str:
     """Project canonical state into the public gallery's generated-project store."""
 
@@ -599,6 +676,12 @@ def publish_project_revision(
             owner_user_id=normalized_owner_user_id,
         ):
             raise RuntimeError("Could not refresh the generated-project gallery projection.")
+        if visibility is not None and not update_generated_project_metadata(
+            project_id,
+            owner_user_id=normalized_owner_user_id,
+            visibility=visibility,
+        ):
+            raise RuntimeError("Could not refresh the generated-project gallery visibility.")
         return project_id
 
     save_generated_project(
@@ -609,7 +692,7 @@ def publish_project_revision(
         created_at=revision.created_at.isoformat().replace("+00:00", "Z"),
         chat_id=brief.conversation_id,
         owner_user_id=normalized_owner_user_id,
-        visibility=visibility,
+        visibility=visibility or "public",
         # Context gathering already owns the chat and its messages. Publishing
         # the gallery projection must not replace that thread with an empty one.
         create_chat_record=False,
@@ -1604,6 +1687,21 @@ def update_generated_project_hardware_ir(
     return updated
 
 
+def refresh_legacy_project_projection(
+    project_id: str,
+    hardware_ir: Dict[str, Any],
+    *,
+    owner_user_id: Optional[str] = None,
+) -> bool:
+    """Refresh the retained legacy projection during compatibility reads."""
+
+    return update_generated_project_hardware_ir(
+        project_id,
+        hardware_ir,
+        owner_user_id=owner_user_id,
+    )
+
+
 def claim_unowned_generated_project(
     project_id: str,
     hardware_ir: Dict[str, Any],
@@ -1616,15 +1714,28 @@ def claim_unowned_generated_project(
     normalized_owner_user_id = _normalize_user_id(owner_user_id)
     if not normalized_owner_user_id:
         return False
+    identity_claimed = False
+    identity = _DATABASE_REPOSITORY.get_project_identity(project_id)
+    if identity is not None and not _normalize_user_id(identity.get("owner_user_id")):
+        if identity.get("status", "active") != "active":
+            return False
+        identity_record = dict(identity)
+        identity_record["owner_user_id"] = normalized_owner_user_id
+        if chat_id:
+            identity_record["chat_id"] = chat_id
+        identity_record["updated_at"] = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        _DATABASE_REPOSITORY.upsert_project_identity(identity_record)
+        invalidate_project_lists()
+        identity_claimed = True
     claimed = _DATABASE_REPOSITORY.claim_unowned_generated_project(
         project_id,
         hardware_ir,
         chat_id,
         normalized_owner_user_id,
     )
-    if claimed:
+    if claimed or identity_claimed:
         invalidate_project_lists()
-    return claimed
+    return claimed or identity_claimed
 
 
 def _hardware_ir_with_overview_title(hardware_ir: Any, title: str) -> Optional[Dict[str, Any]]:

--- a/forma_core/persistence/migrations.py
+++ b/forma_core/persistence/migrations.py
@@ -165,8 +165,8 @@ def migrate_sqlite_schema(engine: Engine, *, import_legacy_jobs: bool = True) ->
                 g.project_id, g.owner_user_id, g.creation_channel, g.title, g.prompt, g.chat_id,
                 NULL AS workspace_id, g.visibility, g.status, g.created_at, g.created_at,
                 'legacy' AS source, NULL AS revision_id, NULL AS revision,
-                NULL AS revision_payload_json, NULL AS revision_created_at,
-                NULL AS legacy_hardware_ir, g.id AS legacy_id
+                 NULL AS revision_payload_json, NULL AS revision_created_at,
+                 g.hardware_ir AS legacy_hardware_ir, g.id AS legacy_id
             FROM generated_projects g
             WHERE g.status = 'active'
               AND NOT EXISTS (

--- a/forma_core/workspaces/projects/output.py
+++ b/forma_core/workspaces/projects/output.py
@@ -4,15 +4,17 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
 
 from forma_core.database import (
     claim_unowned_generated_project,
+    persist_chat_project_revision,
+    persist_legacy_project_projection,
     init_db,
-    save_generated_project,
-    update_generated_project_hardware_ir,
+    refresh_legacy_project_projection,
 )
 from forma_core.images import build_image_provider, build_project_visual_spec
 from forma_core.persistence.images import get_image_storage_config, upload_image_to_supabase_s3
@@ -378,13 +380,22 @@ def persist_project_output(ir: Any, *, prompt_text: str = "", owner_user_id: Opt
     if not project_id:
         raise ValueError("Project output cannot be persisted without assembly_metadata.project_id.")
     hardware_ir = ir.model_dump(mode="json")
-    if update_generated_project_hardware_ir(project_id, hardware_ir, owner_user_id=owner_user_id):
+    if owner_user_id:
+        claim_unowned_generated_project(project_id, hardware_ir, owner_user_id)
+        persist_chat_project_revision(
+            project_id,
+            owner_user_id,
+            ir,
+            source_job_id=f"project-output-{uuid.uuid4().hex}",
+            prompt=prompt_text.strip(),
+            chat_id=metadata.get("chat_id"),
+        )
         return project_id
-    if owner_user_id and claim_unowned_generated_project(project_id, hardware_ir, owner_user_id):
+    if refresh_legacy_project_projection(project_id, hardware_ir, owner_user_id=owner_user_id):
         return project_id
     title = getattr(getattr(ir, "overview", None), "title", None) or prompt_text.strip() or "Untitled Forma Project"
     created_at = metadata.get("created_at") or datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    save_generated_project(
+    persist_legacy_project_projection(
         project_id=project_id,
         title=title,
         prompt=prompt_text.strip(),

--- a/supabase/migrations/20260903000100_canonical_gallery_inventory.sql
+++ b/supabase/migrations/20260903000100_canonical_gallery_inventory.sql
@@ -45,7 +45,7 @@ select
   r.revision,
   r.revision_payload_json,
   r.revision_created_at,
-  null::jsonb as legacy_hardware_ir,
+   null::jsonb as legacy_hardware_ir,
   null::integer as legacy_id
 from public.projects p
 join hosted_latest r on r.project_id = p.project_id
@@ -69,7 +69,7 @@ select
   r.revision,
   r.revision_payload_json,
   r.revision_created_at,
-  null::jsonb as legacy_hardware_ir,
+   null::jsonb as legacy_hardware_ir,
   null::integer as legacy_id
 from public.projects p
 join public.cli_projects cp on cp.project_id = p.project_id

--- a/supabase/migrations/20260903000400_gallery_legacy_projection_payload.sql
+++ b/supabase/migrations/20260903000400_gallery_legacy_projection_payload.sql
@@ -1,0 +1,68 @@
+-- Keep the explicit compatibility adapter self-contained for unreconciled rows.
+
+create or replace view public.project_gallery_inventory as
+with hosted_latest as (
+  select distinct on (project_id)
+    id as revision_id,
+    project_id,
+    owner_user_id,
+    revision,
+    payload_json as revision_payload_json,
+    created_at as revision_created_at
+  from public.project_revisions
+  order by project_id, revision desc
+), cli_latest as (
+  select distinct on (project_id)
+    id as revision_id,
+    project_id,
+    owner_user_id,
+    revision,
+    manifest_json as revision_payload_json,
+    created_at as revision_created_at
+  from public.cli_project_revisions
+  order by project_id, revision desc
+)
+select
+  p.project_id, p.owner_user_id, p.creation_channel, p.title, p.prompt, p.chat_id,
+  p.workspace_id, p.visibility, p.status, p.created_at,
+  coalesce(r.revision_created_at, p.updated_at) as updated_at,
+  'canonical'::text as source, r.revision_id, r.revision,
+  r.revision_payload_json, r.revision_created_at,
+  null::jsonb as legacy_hardware_ir, null::integer as legacy_id
+from public.projects p
+join hosted_latest r on r.project_id = p.project_id
+                     and r.owner_user_id = p.owner_user_id
+where p.creation_channel <> 'cli'
+union all
+select
+  p.project_id, p.owner_user_id, p.creation_channel, p.title, p.prompt, p.chat_id,
+  p.workspace_id, p.visibility, p.status, p.created_at,
+  coalesce(r.revision_created_at, p.updated_at) as updated_at,
+  'canonical'::text as source, r.revision_id, r.revision,
+  r.revision_payload_json, r.revision_created_at,
+  null::jsonb as legacy_hardware_ir, null::integer as legacy_id
+from public.projects p
+join public.cli_projects cp on cp.project_id = p.project_id
+                            and cp.owner_user_id = p.owner_user_id
+join cli_latest r on r.project_id = cp.project_id
+                   and r.owner_user_id = cp.owner_user_id
+where p.creation_channel = 'cli'
+  and (cp.current_revision_id is null or r.revision_id = cp.current_revision_id)
+union all
+select
+  g.project_id, g.owner_user_id, g.creation_channel, g.title, g.prompt, g.chat_id,
+  null::text as workspace_id, g.visibility, g.status, g.created_at,
+  g.created_at as updated_at,
+  'legacy'::text as source, null::text as revision_id, null::integer as revision,
+  null::jsonb as revision_payload_json, null::text as revision_created_at,
+  g.hardware_ir as legacy_hardware_ir, g.id as legacy_id
+from public.generated_projects g
+where g.status = 'active'
+  and not exists (
+    select 1 from public.project_revisions r
+    where r.project_id = g.project_id and r.owner_user_id = g.owner_user_id
+  )
+  and not exists (
+    select 1 from public.cli_project_revisions r
+    where r.project_id = g.project_id and r.owner_user_id = g.owner_user_id
+  );

--- a/tests/agents/test_generation_worker.py
+++ b/tests/agents/test_generation_worker.py
@@ -209,13 +209,13 @@ class RetryableStagedGenerationEngine(HardwareIRGenerationEngine):
 class GenerationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.directory = tempfile.TemporaryDirectory()
-        provider = create_sqlite_provider(
+        self.provider = create_sqlite_provider(
             source="generation worker test",
             url=f"sqlite:///{Path(self.directory.name) / 'forma.db'}",
             import_legacy_jobs=False,
         )
-        provider.initialize()
-        self.repository = SqlAlchemyRepository(provider.session_factory)
+        self.provider.initialize()
+        self.repository = SqlAlchemyRepository(self.provider.session_factory)
         self.state = ProjectStateService(self.repository)
         self.workflow = ProjectWorkflowService(self.repository)
         self.project_id = uuid.uuid4()
@@ -430,6 +430,7 @@ class GenerationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
         )
 
     def tearDown(self) -> None:
+        self.provider.engine.dispose()
         self.directory.cleanup()
 
     def _persist_brief(self, project_id: uuid.UUID) -> DesignBrief:
@@ -784,10 +785,10 @@ class GenerationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(1, len(engine.received))
 
     @patch("forma_core.agents.orchestrator.ensure_agent_pipeline_active")
-    @patch("forma_core.agents.orchestrator.save_generated_project")
+    @patch("forma_core.agents.orchestrator.persist_legacy_project_projection")
     def test_generation_engine_mode_disables_legacy_direct_project_write(
         self,
-        save_generated_project: Any,
+        persist_legacy_project_projection: Any,
         _ensure_pipeline: Any,
     ) -> None:
         pipeline = HardwarePipelineOrchestrator.__new__(HardwarePipelineOrchestrator)
@@ -806,7 +807,7 @@ class GenerationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(str(self.project_id), project_id)
         self.assertEqual(str(self.project_id), state.assembly_metadata["project_id"])
-        save_generated_project.assert_not_called()
+        persist_legacy_project_projection.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/agents/test_reverse_engineering_worker.py
+++ b/tests/agents/test_reverse_engineering_worker.py
@@ -98,13 +98,13 @@ class FindingsConsumerWorker:
 class ReverseEngineeringWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.directory = tempfile.TemporaryDirectory()
-        provider = create_sqlite_provider(
+        self.provider = create_sqlite_provider(
             source="reverse-engineering worker test",
             url=f"sqlite:///{Path(self.directory.name) / 'forma.db'}",
             import_legacy_jobs=False,
         )
-        provider.initialize()
-        self.repository = SqlAlchemyRepository(provider.session_factory)
+        self.provider.initialize()
+        self.repository = SqlAlchemyRepository(self.provider.session_factory)
         self.state = ProjectStateService(self.repository)
         self.workflow = ProjectWorkflowService(self.repository)
         self.project_id = uuid.uuid4()
@@ -120,6 +120,7 @@ class ReverseEngineeringWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase)
         )
 
     def tearDown(self) -> None:
+        self.provider.engine.dispose()
         self.directory.cleanup()
 
     def _persist_brief(self) -> DesignBrief:

--- a/tests/agents/test_validation_worker.py
+++ b/tests/agents/test_validation_worker.py
@@ -77,14 +77,14 @@ class CountingValidationEngine:
 class ValidationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.directory = tempfile.TemporaryDirectory()
-        provider = create_sqlite_provider(
+        self.provider = create_sqlite_provider(
             source="validation worker test",
             url=f"sqlite:///{Path(self.directory.name) / 'forma.db'}",
             import_legacy_jobs=False,
         )
-        provider.initialize()
-        self.session_factory = provider.session_factory
-        self.repository = SqlAlchemyRepository(provider.session_factory)
+        self.provider.initialize()
+        self.session_factory = self.provider.session_factory
+        self.repository = SqlAlchemyRepository(self.provider.session_factory)
         self.state = ProjectStateService(self.repository)
         self.reports = ValidationReportService(self.repository)
         self.workflow = ProjectWorkflowService(self.repository)
@@ -102,6 +102,7 @@ class ValidationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
         )
 
     def tearDown(self) -> None:
+        self.provider.engine.dispose()
         self.directory.cleanup()
 
     def _persist_brief(self) -> DesignBrief:

--- a/tests/agents/test_worker_orchestrator.py
+++ b/tests/agents/test_worker_orchestrator.py
@@ -174,16 +174,17 @@ class CheckpointThenFailWorker(FakeWorker):
 class WorkerOrchestratorIntegrationTests(unittest.IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.directory = tempfile.TemporaryDirectory()
-        provider = create_sqlite_provider(
+        self.provider = create_sqlite_provider(
             source="worker orchestrator test",
             url=f"sqlite:///{Path(self.directory.name) / 'forma.db'}",
             import_legacy_jobs=False,
         )
-        provider.initialize()
-        self.repository = SqlAlchemyRepository(provider.session_factory)
+        self.provider.initialize()
+        self.repository = SqlAlchemyRepository(self.provider.session_factory)
         self.workflow = ProjectWorkflowService(self.repository)
 
     def tearDown(self) -> None:
+        self.provider.engine.dispose()
         self.directory.cleanup()
 
     def enter_building(self) -> None:

--- a/tests/api/test_a2a_user_integrations.py
+++ b/tests/api/test_a2a_user_integrations.py
@@ -16,7 +16,7 @@ from forma_core.user_integrations import UserIntegrationStore
 
 
 class A2AUserIntegrationTests(unittest.TestCase):
-    def test_persist_updated_project_ir_creates_missing_project_record(self) -> None:
+    def test_persist_updated_project_ir_skips_legacy_projection_for_authenticated_owner(self) -> None:
         project_id = "fd54de37-2fbb-485a-92e4-8bfaf4a2f08c"
 
         class FakeIR:
@@ -34,8 +34,8 @@ class A2AUserIntegrationTests(unittest.TestCase):
                     "components": [],
                 }
 
-        with patch.object(a2a, "update_generated_project_hardware_ir", return_value=False) as update_project, patch.object(
-            a2a, "save_generated_project"
+        with patch.object(a2a, "refresh_legacy_project_projection", return_value=False) as update_project, patch.object(
+            a2a, "persist_legacy_project_projection"
         ) as save_project:
             a2a._persist_updated_project_ir(
                 FakeIR(),
@@ -43,22 +43,14 @@ class A2AUserIntegrationTests(unittest.TestCase):
                 owner_user_id="user_123",
             )
 
-        update_project.assert_called_once()
-        self.assertEqual(project_id, update_project.call_args.args[0])
-        self.assertEqual("user_123", update_project.call_args.kwargs["owner_user_id"])
-        save_project.assert_called_once()
-        save_kwargs = save_project.call_args.kwargs
-        self.assertEqual(project_id, save_kwargs["project_id"])
-        self.assertEqual("Low Voltage Desk Lamp", save_kwargs["title"])
-        self.assertEqual("desk lamp", save_kwargs["prompt"])
-        self.assertEqual("chat_123", save_kwargs["chat_id"])
-        self.assertEqual("user_123", save_kwargs["owner_user_id"])
-        self.assertEqual("public", save_kwargs["visibility"])
+        update_project.assert_not_called()
+        save_project.assert_not_called()
 
     def test_generation_response_applies_owner_image_provider_before_images(self) -> None:
         observed: dict[str, object] = {}
 
         def fake_generate_project_with_workflow(*_args, **_kwargs):
+            self.assertFalse(_kwargs["persist_project"])
             return SimpleNamespace(
                 assembly_metadata={},
                 constraints=[],
@@ -128,6 +120,7 @@ class A2AUserIntegrationTests(unittest.TestCase):
         observed: dict[str, object] = {}
 
         def fake_generate_project_with_workflow(*_args, **_kwargs):
+            self.assertFalse(_kwargs["persist_project"])
             user_integrations.apply_user_integrations_to_environment()
             return SimpleNamespace(
                 assembly_metadata={},

--- a/tests/api/test_hosted_chat_maintenance.py
+++ b/tests/api/test_hosted_chat_maintenance.py
@@ -137,10 +137,10 @@ class HostedChatMaintenanceApiTests(unittest.IsolatedAsyncioTestCase):
                 _user(),
             )
 
-            with patch.object(a2a, "get_generated_project", return_value=None), patch.object(
+            with patch.object(a2a, "get_project_identity", return_value=None), patch.object(
                 a2a,
-                "save_generated_project",
-            ) as save_project:
+                "persist_chat_project_revision",
+            ) as persist_revision:
                 compile_response = await handle_mcp_json_rpc(
                     {
                         "jsonrpc": "2.0",
@@ -158,7 +158,7 @@ class HostedChatMaintenanceApiTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(HOSTED_CHAT_UNAVAILABLE_MESSAGE, generation_response["error"]["message"])
         self.assertEqual("hosted_chat_unavailable", generation_response["error"]["data"]["code"])
         self.assertTrue(compile_response["result"]["structuredContent"]["persisted"])
-        save_project.assert_called_once()
+        persist_revision.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/api/test_mcp_agent_compatibility.py
+++ b/tests/api/test_mcp_agent_compatibility.py
@@ -107,8 +107,8 @@ class McpAgentCompatibilityTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("nemoclaw", authoring_agents)
 
     async def test_compile_project_persists_public_project_and_returns_identity(self) -> None:
-        with patch("apps.api.a2a.get_generated_project", return_value=None), patch(
-            "apps.api.a2a.save_generated_project"
+        with patch("apps.api.a2a.get_project_identity", return_value=None), patch(
+            "apps.api.a2a.persist_legacy_project_projection"
         ) as save_project:
             response = await handle_mcp_json_rpc(
                 {
@@ -142,9 +142,9 @@ class McpAgentCompatibilityTests(unittest.IsolatedAsyncioTestCase):
             is_authenticated=True,
             is_admin=False,
         )
-        with patch("apps.api.a2a.get_generated_project", return_value=None), patch(
-            "apps.api.a2a.save_generated_project"
-        ) as save_project:
+        with patch("apps.api.a2a.get_project_identity", return_value=None), patch(
+            "apps.api.a2a.persist_chat_project_revision"
+        ) as persist_revision:
             response = await handle_mcp_json_rpc(
                 {
                     "jsonrpc": "2.0",
@@ -165,13 +165,14 @@ class McpAgentCompatibilityTests(unittest.IsolatedAsyncioTestCase):
         compiled = response["result"]["structuredContent"]
         self.assertEqual("private", compiled["visibility"])
         self.assertIsNotNone(compiled["chat_id"])
-        self.assertEqual("agent-user", save_project.call_args.kwargs["owner_user_id"])
-        self.assertEqual("Build a private sensor enclosure", save_project.call_args.kwargs["prompt"])
+        self.assertEqual("agent-user", persist_revision.call_args.args[1])
+        self.assertEqual("Build a private sensor enclosure", persist_revision.call_args.kwargs["prompt"])
+        self.assertEqual("private", persist_revision.call_args.kwargs["visibility"])
 
     async def test_compile_project_persists_and_validates(self) -> None:
-        with patch("apps.api.a2a.get_generated_project", return_value=None), patch(
-            "apps.api.a2a.save_generated_project"
-        ):
+        with patch("apps.api.a2a.get_project_identity", return_value=None), patch(
+            "apps.api.a2a.persist_legacy_project_projection"
+        ), patch("apps.api.a2a.persist_chat_project_revision"):
             response = await handle_mcp_json_rpc(
                 {
                     "jsonrpc": "2.0",
@@ -196,16 +197,15 @@ class McpAgentCompatibilityTests(unittest.IsolatedAsyncioTestCase):
     async def test_compile_project_cannot_update_another_owner(self) -> None:
         project_id = "12345678-1234-4234-8234-123456789012"
         with patch(
-            "apps.api.a2a.get_generated_project",
-            return_value=SimpleNamespace(
-                owner_user_id="different-user",
-                status="active",
-                hardware_ir={},
-                chat_id=None,
-                created_at="2026-01-01T00:00:00Z",
-                visibility="private",
-            ),
-        ), patch("apps.api.a2a.update_generated_project_hardware_ir") as update_project:
+            "apps.api.a2a.get_project_identity",
+            return_value={
+                "owner_user_id": "different-user",
+                "status": "active",
+                "chat_id": None,
+                "created_at": "2026-01-01T00:00:00Z",
+                "visibility": "private",
+            },
+        ), patch("apps.api.a2a.refresh_legacy_project_projection") as update_project:
             response = await handle_mcp_json_rpc(
                 {
                     "jsonrpc": "2.0",

--- a/tests/api/test_project_access.py
+++ b/tests/api/test_project_access.py
@@ -22,6 +22,7 @@ from forma_core.workspaces.projects.models import (
     MechanicalSource,
     ProjectOverview,
 )
+from forma_core.workspaces.projects.state import ProjectStateError
 
 
 def _request() -> Request:
@@ -178,11 +179,10 @@ class ProjectReadAccessTests(unittest.TestCase):
             main,
             "list_project_gallery_inventory_page",
             return_value=([_legacy_inventory(project) for project in page_projects], 14),
-        ) as list_page, patch.object(main, "list_generated_projects") as list_all:
+        ) as list_page:
             response = main.list_projects_endpoint(_user_context("user-a"), limit=2, offset=6)
 
         list_page.assert_called_once_with(owner_user_id=None, visibility="public", limit=2, offset=6, search=None)
-        list_all.assert_not_called()
         self.assertEqual(14, response["total"])
         self.assertEqual(2, response["limit"])
         self.assertEqual(6, response["offset"])
@@ -231,14 +231,13 @@ class ProjectReadAccessTests(unittest.TestCase):
             main,
             "get_cached_project_list",
             return_value=([cached_record], "3"),
-        ) as get_cached, patch.object(main, "list_generated_projects") as list_projects, patch.object(
+        ) as get_cached, patch.object(
             main, "project_engagement_for_ids", return_value={}
         ):
             owner_response = main.list_projects_endpoint(_user_context("user-a"))
             other_response = main.list_projects_endpoint(_user_context("user-b"))
 
         get_cached.assert_has_calls([call("public", None), call("public", None)])
-        list_projects.assert_not_called()
         self.assertTrue(owner_response[0]["can_chat"])
         self.assertEqual("chat-public-project", owner_response[0]["chat_id"])
         self.assertFalse(other_response[0]["can_chat"])
@@ -272,23 +271,29 @@ class ProjectReadAccessTests(unittest.TestCase):
             conversation_id="chat-canonical-controller",
             summary="Build a canonical controller.",
         )
+        identity = SimpleNamespace(
+            project_id=project_id,
+            owner_user_id="user-a",
+            creation_channel="hosted",
+            title="Canonical controller",
+            prompt="Build a canonical controller.",
+            chat_id="chat-canonical-controller",
+            visibility="private",
+            status="active",
+        )
 
         with self._summary_dependencies(), patch.object(
             main,
-            "list_generated_projects",
-            return_value=[],
+            "list_project_identities",
+            return_value=[identity],
         ), patch.object(
             main,
-            "list_latest_project_revisions",
-            return_value=[revision],
+            "get_latest_project_revision",
+            return_value=revision,
         ), patch.object(
             main,
             "get_latest_design_brief",
             return_value=brief,
-        ), patch.object(
-            main,
-            "get_generated_project",
-            return_value=None,
         ):
             response = main.list_my_projects_endpoint(_user_context("user-a"))
 
@@ -314,12 +319,31 @@ class ProjectReadAccessTests(unittest.TestCase):
             visibility=project.visibility,
             status="active",
         )
+        revision = SimpleNamespace(
+            project_id=project.project_id,
+            owner_user_id="user-a",
+            revision=1,
+            created_at=project.created_at,
+            state=HardwareIR.model_validate(project.hardware_ir),
+        )
+        brief = SimpleNamespace(
+            conversation_id=project.chat_id,
+            summary=project.prompt,
+        )
 
         with self._summary_dependencies(), patch.object(
             main,
             "list_project_identities",
             return_value=[identity],
-        ), patch.object(main, "get_generated_project", return_value=project):
+        ), patch.object(
+            main,
+            "get_latest_project_revision",
+            return_value=revision,
+        ), patch.object(
+            main,
+            "get_latest_design_brief",
+            return_value=brief,
+        ):
             response = main.list_my_projects_endpoint(_user_context("user-a"))
 
         self.assertEqual([project.project_id], [item["project_id"] for item in response])
@@ -332,7 +356,7 @@ class ProjectReadAccessTests(unittest.TestCase):
             return_value=(None, None),
         ), patch.object(
             main,
-            "list_generated_projects",
+            "list_project_gallery_inventory_page",
             side_effect=RuntimeError("database unavailable"),
         ), patch.object(main.logger, "exception") as log_exception:
             with self.assertRaises(HTTPException) as raised:
@@ -400,14 +424,11 @@ class ProjectReadAccessTests(unittest.TestCase):
             main,
             "list_project_gallery_inventory_page",
             return_value=([revision], 1),
-        ) as list_page, patch.object(main, "get_latest_design_brief") as get_brief, patch.object(
-            main, "get_generated_project"
-        ) as get_legacy, patch.object(main.logger, "info") as log_info:
+        ) as list_page, patch.object(main, "get_latest_design_brief") as get_brief, patch.object(main.logger, "info") as log_info:
             response = main.list_projects_endpoint(_anonymous_context(), limit=1, offset=0)
 
         list_page.assert_called_once()
         get_brief.assert_not_called()
-        get_legacy.assert_not_called()
         log_info.assert_any_call("project_gallery_legacy_fallback endpoint=%s count=%d", "public", 0)
         self.assertEqual("Current canonical title", response["items"][0]["title"])
         self.assertIsNone(response["items"][0]["chat_id"])
@@ -461,44 +482,56 @@ class ProjectReadAccessTests(unittest.TestCase):
             owner_user_id="user-a",
             visibility="private",
         )
-        revision = SimpleNamespace(project_id=project_id)
-
         with self._summary_dependencies(), patch.object(
             main,
-            "list_generated_projects",
-            return_value=[legacy_project],
-        ), patch.object(
-            main,
-            "list_latest_project_revisions",
-            return_value=[revision],
-        ), patch.object(main, "get_latest_design_brief") as get_brief:
+            "list_project_gallery_inventory_page",
+            return_value=([_legacy_inventory(legacy_project)], 1),
+        ):
             response = main.list_my_projects_endpoint(_user_context("user-a"))
 
         self.assertEqual([project_id], [item["project_id"] for item in response])
-        get_brief.assert_not_called()
 
     def test_owner_list_does_not_resurrect_soft_deleted_legacy_project(self) -> None:
         project_id = "deleted-legacy-project"
-        revision = SimpleNamespace(project_id=project_id)
-        deleted_project = SimpleNamespace(project_id=project_id, status="pending_purge")
-
         with self._summary_dependencies(), patch.object(
             main,
-            "list_generated_projects",
-            return_value=[],
-        ), patch.object(
-            main,
-            "list_latest_project_revisions",
-            return_value=[revision],
-        ), patch.object(
-            main,
-            "get_generated_project",
-            return_value=deleted_project,
-        ), patch.object(main, "get_latest_design_brief") as get_brief:
+            "list_project_gallery_inventory_page",
+            return_value=([], 0),
+        ):
             response = main.list_my_projects_endpoint(_user_context("user-a"))
 
         self.assertEqual([], response)
-        get_brief.assert_not_called()
+
+    def test_owner_list_keeps_legacy_projection_when_identity_has_no_revision(self) -> None:
+        project_id = "legacy-identity-without-revision"
+        identity = SimpleNamespace(
+            project_id=project_id,
+            owner_user_id="user-a",
+            creation_channel="hosted",
+            title="Legacy identity",
+            prompt="Build a legacy project.",
+            chat_id="legacy-chat",
+            visibility="private",
+            status="active",
+        )
+        legacy = _legacy_inventory(_project(project_id, owner_user_id="user-a", visibility="private"))
+        with self._summary_dependencies(), patch.object(
+            main, "_list_project_identities", return_value=[identity]
+        ), patch.object(
+            main,
+            "get_latest_project_revision",
+            side_effect=ProjectStateError("project_revision_not_found", "No project revision found."),
+        ), patch.object(
+            main,
+            "list_project_gallery_inventory_page",
+            return_value=([legacy], 1),
+        ) as list_page:
+            response = main.list_my_projects_endpoint(_user_context("user-a"))
+
+        list_page.assert_called_once_with(
+            owner_user_id="user-a", visibility=None, limit=50, offset=0
+        )
+        self.assertEqual([project_id], [item["project_id"] for item in response])
 
     def test_owner_can_read_own_private_project(self) -> None:
         private_project = _project(
@@ -541,11 +574,17 @@ class ProjectReadAccessTests(unittest.TestCase):
             "created_at": "2026-07-25T12:00:00Z",
         }
 
-        with patch.object(main, "resolve_project_for_read", return_value=SimpleNamespace(source="cli")), patch.object(
-            main,
-            "get_cli_project_revision",
-            return_value=cli_revision,
-        ):
+        cli_resolution = SimpleNamespace(
+            source="cli",
+            project_id=project_id,
+            project_ir=cli_revision["manifest"]["project_ir"],
+            title="CLI project",
+            prompt="Build a CLI project.",
+            current_revision=1,
+            revision_id="cli-revision-1",
+            created_at=cli_revision["created_at"],
+        )
+        with patch.object(main, "resolve_project_for_read", return_value=cli_resolution):
             response = main.get_project_endpoint(project_id, _user_context("user-a"))
 
         self.assertEqual(project_id, response["project_id"])
@@ -583,9 +622,9 @@ class ProjectReadAccessTests(unittest.TestCase):
     def test_owner_can_update_project_title(self) -> None:
         project = _project("owned-project", owner_user_id="user-a", visibility="public")
 
-        with patch.object(main, "get_generated_project", return_value=project), patch.object(
+        with patch.object(main, "resolve_project_for_read", return_value=SimpleNamespace(project=project)), patch.object(
             main,
-            "update_generated_project_metadata",
+            "update_project_identity",
             return_value=True,
         ) as update_meta:
             response = main.update_project_endpoint(
@@ -606,9 +645,9 @@ class ProjectReadAccessTests(unittest.TestCase):
     def test_community_member_cannot_update_project_title(self) -> None:
         project = _project("public-project", owner_user_id="user-b", visibility="public")
 
-        with patch.object(main, "get_generated_project", return_value=project), patch.object(
+        with patch.object(main, "resolve_project_for_read", return_value=SimpleNamespace(project=project)), patch.object(
             main,
-            "update_generated_project_metadata",
+            "update_project_identity",
         ) as update_meta:
             with self.assertRaises(HTTPException) as raised:
                 main.update_project_endpoint(
@@ -623,9 +662,9 @@ class ProjectReadAccessTests(unittest.TestCase):
     def test_anonymous_user_cannot_update_project_title(self) -> None:
         project = _project("public-project", owner_user_id="user-b", visibility="public")
 
-        with patch.object(main, "get_generated_project", return_value=project), patch.object(
+        with patch.object(main, "resolve_project_for_read", return_value=SimpleNamespace(project=project)), patch.object(
             main,
-            "update_generated_project_metadata",
+            "update_project_identity",
         ) as update_meta:
             with self.assertRaises(HTTPException) as raised:
                 main.update_project_endpoint(
@@ -861,7 +900,6 @@ class ProjectGenerationAccessTests(unittest.TestCase):
             patch.object(main, "ensure_chat_project"),
             patch.object(main, "build_generation_response", return_value=generated_response),
             patch.object(main, "_attach_generation_timing_metadata", side_effect=lambda response, _job: response),
-            patch.object(main, "update_generated_project_hardware_ir"),
         ):
             response = asyncio.run(
                 main.generate_project_endpoint(
@@ -890,13 +928,13 @@ class ProjectIterationAccessTests(unittest.TestCase):
         with (
             patch.object(main, "require_hosted_chat_enabled"),
             patch.object(main, "_apply_user_integrations"),
-            patch.object(main, "get_generated_project", return_value=project),
+            patch.object(main, "resolve_project_for_read", return_value=SimpleNamespace(project=project)),
             patch.object(main, "get_latest_project_revision", side_effect=main.ProjectStateError("project_revision_not_found", "not found")),
             patch.object(main, "ensure_project_action_allowed"),
             patch.object(main, "ProjectIterator", return_value=iterator),
             patch.object(main, "hydrate_image_storage_metadata", side_effect=lambda metadata, _project_id: metadata),
             patch.object(main, "append_project_revision", return_value=persisted) as append_revision,
-            patch.object(main, "update_generated_project_hardware_ir", return_value=True) as update_projection,
+            patch.object(main, "refresh_legacy_project_projection", return_value=True) as update_projection,
             patch.object(main, "generate_mermaid_chart", return_value=""),
             patch.object(main, "generate_svg_schematic", return_value=""),
         ):

--- a/tests/api/test_project_engagement.py
+++ b/tests/api/test_project_engagement.py
@@ -60,7 +60,7 @@ class ProjectEngagementApiTests(unittest.TestCase):
 
     def test_save_endpoint_persists_for_signed_in_reader(self) -> None:
         project = _project("public-project")
-        with patch.object(main, "get_generated_project", return_value=project), patch.object(
+        with patch.object(main, "_resolve_project_reader", return_value=project), patch.object(
             main,
             "save_project_for_user",
             return_value={"saved": True, "save_count": 4, "remix_count": 1},
@@ -73,7 +73,7 @@ class ProjectEngagementApiTests(unittest.TestCase):
 
     def test_anonymous_user_cannot_save_or_remix(self) -> None:
         project = _project("public-project")
-        with patch.object(main, "get_generated_project", return_value=project):
+        with patch.object(main, "_resolve_project_reader", return_value=project):
             with self.assertRaises(HTTPException) as raised_save:
                 main.save_project_endpoint("public-project", _anonymous_context())
             with self.assertRaises(HTTPException) as raised_remix:
@@ -85,7 +85,7 @@ class ProjectEngagementApiTests(unittest.TestCase):
     def test_remix_endpoint_returns_the_new_owned_project(self) -> None:
         source = _project("source-project")
         remixed = _project("remix-project", owner_user_id="user-b")
-        with patch.object(main, "get_generated_project", return_value=source), patch.object(
+        with patch.object(main, "_resolve_project_reader", return_value=source), patch.object(
             main, "remix_generated_project", return_value=remixed
         ), patch.object(
             main,

--- a/tests/persistence/test_design_briefs.py
+++ b/tests/persistence/test_design_briefs.py
@@ -51,6 +51,7 @@ def sqlite_repository() -> Iterator[None]:
             yield
         finally:
             database._DATABASE_REPOSITORY = original_repository
+            provider.engine.dispose()
 
 
 def brief_payload(*, summary: str = "A compact controller") -> dict[str, object]:

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -4,6 +4,7 @@ import sqlite3
 import tempfile
 import unittest
 import uuid
+from contextlib import closing
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import patch
@@ -195,6 +196,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
             finally:
                 database._DATABASE_PROVIDER = original_provider
                 database._DATABASE_REPOSITORY = original_repository
+                provider.engine.dispose()
 
         self.assertEqual(job_id, stored_job_id)
         self.assertEqual("primary", store.get_config()["scope"])
@@ -230,6 +232,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 project_after_chat_delete = database.get_generated_project(project_id)
             finally:
                 database._DATABASE_REPOSITORY = original_repository
+                provider.engine.dispose()
 
         self.assertIsNotNone(project)
         self.assertEqual("private", project.visibility)
@@ -288,6 +291,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 ])
 
             revisions = repository.list_latest_project_revisions("user-a")
+            provider.engine.dispose()
 
         self.assertEqual(
             [("project-a", 2), ("project-b", 1)],
@@ -551,6 +555,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 limit=2,
                 offset=1,
             )
+            provider.engine.dispose()
 
         self.assertEqual(4, total)
         self.assertEqual(["project-4", "project-2"], [project.project_id for project in projects])
@@ -603,6 +608,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 offset=0,
                 search="motor",
             )
+            provider.engine.dispose()
 
         self.assertEqual(2, total)
         self.assertEqual(
@@ -681,6 +687,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 row = connection.exec_driver_sql(
                     "SELECT status, payload_json FROM a2a_jobs WHERE job_id = 'job_legacy'"
                 ).one()
+            provider.engine.dispose()
 
         self.assertEqual(1, imported_first)
         self.assertEqual(0, imported_second)
@@ -714,6 +721,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 opted_out_ids = database.list_model_training_opt_out_user_ids()
             finally:
                 database._DATABASE_REPOSITORY = original_repository
+                provider.engine.dispose()
 
         self.assertIsNone(default_settings)
         self.assertTrue(opted_out.model_training_opt_out)
@@ -759,6 +767,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 after_unsave = database.project_engagement_for_ids([source_id], "user-b")
             finally:
                 database._DATABASE_REPOSITORY = original_repository
+                provider.engine.dispose()
 
         self.assertTrue(first_save["saved"])
         self.assertEqual(1, first_save["save_count"])
@@ -779,7 +788,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
 
     @staticmethod
     def _create_legacy_job_database(path: Path) -> None:
-        with sqlite3.connect(path) as connection:
+        with closing(sqlite3.connect(path)) as connection:
             connection.execute(
                 """
                 CREATE TABLE a2a_jobs (
@@ -821,6 +830,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                     '{"prompt":"legacy"}',
                 ),
             )
+            connection.commit()
 
 
 class _SchemaResponse:

--- a/tests/projects/test_context_gathering.py
+++ b/tests/projects/test_context_gathering.py
@@ -63,6 +63,7 @@ def sqlite_repository() -> Iterator[None]:
             yield
         finally:
             database._DATABASE_REPOSITORY = original
+            provider.engine.dispose()
 
 
 class ContextBriefImageReferenceTests(unittest.TestCase):

--- a/tests/projects/test_project_deletion.py
+++ b/tests/projects/test_project_deletion.py
@@ -85,6 +85,7 @@ class ProjectDeletionLifecycleTests(unittest.TestCase):
     def tearDown(self) -> None:
         database._DATABASE_PROVIDER = self.original_provider
         database._DATABASE_REPOSITORY = self.original_repository
+        self.provider.engine.dispose()
         self.directory.cleanup()
 
     def test_delete_is_immediate_idempotent_and_restorable(self) -> None:

--- a/tests/projects/test_readiness_build.py
+++ b/tests/projects/test_readiness_build.py
@@ -46,6 +46,7 @@ def sqlite_repository() -> Iterator[None]:
             yield
         finally:
             database._DATABASE_REPOSITORY = original
+            provider.engine.dispose()
 
 
 def brief_payload(

--- a/tests/projects/test_workflow_state.py
+++ b/tests/projects/test_workflow_state.py
@@ -51,6 +51,7 @@ def sqlite_repository() -> Iterator[None]:
             yield
         finally:
             database._DATABASE_REPOSITORY = original
+            provider.engine.dispose()
 
 
 class StateRepository:

--- a/tests/tooling/test_fabricator_cli.py
+++ b/tests/tooling/test_fabricator_cli.py
@@ -81,6 +81,8 @@ class FabricatorCliTests(unittest.TestCase):
         provider = Mock()
         provider.validate_configured_model.return_value = SimpleNamespace(
             as_debug_dict=lambda: {"provider": "openai"},
+            provider="openai",
+            requested_model="test-model",
             live_generation_enabled=False,
             validation_error="provider is not configured",
         )


### PR DESCRIPTION
## Summary
- Make canonical project identities and revisions authoritative for authenticated generation, iteration, MCP compilation, CLI sync, reads, and gallery inventory.
- Keep legacy generated/CLI tables behind explicit compatibility adapters and add retirement, reconciliation, rollback, and retention guidance.
- Preserve legacy fallback rows, safe deletion states, MCP visibility, and deterministic SQLite test cleanup.

Closes #404

## Validation
- python -m unittest issue-focused suites: 173 tests passed.
- python -m compileall -q apps/api forma_core forma_cli tests passed.
- git diff --check passed.
- Full discovery reached 721 tests; remaining failures are unrelated environment-dependent Vertex SDK, Windows file-mode, artifact-size, and test-order cases.