### PR TITLE
fix: show CLI project images in gallery

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -2021,7 +2021,7 @@ def _gallery_inventory_summary(record: Any, *, current_user_id: Optional[str]) -
             project,
             current_user_id=current_user_id,
             hydrate_storage=False,
-            include_inline_images=False,
+            include_inline_images=True,
         )
 
     identity = {


### PR DESCRIPTION
Fixes #422\n\nCLI project gallery summaries were stripping inline product image data, while CLI revisions have no URL fallback. Preserve inline image metadata for CLI gallery summaries so uploaded product images appear in gallery cards, matching project detail behavior.