### PR TITLE
feat: add hosted client compatibility checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ uploads.
 
 ```bash
 forma-oss --help
+forma-oss version
+forma-oss doctor
 forma-oss init ./my-project
 forma-oss status --path ./my-project
 forma-oss render --path ./my-project --output ./my-project/mechanical-render.png
@@ -180,6 +182,14 @@ forma-oss login
 forma-oss projects push --path ./my-project
 forma-oss projects pull --path ./my-project
 ```
+
+Hosted CLI operations check the package and hosted protocol contract. A
+supported older client continues with an upgrade notice; a client below the
+hosted minimum is rejected before a cloud mutation or upload. Local generation,
+validation, rendering, and offline project work do not require the hosted
+compatibility endpoint. `forma-oss version` always reports the installed CLI
+version, while `forma-oss doctor` reports compatibility and authentication
+status when available.
 
 `projects push` validates and uploads every file declared in the local
 manifest. `projects pull` verifies downloaded bytes, restores them beneath the
@@ -426,6 +436,10 @@ Use the shared `LLM_API_KEY`, `LLM_MODEL`, and `LLM_BASE_URL` variables with `LL
 - `FORMA_CLI_ARTIFACT_STORAGE_BACKEND`: Optional `supabase`, `s3-compatible`, or `local` override for CLI artifacts. Supabase-primary hosted deployments use Supabase by default; SQLite/local deployments use the local API storage directory by default.
 - `FORMA_CLI_ARTIFACT_STORAGE_DIR`: Local artifact directory when the CLI artifact backend is `local` (default: `./.forma/cli-artifacts`).
 - `FORMA_CLI_ARTIFACT_MAX_BYTES`: Maximum size of one transferred artifact (default: `52428800`).
+- `FORMA_HOSTED_LATEST_VERSION`: Hosted package version advertised by `/forma/version` (defaults to the installed core version).
+- `FORMA_HOSTED_MINIMUM_SUPPORTED_VERSION`: Oldest package version accepted by hosted CLI requests (defaults to the installed core version).
+- `FORMA_HOSTED_PROTOCOL_VERSION`: Hosted CLI/API protocol version (default: `1`).
+- `FORMA_SUPPORTED_HARDWARE_IR_VERSIONS`: Comma-separated Hardware IR schemas accepted by hosted uploads (default: `0.2`).
 - `HF_ARTIFACT_REPO_ID` / `HUGGINGFACE_ARTIFACT_REPO_ID` / `HF_DATASET_REPO_ID`: Optional Hugging Face dataset repo for uploaded benchmark, output, and eval artifacts.
 - `HF_ARTIFACT_PATH_PREFIX`: Optional path prefix inside the artifact repo. Defaults to `forma`.
 - `EXTERNAL_SOURCE_PROVIDER`: External web/source provider for `workflow=web_research`. Firecrawl is the only active provider for now; legacy `auto` or `tavily` values are normalized to `firecrawl`.

--- a/apps/api/cli_projects_api.py
+++ b/apps/api/cli_projects_api.py
@@ -9,6 +9,11 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
 from pydantic import BaseModel, Field
 
 from apps.api.auth import UserContext, require_user_context
+from forma_core.config.compatibility import (
+    UnsupportedHardwareIRVersion,
+    ensure_supported_hardware_ir_version,
+    hosted_compatibility_metadata,
+)
 from forma_core.database import (
     CliProjectConflictError,
     get_cli_project_revision,
@@ -57,6 +62,11 @@ async def push_cli_project(
 ) -> dict[str, Any]:
     owner = _owner(user)
     try:
+        compatibility = hosted_compatibility_metadata()
+        ensure_supported_hardware_ir_version(
+            request.manifest,
+            supported_versions=compatibility.supported_hardware_ir_versions,
+        )
         manifest = ProjectManifest.from_document(request.manifest)
         payload = manifest.upload_payload()
         payload["artifacts"] = validate_artifact_references(payload.get("artifacts"), require_integrity=True)
@@ -72,6 +82,15 @@ async def push_cli_project(
         )
     except CliProjectConflictError as exc:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+    except UnsupportedHardwareIRVersion as exc:
+        raise HTTPException(
+            status_code=status.HTTP_426_UPGRADE_REQUIRED,
+            detail={
+                "code": "UNSUPPORTED_HARDWARE_IR_VERSION",
+                "message": str(exc),
+                "hardware_ir_version": exc.version,
+            },
+        ) from exc
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 

--- a/apps/api/compatibility.py
+++ b/apps/api/compatibility.py
@@ -1,0 +1,51 @@
+"""Server-side compatibility checks for CLI/SDK requests."""
+
+from __future__ import annotations
+
+from fastapi import HTTPException, Request, status
+
+from forma_core._version import __version__
+from forma_core.config.compatibility import (
+    CURRENT_PROTOCOL_VERSION,
+    compatibility_error_detail,
+    evaluate_compatibility,
+    hosted_compatibility_metadata,
+)
+
+
+def require_client_compatibility(request: Request) -> None:
+    """Reject explicitly identified clients that cannot use the hosted contract.
+
+    Missing headers remain permissive for older clients so the hosted service can
+    roll out the gate without making an otherwise valid legacy client fail before
+    it has an opportunity to upgrade.
+    """
+
+    client_version = request.headers.get("x-forma-client-version")
+    client_protocol = request.headers.get("x-forma-protocol-version")
+    if not client_version and not client_protocol:
+        return
+    try:
+        protocol_version = int(client_protocol or CURRENT_PROTOCOL_VERSION)
+    except ValueError:
+        raise HTTPException(
+            status_code=status.HTTP_426_UPGRADE_REQUIRED,
+            detail={
+                "code": "UNSUPPORTED_PROTOCOL_VERSION",
+                "message": "X-Forma-Protocol-Version must be an integer.",
+                "protocol_version": hosted_compatibility_metadata().protocol_version,
+            },
+        ) from None
+    result = evaluate_compatibility(
+        client_version or __version__,
+        hosted_compatibility_metadata(),
+        client_protocol_version=protocol_version,
+    )
+    if result.is_blocking:
+        raise HTTPException(
+            status_code=status.HTTP_426_UPGRADE_REQUIRED,
+            detail=compatibility_error_detail(result),
+        )
+
+
+__all__ = ["require_client_compatibility"]

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -50,6 +50,7 @@ from forma_core.debug import (
     get_debug_mode_config,
     runtime_safe_error_message,
 )
+from forma_core._version import __version__
 from fastapi import Body, Depends, FastAPI, HTTPException, Query, Request, WebSocket, status
 from fastapi.encoders import jsonable_encoder
 from fastapi.exception_handlers import request_validation_exception_handler
@@ -164,6 +165,8 @@ from apps.api.user_settings_api import router as user_settings_router
 from apps.api.cli_auth_api import router as cli_auth_router
 from apps.api.cli_projects_api import router as cli_projects_router
 from apps.api.cli_credentials_api import router as cli_credentials_router
+from apps.api.compatibility import require_client_compatibility
+from apps.api.version_api import router as version_router
 from apps.api.hosted_chat import require_hosted_chat_enabled
 from apps.api.auth import (
     UserContext,
@@ -273,7 +276,7 @@ def _attach_generation_timing_metadata(response: Dict[str, Any], job: Optional[D
 app = FastAPI(
     title="Forma Open-Source API",
     description="AI-native prompt-to-hardware compilation, validation, and design generation platform.",
-    version="1.0.0",
+    version=__version__,
     docs_url="/docs",
     redoc_url="/redoc",
     openapi_url="/openapi.json",
@@ -357,9 +360,10 @@ app.include_router(readiness_router)
 app.include_router(worker_plans_router)
 app.include_router(user_integrations_router)
 app.include_router(user_settings_router)
-app.include_router(cli_auth_router)
-app.include_router(cli_projects_router)
-app.include_router(cli_credentials_router)
+app.include_router(cli_auth_router, dependencies=[Depends(require_client_compatibility)])
+app.include_router(cli_projects_router, dependencies=[Depends(require_client_compatibility)])
+app.include_router(cli_credentials_router, dependencies=[Depends(require_client_compatibility)])
+app.include_router(version_router)
 
 
 def _deployment_runtime_config(llm_config: Dict[str, Any]) -> Dict[str, Any]:
@@ -547,7 +551,7 @@ def read_root():
     return {
         "status": "online",
         "service": "Forma Open-Source Hardware Compiler",
-        "version": "1.0.0",
+        "version": __version__,
         "docs_url": "/api/docs"
     }
 

--- a/apps/api/version_api.py
+++ b/apps/api/version_api.py
@@ -1,0 +1,18 @@
+"""Public hosted compatibility metadata for Forma clients."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+from forma_core.config.compatibility import CompatibilityMetadata, hosted_compatibility_metadata
+
+
+router = APIRouter(tags=["compatibility"])
+
+
+@router.get("/forma/version", response_model=CompatibilityMetadata)
+def forma_version() -> CompatibilityMetadata:
+    return hosted_compatibility_metadata()
+
+
+__all__ = ["router"]

--- a/forma_cli/app.py
+++ b/forma_cli/app.py
@@ -37,6 +37,7 @@ from forma_cli.project_artifacts import (
     prepare_project_upload,
 )
 from forma_cli.sdk import FormaAPIClient, FormaAPIError, ProjectArtifactDownload
+from forma_core.config.compatibility import CompatibilityStatus
 from forma_core.workspaces.projects.manifest import (
     ProjectManifest,
     normalize_artifact_media_type,
@@ -51,7 +52,73 @@ def _print_json(value: Any) -> None:
 
 
 def _client(args: argparse.Namespace) -> FormaAPIClient:
-    return FormaAPIClient(base_url=args.api_url if getattr(args, "api_url", None) else None)
+    client = FormaAPIClient(base_url=args.api_url if getattr(args, "api_url", None) else None)
+    notice = client.compatibility_notice()
+    if notice:
+        print(notice, file=sys.stderr)
+    return client
+
+
+def cmd_version(args: argparse.Namespace) -> int:
+    result = _client(args).check_compatibility()
+    payload = {
+        "cli_version": __version__,
+        "status": result.status.value,
+        "latest_version": result.latest_version,
+        "minimum_supported_version": result.minimum_supported_version,
+        "protocol_version": result.protocol_version,
+        "hardware_ir_version": result.hardware_ir_version,
+        "message": result.message,
+        "upgrade_command": result.upgrade_command,
+    }
+    if args.json:
+        _print_json(payload)
+    else:
+        print("Forma-OSS")
+        print(f"CLI:            {payload['cli_version']}")
+        print(f"Latest:         {payload['latest_version'] or 'unavailable'}")
+        print(f"Minimum:        {payload['minimum_supported_version'] or 'unavailable'}")
+        print(f"Protocol:       {payload['protocol_version'] or 'unavailable'}")
+        print(f"Hardware IR:    {payload['hardware_ir_version'] or 'unavailable'}")
+        print(f"Status:         {payload['status']}")
+        if result.status == CompatibilityStatus.UPDATE_AVAILABLE:
+            print(f"Upgrade:        {result.upgrade_command}")
+        elif result.status == CompatibilityStatus.REMOTE_VERSION_UNAVAILABLE:
+            print(result.message)
+    return 0
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    client = _client(args)
+    compatibility = client.check_compatibility()
+    checks: list[dict[str, str]] = [
+        {
+            "name": "Forma version",
+            "status": "ok" if not compatibility.is_blocking else "fail",
+            "message": compatibility.message,
+        },
+        {
+            "name": "Hosted compatibility endpoint",
+            "status": "ok" if compatibility.status != CompatibilityStatus.REMOTE_VERSION_UNAVAILABLE else "unavailable",
+            "message": compatibility.status.value,
+        },
+    ]
+    if client._saved_tokens():
+        try:
+            identity = client.whoami()
+        except FormaAPIError as exc:
+            checks.append({"name": "Authentication", "status": "fail", "message": str(exc)})
+        else:
+            checks.append({"name": "Authentication", "status": "ok", "message": identity.subject})
+    else:
+        checks.append({"name": "Authentication", "status": "not configured", "message": "Run `forma-oss login`."})
+    if args.json:
+        _print_json({"cli_version": __version__, "checks": checks})
+    else:
+        print("Forma-OSS doctor")
+        for check in checks:
+            print(f"{check['status'].upper():14} {check['name']}: {check['message']}")
+    return 1 if any(check["status"] == "fail" for check in checks) else 0
 
 
 def cmd_login(args: argparse.Namespace) -> int:
@@ -627,6 +694,13 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--api-url", default=None, help="Forma API endpoint; defaults to local config or FORMA_API_URL.")
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
     subparsers = parser.add_subparsers(dest="command", required=True)
+
+    version = subparsers.add_parser("version", help="Show local and hosted compatibility information.")
+    version.add_argument("--json", action="store_true")
+    version.set_defaults(func=cmd_version)
+    doctor = subparsers.add_parser("doctor", help="Check local, hosted, and authentication compatibility.")
+    doctor.add_argument("--json", action="store_true")
+    doctor.set_defaults(func=cmd_doctor)
 
     login = subparsers.add_parser("login", help="Authenticate with browser/device authorization.")
     login.add_argument("--no-browser", action="store_true", help="Print the approval URL without opening a browser.")

--- a/forma_cli/sdk.py
+++ b/forma_cli/sdk.py
@@ -3,16 +3,26 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Mapping
 from urllib.error import HTTPError, URLError
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 from urllib.request import Request, urlopen
 
 from pydantic import BaseModel, ConfigDict, Field
 
 from forma_cli.config import api_url
 from forma_cli.credentials import CredentialStore, SESSION_KEY
+from forma_core._version import __version__
+from forma_core.config.compatibility import (
+    CURRENT_PROTOCOL_VERSION,
+    CompatibilityMetadata,
+    CompatibilityResult,
+    CompatibilityStatus,
+    ensure_supported_hardware_ir_version,
+    evaluate_compatibility,
+    unavailable_result,
+)
 
 
 class FormaAPIError(RuntimeError):
@@ -118,6 +128,8 @@ class FormaAPIClient:
     base_url: str | None = None
     credential_store: CredentialStore | None = None
     timeout_seconds: float = 30.0
+    _compatibility_result: CompatibilityResult | None = field(default=None, init=False, repr=False)
+    _compatibility_notice_emitted: bool = field(default=False, init=False, repr=False)
 
     def __post_init__(self) -> None:
         self.base_url = (self.base_url or api_url()).rstrip("/")
@@ -136,6 +148,44 @@ class FormaAPIClient:
         self._store.set_json(SESSION_KEY, tokens.model_dump(mode="json"))
         return tokens
 
+    @staticmethod
+    def _is_local_endpoint(base_url: str) -> bool:
+        host = (urlparse(base_url).hostname or "").lower()
+        return host in {"localhost", "127.0.0.1", "::1"} or host.endswith(".localhost")
+
+    def check_compatibility(self, *, force: bool = False) -> CompatibilityResult:
+        """Fetch and cache hosted compatibility metadata for this client."""
+        if self._compatibility_result is not None and not force:
+            return self._compatibility_result
+        if self._is_local_endpoint(self.base_url or ""):
+            result = unavailable_result(__version__)
+        else:
+            try:
+                raw, _headers = self._request_wire(
+                    "/forma/version",
+                    authenticated=False,
+                    retry_refresh=False,
+                    _skip_compatibility=True,
+                )
+                metadata = CompatibilityMetadata.model_validate(self._decode_json(raw))
+                result = evaluate_compatibility(
+                    __version__,
+                    metadata,
+                    client_protocol_version=CURRENT_PROTOCOL_VERSION,
+                )
+            except (FormaAPIError, ValueError):
+                result = unavailable_result(__version__)
+        self._compatibility_result = result
+        return result
+
+    def compatibility_notice(self) -> str | None:
+        """Return the update notice once per client instance."""
+        result = self.check_compatibility()
+        if result.status != CompatibilityStatus.UPDATE_AVAILABLE or self._compatibility_notice_emitted:
+            return None
+        self._compatibility_notice_emitted = True
+        return f"WARNING: {result.message}"
+
     def _request_wire(
         self,
         path: str,
@@ -147,12 +197,19 @@ class FormaAPIClient:
         accept: str = "application/json",
         authenticated: bool = False,
         retry_refresh: bool = True,
+        _skip_compatibility: bool = False,
     ) -> tuple[bytes, dict[str, str]]:
         if payload is not None and body is not None:
             raise ValueError("A Forma API request cannot contain both JSON and binary payloads.")
+        if not _skip_compatibility:
+            result = self.check_compatibility()
+            if result.is_blocking:
+                raise FormaAPIError(result.message, status_code=426, detail=result.model_dump(mode="json"))
         headers = {
             "Accept": accept,
-            "User-Agent": "forma-oss-cli/0.1",
+            "User-Agent": f"forma-oss-cli/{__version__}",
+            "X-Forma-Client-Version": __version__,
+            "X-Forma-Protocol-Version": str(CURRENT_PROTOCOL_VERSION),
         }
         tokens = self._saved_tokens() if authenticated else None
         if authenticated:
@@ -188,6 +245,7 @@ class FormaAPIClient:
                         accept=accept,
                         authenticated=authenticated,
                         retry_refresh=False,
+                        _skip_compatibility=_skip_compatibility,
                     )
             raise FormaAPIError(
                 self._error_message(detail, fallback=f"Forma API request failed ({exc.code})."),
@@ -260,7 +318,8 @@ class FormaAPIClient:
     @staticmethod
     def _error_message(detail: Any, *, fallback: str) -> str:
         if isinstance(detail, dict):
-            message = detail.get("message") or detail.get("detail")
+            nested = detail.get("detail") if isinstance(detail.get("detail"), dict) else detail
+            message = nested.get("message") or nested.get("detail")
             if isinstance(message, str) and message.strip():
                 return message.strip()
         if isinstance(detail, str) and detail.strip():
@@ -322,6 +381,7 @@ class FormaAPIClient:
         *,
         parent_revision_id: str | None = None,
     ) -> CloudProjectRevision:
+        ensure_supported_hardware_ir_version(manifest)
         payload = self._request(
             "/cli/projects/push",
             method="POST",
@@ -393,6 +453,9 @@ __all__ = [
     "AccountIdentity",
     "CloudProjectRevision",
     "CloudProjectSummary",
+    "CompatibilityMetadata",
+    "CompatibilityResult",
+    "CompatibilityStatus",
     "DeviceAuthorization",
     "DevicePollResult",
     "FormaAPIClient",

--- a/forma_core/config/compatibility.py
+++ b/forma_core/config/compatibility.py
@@ -1,0 +1,278 @@
+"""Shared package, hosted protocol, and Hardware IR compatibility policy."""
+
+from __future__ import annotations
+
+from enum import StrEnum
+import re
+from typing import Any, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from forma_core._version import __version__
+from forma_core.config.environment import config
+
+
+CURRENT_PROTOCOL_VERSION = 1
+CURRENT_HARDWARE_IR_VERSION = "0.2"
+SUPPORTED_HARDWARE_IR_VERSIONS = frozenset({CURRENT_HARDWARE_IR_VERSION})
+UPGRADE_COMMAND = "pipx upgrade forma-oss"
+_VERSION_PATTERN = re.compile(r"^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$")
+
+
+class CompatibilityStatus(StrEnum):
+    CURRENT = "CURRENT"
+    UPDATE_AVAILABLE = "UPDATE_AVAILABLE"
+    UNSUPPORTED_CLIENT = "UNSUPPORTED_CLIENT"
+    UNSUPPORTED_PROTOCOL = "UNSUPPORTED_PROTOCOL"
+    UNSUPPORTED_HARDWARE_IR = "UNSUPPORTED_HARDWARE_IR"
+    REMOTE_VERSION_UNAVAILABLE = "REMOTE_VERSION_UNAVAILABLE"
+
+
+class CompatibilityMetadata(BaseModel):
+    """Machine-readable compatibility information published by hosted Forma."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    latest_version: str
+    minimum_supported_version: str
+    protocol_version: int = Field(ge=1)
+    hardware_ir_version: str
+    supported_hardware_ir_versions: list[str] = Field(default_factory=list)
+    upgrade_message: str | None = None
+
+
+class CompatibilityResult(BaseModel):
+    """The result of comparing one client with a hosted compatibility contract."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    status: CompatibilityStatus
+    client_version: str
+    latest_version: str | None = None
+    minimum_supported_version: str | None = None
+    client_protocol_version: int | None = None
+    protocol_version: int | None = None
+    hardware_ir_version: str | None = None
+    message: str
+    upgrade_command: str = UPGRADE_COMMAND
+
+    @property
+    def is_blocking(self) -> bool:
+        return self.status in {
+            CompatibilityStatus.UNSUPPORTED_CLIENT,
+            CompatibilityStatus.UNSUPPORTED_PROTOCOL,
+            CompatibilityStatus.UNSUPPORTED_HARDWARE_IR,
+        }
+
+
+class UnsupportedHardwareIRVersion(ValueError):
+    """Raised when a serialized Hardware IR document uses an unsupported schema."""
+
+    def __init__(self, version: str) -> None:
+        self.version = version
+        super().__init__(f"Hardware IR schema version {version!r} is not supported by this Forma service.")
+
+
+def _version_tuple(value: str) -> tuple[int, int, int]:
+    match = _VERSION_PATTERN.fullmatch(str(value).strip())
+    if match is None:
+        raise ValueError(f"Invalid Forma version: {value!r}")
+    return tuple(int(part) for part in match.groups())  # type: ignore[return-value]
+
+
+def compare_versions(left: str, right: str) -> int:
+    """Compare two release versions without adding a packaging dependency."""
+
+    left_tuple = _version_tuple(left)
+    right_tuple = _version_tuple(right)
+    return (left_tuple > right_tuple) - (left_tuple < right_tuple)
+
+
+def _configured_version(*names: str, default: str) -> str:
+    for name in names:
+        value = config.optional(name)
+        if value and value.strip():
+            return value.strip()
+    return default
+
+
+def _configured_protocol_version() -> int:
+    raw = config.optional("FORMA_HOSTED_PROTOCOL_VERSION")
+    if not raw:
+        return CURRENT_PROTOCOL_VERSION
+    try:
+        value = int(raw)
+    except ValueError as exc:
+        raise ValueError("FORMA_HOSTED_PROTOCOL_VERSION must be an integer.") from exc
+    if value < 1:
+        raise ValueError("FORMA_HOSTED_PROTOCOL_VERSION must be at least 1.")
+    return value
+
+
+def hosted_compatibility_metadata() -> CompatibilityMetadata:
+    """Resolve the hosted policy from explicit deployment configuration."""
+
+    latest = _configured_version(
+        "FORMA_HOSTED_LATEST_VERSION",
+        "FORMA_LATEST_VERSION",
+        default=__version__,
+    )
+    minimum = _configured_version(
+        "FORMA_HOSTED_MINIMUM_SUPPORTED_VERSION",
+        "FORMA_MINIMUM_SUPPORTED_VERSION",
+        default=__version__,
+    )
+    if compare_versions(minimum, latest) > 0:
+        raise ValueError("The minimum supported Forma version cannot be newer than the latest version.")
+    supported = sorted(
+        {
+            item.strip()
+            for item in (config.optional("FORMA_SUPPORTED_HARDWARE_IR_VERSIONS") or CURRENT_HARDWARE_IR_VERSION).split(",")
+            if item.strip()
+        }
+    )
+    if not supported:
+        supported = [CURRENT_HARDWARE_IR_VERSION]
+    current_ir = config.optional("FORMA_HARDWARE_IR_VERSION") or CURRENT_HARDWARE_IR_VERSION
+    if current_ir not in supported:
+        supported.insert(0, current_ir)
+    return CompatibilityMetadata(
+        latest_version=latest,
+        minimum_supported_version=minimum,
+        protocol_version=_configured_protocol_version(),
+        hardware_ir_version=current_ir,
+        supported_hardware_ir_versions=supported,
+        upgrade_message=config.optional("FORMA_UPGRADE_MESSAGE"),
+    )
+
+
+def evaluate_compatibility(
+    client_version: str,
+    metadata: CompatibilityMetadata,
+    *,
+    client_protocol_version: int = CURRENT_PROTOCOL_VERSION,
+    hardware_ir_version: str | None = None,
+) -> CompatibilityResult:
+    """Compare client dimensions in order of the most actionable failure."""
+
+    base = {
+        "client_version": client_version,
+        "latest_version": metadata.latest_version,
+        "minimum_supported_version": metadata.minimum_supported_version,
+        "client_protocol_version": client_protocol_version,
+        "protocol_version": metadata.protocol_version,
+        "hardware_ir_version": hardware_ir_version,
+    }
+    if client_protocol_version != metadata.protocol_version:
+        return CompatibilityResult(
+            **base,
+            status=CompatibilityStatus.UNSUPPORTED_PROTOCOL,
+            message=(
+                f"Forma hosted protocol version {metadata.protocol_version} is required; "
+                f"this client uses protocol version {client_protocol_version}."
+            ),
+        )
+    if hardware_ir_version is not None and hardware_ir_version not in set(
+        metadata.supported_hardware_ir_versions or [metadata.hardware_ir_version]
+    ):
+        return CompatibilityResult(
+            **base,
+            status=CompatibilityStatus.UNSUPPORTED_HARDWARE_IR,
+            message=(
+                f"Hardware IR schema version {hardware_ir_version} is not supported by the Forma hosted API. "
+                f"Supported version(s): {', '.join(metadata.supported_hardware_ir_versions or [metadata.hardware_ir_version])}."
+            ),
+        )
+    if compare_versions(client_version, metadata.minimum_supported_version) < 0:
+        return CompatibilityResult(
+            **base,
+            status=CompatibilityStatus.UNSUPPORTED_CLIENT,
+            message=(
+                f"Forma-OSS {client_version} is no longer compatible with the Forma hosted API. "
+                f"Minimum supported version: {metadata.minimum_supported_version}."
+            ),
+        )
+    if compare_versions(client_version, metadata.latest_version) < 0:
+        return CompatibilityResult(
+            **base,
+            status=CompatibilityStatus.UPDATE_AVAILABLE,
+            message=metadata.upgrade_message
+            or (
+                f"Forma-OSS {metadata.latest_version} is available. You are running {client_version}. "
+                f"Upgrade with `{UPGRADE_COMMAND}`."
+            ),
+        )
+    return CompatibilityResult(
+        **base,
+        status=CompatibilityStatus.CURRENT,
+        message=f"Forma-OSS {client_version} is compatible with the hosted API.",
+    )
+
+
+def hardware_ir_version_from_document(document: Mapping[str, Any]) -> str | None:
+    """Read an explicitly serialized IR version before Pydantic migrations normalize it."""
+
+    nested = document.get("project_ir")
+    if not isinstance(nested, Mapping):
+        nested = document.get("hardware_ir")
+    if not isinstance(nested, Mapping):
+        nested = document
+    value = nested.get("hardware_ir_version")
+    return str(value).strip() if value is not None and str(value).strip() else None
+
+
+def ensure_supported_hardware_ir_version(
+    document: Mapping[str, Any],
+    *,
+    supported_versions: set[str] | frozenset[str] | list[str] | None = None,
+) -> None:
+    version = hardware_ir_version_from_document(document)
+    supported = set(supported_versions or SUPPORTED_HARDWARE_IR_VERSIONS)
+    if version is not None and version not in supported:
+        raise UnsupportedHardwareIRVersion(version)
+
+
+def unavailable_result(client_version: str) -> CompatibilityResult:
+    return CompatibilityResult(
+        status=CompatibilityStatus.REMOTE_VERSION_UNAVAILABLE,
+        client_version=client_version,
+        message="Hosted Forma compatibility information is unavailable; continuing without a remote version check.",
+    )
+
+
+def compatibility_error_detail(result: CompatibilityResult) -> dict[str, Any]:
+    """Return a stable server/client error payload for blocked operations."""
+
+    code_by_status = {
+        CompatibilityStatus.UNSUPPORTED_CLIENT: "UNSUPPORTED_CLIENT_VERSION",
+        CompatibilityStatus.UNSUPPORTED_PROTOCOL: "UNSUPPORTED_PROTOCOL_VERSION",
+        CompatibilityStatus.UNSUPPORTED_HARDWARE_IR: "UNSUPPORTED_HARDWARE_IR_VERSION",
+    }
+    return {
+        "code": code_by_status[result.status],
+        "message": result.message,
+        "latest_version": result.latest_version,
+        "minimum_supported_version": result.minimum_supported_version,
+        "protocol_version": result.protocol_version,
+        "hardware_ir_version": result.hardware_ir_version,
+        "upgrade_command": result.upgrade_command,
+    }
+
+
+__all__ = [
+    "CURRENT_HARDWARE_IR_VERSION",
+    "CURRENT_PROTOCOL_VERSION",
+    "CompatibilityMetadata",
+    "CompatibilityResult",
+    "CompatibilityStatus",
+    "SUPPORTED_HARDWARE_IR_VERSIONS",
+    "UPGRADE_COMMAND",
+    "UnsupportedHardwareIRVersion",
+    "compatibility_error_detail",
+    "compare_versions",
+    "ensure_supported_hardware_ir_version",
+    "evaluate_compatibility",
+    "hardware_ir_version_from_document",
+    "hosted_compatibility_metadata",
+    "unavailable_result",
+]

--- a/tests/api/test_cli_project_artifacts.py
+++ b/tests/api/test_cli_project_artifacts.py
@@ -182,6 +182,22 @@ class CliProjectArtifactApiTests(unittest.IsolatedAsyncioTestCase):
             await cli_projects_api.push_cli_project(request, _user())
         self.assertEqual(400, raised.exception.status_code)
 
+    async def test_push_rejects_unsupported_hardware_ir_before_persisting(self) -> None:
+        request = cli_projects_api.ProjectPushRequest(
+            manifest={
+                "format": "forma-project",
+                "project_id": "project-a",
+                "project_ir": {"hardware_ir_version": "9.0"},
+            }
+        )
+        with patch.object(cli_projects_api, "insert_cli_project_revision") as insert:
+            with self.assertRaises(HTTPException) as raised:
+                await cli_projects_api.push_cli_project(request, _user())
+
+        self.assertEqual(426, raised.exception.status_code)
+        self.assertEqual("UNSUPPORTED_HARDWARE_IR_VERSION", raised.exception.detail["code"])
+        insert.assert_not_called()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/providers/test_compatibility.py
+++ b/tests/providers/test_compatibility.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from unittest.mock import patch
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from apps.api.compatibility import require_client_compatibility
+from apps.api.main import app
+from forma_cli.credentials import CredentialStore
+from forma_cli.sdk import FormaAPIClient
+from forma_core._version import __version__
+from forma_core.config.compatibility import (
+    CURRENT_PROTOCOL_VERSION,
+    CompatibilityMetadata,
+    CompatibilityStatus,
+    evaluate_compatibility,
+)
+
+
+class Response:
+    def __init__(self, payload: object) -> None:
+        self.payload = payload
+        self.headers: dict[str, str] = {}
+
+    def __enter__(self) -> "Response":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return json.dumps(self.payload).encode("utf-8")
+
+
+def _metadata(**overrides: object) -> dict[str, object]:
+    return {
+        "latest_version": __version__,
+        "minimum_supported_version": __version__,
+        "protocol_version": CURRENT_PROTOCOL_VERSION,
+        "hardware_ir_version": "0.2",
+        "supported_hardware_ir_versions": ["0.2"],
+        **overrides,
+    }
+
+
+def _request(headers: dict[str, str]) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "scheme": "https",
+            "path": "/cli/projects",
+            "raw_path": b"/cli/projects",
+            "query_string": b"",
+            "headers": [(key.lower().encode(), value.encode()) for key, value in headers.items()],
+            "server": ("testserver", 443),
+            "client": ("testclient", 50000),
+        }
+    )
+
+
+class CompatibilityPolicyTests(unittest.TestCase):
+    def test_current_client_is_current(self) -> None:
+        result = evaluate_compatibility(__version__, CompatibilityMetadata.model_validate(_metadata()))
+
+        self.assertEqual(CompatibilityStatus.CURRENT, result.status)
+
+    def test_older_supported_client_gets_update_notice(self) -> None:
+        result = evaluate_compatibility(
+            "0.3.3",
+            CompatibilityMetadata.model_validate(
+                _metadata(latest_version="0.3.5", minimum_supported_version="0.3.0")
+            ),
+        )
+
+        self.assertEqual(CompatibilityStatus.UPDATE_AVAILABLE, result.status)
+        self.assertIn("pipx upgrade forma-oss", result.message)
+
+    def test_client_below_minimum_is_blocked(self) -> None:
+        result = evaluate_compatibility(
+            "0.2.9",
+            CompatibilityMetadata.model_validate(_metadata(minimum_supported_version="0.3.0")),
+        )
+
+        self.assertEqual(CompatibilityStatus.UNSUPPORTED_CLIENT, result.status)
+        self.assertTrue(result.is_blocking)
+
+    def test_protocol_mismatch_is_distinct(self) -> None:
+        result = evaluate_compatibility(
+            __version__,
+            CompatibilityMetadata.model_validate(_metadata(protocol_version=2)),
+        )
+
+        self.assertEqual(CompatibilityStatus.UNSUPPORTED_PROTOCOL, result.status)
+
+    def test_sdk_caches_remote_compatibility_and_sends_contract_headers(self) -> None:
+        client = FormaAPIClient(base_url="https://api.example.test", credential_store=CredentialStore())
+        with patch(
+            "forma_cli.sdk.urlopen",
+            side_effect=[Response(_metadata()), Response({"ok": True})],
+        ) as urlopen:
+            result = client.check_compatibility()
+            client._request("/health")
+
+        self.assertEqual(CompatibilityStatus.CURRENT, result.status)
+        self.assertEqual(2, urlopen.call_count)
+        request = urlopen.call_args_list[1].args[0]
+        self.assertEqual(__version__, request.get_header("X-forma-client-version"))
+        self.assertEqual(str(CURRENT_PROTOCOL_VERSION), request.get_header("X-forma-protocol-version"))
+
+    def test_sdk_force_refresh_does_not_trust_stale_compatible_metadata(self) -> None:
+        client = FormaAPIClient(base_url="https://api.example.test", credential_store=CredentialStore())
+        with patch(
+            "forma_cli.sdk.urlopen",
+            side_effect=[
+                Response(_metadata()),
+                Response(_metadata(minimum_supported_version="0.4.0")),
+            ],
+        ):
+            self.assertEqual(CompatibilityStatus.CURRENT, client.check_compatibility().status)
+            refreshed = client.check_compatibility(force=True)
+
+        self.assertEqual(CompatibilityStatus.UNSUPPORTED_CLIENT, refreshed.status)
+
+    def test_local_sdk_does_not_require_remote_compatibility(self) -> None:
+        client = FormaAPIClient(base_url="http://127.0.0.1:8000", credential_store=CredentialStore())
+
+        result = client.check_compatibility()
+
+        self.assertEqual(CompatibilityStatus.REMOTE_VERSION_UNAVAILABLE, result.status)
+
+    def test_server_rejects_explicitly_unsupported_client(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "FORMA_HOSTED_LATEST_VERSION": "0.3.4",
+                "FORMA_HOSTED_MINIMUM_SUPPORTED_VERSION": "0.3.0",
+            },
+            clear=False,
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                require_client_compatibility(
+                    _request(
+                        {
+                            "X-Forma-Client-Version": "0.2.9",
+                            "X-Forma-Protocol-Version": str(CURRENT_PROTOCOL_VERSION),
+                        }
+                    )
+                )
+
+        self.assertEqual(426, raised.exception.status_code)
+        self.assertEqual("UNSUPPORTED_CLIENT_VERSION", raised.exception.detail["code"])
+
+    def test_cli_route_applies_server_compatibility_backstop(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "FORMA_HOSTED_LATEST_VERSION": "0.3.4",
+                "FORMA_HOSTED_MINIMUM_SUPPORTED_VERSION": "0.3.0",
+            },
+            clear=False,
+        ):
+            response = TestClient(app).post(
+                "/cli/device/authorize",
+                headers={
+                    "X-Forma-Client-Version": "0.2.9",
+                    "X-Forma-Protocol-Version": str(CURRENT_PROTOCOL_VERSION),
+                },
+            )
+
+        self.assertEqual(426, response.status_code)
+        self.assertEqual("UNSUPPORTED_CLIENT_VERSION", response.json()["detail"]["code"])
+
+    def test_public_endpoint_exposes_machine_readable_contract(self) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "FORMA_HOSTED_LATEST_VERSION": "0.3.5",
+                "FORMA_HOSTED_MINIMUM_SUPPORTED_VERSION": "0.3.0",
+                "FORMA_HOSTED_PROTOCOL_VERSION": "2",
+            },
+            clear=False,
+        ):
+            response = TestClient(app).get("/forma/version")
+
+        self.assertEqual(200, response.status_code)
+        self.assertEqual("0.3.5", response.json()["latest_version"])
+        self.assertEqual(2, response.json()["protocol_version"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tooling/test_oss_cli.py
+++ b/tests/tooling/test_oss_cli.py
@@ -69,7 +69,7 @@ class OssCliTests(unittest.TestCase):
         self.assertEqual(
             {
                 "login", "logout", "whoami", "init", "build", "import", "metadata", "metadata-api",
-                "status", "render", "projects", "keys",
+                "status", "render", "projects", "keys", "version", "doctor",
             },
             set(parser._subparsers._group_actions[0].choices),
         )
@@ -301,6 +301,12 @@ class OssCliTests(unittest.TestCase):
         with patch(
             "forma_cli.sdk.urlopen",
             side_effect=[
+                Response({
+                    "latest_version": "0.3.4",
+                    "minimum_supported_version": "0.3.4",
+                    "protocol_version": 1,
+                    "hardware_ir_version": "0.2",
+                }),
                 Response({"status": "uploaded", "sha256": sha256}),
                 BinaryResponse(
                     content,
@@ -315,7 +321,7 @@ class OssCliTests(unittest.TestCase):
             uploaded = client.upload_project_artifact("project/a", "revision-1", sha256, content, "model/step")
             downloaded = client.download_project_artifact("project/a", "revision-1", sha256)
 
-        upload_request = urlopen.call_args_list[0].args[0]
+        upload_request = urlopen.call_args_list[1].args[0]
         self.assertEqual(content, upload_request.data)
         self.assertEqual("model/step", upload_request.get_header("Content-type"))
         self.assertEqual("uploaded", uploaded["status"])


### PR DESCRIPTION
## Summary\n- add a centralized package, hosted protocol, and Hardware IR compatibility contract\n- expose GET /forma/version for machine-readable hosted compatibility metadata\n- add cached SDK checks, client/protocol headers, structured blocking errors, and explicit upgrade notices\n- add orma-oss version and orma-oss doctor without affecting local/offline workflows\n- add server-side CLI backstop checks and reject unsupported Hardware IR uploads before persistence\n- document compatibility configuration and behavior\n\n## Validation\n- python -m unittest tests.providers.test_compatibility tests.tooling.test_oss_cli tests.api.test_cli_project_artifacts tests.tooling.test_cli_auth_api -v\n- python -m compileall -q forma_core forma_cli apps/api tests/providers/test_compatibility.py\n- local ersion and doctor CLI smoke checks\n- Full suite: 734 tests; 7 pre-existing Vertex/provider/filesystem failures and 1 pre-existing artifact-size failure, with all compatibility tests passing.\n\nCloses #370