### PR TITLE
fix: release SQLite resources before test cleanup

### DIFF
--- a/forma_core/jobs/store.py
+++ b/forma_core/jobs/store.py
@@ -226,6 +226,12 @@ class JobMetadataStore:
         config.update({"table": "a2a_jobs", "scope": "standalone" if self._standalone else "primary"})
         return config
 
+    def close(self) -> None:
+        """Release a standalone SQLite provider owned by this store."""
+
+        if self._standalone and isinstance(self._provider, SQLiteProvider):
+            self._provider.dispose()
+
     def init_db(self) -> None:
         if self._initialized:
             return

--- a/forma_core/persistence/providers/sqlite.py
+++ b/forma_core/persistence/providers/sqlite.py
@@ -65,6 +65,11 @@ class SQLiteProvider(DatabaseProvider):
         connection.driver_connection.row_factory = sqlite3.Row
         return connection
 
+    def dispose(self) -> None:
+        """Release pooled SQLite connections owned by this provider."""
+
+        self.engine.dispose()
+
     def describe(self) -> dict[str, Any]:
         config = super().describe()
         config.update({"client": "sqlite/sqlalchemy", "database": make_url(self.url).database})

--- a/tests/agents/test_generation_worker.py
+++ b/tests/agents/test_generation_worker.py
@@ -430,7 +430,7 @@ class GenerationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
         )
 
     def tearDown(self) -> None:
-        self.provider.engine.dispose()
+        self.provider.dispose()
         self.directory.cleanup()
 
     def _persist_brief(self, project_id: uuid.UUID) -> DesignBrief:

--- a/tests/agents/test_reverse_engineering_worker.py
+++ b/tests/agents/test_reverse_engineering_worker.py
@@ -120,7 +120,7 @@ class ReverseEngineeringWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase)
         )
 
     def tearDown(self) -> None:
-        self.provider.engine.dispose()
+        self.provider.dispose()
         self.directory.cleanup()
 
     def _persist_brief(self) -> DesignBrief:

--- a/tests/agents/test_validation_worker.py
+++ b/tests/agents/test_validation_worker.py
@@ -102,7 +102,7 @@ class ValidationWorkerIntegrationTests(unittest.IsolatedAsyncioTestCase):
         )
 
     def tearDown(self) -> None:
-        self.provider.engine.dispose()
+        self.provider.dispose()
         self.directory.cleanup()
 
     def _persist_brief(self) -> DesignBrief:

--- a/tests/agents/test_worker_orchestrator.py
+++ b/tests/agents/test_worker_orchestrator.py
@@ -184,7 +184,7 @@ class WorkerOrchestratorIntegrationTests(unittest.IsolatedAsyncioTestCase):
         self.workflow = ProjectWorkflowService(self.repository)
 
     def tearDown(self) -> None:
-        self.provider.engine.dispose()
+        self.provider.dispose()
         self.directory.cleanup()
 
     def enter_building(self) -> None:

--- a/tests/jobs/test_job_metrics.py
+++ b/tests/jobs/test_job_metrics.py
@@ -28,8 +28,7 @@ class JobMetricsTests(unittest.TestCase):
 
             metrics = store.get_metrics(days=7, hours=24)
         finally:
-            assert store._provider is not None
-            store._provider.engine.dispose()
+            store.close()
 
         self.assertEqual(3, metrics["jobs_today"])
         self.assertEqual(3, metrics["jobs_last_hour"])
@@ -63,8 +62,7 @@ class JobMetricsTests(unittest.TestCase):
                 ],
             )
         finally:
-            assert store._provider is not None
-            store._provider.engine.dispose()
+            store.close()
 
         self.assertEqual(2, metrics["jobs_today"])
         self.assertEqual(2, metrics["completed_jobs"])

--- a/tests/jobs/test_job_progress.py
+++ b/tests/jobs/test_job_progress.py
@@ -37,8 +37,7 @@ class JobProgressTests(unittest.TestCase):
                 )
                 job = store.get_job("job_frontend_progress")
             finally:
-                assert store._provider is not None
-                store._provider.engine.dispose()
+                store.close()
 
         self.assertIsNotNone(job)
         assert job is not None
@@ -92,8 +91,7 @@ class JobProgressTests(unittest.TestCase):
                 store.mark_failed("job_frontend_cancelled", "late failure")
                 final_job = store.get_job("job_frontend_cancelled")
             finally:
-                assert store._provider is not None
-                store._provider.engine.dispose()
+                store.close()
 
         self.assertIsNotNone(final_job)
         assert final_job is not None
@@ -152,8 +150,7 @@ class JobProgressTests(unittest.TestCase):
 
             job = store.get_job("job_atomic")
         finally:
-            assert store._provider is not None
-            store._provider.engine.dispose()
+            store.close()
 
         self.assertIsNotNone(job)
         assert job is not None

