### PR TITLE
feat: add fabrication slicing stage

### DIFF
--- a/forma_cli/app.py
+++ b/forma_cli/app.py
@@ -26,6 +26,7 @@ from forma_cli.local import (
     init_project,
     project_root,
     read_project,
+    slice_local_project,
     status_project,
     update_linkage,
 )
@@ -260,6 +261,138 @@ def cmd_render(args: argparse.Namespace) -> int:
         ),
     )
     print(f"Rendered {manifest.title or manifest.project_id} at {output}")
+    return 0
+
+
+def _printer_registry():
+    from forma_core.workspaces.projects.fabrication import load_printer_registry
+
+    return load_printer_registry()
+
+
+def cmd_printer_list(args: argparse.Namespace) -> int:
+    registry = _printer_registry()
+    rows = [
+        {
+            "printer_id": printer.printer_id,
+            "display_name": printer.display_name,
+            "backend": printer.backend,
+            "default_profile": printer.default_profile,
+            "default": registry.default_printer == printer.printer_id,
+            "profiles": sorted(printer.profiles),
+        }
+        for printer in sorted(registry.printers.values(), key=lambda item: item.printer_id)
+    ]
+    if args.json:
+        _print_json(rows)
+    else:
+        for row in rows:
+            marker = "*" if row["default"] else " "
+            print(f"{marker} {row['printer_id']}\t{row['backend']}\t{row['default_profile']}\t{row['display_name']}")
+    return 0
+
+
+def cmd_printer_show(args: argparse.Namespace) -> int:
+    registry = _printer_registry()
+    printer = registry.printers.get(args.printer_id)
+    if printer is None:
+        raise ValueError(f"Printer configuration not found: {args.printer_id}")
+    payload = printer.model_dump(mode="json")
+    payload["default"] = registry.default_printer == printer.printer_id
+    if args.json:
+        _print_json(payload)
+    else:
+        print(f"{printer.display_name} ({printer.printer_id})")
+        print(f"Backend: {printer.backend}")
+        print(f"Default profile: {printer.default_profile}")
+        for name, profile in sorted(printer.profiles.items()):
+            print(f"Profile {name}: {profile.native_config}")
+    return 0
+
+
+def cmd_printer_add(args: argparse.Namespace) -> int:
+    from forma_core.workspaces.projects.fabrication import (
+        PrinterProfileReference,
+        UserPrinterConfig,
+        save_printer_registry,
+    )
+
+    registry = _printer_registry()
+    if args.printer_id in registry.printers:
+        raise ValueError(f"Printer configuration already exists: {args.printer_id}")
+    if not args.profiles:
+        raise ValueError("At least one --profile NAME=PATH is required.")
+    profiles = {}
+    for value in args.profiles:
+        name, separator, native_config = value.partition("=")
+        if not separator or not name.strip() or not native_config.strip():
+            raise ValueError("Profiles must use NAME=PATH format.")
+        profiles[name.strip()] = PrinterProfileReference(native_config=native_config.strip())
+    printer = UserPrinterConfig(
+        printer_id=args.printer_id,
+        display_name=args.display_name or args.printer_id,
+        backend=args.backend,
+        default_profile=args.default_profile or next(iter(profiles)),
+        profiles=profiles,
+    )
+    registry.printers[printer.printer_id] = printer
+    if args.set_default or registry.default_printer is None:
+        registry.default_printer = printer.printer_id
+    save_printer_registry(registry)
+    print(f"Added printer {printer.printer_id}")
+    return 0
+
+
+def cmd_printer_set_default(args: argparse.Namespace) -> int:
+    from forma_core.workspaces.projects.fabrication import save_printer_registry
+
+    registry = _printer_registry()
+    if args.printer_id not in registry.printers:
+        raise ValueError(f"Printer configuration not found: {args.printer_id}")
+    registry.default_printer = args.printer_id
+    save_printer_registry(registry)
+    print(f"Default printer: {args.printer_id}")
+    return 0
+
+
+def cmd_printer_remove(args: argparse.Namespace) -> int:
+    from forma_core.workspaces.projects.fabrication import save_printer_registry
+
+    registry = _printer_registry()
+    if args.printer_id not in registry.printers:
+        raise ValueError(f"Printer configuration not found: {args.printer_id}")
+    del registry.printers[args.printer_id]
+    if registry.default_printer == args.printer_id:
+        registry.default_printer = next(iter(sorted(registry.printers)), None)
+    save_printer_registry(registry)
+    print(f"Removed printer {args.printer_id}")
+    return 0
+
+
+def cmd_project_slice(args: argparse.Namespace) -> int:
+    if args.project_id:
+        project_id = read_project(args.path).project_id
+        if args.project_id != project_id:
+            raise ValueError(f"Project ID mismatch: manifest contains {project_id}, requested {args.project_id}.")
+    manifest = slice_local_project(
+        args.path,
+        printer_id=args.printer,
+        backend=args.backend,
+        profile=args.profile,
+        profile_name=args.profile_name,
+        output_name=args.output_name,
+    )
+    result = {
+        "project_id": manifest.project_id,
+        "operation": "slice",
+        "artifacts": [artifact.model_dump(mode="json") for artifact in manifest.artifacts if artifact.path.startswith("fabrication/")],
+    }
+    if args.json:
+        _print_json(result)
+    else:
+        print(f"Sliced project {manifest.project_id}")
+        for artifact in result["artifacts"]:
+            print(f"Wrote {artifact['path']}")
     return 0
 
 
@@ -757,6 +890,43 @@ def build_parser() -> argparse.ArgumentParser:
     render.add_argument("--height", type=int, default=900)
     render.add_argument("--yaw", type=float, default=0.0)
     render.set_defaults(func=cmd_render)
