### PR TITLE
fix: show CLI-uploaded images as product images

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
 import asyncio
+import base64
 from concurrent.futures import ThreadPoolExecutor
 import hashlib
 import json
@@ -203,6 +204,7 @@ from forma_core.runtime import (
 )
 from forma_core.config.runtime import forma_dev_mode_enabled, validate_runtime_configuration
 from apps.api.storage import get_image_storage_config, hydrate_image_storage_metadata
+from forma_core.persistence.project_artifacts import ProjectArtifactStorage, ProjectArtifactStorageError
 from forma_core.validation import validate_circuit
 from forma_core.utils import generate_mermaid_chart, generate_svg_schematic
 from apps.api.video_providers import (
@@ -1839,6 +1841,33 @@ async def a2a_mcp_endpoint(payload: Any = Body(...), _user: UserContext = Depend
     return response
 
 
+def _hydrate_cli_product_image_artifact(metadata: Dict[str, Any], project_id: str) -> Dict[str, Any]:
+    """Load one owner-scoped CLI image artifact into the existing image contract."""
+    hydrated = dict(metadata or {})
+    if hydrated.get("product_image_url") or hydrated.get("product_image_data"):
+        return hydrated
+    reference = hydrated.get("product_image_artifact")
+    if not isinstance(reference, dict):
+        return hydrated
+    sha256 = str(reference.get("sha256") or "").strip().lower()
+    media_type = str(reference.get("media_type") or "").strip().lower()
+    if not sha256 or not media_type.startswith("image/"):
+        return hydrated
+    try:
+        stored = ProjectArtifactStorage().get(project_id, sha256, media_type)
+        content = stored.content or b""
+        if hashlib.sha256(content).hexdigest() != sha256:
+            return hydrated
+        if reference.get("size_bytes") is not None and len(content) != reference["size_bytes"]:
+            return hydrated
+    except (FileNotFoundError, OSError, ProjectArtifactStorageError, ValueError):
+        return hydrated
+    hydrated["product_image_data"] = base64.b64encode(content).decode("ascii")
+    hydrated["product_image_content_type"] = stored.media_type
+    hydrated["product_image_storage_method"] = "cli-artifact"
+    return hydrated
+
+
 def _project_summary_response(
     project: Any,
     current_user_id: Optional[str] = None,
@@ -1859,6 +1888,8 @@ def _project_summary_response(
     # Resolved metadata is authoritative for cross-store project reads. The
     # legacy project payload remains the fallback for callers without a resolver.
     metadata = image_metadata if isinstance(image_metadata, dict) else project_metadata
+    if metadata and hydrate_storage and can_chat and getattr(project, "creation_channel", "") == "cli":
+        metadata = _hydrate_cli_product_image_artifact(metadata, project.project_id)
     hydrated_metadata = (
         hydrate_image_storage_metadata(metadata, project.project_id)
         if metadata and hydrate_storage
@@ -2230,6 +2261,7 @@ def _cli_project_response(project_id: str, owner_user_id: str) -> Optional[Proje
             "project_source": "cli",
         }
     )
+    metadata = _hydrate_cli_product_image_artifact(metadata, str(resolved.project_id))
     project_ir["assembly_metadata"] = metadata
     overview = project_ir.get("overview") if isinstance(project_ir.get("overview"), dict) else {}
     components = project_ir.get("components") if isinstance(project_ir.get("components"), list) else []
@@ -2263,6 +2295,7 @@ def _cli_project_response(project_id: str, owner_user_id: str) -> Optional[Proje
         has_product_image=bool(product_image_url or product_image_data),
         product_image_url=product_image_url,
         product_image_data=product_image_data,
+        product_image_content_type=metadata.get("product_image_content_type"),
         product_visual_sequence=metadata.get("product_visual_sequence") or [],
         project_ir=project_ir,
         project_object=project_object,

--- a/forma_core/workspaces/projects/resolver.py
+++ b/forma_core/workspaces/projects/resolver.py
@@ -11,7 +11,7 @@ from typing import Any, Optional
 from forma_core.persistence.repositories.base import ApplicationRepository
 from forma_core.workspaces.design_briefs import DesignBrief
 from forma_core.workspaces.projects.identity import ProjectCreationChannel
-from forma_core.workspaces.projects.manifest import ProjectManifest
+from forma_core.workspaces.projects.manifest import ProjectManifest, validate_artifact_references
 from forma_core.workspaces.projects.state import ProjectRevision, ProjectStateError, ProjectStateService
 
 
@@ -73,6 +73,38 @@ def _project_ir_metadata(project_ir: Any) -> dict[str, Any]:
         return {}
     metadata = project_ir.get("assembly_metadata")
     return deepcopy(metadata) if isinstance(metadata, dict) else {}
+
+
+def _cli_product_image_artifact(manifest: ProjectManifest) -> dict[str, Any]:
+    """Expose a declared image artifact as product-image metadata."""
+    try:
+        artifacts = validate_artifact_references(manifest.artifacts, require_integrity=False)
+    except ValueError:
+        return {}
+
+    candidates: list[tuple[int, dict[str, Any]]] = []
+    for artifact in artifacts:
+        media_type = str(artifact.get("media_type") or "").strip().lower()
+        sha256 = str(artifact.get("sha256") or "").strip().lower()
+        if not media_type.startswith("image/") or not sha256:
+            continue
+        role = str(artifact.get("role") or artifact.get("kind") or "").strip().lower().replace("-", "_")
+        if role in {"hardware_reference", "reference_image", "input_image"}:
+            continue
+        priority = 0 if role in {"product_image", "product_render", "render", "preview"} else 1
+        candidates.append((priority, artifact))
+
+    if not candidates:
+        return {}
+    artifact = min(candidates, key=lambda item: item[0])[1]
+    reference = {
+        "path": artifact["path"],
+        "sha256": artifact["sha256"],
+        "media_type": artifact["media_type"],
+    }
+    if artifact.get("size_bytes") is not None:
+        reference["size_bytes"] = artifact["size_bytes"]
+    return {"product_image_artifact": reference}
 
 
 def _identity_record(value: Any) -> Any:
@@ -345,6 +377,7 @@ class ProjectReadResolver:
             return None
         project_ir = deepcopy(manifest.project_ir)
         metadata = _project_ir_metadata(project_ir)
+        metadata.update(_cli_product_image_artifact(manifest))
         metadata.update({"project_id": project_id, "chat_id": None, "project_source": "cli"})
         project_ir["assembly_metadata"] = metadata
         project = SimpleNamespace(

--- a/tests/api/test_project_access.py
+++ b/tests/api/test_project_access.py
@@ -568,7 +568,11 @@ class ProjectReadAccessTests(unittest.TestCase):
                 "prompt": "Build a CLI project.",
                 "project_ir": {
                     "components": [],
-                    "assembly_metadata": {"project_id": project_id},
+                    "assembly_metadata": {
+                        "project_id": project_id,
+                        "product_image_data": "inline-cli-image",
+                        "product_image_content_type": "image/jpeg",
+                    },
                 },
             },
             "created_at": "2026-07-25T12:00:00Z",
@@ -592,6 +596,7 @@ class ProjectReadAccessTests(unittest.TestCase):
         self.assertIsNone(response["chat_id"])
         self.assertEqual("cli", response["project_ir"]["assembly_metadata"]["project_source"])
         self.assertEqual("cli-revision-1", response["project_ir"]["assembly_metadata"]["cloud_revision_id"])
+        self.assertEqual("image/jpeg", response["product_image_content_type"])
 
     def test_owner_can_read_canonical_only_project_through_project_endpoint(self) -> None:
         project_id = "11111111-1111-4111-8111-111111111111"

--- a/tests/api/test_project_summary.py
+++ b/tests/api/test_project_summary.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import hashlib
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -121,6 +123,43 @@ class ProjectSummaryTests(unittest.TestCase):
         self.assertEqual("openai/gpt-image-2", summary["product_image_model"])
         self.assertEqual("succeeded", summary["image_output_status"])
         self.assertEqual("https://storage.example.test/signed-product-case.png", summary["product_visual_sequence"][0]["url"])
+
+    def test_project_summary_hydrates_owner_cli_image_artifact(self) -> None:
+        content = b"cli image bytes"
+        sha256 = hashlib.sha256(content).hexdigest()
+        project = SimpleNamespace(
+            project_id="cli-image-project",
+            chat_id=None,
+            title="CLI image project",
+            prompt="Build a CLI project.",
+            created_at="2026-08-01T12:00:00Z",
+            owner_user_id="user_123",
+            creation_channel="cli",
+            hardware_ir={
+                "components": [],
+                "assembly_metadata": {
+                    "product_image_artifact": {
+                        "path": "project-render.png",
+                        "sha256": sha256,
+                        "media_type": "image/png",
+                        "size_bytes": len(content),
+                    },
+                },
+            },
+        )
+
+        with patch.object(main, "creator_display_name", return_value="isayahc"), patch.object(
+            main,
+            "ProjectArtifactStorage",
+            return_value=SimpleNamespace(
+                get=lambda *_args: SimpleNamespace(content=content, media_type="image/png")
+            ),
+        ), patch.object(main, "hydrate_image_storage_metadata", side_effect=lambda metadata, _project_id: metadata):
+            summary = main._project_summary_response(project, current_user_id="user_123")
+
+        self.assertTrue(summary["has_product_image"])
+        self.assertEqual("image/png", summary["product_image_content_type"])
+        self.assertEqual(base64.b64encode(content).decode("ascii"), summary["product_image_data"])
 
     def test_project_image_summary_endpoint_does_not_validate_full_ir(self) -> None:
         project = SimpleNamespace(

--- a/tests/projects/test_project_read_resolver.py
+++ b/tests/projects/test_project_read_resolver.py
@@ -148,6 +148,49 @@ class ProjectReadResolverTests(unittest.TestCase):
         self.assertEqual(1, resolved.current_revision)
         self.assertFalse(resolved.can_chat)
 
+    def test_cli_project_projects_image_artifact_into_product_image_metadata(self) -> None:
+        image_sha256 = "a" * 64
+        repository = Mock()
+        repository.get_generated_project.return_value = None
+        repository.get_cli_project_revision.return_value = SimpleNamespace(
+            revision_id="cli-revision-image",
+            revision=1,
+            created_at="2026-08-02T12:00:00Z",
+            manifest_json={
+                "format": "forma-project",
+                "version": 1,
+                "project_id": PROJECT_ID,
+                "title": "CLI image project",
+                "project_ir": {"components": [], "assembly_metadata": {}},
+                "artifacts": [
+                    {
+                        "path": "project-render.png",
+                        "sha256": image_sha256,
+                        "media_type": "image/png",
+                        "size_bytes": 12,
+                    }
+                ],
+            },
+        )
+        resolver = ProjectReadResolver(repository)
+        resolver._state.get_latest = Mock(side_effect=ProjectStateError("project_revision_not_found", "missing"))
+
+        resolved = resolver.resolve(PROJECT_ID, "owner-a")
+
+        self.assertEqual(
+            {
+                "path": "project-render.png",
+                "sha256": image_sha256,
+                "media_type": "image/png",
+                "size_bytes": 12,
+            },
+            resolved.image_metadata["product_image_artifact"],
+        )
+        self.assertEqual(
+            resolved.image_metadata["product_image_artifact"],
+            resolved.project_ir["assembly_metadata"]["product_image_artifact"],
+        )
+
     def test_private_and_deleted_projects_are_hidden_without_owner_access(self) -> None:
         for status, include_deleted in (("active", False), ("deletion_pending", True)):
             project = SimpleNamespace(


### PR DESCRIPTION
Closes #418

## Summary
- Projects CLI manifests with image artifacts into product-image metadata.
- Hydrates verified private artifact bytes for authorized project reads.
- Preserves image content type in project detail responses.

## Tests
- python -m unittest tests.projects.test_project_read_resolver tests.api.test_project_summary tests.api.test_cli_project_artifacts tests.api.test_project_access
- python -m compileall -q apps forma_core forma_cli tests
- Full unittest discovery ran; unrelated provider, filesystem-permission, and existing fixture failures remain.