--- a/tests/jobs/test_project_deletion_jobs.py
+++ b/tests/jobs/test_project_deletion_jobs.py
@@ -44,8 +44,7 @@ class ProjectDeletionJobTests(unittest.TestCase):
             self.assertTrue(all(store.get_job(job_id) is None for job_id in matching_ids))
             self.assertIsNotNone(store.get_job("job-2"))
         finally:
-            assert store._provider is not None
-            store._provider.engine.dispose()
+            store.close()
 
 
 if __name__ == "__main__":

--- a/tests/persistence/test_chat_project_creation.py
+++ b/tests/persistence/test_chat_project_creation.py
@@ -32,7 +32,7 @@ def sqlite_repository() -> Iterator[None]:
             yield
         finally:
             database._DATABASE_REPOSITORY = original
-            provider.engine.dispose()
+            provider.dispose()
 
 
 def project_state(project_id: str) -> HardwareIR:

--- a/tests/persistence/test_design_briefs.py
+++ b/tests/persistence/test_design_briefs.py
@@ -51,7 +51,7 @@ def sqlite_repository() -> Iterator[None]:
             yield
         finally:
             database._DATABASE_REPOSITORY = original_repository
-            provider.engine.dispose()
+            provider.dispose()
 
 
 def brief_payload(*, summary: str = "A compact controller") -> dict[str, object]:

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -22,6 +22,21 @@ from forma_core.workspaces.projects.models import HardwareIR, ProjectOverview
 
 
 class PersistenceArchitectureTests(unittest.TestCase):
+    def test_disposing_sqlite_provider_releases_database_file(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            database_path = Path(directory) / "forma.db"
+            provider = create_sqlite_provider(
+                source="test provider lifecycle",
+                url=f"sqlite:///{database_path}",
+                import_legacy_jobs=False,
+            )
+            provider.initialize()
+            provider.dispose()
+
+            database_path.unlink()
+
+        self.assertFalse(database_path.exists())
+
     def test_canonical_revision_publication_creates_public_gallery_projection_without_replacing_chat(self) -> None:
         project_id = uuid.uuid4()
         design_brief_id = uuid.uuid4()
@@ -125,7 +140,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 briefs = database.list_design_brief_versions(project_id, "legacy-owner")
             finally:
                 database._DATABASE_REPOSITORY = original_repository
-                provider.engine.dispose()
+                provider.dispose()
 
         self.assertEqual(2, first.revision)
         self.assertEqual(1, first.parent_revision)
@@ -196,7 +211,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
             finally:
                 database._DATABASE_PROVIDER = original_provider
                 database._DATABASE_REPOSITORY = original_repository
-                provider.engine.dispose()
+                provider.dispose()
 
         self.assertEqual(job_id, stored_job_id)
         self.assertEqual("primary", store.get_config()["scope"])
@@ -232,7 +247,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 project_after_chat_delete = database.get_generated_project(project_id)
             finally:
                 database._DATABASE_REPOSITORY = original_repository
-                provider.engine.dispose()
+                provider.dispose()
 
         self.assertIsNotNone(project)
         self.assertEqual("private", project.visibility)
@@ -291,7 +306,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 ])
 
             revisions = repository.list_latest_project_revisions("user-a")
-            provider.engine.dispose()
+            provider.dispose()
 
         self.assertEqual(
             [("project-a", 2), ("project-b", 1)],
@@ -414,7 +429,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
             rows, total = repository.list_project_gallery_inventory_page(
                 "user-a", visibility="public", limit=10, offset=0
             )
-            provider.engine.dispose()
+            provider.dispose()
 
         self.assertEqual(2, total)
         self.assertEqual(["legacy", "canonical"], [row.source for row in rows])
@@ -469,7 +484,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 identity = repository.get_project_identity("cli-summary")
             finally:
                 assert provider.engine is not None
-                provider.engine.dispose()
+                provider.dispose()
 
         self.assertIsNotNone(project)
         self.assertEqual("workspace-b", project.workspace_id)
@@ -518,7 +533,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 )
                 canonical = repository.get_latest_project_revision(project_id, "user-a")
             finally:
-                provider.engine.dispose()
+                provider.dispose()
 
         self.assertIsNotNone(saved)
         self.assertIsNotNone(canonical)
@@ -555,7 +570,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 limit=2,
                 offset=1,
             )
-            provider.engine.dispose()
+            provider.dispose()
 
         self.assertEqual(4, total)
         self.assertEqual(["project-4", "project-2"], [project.project_id for project in projects])
@@ -608,7 +623,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 offset=0,
                 search="motor",
             )