+
+    printer = subparsers.add_parser("printer", help="Manage the local user printer registry.")
+    printer_commands = printer.add_subparsers(dest="printer_command", required=True)
+    printer_add = printer_commands.add_parser("add", help="Register a printer and native slicing profile.")
+    printer_add.add_argument("printer_id")
+    printer_add.add_argument("--backend", required=True)
+    printer_add.add_argument("--profile", dest="profiles", action="append", required=True, metavar="NAME=PATH")
+    printer_add.add_argument("--display-name")
+    printer_add.add_argument("--default-profile")
+    printer_add.add_argument("--set-default", action="store_true")
+    printer_add.set_defaults(func=cmd_printer_add)
+    printer_list = printer_commands.add_parser("list", help="List registered printers.")
+    printer_list.add_argument("--json", action="store_true")
+    printer_list.set_defaults(func=cmd_printer_list)
+    printer_show = printer_commands.add_parser("show", help="Show a registered printer.")
+    printer_show.add_argument("printer_id")
+    printer_show.add_argument("--json", action="store_true")
+    printer_show.set_defaults(func=cmd_printer_show)
+    printer_default = printer_commands.add_parser("set-default", help="Select the default printer.")
+    printer_default.add_argument("printer_id")
+    printer_default.set_defaults(func=cmd_printer_set_default)
+    printer_remove = printer_commands.add_parser("remove", help="Remove a registered printer.")
+    printer_remove.add_argument("printer_id")
+    printer_remove.set_defaults(func=cmd_printer_remove)
+
+    project = subparsers.add_parser("project", help="Run operations on a local Forma project.")
+    project_commands = project.add_subparsers(dest="project_command", required=True)
+    project_slice = project_commands.add_parser("slice", help="Slice an existing project mesh into validated G-code.")
+    project_slice.add_argument("project_id", nargs="?")
+    project_slice.add_argument("--path", default=".")
+    project_slice.add_argument("--printer")
+    project_slice.add_argument("--backend")
+    project_slice.add_argument("--profile", help="Native slicer profile/config path.")
+    project_slice.add_argument("--profile-name")
+    project_slice.add_argument("--output-name")
+    project_slice.add_argument("--json", action="store_true")
+    project_slice.set_defaults(func=cmd_project_slice)
 
     projects = subparsers.add_parser("projects", help="Manage explicit cloud project synchronization.")
     project_commands = projects.add_subparsers(dest="projects_command", required=True)

--- a/forma_cli/local.py
+++ b/forma_cli/local.py
@@ -396,6 +396,124 @@ def status_project(path: str | Path | None = None) -> dict[str, Any]:
     }
 
 
+def slice_local_project(
+    path: str | Path | None = None,
+    *,
+    printer_id: str | None = None,
+    backend: str | None = None,
+    profile: str | Path | None = None,
+    profile_name: str | None = None,
+    output_name: str | None = None,
+) -> ProjectManifest:
+    """Slice an existing local CAD mesh without regenerating the project."""
+    root = project_root(path)
+    manifest = read_project(root)
+    from forma_core.workspaces.projects.fabrication import (
+        SliceRequest,
+        load_printer_registry,
+        resolve_slice_profile,
+        slice_project as run_slice_project,
+    )
+    from forma_core.workspaces.projects.models import HardwareIR
+    from forma_core.workspaces.projects.state import ProjectArtifact
+
+    try:
+        ir = HardwareIR.model_validate(manifest.project_ir)
+    except Exception as exc:
+        raise LocalProjectError("Project manifest contains invalid HardwareIR.") from exc
+    cad = ir.cad_model if isinstance(ir.cad_model, dict) else {}
+    mesh_path = str(cad.get("preview_path") or "").strip()
+    if not mesh_path:
+        for artifact in manifest.artifacts:
+            if (artifact.media_type or "").lower() == "model/stl":
+                mesh_path = artifact.path
+                break
+    if not mesh_path:
+        raise LocalProjectError("Project has no printable STL mesh artifact. Generate or import CAD first.")
+    mesh = Path(mesh_path).expanduser()
+    if not mesh.is_absolute():
+        mesh = (root / mesh).resolve()
+    if not mesh.is_file():
+        raise LocalProjectError(f"Printable mesh artifact does not exist: {mesh}")
+    registry = load_printer_registry()
+    try:
+        resolved = resolve_slice_profile(
+            registry,
+            printer_id=printer_id,
+            backend=backend,
+            native_config=str(profile) if profile else None,
+            profile_name=profile_name,
+        )
+    except (ValueError, RuntimeError) as exc:
+        raise LocalProjectError(str(exc)) from exc
+    output = root / "fabrication" / (output_name or f"{mesh.stem}.gcode")
+    if output_name and Path(output_name).name != output_name:
+        raise LocalProjectError("Slice output name must be a filename, not a path.")
+    mesh_artifact = ProjectArtifact(
+        artifact_id="native-cad-mesh",
+        kind="mesh.stl",
+        uri=str(mesh),
+        media_type="model/stl",
+        checksum=f"sha256:{hashlib.sha256(mesh.read_bytes()).hexdigest()}",
+        metadata={"path": str(mesh)},
+    )
+    try:
+        result = run_slice_project(
+            SliceRequest(
+                mesh_artifact=mesh_artifact,
+                profile=resolved,
+                output_path=str(output),
+                project_id=manifest.project_id,
+            )
+        )
+    except Exception as exc:
+        raise LocalProjectError(str(exc)) from exc
+
+    metadata = dict(ir.assembly_metadata or {})
+    metadata["fabrication"] = {
+        "status": "succeeded",
+        "backend": result.backend,
+        "printer_name": result.printer_name,
+        "profile_name": result.profile_name,
+        "gcode_sha256": result.gcode_artifact.checksum,
+        "report_uri": result.report_artifact.uri if result.report_artifact else None,
+    }
+    ir.assembly_metadata = metadata
+    from forma_core.workspaces.projects.output import persist_project_output
+
+    persist_project_output(ir, prompt_text=manifest.prompt or manifest.title, owner_user_id=LOCAL_OWNER_USER_ID)
+    references = [
+        artifact
+        for artifact in manifest.artifacts
+        if artifact.path not in {"fabrication/" + output.name, "fabrication/" + output.with_suffix(".report.json").name}
+    ]
+    for artifact in (result.gcode_artifact, result.report_artifact):
+        if artifact is None:
+            continue
+        artifact_path = Path(artifact.uri).resolve().relative_to(root.resolve()).as_posix()
+        references.append(
+            ProjectArtifactReference(
+                path=artifact_path,
+                sha256=str(artifact.checksum or "").removeprefix("sha256:"),
+                media_type=artifact.media_type,
+                size_bytes=Path(artifact.uri).stat().st_size,
+            )
+        )
+    updated = ProjectManifest(
+        format=PROJECT_MANIFEST_FORMAT,
+        version=1,
+        project_id=manifest.project_id,
+        workspace_id=manifest.workspace_id,
+        title=manifest.title,
+        prompt=manifest.prompt,
+        visibility=manifest.visibility,
+        project_ir=ir.model_dump(mode="json"),
+        artifacts=references,
+    )
+    write_project_manifest(root / PROJECT_FILENAME, updated)
+    return updated
+
+
 def update_linkage(path: str | Path, **values: Any) -> dict[str, Any]:
     root = project_root(path)
     linkage = {**load_linkage(root), **values}
@@ -414,5 +532,6 @@ __all__ = [
     "project_root",
     "read_project",
     "status_project",
+    "slice_local_project",
     "update_linkage",
 ]

--- a/forma_core/workspaces/projects/__init__.py
+++ b/forma_core/workspaces/projects/__init__.py
@@ -28,6 +28,15 @@ from forma_core.workspaces.projects.resolver import (
     ProjectReadResolver,
 )
 from forma_core.workspaces.projects.models import ProjectDetail, ProjectIdentityResponse, ProjectSummary
+from forma_core.workspaces.projects.fabrication import (
+    PrinterProfileReference,
+    PrinterRegistry,
+    SliceProfile,
+    SliceRequest,
+    SliceResult,
+    SliceValidationResult,
+    UserPrinterConfig,
+)
 
 __all__ = [
     "PROJECT_REVISION_SCHEMA_VERSION",
@@ -55,4 +64,11 @@ __all__ = [
     "ProjectReadNotFoundError",
     "ProjectReadResolution",
     "ProjectReadResolver",
+    "PrinterProfileReference",
+    "PrinterRegistry",
+    "SliceProfile",
+    "SliceRequest",
+    "SliceResult",
+    "SliceValidationResult",
+    "UserPrinterConfig",
 ]

--- a/forma_core/workspaces/projects/cad_generation.py
+++ b/forma_core/workspaces/projects/cad_generation.py
@@ -443,9 +443,32 @@ def cad_project_artifact(project: HardwareIR, project_id: str) -> ProjectArtifac
     )
 
 
+def mesh_project_artifact(project: HardwareIR, project_id: str) -> ProjectArtifact | None:
+    """Return the printable STL preview as a downstream fabrication input."""
+    cad = project.cad_model
+    if not isinstance(cad, dict):
+        return None
+    path = str(cad.get("preview_path") or "").strip()
+    if not path:
+        return None
+    checksum = ""
+    preview = Path(path)
+    if preview.is_file():
+        checksum = hashlib.sha256(preview.read_bytes()).hexdigest()
+    return ProjectArtifact(
+        artifact_id="native-cad-mesh",
+        kind="mesh.stl",
+        uri=str(preview),
+        media_type="model/stl",
+        checksum=f"sha256:{checksum}" if checksum else None,
+        metadata={"path": str(preview), "source_project_id": project_id, "format": "stl"},
+    )
+
+
 __all__ = [
     "CAD_ADAPTER_NAME",
     "CadGenerationError",
     "cad_project_artifact",
     "ensure_native_cad_model",
+    "mesh_project_artifact",
 ]

--- a/forma_core/workspaces/projects/fabrication/__init__.py
+++ b/forma_core/workspaces/projects/fabrication/__init__.py
@@ -1,0 +1,54 @@
+"""Deterministic fabrication services that operate downstream of project CAD."""
+
+from forma_core.workspaces.projects.fabrication.models import (
+    FabricationError,
+    PrinterConfigurationError,
+    SliceInspection,
+    SliceProfile,
+    SliceRequest,
+    SliceResult,
+    SliceValidationResult,
+    SlicerUnavailableError,
+)
+from forma_core.workspaces.projects.fabrication.printer_config import (
+    PrinterProfileReference,
+    PrinterRegistry,
+    UserPrinterConfig,
+    default_printer_config_path,
+    load_printer_registry,
+    resolve_slice_profile,
+    save_printer_registry,
+)
+from forma_core.workspaces.projects.fabrication.slicing import (
+    SlicerCapability,
+    discover_slicers,
+    ensure_slice_artifact,
+    get_slicer_adapter,
+    slice_project,
+)
+from forma_core.workspaces.projects.fabrication.slicers import CuraSlicerAdapter, SlicerAdapter
+
+__all__ = [
+    "FabricationError",
+    "PrinterConfigurationError",
+    "PrinterProfileReference",
+    "PrinterRegistry",
+    "SliceInspection",
+    "SliceProfile",
+    "SliceRequest",
+    "SliceResult",
+    "SliceValidationResult",
+    "SlicerCapability",
+    "SlicerUnavailableError",
+    "UserPrinterConfig",
+    "default_printer_config_path",
+    "CuraSlicerAdapter",
+    "discover_slicers",
+    "ensure_slice_artifact",
+    "get_slicer_adapter",
+    "load_printer_registry",
+    "resolve_slice_profile",
+    "save_printer_registry",
+    "slice_project",
+    "SlicerAdapter",
+]

--- a/forma_core/workspaces/projects/fabrication/models.py
+++ b/forma_core/workspaces/projects/fabrication/models.py
@@ -1,0 +1,120 @@
+"""Typed inputs and outputs for project fabrication."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from forma_core.workspaces.projects.state import ProjectArtifact
+
+
+class FabricationError(RuntimeError):
+    """Raised when a fabrication operation cannot produce a safe result."""
+
+
+class PrinterConfigurationError(FabricationError):
+    """Raised when a real printer/profile was not resolved."""
+
+
+class SlicerUnavailableError(FabricationError):
+    """Raised when the requested slicer executable is unavailable."""
+
+
+class SliceInspection(BaseModel):
+    """Inspection result for a mesh before it reaches a slicer."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    valid: bool
+    path: str | None = None
+    errors: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class SliceProfile(BaseModel):
+    """Resolved printer and process context for one slicing operation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    backend: str = Field(min_length=1)
+    printer_name: str = Field(min_length=1)
+    profile_name: str | None = None
+    native_config: str | None = None
+    native_settings: list[str] = Field(default_factory=list)
+    native_filaments: list[str] = Field(default_factory=list)
+    material: str | None = None
+    nozzle_diameter_mm: float | None = Field(default=None, gt=0)
+    bed_size_mm: tuple[float, float] | None = None
+    z_height_mm: float | None = Field(default=None, gt=0)
+    require_temperatures: bool = False
+    require_extrusion: bool = True
+
+    @field_validator("backend", mode="before")
+    @classmethod
+    def normalize_backend(cls, value: Any) -> str:
+        return str(value or "").strip().lower()
+
+    @field_validator("bed_size_mm")
+    @classmethod
+    def validate_bed_size(cls, value: tuple[float, float] | None) -> tuple[float, float] | None:
+        if value is not None and (value[0] <= 0 or value[1] <= 0):
+            raise ValueError("bed_size_mm values must be positive.")
+        return value
+
+
+class SliceRequest(BaseModel):
+    """A mesh artifact and an already-resolved fabrication profile."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    mesh_artifact: ProjectArtifact
+    profile: SliceProfile
+    output_name: str | None = None
+    output_path: str | None = None
+    project_id: str | None = None
+
+
+class SliceValidationResult(BaseModel):
+    """Deterministic checks applied to generated G-code."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    valid: bool
+    errors: list[str] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+    movement_commands: int = 0
+    extrusion_commands: int = 0
+    temperature_commands: int = 0
+    min_position: tuple[float, float, float] | None = None
+    max_position: tuple[float, float, float] | None = None
+
+
+class SliceResult(BaseModel):
+    """G-code plus normalized provenance from one slicer invocation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    gcode_artifact: ProjectArtifact
+    backend: str
+    profile_name: str | None = None
+    printer_name: str | None = None
+    estimated_print_time_s: float | None = None
+    filament_length_mm: float | None = None
+    filament_mass_g: float | None = None
+    layer_count: int | None = None
+    warnings: list[str] = Field(default_factory=list)
+    validation: SliceValidationResult | None = None
+    report_artifact: ProjectArtifact | None = None
+
+
+__all__ = [
+    "FabricationError",
+    "PrinterConfigurationError",
+    "SliceInspection",
+    "SliceProfile",
+    "SliceRequest",
+    "SliceResult",
+    "SliceValidationResult",
+    "SlicerUnavailableError",
+]