-            provider.engine.dispose()
+            provider.dispose()
 
         self.assertEqual(2, total)
         self.assertEqual(
@@ -687,7 +702,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 row = connection.exec_driver_sql(
                     "SELECT status, payload_json FROM a2a_jobs WHERE job_id = 'job_legacy'"
                 ).one()
-            provider.engine.dispose()
+            provider.dispose()
 
         self.assertEqual(1, imported_first)
         self.assertEqual(0, imported_second)
@@ -721,7 +736,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 opted_out_ids = database.list_model_training_opt_out_user_ids()
             finally:
                 database._DATABASE_REPOSITORY = original_repository
-                provider.engine.dispose()
+                provider.dispose()
 
         self.assertIsNone(default_settings)
         self.assertTrue(opted_out.model_training_opt_out)
@@ -767,7 +782,7 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 after_unsave = database.project_engagement_for_ids([source_id], "user-b")
             finally:
                 database._DATABASE_REPOSITORY = original_repository
-                provider.engine.dispose()
+                provider.dispose()
 
         self.assertTrue(first_save["saved"])
         self.assertEqual(1, first_save["save_count"])

--- a/tests/persistence/test_project_reconciliation.py
+++ b/tests/persistence/test_project_reconciliation.py
@@ -59,7 +59,7 @@ class ProjectReconciliationTests(unittest.TestCase):
             with provider.session_factory() as session:
                 self.assertEqual(1, session.query(DBGeneratedProject).count())
                 self.assertEqual(1, session.query(DBGeneratedProject).filter_by(project_id=project_id).count())
-            provider.engine.dispose()
+            provider.dispose()
 
     def test_cli_backfill_rebuilds_all_compatibility_revisions(self) -> None:
         project_id = str(uuid4())
@@ -101,7 +101,7 @@ class ProjectReconciliationTests(unittest.TestCase):
             with provider.session_factory() as session:
                 self.assertEqual(2, session.query(DBCliProjectRevision).filter_by(project_id=project_id).count())
                 self.assertEqual(2, session.query(DBProjectRevision).filter_by(project_id=project_id).count())
-            provider.engine.dispose()
+            provider.dispose()
 
     def test_canonical_only_projects_rebuild_missing_compatibility_projection(self) -> None:
         project_id = uuid4()
@@ -158,7 +158,7 @@ class ProjectReconciliationTests(unittest.TestCase):
             self.assertEqual(1, report.scanned)
             with provider.session_factory() as session:
                 self.assertEqual(1, session.query(DBGeneratedProject).filter_by(project_id=str(project_id)).count())
-            provider.engine.dispose()
+            provider.dispose()
 
 
 if __name__ == "__main__":

--- a/tests/projects/test_context_gathering.py
+++ b/tests/projects/test_context_gathering.py
@@ -63,7 +63,7 @@ def sqlite_repository() -> Iterator[None]:
             yield
         finally:
             database._DATABASE_REPOSITORY = original
-            provider.engine.dispose()
+            provider.dispose()
 
 
 class ContextBriefImageReferenceTests(unittest.TestCase):

--- a/tests/projects/test_project_deletion.py
+++ b/tests/projects/test_project_deletion.py
@@ -85,7 +85,7 @@ class ProjectDeletionLifecycleTests(unittest.TestCase):
     def tearDown(self) -> None:
         database._DATABASE_PROVIDER = self.original_provider
         database._DATABASE_REPOSITORY = self.original_repository
-        self.provider.engine.dispose()
+        self.provider.dispose()
         self.directory.cleanup()
 
     def test_delete_is_immediate_idempotent_and_restorable(self) -> None:

--- a/tests/projects/test_readiness_build.py
+++ b/tests/projects/test_readiness_build.py
@@ -46,7 +46,7 @@ def sqlite_repository() -> Iterator[None]:
             yield
         finally:
             database._DATABASE_REPOSITORY = original
-            provider.engine.dispose()
+            provider.dispose()
 
 
 def brief_payload(

--- a/tests/projects/test_workflow_state.py
+++ b/tests/projects/test_workflow_state.py
@@ -51,7 +51,7 @@ def sqlite_repository() -> Iterator[None]:
             yield
         finally:
             database._DATABASE_REPOSITORY = original
-            provider.engine.dispose()
+            provider.dispose()
 
 
 class StateRepository:


### PR DESCRIPTION
## Summary\n- add an explicit SQLiteProvider.dispose() lifecycle method\n- add JobMetadataStore.close() for owned standalone SQLite stores\n- route SQLite test teardown through public lifecycle APIs\n- add regression coverage proving disposed providers release database files\n\n## Validation\n- python -m unittest tests.persistence.test_persistence tests.jobs.test_job_progress tests.jobs.test_job_metrics tests.jobs.test_project_deletion_jobs tests.agents.test_generation_worker tests.agents.test_worker_orchestrator tests.agents.test_validation_worker tests.agents.test_reverse_engineering_worker -q\n- Full unittest discovery has unrelated environment/configuration failures documented in the handoff.\n\nCloses #405