--- a/forma_core/workspaces/projects/fabrication/printer_config.py
+++ b/forma_core/workspaces/projects/fabrication/printer_config.py
@@ -1,0 +1,205 @@
+"""Persistent, non-secret user printer registry and profile resolution."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import platform
+import tomllib
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from forma_core.config import config
+from forma_core.workspaces.projects.fabrication.models import PrinterConfigurationError, SliceProfile
+
+
+class PrinterProfileReference(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    native_config: str = Field(min_length=1)
+    material: str | None = None
+    nozzle_diameter_mm: float | None = Field(default=None, gt=0)
+    bed_size_mm: tuple[float, float] | None = None
+    z_height_mm: float | None = Field(default=None, gt=0)
+    require_temperatures: bool = False
+    require_extrusion: bool = True
+
+
+class UserPrinterConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    printer_id: str = Field(min_length=1)
+    display_name: str = Field(min_length=1)
+    backend: str = Field(min_length=1)
+    default_profile: str = Field(min_length=1)
+    profiles: dict[str, PrinterProfileReference] = Field(default_factory=dict)
+
+    @field_validator("backend", mode="before")
+    @classmethod
+    def normalize_backend(cls, value: Any) -> str:
+        return str(value or "").strip().lower()
+
+    @model_validator(mode="after")
+    def require_default_profile(self) -> "UserPrinterConfig":
+        if self.default_profile not in self.profiles:
+            raise ValueError(f"Default profile {self.default_profile!r} is not configured for {self.printer_id!r}.")
+        return self
+
+
+class PrinterRegistry(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    default_printer: str | None = None
+    printers: dict[str, UserPrinterConfig] = Field(default_factory=dict)
+
+    @model_validator(mode="after")
+    def require_default_printer(self) -> "PrinterRegistry":
+        if self.default_printer is not None and self.default_printer not in self.printers:
+            raise ValueError(f"Default printer {self.default_printer!r} is not configured.")
+        return self
+
+
+def default_printer_config_path() -> Path:
+    configured = config.optional("FORMA_PRINTER_CONFIG_PATH")
+    if configured:
+        return Path(configured).expanduser()
+    if platform.system() == "Windows":
+        root = config.optional("APPDATA") or str(Path.home() / "AppData" / "Roaming")
+        return Path(root) / "Forma" / "printers.toml"
+    if platform.system() == "Darwin":
+        return Path.home() / "Library" / "Application Support" / "Forma" / "printers.toml"
+    return Path(config.optional("XDG_CONFIG_HOME") or Path.home() / ".config") / "forma" / "printers.toml"
+
+
+def _profile_payload(value: dict[str, Any]) -> PrinterProfileReference:
+    return PrinterProfileReference.model_validate(value)
+
+
+def load_printer_registry(path: str | Path | None = None) -> PrinterRegistry:
+    target = Path(path).expanduser() if path else default_printer_config_path()
+    if not target.exists():
+        return PrinterRegistry()
+    try:
+        raw = tomllib.loads(target.read_text(encoding="utf-8"))
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise PrinterConfigurationError(f"Could not read printer configuration: {target}") from exc
+    if not isinstance(raw, dict):
+        raise PrinterConfigurationError(f"Printer configuration must be a TOML table: {target}")
+    printers: dict[str, UserPrinterConfig] = {}
+    for printer_id, value in (raw.get("printers") or {}).items():
+        if not isinstance(value, dict):
+            raise PrinterConfigurationError(f"Printer {printer_id!r} must be a TOML table.")
+        profiles = {
+            str(profile_id): _profile_payload(profile)
+            for profile_id, profile in (value.get("profiles") or {}).items()
+            if isinstance(profile, dict)
+        }
+        printers[str(printer_id)] = UserPrinterConfig(
+            printer_id=str(printer_id),
+            display_name=str(value.get("display_name") or printer_id),
+            backend=str(value.get("backend") or ""),
+            default_profile=str(value.get("default_profile") or ""),
+            profiles=profiles,
+        )
+    try:
+        return PrinterRegistry(default_printer=raw.get("default_printer"), printers=printers)
+    except ValueError as exc:
+        raise PrinterConfigurationError(str(exc)) from exc
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value)
+
+
+def save_printer_registry(registry: PrinterRegistry, path: str | Path | None = None) -> Path:
+    target = Path(path).expanduser() if path else default_printer_config_path()
+    lines: list[str] = []
+    if registry.default_printer:
+        lines.append(f"default_printer = {_toml_string(registry.default_printer)}")
+        lines.append("")
+    for printer_id in sorted(registry.printers):
+        printer = registry.printers[printer_id]
+        lines.extend(
+            (
+                f"[printers.{_toml_string(printer_id)}]",
+                f"display_name = {_toml_string(printer.display_name)}",
+                f"backend = {_toml_string(printer.backend)}",
+                f"default_profile = {_toml_string(printer.default_profile)}",
+                "",
+            )
+        )
+        for profile_id in sorted(printer.profiles):
+            profile = printer.profiles[profile_id]
+            lines.extend(
+                (
+                    f"[printers.{_toml_string(printer_id)}.profiles.{_toml_string(profile_id)}]",
+                    f"native_config = {_toml_string(profile.native_config)}",
+                )
+            )
+            for key, value in (
+                ("material", profile.material),
+                ("nozzle_diameter_mm", profile.nozzle_diameter_mm),
+                ("bed_size_mm", profile.bed_size_mm),
+                ("z_height_mm", profile.z_height_mm),
+                ("require_temperatures", profile.require_temperatures),
+                ("require_extrusion", profile.require_extrusion),
+            ):
+                if value is not None:
+                    encoded = json.dumps(list(value) if isinstance(value, tuple) else value)
+                    lines.append(f"{key} = {encoded}")
+            lines.append("")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = target.with_suffix(f"{target.suffix}.tmp")
+    temporary.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+    temporary.replace(target)
+    return target
+
+
+def resolve_slice_profile(
+    registry: PrinterRegistry,
+    *,
+    printer_id: str | None = None,
+    backend: str | None = None,
+    native_config: str | None = None,
+    profile_name: str | None = None,
+) -> SliceProfile:
+    """Resolve explicit settings, then named/default printer settings, deterministically."""
+    selected_id = printer_id or (None if backend or native_config else registry.default_printer)
+    if selected_id:
+        printer = registry.printers.get(selected_id)
+        if printer is None:
+            raise PrinterConfigurationError(f"Printer configuration not found: {selected_id}")
+        selected_profile_name = profile_name or printer.default_profile
+        selected_profile = printer.profiles.get(selected_profile_name)
+        if selected_profile is None:
+            raise PrinterConfigurationError(
+                f"Profile {selected_profile_name!r} is not configured for printer {selected_id!r}."
+            )
+        return SliceProfile(
+            backend=printer.backend,
+            printer_name=printer.display_name,
+            profile_name=selected_profile_name,
+            **selected_profile.model_dump(mode="python"),
+        )
+    if backend and native_config:
+        return SliceProfile(
+            backend=backend,
+            printer_name=printer_id or "Explicit profile",
+            profile_name=profile_name,
+            native_config=native_config,
+        )
+    raise PrinterConfigurationError(
+        "Printer configuration required: pass a configured printer or both backend and profile."
+    )
+
+
+__all__ = [
+    "PrinterProfileReference",
+    "PrinterRegistry",
+    "UserPrinterConfig",
+    "default_printer_config_path",
+    "load_printer_registry",
+    "resolve_slice_profile",
+    "save_printer_registry",
+]

--- a/forma_core/workspaces/projects/fabrication/slicers/__init__.py
+++ b/forma_core/workspaces/projects/fabrication/slicers/__init__.py
@@ -1,0 +1,6 @@
+"""Slicer backends."""
+
+from forma_core.workspaces.projects.fabrication.slicers.base import SlicerAdapter
+from forma_core.workspaces.projects.fabrication.slicers.cura import CuraSlicerAdapter
+
+__all__ = ["CuraSlicerAdapter", "SlicerAdapter"]

--- a/forma_core/workspaces/projects/fabrication/slicers/base.py
+++ b/forma_core/workspaces/projects/fabrication/slicers/base.py
@@ -1,0 +1,25 @@
+"""Stable adapter contract shared by all slicer backends."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from forma_core.workspaces.projects.fabrication.models import (
+    SliceRequest,
+    SliceResult,
+    SliceInspection,
+    SliceValidationResult,
+)
+
+
+class SlicerAdapter(Protocol):
+    name: str
+
+    def is_available(self) -> bool: ...
+
+    def inspect(self, mesh_path: Path) -> SliceInspection: ...
+
+    def slice(self, request: SliceRequest) -> SliceResult: ...
+
+    def validate(self, result: SliceResult) -> SliceValidationResult: ...

--- a/forma_core/workspaces/projects/fabrication/slicers/cura.py
+++ b/forma_core/workspaces/projects/fabrication/slicers/cura.py
@@ -1,0 +1,125 @@
+"""CuraEngine adapter. Cura-specific subprocess details stay in this module."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+import shutil
+import subprocess
+
+from forma_core.config import config
+from forma_core.workspaces.projects.fabrication.models import (
+    SliceInspection,
+    SliceRequest,
+    SliceResult,
+    SliceValidationResult,
+    SlicerUnavailableError,
+)
+from forma_core.workspaces.projects.state import ProjectArtifact
+
+
+class CuraSlicerAdapter:
+    name = "cura"
+
+    def __init__(self, executable: str | Path | None = None) -> None:
+        self.executable = str(executable or config.optional("FORMA_CURA_ENGINE_PATH") or "").strip() or None
+
+    def executable_path(self) -> Path | None:
+        if self.executable:
+            configured = Path(self.executable).expanduser()
+            return configured if configured.is_file() else None
+        discovered = shutil.which("CuraEngine") or shutil.which("curaengine")
+        return Path(discovered) if discovered else None
+
+    def is_available(self) -> bool:
+        return self.executable_path() is not None
+
+    def inspect(self, mesh_path: Path) -> SliceInspection:
+        if not mesh_path.is_file():
+            return SliceInspection(valid=False, path=str(mesh_path), errors=[f"Mesh artifact does not exist: {mesh_path}"])
+        valid = mesh_path.suffix.lower() in {".stl", ".3mf", ".obj"}
+        return SliceInspection(
+            valid=valid,
+            path=str(mesh_path),
+            errors=[] if valid else ["Mesh must be an STL, 3MF, or OBJ file."],
+        )
+
+    @staticmethod
+    def _mesh_path(request: SliceRequest) -> Path:
+        raw = request.mesh_artifact.metadata.get("path") or request.mesh_artifact.uri
+        if str(raw).startswith("forma://"):
+            raise SlicerUnavailableError("A local mesh path is required to invoke CuraEngine.")
+        return Path(str(raw)).expanduser().resolve()
+
+    def slice(self, request: SliceRequest) -> SliceResult:
+        executable = self.executable_path()
+        if executable is None:
+            raise SlicerUnavailableError(
+                "CuraEngine is unavailable. Install CuraEngine or set FORMA_CURA_ENGINE_PATH."
+            )
+        mesh_path = self._mesh_path(request)
+        if not mesh_path.is_file() or mesh_path.suffix.lower() not in {".stl", ".3mf", ".obj"}:
+            raise ValueError("Cura slicing requires an existing STL, 3MF, or OBJ mesh artifact.")
+        if mesh_path.stat().st_size == 0:
+            raise ValueError(f"Cura slicing requires a non-empty mesh artifact: {mesh_path}")
+        if not request.profile.native_config:
+            raise ValueError("Cura slicing requires an explicit native_config profile path.")
+        native_config = Path(request.profile.native_config).expanduser().resolve()
+        if not native_config.is_file():
+            raise ValueError(f"Cura profile does not exist: {native_config}")
+        output = Path(request.output_path).expanduser().resolve() if request.output_path else None
+        if output is None:
+            if request.output_name and Path(request.output_name).name != request.output_name:
+                raise ValueError("Slice output_name must be a filename, not a path.")
+            output_dir = mesh_path.parent / "fabrication"
+            output = output_dir / (request.output_name or f"{mesh_path.stem}.gcode")
+        if output.suffix.lower() not in {".gcode", ".gc"}:
+            output = output.with_suffix(".gcode")
+        output.parent.mkdir(parents=True, exist_ok=True)
+        command = [str(executable), "slice", "-j", str(native_config), "-l", str(mesh_path), "-o", str(output)]
+        for setting in request.profile.native_settings:
+            command.extend(("-s", setting))
+        try:
+            completed = subprocess.run(
+                command,
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=config.number("FORMA_SLICER_TIMEOUT_SECONDS", 900.0),
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            raise SlicerUnavailableError(f"CuraEngine invocation failed: {exc}") from exc
+        if completed.returncode != 0 or not output.is_file():
+            detail = (completed.stderr or completed.stdout or "unknown CuraEngine error").strip()
+            raise RuntimeError(f"CuraEngine slicing failed: {detail[-1200:]}")
+        content = output.read_bytes()
+        artifact = ProjectArtifact(
+            artifact_id=f"slice-gcode-{hashlib.sha256(content).hexdigest()[:16]}",
+            kind="slice.gcode",
+            uri=str(output),
+            media_type="text/x.gcode",
+            checksum=f"sha256:{hashlib.sha256(content).hexdigest()}",
+            metadata={
+                "path": str(output),
+                "input_mesh": str(mesh_path),
+                "input_mesh_sha256": hashlib.sha256(mesh_path.read_bytes()).hexdigest(),
+                "slicer_executable": str(executable),
+                "stdout": completed.stdout[-2000:],
+                "stderr": completed.stderr[-2000:],
+            },
+        )
+        return SliceResult(
+            gcode_artifact=artifact,
+            backend=self.name,
+            profile_name=request.profile.profile_name,
+            printer_name=request.profile.printer_name,
+        )
+
+    def validate(self, result: SliceResult) -> SliceValidationResult:
+        from forma_core.workspaces.projects.fabrication.validation import validate_gcode
+
+        path = Path(result.gcode_artifact.uri)
+        return validate_gcode(path, profile=None)
+
+
+__all__ = ["CuraSlicerAdapter"]

--- a/forma_core/workspaces/projects/fabrication/slicing.py
+++ b/forma_core/workspaces/projects/fabrication/slicing.py
@@ -1,0 +1,194 @@
+"""Slicer discovery, orchestration, provenance, and project-level isolation."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import time
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+from forma_core.workspaces.projects.fabrication.models import (
+    FabricationError,
+    SliceRequest,
+    SliceResult,
+    SliceValidationResult,
+    SlicerUnavailableError,
+)
+from forma_core.workspaces.projects.fabrication.slicers.base import SlicerAdapter
+from forma_core.workspaces.projects.fabrication.slicers.cura import CuraSlicerAdapter
+from forma_core.workspaces.projects.fabrication.validation import validate_gcode
+from forma_core.workspaces.projects.state import ProjectArtifact
+
+
+class SlicerCapability(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+    available: bool
+    executable: str | None = None
+
+
+def _adapters() -> list[SlicerAdapter]:
+    return [CuraSlicerAdapter()]
+
+
+def discover_slicers() -> list[SlicerCapability]:
+    """Return structured availability information without requiring a slicer binary."""
+    result = []
+    for adapter in _adapters():
+        executable = getattr(adapter, "executable_path", lambda: None)()
+        result.append(
+            SlicerCapability(
+                name=adapter.name,
+                available=bool(executable),
+                executable=str(executable) if executable else None,
+            )
+        )
+    return result
+
+
+def get_slicer_adapter(backend: str, *, adapters: list[SlicerAdapter] | None = None) -> SlicerAdapter:
+    name = str(backend or "").strip().lower()
+    selected = next((adapter for adapter in (adapters or _adapters()) if adapter.name == name), None)
+    if selected is None:
+        raise SlicerUnavailableError(f"Unsupported slicer backend: {backend}")
+    if not selected.is_available():
+        raise SlicerUnavailableError(f"Slicer backend {name!r} is not available.")
+    return selected
+
+
+def _report_artifact(
+    result: SliceResult,
+    request: SliceRequest,
+    validation: SliceValidationResult,
+    *,
+    elapsed_s: float,
+) -> ProjectArtifact:
+    gcode = Path(result.gcode_artifact.uri)
+    report_path = gcode.with_suffix(".report.json")
+    gcode_checksum = hashlib.sha256(gcode.read_bytes()).hexdigest()
+    input_uri = request.mesh_artifact.uri
+    input_path = request.mesh_artifact.metadata.get("path") or input_uri
+    input_path_obj = Path(str(input_path)).expanduser()
+    input_checksum = request.mesh_artifact.checksum
+    if input_path_obj.is_file():
+        input_checksum = hashlib.sha256(input_path_obj.read_bytes()).hexdigest()
+    payload = {
+        "project_id": request.project_id,
+        "backend": result.backend,
+        "profile_name": result.profile_name,
+        "printer_name": result.printer_name,
+        "native_config": request.profile.native_config,
+        "material": request.profile.material,
+        "nozzle_diameter_mm": request.profile.nozzle_diameter_mm,
+        "bed_size_mm": request.profile.bed_size_mm,
+        "z_height_mm": request.profile.z_height_mm,
+        "input_mesh": str(input_uri),
+        "input_mesh_kind": request.mesh_artifact.kind,
+        "input_mesh_sha256": str(input_checksum or "").removeprefix("sha256:"),
+        "gcode_sha256": gcode_checksum,
+        "elapsed_s": round(elapsed_s, 3),
+        "warnings": [*result.warnings, *validation.warnings],
+        "validation": validation.model_dump(mode="json"),
+    }
+    report_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    report_checksum = hashlib.sha256(report_path.read_bytes()).hexdigest()
+    return ProjectArtifact(
+        artifact_id=f"slice-report-{report_checksum[:16]}",
+        kind="slice.report.json",
+        uri=str(report_path),
+        media_type="application/json",
+        checksum=f"sha256:{report_checksum}",
+        metadata={"path": str(report_path), "gcode_sha256": gcode_checksum},
+    )
+
+
+def slice_project(request: SliceRequest, *, adapter: SlicerAdapter | None = None) -> SliceResult:
+    """Slice an existing mesh, validate it, and emit a reproducibility report."""
+    selected = adapter or get_slicer_adapter(request.profile.backend)
+    mesh_raw = request.mesh_artifact.metadata.get("path") or request.mesh_artifact.uri
+    mesh_path = Path(str(mesh_raw)).expanduser()
+    inspection = selected.inspect(mesh_path)
+    inspection_valid = inspection.valid if hasattr(inspection, "valid") else inspection.get("valid")
+    if inspection_valid is False:
+        inspection_errors = inspection.errors if hasattr(inspection, "errors") else [inspection.get("error", "")]
+        raise FabricationError("Mesh inspection failed: " + "; ".join(str(error) for error in inspection_errors if error))
+    started = time.monotonic()
+    result = selected.slice(request)
+    output = Path(result.gcode_artifact.uri).expanduser()
+    if not output.is_file() or output.stat().st_size == 0:
+        raise FabricationError("Slicer returned no G-code output.")
+    actual_output_checksum = hashlib.sha256(output.read_bytes()).hexdigest()
+    declared_output_checksum = str(result.gcode_artifact.checksum or "").removeprefix("sha256:").lower()
+    if declared_output_checksum and declared_output_checksum != actual_output_checksum:
+        raise FabricationError("Slicer returned G-code with an invalid checksum.")
+    adapter_validation = selected.validate(result)
+    generic_validation = validate_gcode(output, request.profile)
+    validation = SliceValidationResult(
+        valid=adapter_validation.valid and generic_validation.valid,
+        errors=[*adapter_validation.errors, *generic_validation.errors],
+        warnings=[*adapter_validation.warnings, *generic_validation.warnings],
+        movement_commands=generic_validation.movement_commands,
+        extrusion_commands=generic_validation.extrusion_commands,
+        temperature_commands=generic_validation.temperature_commands,
+        min_position=generic_validation.min_position,
+        max_position=generic_validation.max_position,
+    )
+    if not validation.valid:
+        raise FabricationError("Generated G-code failed validation: " + "; ".join(validation.errors))
+    result.validation = validation
+    result.warnings = [*result.warnings, *validation.warnings]
+    elapsed_s = time.monotonic() - started
+    result.report_artifact = _report_artifact(result, request, validation, elapsed_s=elapsed_s)
+    result.gcode_artifact.metadata = {
+        **result.gcode_artifact.metadata,
+        "elapsed_s": round(elapsed_s, 3),
+        "validation": validation.model_dump(mode="json"),
+        "report_uri": result.report_artifact.uri,
+    }
+    return result
+
+
+def ensure_slice_artifact(
+    project: Any,
+    *,
+    fabrication_request: SliceRequest,
+    required: bool,
+    adapter: SlicerAdapter | None = None,
+) -> SliceResult | None:
+    """Run slicing downstream of CAD while isolating optional failures in metadata."""
+    metadata = dict(project.assembly_metadata or {})
+    try:
+        result = slice_project(fabrication_request, adapter=adapter)
+    except Exception as exc:
+        metadata["fabrication"] = {"status": "failed", "required": required, "error": str(exc)[:500]}
+        project.assembly_metadata = metadata
+        if required:
+            raise
+        return None
+    metadata["fabrication"] = {
+        "status": "succeeded",
+        "required": required,
+        "backend": result.backend,
+        "printer_name": result.printer_name,
+        "profile_name": result.profile_name,
+        "artifacts": [
+            artifact.model_dump(mode="json")
+            for artifact in (result.gcode_artifact, result.report_artifact)
+            if artifact is not None
+        ],
+    }
+    project.assembly_metadata = metadata
+    return result
+
+
+__all__ = [
+    "SlicerCapability",
+    "discover_slicers",
+    "ensure_slice_artifact",
+    "get_slicer_adapter",
+    "slice_project",
+]

--- a/forma_core/workspaces/projects/fabrication/validation.py
+++ b/forma_core/workspaces/projects/fabrication/validation.py
@@ -1,0 +1,103 @@
+"""Deterministic safety checks for generated FDM G-code."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+import re
+
+from forma_core.workspaces.projects.fabrication.models import SliceProfile, SliceValidationResult
+
+
+_COMMAND_RE = re.compile(r"^\s*([GMT]\d+(?:\.\d+)?)\b", re.IGNORECASE)
+_VALUE_RE = re.compile(r"([XYZEF])\s*(-?(?:\d+(?:\.\d*)?|\.\d+))", re.IGNORECASE)
+_KNOWN_COMMANDS = {"G0", "G1", "G2", "G3", "G28", "G90", "G91", "G92", "M82", "M83", "M104", "M109", "M140", "M190", "M106", "M107", "M84", "M117", "M220", "M221"}
+
+
+def validate_gcode(path: str | Path, profile: SliceProfile | None = None) -> SliceValidationResult:
+    """Validate a G-code file without executing it or trusting slicer output."""
+    target = Path(path).expanduser()
+    errors: list[str] = []
+    warnings: list[str] = []
+    if not target.is_file():
+        return SliceValidationResult(valid=False, errors=[f"G-code output does not exist: {target}"])
+    try:
+        lines = target.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError as exc:
+        return SliceValidationResult(valid=False, errors=[f"G-code output could not be read: {exc}"])
+    if not target.stat().st_size:
+        return SliceValidationResult(valid=False, errors=["G-code output is empty."])
+
+    movement_commands = 0
+    extrusion_commands = 0
+    temperature_commands = 0
+    positions: list[tuple[float, float, float]] = []
+    current = [0.0, 0.0, 0.0]
+    relative_positioning = False
+    has_e = False
+    for raw_line in lines:
+        line = raw_line.split(";", 1)[0].strip()
+        if not line:
+            continue
+        match = _COMMAND_RE.match(line)
+        if not match:
+            warnings.append(f"Unrecognized G-code line: {raw_line[:120]}")
+            continue
+        command = match.group(1).upper()
+        if command not in _KNOWN_COMMANDS:
+            warnings.append(f"Unsupported G-code command: {command}")
+        values = {key.upper(): float(value) for key, value in _VALUE_RE.findall(line)}
+        if command in {"G0", "G1"}:
+            movement_commands += 1
+            for index, axis in enumerate(("X", "Y", "Z")):
+                if axis in values:
+                    current[index] = current[index] + values[axis] if relative_positioning else values[axis]
+            if "E" in values:
+                has_e = True
+                extrusion_commands += 1
+            positions.append(tuple(current))
+        elif command == "G90":
+            relative_positioning = False
+        elif command == "G91":
+            relative_positioning = True
+        elif command == "G92":
+            for index, axis in enumerate(("X", "Y", "Z")):
+                if axis in values:
+                    current[index] = values[axis]
+        if command in {"M104", "M109", "M140", "M190"}:
+            temperature_commands += 1
+
+    if movement_commands == 0:
+        errors.append("G-code contains no movement commands.")
+    if (profile is None or profile.require_extrusion) and not has_e:
+        errors.append("G-code contains no extrusion commands.")
+    if profile is not None and profile.require_temperatures and temperature_commands == 0:
+        errors.append("G-code contains no temperature commands for the selected profile.")
+
+    min_position = max_position = None
+    if positions:
+        min_position = tuple(min(position[index] for position in positions) for index in range(3))
+        max_position = tuple(max(position[index] for position in positions) for index in range(3))
+    if profile is not None and positions:
+        if profile.bed_size_mm:
+            bounds = (*profile.bed_size_mm, profile.z_height_mm or math.inf)
+            for index, axis in enumerate(("X", "Y", "Z")):
+                if min_position[index] < 0 or max_position[index] > bounds[index]:
+                    errors.append(
+                        f"{axis} moves exceed configured machine bounds: "
+                        f"{min_position[index]:g}..{max_position[index]:g}."
+                    )
+
+    return SliceValidationResult(
+        valid=not errors,
+        errors=errors,
+        warnings=warnings,
+        movement_commands=movement_commands,
+        extrusion_commands=extrusion_commands,
+        temperature_commands=temperature_commands,
+        min_position=min_position,
+        max_position=max_position,
+    )
+
+
+__all__ = ["validate_gcode"]

--- a/forma_core/workspaces/projects/manifest.py
+++ b/forma_core/workspaces/projects/manifest.py
@@ -83,6 +83,8 @@ def infer_artifact_media_type(path: str) -> str:
         return "model/stl"
     if suffix == ".3mf":
         return "model/3mf"
+    if suffix in {".gcode", ".gc", ".gco"}:
+        return "text/x-gcode"
     return mimetypes.guess_type(path)[0] or "application/octet-stream"
 
 

--- a/tests/projects/test_fabrication.py
+++ b/tests/projects/test_fabrication.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+
+from forma_core.workspaces.projects.fabrication import (
+    PrinterProfileReference,
+    PrinterRegistry,
+    SliceProfile,
+    SliceRequest,
+    SliceResult,
+    UserPrinterConfig,
+    load_printer_registry,
+    resolve_slice_profile,
+    save_printer_registry,
+    slice_project,
+)
+from forma_core.workspaces.projects.fabrication.validation import validate_gcode
+from forma_core.workspaces.projects.state import ProjectArtifact
+
+
+class FakeSlicer:
+    name = "fake"
+
+    def is_available(self) -> bool:
+        return True
+
+    def inspect(self, mesh_path: Path) -> dict[str, object]:
+        return {"valid": mesh_path.is_file()}
+
+    def slice(self, request: SliceRequest) -> SliceResult:
+        output = Path(request.output_path or "output.gcode")
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text("G90\nG1 X10 Y10 Z0.2 F1200\nG1 X20 Y10 E1.2 F600\n", encoding="ascii")
+        digest = hashlib.sha256(output.read_bytes()).hexdigest()
+        return SliceResult(
+            gcode_artifact=ProjectArtifact(
+                artifact_id="fake-gcode",
+                kind="slice.gcode",
+                uri=str(output),
+                media_type="text/x-gcode",
+                checksum=f"sha256:{digest}",
+            ),
+            backend="fake",
+            profile_name=request.profile.profile_name,
+            printer_name=request.profile.printer_name,
+        )
+
+    def validate(self, result: SliceResult):
+        return validate_gcode(result.gcode_artifact.uri)
+
+
+class FabricationTests(unittest.TestCase):
+    def test_printer_registry_round_trips_dotted_profile_ids(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "printers.toml"
+            registry = PrinterRegistry(
+                default_printer="ender-2-pro",
+                printers={
+                    "ender-2-pro": UserPrinterConfig(
+                        printer_id="ender-2-pro",
+                        display_name="Ender 2 Pro",
+                        backend="cura",
+                        default_profile="pla-0.2",
+                        profiles={
+                            "pla-0.2": PrinterProfileReference(
+                                native_config="profiles/ender.json",
+                                material="PLA",
+                                bed_size_mm=(165, 165),
+                            )
+                        },
+                    )
+                },
+            )
+            save_printer_registry(registry, path)
+            restored = load_printer_registry(path)
+
+        profile = resolve_slice_profile(restored, printer_id="ender-2-pro")
+        self.assertEqual("pla-0.2", profile.profile_name)
+        self.assertEqual((165.0, 165.0), profile.bed_size_mm)
+        self.assertEqual("cura", profile.backend)
+
+    def test_validation_rejects_empty_or_out_of_bounds_gcode(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "bad.gcode"
+            path.write_text("G1 X200 Y10 Z1\n", encoding="ascii")
+            result = validate_gcode(
+                path,
+                SliceProfile(
+                    backend="fake",
+                    printer_name="Test printer",
+                    bed_size_mm=(165, 165),
+                ),
+            )
+
+        self.assertFalse(result.valid)
+        self.assertTrue(any("extrusion" in error.lower() for error in result.errors))
+        self.assertTrue(any("bounds" in error.lower() for error in result.errors))
+
+    def test_slice_project_creates_report_and_validates_fake_adapter(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            mesh = root / "assembly.stl"
+            mesh.write_text("solid mesh\nendsolid mesh\n", encoding="ascii")
+            result = slice_project(
+                SliceRequest(
+                    mesh_artifact=ProjectArtifact(
+                        artifact_id="mesh",
+                        kind="mesh.stl",
+                        uri=str(mesh),
+                        media_type="model/stl",
+                        metadata={"path": str(mesh)},
+                    ),
+                    profile=SliceProfile(backend="fake", printer_name="Test printer"),
+                    output_path=str(root / "fabrication" / "assembly.gcode"),
+                ),
+                adapter=FakeSlicer(),
+            )
+
+            self.assertTrue(result.validation and result.validation.valid)
+            self.assertIsNotNone(result.report_artifact)
+            self.assertEqual("slice.gcode", result.gcode_artifact.kind)
+            self.assertTrue(Path(result.report_artifact.uri).is_file())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/tooling/test_oss_cli.py
+++ b/tests/tooling/test_oss_cli.py
@@ -69,7 +69,7 @@ class OssCliTests(unittest.TestCase):
         self.assertEqual(
             {
                 "login", "logout", "whoami", "init", "build", "import", "metadata", "metadata-api",
-                "status", "render", "projects", "keys", "version", "doctor",
+                "status", "render", "projects", "project", "printer", "keys", "version", "doctor",
             },
             set(parser._subparsers._group_actions[0].choices),
         )


### PR DESCRIPTION
## Summary
- add a typed fabrication layer with CuraEngine adapter and slicer discovery
- add persistent printer/profile registry with deterministic resolution
- validate G-code, record checksums/provenance, and emit slice reports
- add local printer and project slice CLI commands
- add focused fabrication coverage

Closes #425

## Tests
- python -m unittest tests.projects.test_fabrication tests.projects.test_cad_generation tests.tooling.test_oss_cli tests.tooling.test_config.AppConfigTests.test_non_test_python_uses_only_the_config_environment_boundary -v
- python -m compileall -q forma_core forma_cli tests