### PR TITLE
feat: add domain-scoped context governance

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -93,3 +93,4 @@ flowchart LR
 - Prompt context is projected by ownership: only wiring and electrical validation receive physical pins; architecture, mechanical, and assembly agents receive compact system-level views.
 - Dependency-aware concurrent execution and restart recovery are documented in `docs/worker-orchestration.md`.
 - Frozen-brief generation and canonical revision persistence are documented in `docs/generation-worker.md`.
+- Domain-scoped context sharing, field allowlists, and handoff receipts are documented in `docs/context-governance.md`.

--- a/docs/context-governance.md
+++ b/docs/context-governance.md
@@ -1,0 +1,56 @@
+# Context Governance
+
+Forma treats a project as a set of typed, versioned namespaces. A namespace is
+owned by one domain agent, while cross-domain context is a separate governed
+handoff.
+
+## Contract
+
+`forma_core.workspaces.projects.context_governance` applies a versioned,
+deny-by-default policy:
+
+```text
+project object
+  -> source namespace
+  -> recipient namespace
+  -> explicit attribute and field allowlist
+  -> context projection + audit receipt
+```
+
+An agent may always read its own namespace. A different agent receives nothing
+unless a `ContextShareRule` names both namespaces and the fields that may cross
+the boundary. Inline data and credential-like fields are sanitized even when a
+rule allows the enclosing attribute.
+
+The projection receipt records `allowed_sources`, `denied_sources`, omitted
+attributes, the policy schema version, and the recipient. This makes a handoff
+inspectable without including the denied data in the prompt.
+
+## Initial Handoffs
+
+- Product overview shares intent, requirements, and constraints with domain specialists.
+- Architecture shares the system hierarchy with domain specialists.
+- Electrical shares component summaries with mechanical and BOM agents, interface assignments with firmware, and build-level connectivity with assembly.
+- Electrical shares its complete state only with validation.
+- Mechanical shares the canonical mechanical state with visuals, validation, and assembly.
+- Validation shares safety gates with assembly.
+- BOM and assembly share their approved views with documentation.
+- Project metadata and history are not cross-domain context by default.
+
+This is intentionally an allowlist, not a promise that every domain should see
+the whole project. For example, mechanical placement can use a component's
+identity and envelope purpose without receiving electrical pin definitions.
+
+## Relationship To Issues
+
+Issue `#391` needs canonical mechanical objects upstream of CAD. Issue `#424`
+needs images, placements, and CAD to refer to the same mechanical state. Domain
+governance is the boundary that prevents each artifact agent from inventing or
+silently copying facts owned by another domain:
+
+```text
+intent -> typed project namespaces -> governed handoffs -> artifacts
+```
+
+The policy does not replace the mechanical model or image-reference
+decomposition. It gives those future objects a safe sharing contract.

--- a/forma_core/agents/lattice.py
+++ b/forma_core/agents/lattice.py
@@ -7,6 +7,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from forma_core.agents.contracts import LatticeAgentCard, LatticeCapability, LatticeSchemaContract
+from forma_core.workspaces.projects.context_governance import DEFAULT_CONTEXT_GOVERNANCE_POLICY
 from forma_core.workspaces.projects.objects import ProjectNamespaceDescriptor, list_project_namespaces
 
 
@@ -216,6 +217,7 @@ def namespace_agent_card(descriptor: ProjectNamespaceDescriptor) -> LatticeAgent
             "namespace": descriptor.name,
             "scope": descriptor.scope,
             "agent_kind": profile.get("kind", descriptor.name.rsplit(".", 1)[-1]),
+            "context_governance": DEFAULT_CONTEXT_GOVERNANCE_POLICY.recipient_manifest(descriptor.name),
         },
     )
 

--- a/forma_core/workspaces/projects/__init__.py
+++ b/forma_core/workspaces/projects/__init__.py
@@ -20,6 +20,14 @@ from forma_core.workspaces.projects.manifest import (
     write_project_manifest,
 )
 from forma_core.workspaces.projects.identity import ProjectCreationChannel, ProjectIdentity
+from forma_core.workspaces.projects.context_governance import (
+    CONTEXT_GOVERNANCE_SCHEMA_VERSION,
+    ContextGovernancePolicy,
+    ContextProjection,
+    ContextShareRule,
+    DEFAULT_CONTEXT_GOVERNANCE_POLICY,
+    project_context_for_agent,
+)
 from forma_core.workspaces.projects.resolver import (
     ProjectReadAccessError,
     ProjectReadError,
@@ -59,6 +67,12 @@ __all__ = [
     "write_project_manifest",
     "ProjectCreationChannel",
     "ProjectIdentity",
+    "CONTEXT_GOVERNANCE_SCHEMA_VERSION",
+    "ContextGovernancePolicy",
+    "ContextProjection",
+    "ContextShareRule",
+    "DEFAULT_CONTEXT_GOVERNANCE_POLICY",
+    "project_context_for_agent",
     "ProjectReadAccessError",
     "ProjectReadError",
     "ProjectReadNotFoundError",

--- a/forma_core/workspaces/projects/context_governance.py
+++ b/forma_core/workspaces/projects/context_governance.py
@@ -1,0 +1,365 @@
+"""Deterministic, domain-scoped context sharing for project objects.
+
+Project namespaces are the source of truth for ownership. This module adds the
+policy boundary around those namespaces so an agent receives an explicit
+projection instead of the complete project object.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import re
+from typing import Any, Literal, Mapping
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+CONTEXT_GOVERNANCE_SCHEMA_VERSION = "1.0"
+ContextShareMode = Literal["none", "summary", "full"]
+_NAMESPACE_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*(\.[a-z][a-z0-9_-]*)+$")
+
+
+def _normalize_namespace(value: str) -> str:
+    normalized = str(value or "").strip().lower()
+    if not _NAMESPACE_PATTERN.fullmatch(normalized):
+        raise ValueError("Context namespaces must be dotted, for example product.mech.")
+    return normalized
+
+
+class ContextShareRule(BaseModel):
+    """One explicit source-to-recipient sharing decision.
+
+    ``allowed_attributes`` is an allowlist. An empty field list means the
+    complete attribute value; it does not mean all attributes are allowed.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    source_namespace: str
+    recipient_namespace: str
+    mode: ContextShareMode = "summary"
+    allowed_attributes: dict[str, list[str]] = Field(default_factory=dict)
+    reason: str = Field(..., min_length=1)
+
+    @field_validator("source_namespace", "recipient_namespace", mode="before")
+    @classmethod
+    def normalize_namespaces(cls, value: str) -> str:
+        return _normalize_namespace(value)
+
+    @field_validator("allowed_attributes", mode="before")
+    @classmethod
+    def normalize_attribute_allowlist(cls, value: Any) -> dict[str, list[str]]:
+        if value is None:
+            return {}
+        if not isinstance(value, Mapping):
+            raise ValueError("allowed_attributes must be an object of attribute names to field names.")
+        normalized: dict[str, list[str]] = {}
+        for attribute, fields in value.items():
+            name = str(attribute or "").strip()
+            if not name:
+                raise ValueError("Context attribute names must not be empty.")
+            if fields is None:
+                normalized[name] = []
+                continue
+            if isinstance(fields, str):
+                fields = [fields]
+            if not isinstance(fields, list):
+                raise ValueError(f"Context fields for '{name}' must be a list.")
+            normalized[name] = [str(field).strip() for field in fields if str(field).strip()]
+        return normalized
+
+    @model_validator(mode="after")
+    def require_grant_for_shared_mode(self) -> "ContextShareRule":
+        if self.mode != "none" and not self.allowed_attributes:
+            raise ValueError("A shared context rule must declare allowed_attributes.")
+        return self
+
+
+class ContextGovernancePolicy(BaseModel):
+    """Versioned allowlist for context handoffs between project agents."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["1.0"] = CONTEXT_GOVERNANCE_SCHEMA_VERSION
+    default_mode: Literal["none"] = "none"
+    rules: list[ContextShareRule] = Field(default_factory=list)
+
+    @model_validator(mode="after")
+    def require_unique_rules(self) -> "ContextGovernancePolicy":
+        keys = [(rule.source_namespace, rule.recipient_namespace) for rule in self.rules]
+        if len(keys) != len(set(keys)):
+            raise ValueError("Context governance rules must have unique source and recipient namespaces.")
+        return self
+
+    def rule_for(self, source_namespace: str, recipient_namespace: str) -> ContextShareRule | None:
+        source = _normalize_namespace(source_namespace)
+        recipient = _normalize_namespace(recipient_namespace)
+        return next(
+            (
+                rule
+                for rule in self.rules
+                if rule.source_namespace == source and rule.recipient_namespace == recipient
+            ),
+            None,
+        )
+
+    def recipient_manifest(self, recipient_namespace: str) -> dict[str, Any]:
+        recipient = _normalize_namespace(recipient_namespace)
+        return {
+            "schema_version": self.schema_version,
+            "recipient_namespace": recipient,
+            "default_mode": self.default_mode,
+            "same_namespace_access": "full",
+            "grants": {
+                rule.source_namespace: {
+                    "mode": rule.mode,
+                    "allowed_attributes": deepcopy(rule.allowed_attributes),
+                    "reason": rule.reason,
+                }
+                for rule in self.rules
+                if rule.recipient_namespace == recipient and rule.mode != "none"
+            },
+        }
+
+
+class ContextProjection(BaseModel):
+    """Auditable context passed to one recipient agent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: Literal["1.0"] = CONTEXT_GOVERNANCE_SCHEMA_VERSION
+    object_id: str
+    object_version: int = Field(ge=1)
+    recipient_namespace: str
+    namespaces: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    allowed_sources: list[str] = Field(default_factory=list)
+    denied_sources: list[str] = Field(default_factory=list)
+    omitted_attributes: dict[str, list[str]] = Field(default_factory=dict)
+    policy: dict[str, Any] = Field(default_factory=dict)
+
+
+def project_context_for_agent(
+    project_object: Any,
+    recipient_namespace: str,
+    *,
+    policy: ContextGovernancePolicy | None = None,
+) -> dict[str, Any]:
+    """Return only context permitted for ``recipient_namespace``.
+
+    The result includes a receipt so downstream workers can record which
+    namespaces were allowed or denied. Unknown recipients and missing rules
+    are denied; no prompt or model call is involved in this decision.
+    """
+
+    active_policy = policy if policy is not None else DEFAULT_CONTEXT_GOVERNANCE_POLICY
+    recipient = _normalize_namespace(recipient_namespace)
+    object_id = str(_read(project_object, "object_id") or "")
+    object_version = _positive_int(_read(project_object, "version"), default=1)
+    raw_namespaces = _read(project_object, "namespaces") or []
+
+    projected: dict[str, dict[str, Any]] = {}
+    allowed_sources: list[str] = []
+    denied_sources: list[str] = []
+    omitted_attributes: dict[str, list[str]] = {}
+    for raw_namespace in raw_namespaces:
+        source = str(_read(raw_namespace, "name") or "").strip().lower()
+        if not source:
+            continue
+        payload = _read(raw_namespace, "payload") or {}
+        if not isinstance(payload, Mapping):
+            payload = {}
+
+        if source == recipient:
+            mode = "full"
+            allowed_attributes = {str(key): [] for key in payload}
+        else:
+            rule = active_policy.rule_for(source, recipient)
+            mode = rule.mode if rule else active_policy.default_mode
+            allowed_attributes = rule.allowed_attributes if rule else {}
+
+        if mode == "none":
+            denied_sources.append(source)
+            omitted_attributes[source] = sorted(str(attribute) for attribute in payload)
+            continue
+
+        selected: dict[str, Any] = {}
+        omitted: list[str] = []
+        for attribute, fields in allowed_attributes.items():
+            if attribute not in payload:
+                continue
+            if _is_secret_key(attribute):
+                omitted.append(attribute)
+                continue
+            selected[attribute] = _select_fields(payload[attribute], fields)
+            omitted.extend(_omitted_paths(attribute, payload[attribute], fields))
+        omitted.extend(str(attribute) for attribute in payload if attribute not in allowed_attributes)
+        if omitted:
+            omitted_attributes[source] = sorted(set(omitted))
+        if selected:
+            projected[source] = selected
+            allowed_sources.append(source)
+        else:
+            denied_sources.append(source)
+
+    projection = ContextProjection(
+        object_id=object_id,
+        object_version=object_version,
+        recipient_namespace=recipient,
+        namespaces=projected,
+        allowed_sources=sorted(set(allowed_sources)),
+        denied_sources=sorted(set(denied_sources)),
+        omitted_attributes=omitted_attributes,
+        policy=active_policy.recipient_manifest(recipient),
+    )
+    return projection.model_dump(mode="json")
+
+
+def _read(value: Any, key: str) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(key)
+    return getattr(value, key, None)
+
+
+def _positive_int(value: Any, *, default: int) -> int:
+    try:
+        return max(1, int(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _select_fields(value: Any, fields: list[str]) -> Any:
+    if not fields:
+        return _sanitize(value)
+    allowed = set(fields)
+    if isinstance(value, Mapping):
+        return {
+            str(key): _sanitize(item)
+            for key, item in value.items()
+            if str(key) in allowed and not _is_secret_key(key)
+        }
+    if isinstance(value, list):
+        return [
+            {
+                str(key): _sanitize(item)
+                for key, item in item_value.items()
+                if str(key) in allowed and not _is_secret_key(key)
+            }
+            if isinstance(item_value, Mapping)
+            else _sanitize(item_value)
+            for item_value in value
+        ]
+    return _sanitize(value)
+
+
+def _omitted_paths(prefix: str, value: Any, fields: list[str]) -> list[str]:
+    if not fields:
+        return []
+    allowed = set(fields)
+    if isinstance(value, Mapping):
+        return [
+            f"{prefix}.{key}"
+            for key in value
+            if str(key) not in allowed or _is_secret_key(key)
+        ]
+    if isinstance(value, list):
+        paths: set[str] = set()
+        for item in value:
+            if isinstance(item, Mapping):
+                paths.update(_omitted_paths(f"{prefix}[]", item, fields))
+        return sorted(paths)
+    return []
+
+
+def _sanitize(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {
+            str(key): _sanitize(item)
+            for key, item in value.items()
+            if not _is_secret_key(key)
+        }
+    if isinstance(value, list):
+        return [_sanitize(item) for item in value]
+    if isinstance(value, tuple):
+        return [_sanitize(item) for item in value]
+    if isinstance(value, str) and value.startswith("data:"):
+        return f"<redacted inline data: {len(value)} chars>"
+    return deepcopy(value)
+
+
+def _is_secret_key(value: Any) -> bool:
+    normalized = str(value).strip().lower().replace("-", "_")
+    return normalized in {"key", "credential", "credentials"} or any(
+        marker in normalized
+        for marker in ("api_key", "apikey", "authorization", "password", "secret", "token")
+    )
+
+
+def _rule(source: str, recipient: str, attributes: dict[str, list[str]], reason: str) -> ContextShareRule:
+    return ContextShareRule(
+        source_namespace=source,
+        recipient_namespace=recipient,
+        allowed_attributes=attributes,
+        reason=reason,
+    )
+
+
+_SUMMARY_OVERVIEW = {
+    "overview": ["title", "description", "difficulty", "estimated_cost", "category"],
+    "requirements": ["requirements", "power_needs", "operating_voltage", "physical_constraints", "safety_notes"],
+    "constraints": [],
+}
+_COMPONENT_SUMMARY = {
+    "components": ["ref_des", "part_definition_id", "part_number", "name", "category", "rationale", "configuration"]
+}
+_NET_SUMMARY = {"nets": ["net_id", "name", "net_type", "voltage", "component_refs"]}
+
+
+def _default_rules() -> list[ContextShareRule]:
+    domain_recipients = (
+        "product.architecture",
+        "product.electrical",
+        "product.bom",
+        "product.mech",
+        "product.firmware",
+        "product.visuals",
+        "product.validation",
+        "product.assembly",
+    )
+    rules = [
+        _rule("product.overview", recipient, _SUMMARY_OVERVIEW, "Product intent and constraints are shared with every domain specialist.")
+        for recipient in domain_recipients
+    ]
+    rules.extend(
+        _rule("product.architecture", recipient, {"system_architecture": []}, "The architecture agent routes the shared system hierarchy.")
+        for recipient in domain_recipients
+        if recipient != "product.architecture"
+    )
+    rules.extend([
+        _rule("product.electrical", "product.mech", _COMPONENT_SUMMARY, "Mechanical placement needs component identity, not electrical pins."),
+        _rule("product.electrical", "product.bom", _COMPONENT_SUMMARY, "BOM planning needs procurement identity, not pin-level data."),
+        _rule("product.electrical", "product.firmware", {**_COMPONENT_SUMMARY, "pin_mappings": [], "buses": []}, "Firmware needs hardware interface assignments."),
+        _rule("product.electrical", "product.assembly", {**_COMPONENT_SUMMARY, **_NET_SUMMARY}, "Assembly needs build-level connectivity without pin disclosure."),
+        _rule("product.electrical", "product.validation", {"part_definitions": [], "components": [], "nets": [], "buses": [], "pin_mappings": [], "power_rails": []}, "Validation owns electrical safety checks and requires the complete electrical state."),
+        _rule("product.mech", "product.bom", {"mechanical": [], "fabrication_notes": []}, "BOM planning may use mechanical sourcing and fabrication costs."),
+        _rule("product.mech", "product.visuals", {"mechanical": [], "cad_model": [], "fabrication_notes": []}, "Visuals must render the canonical mechanical form rather than inventing it."),
+        _rule("product.mech", "product.validation", {"mechanical": [], "fabrication_notes": []}, "Validation checks physical constraints and fabrication risks."),
+        _rule("product.mech", "product.assembly", {"mechanical": [], "fabrication_notes": []}, "Assembly needs the canonical mechanical build context."),
+        _rule("product.validation", "product.assembly", {"validation": []}, "Assembly must receive safety gates and blocking findings."),
+        _rule("product.assembly", "project.docs", {"assembly": []}, "Documentation projects the approved builder-facing sequence."),
+        _rule("product.bom", "project.docs", {"bom": []}, "Documentation may publish the approved procurement view."),
+    ])
+    return rules
+
+
+DEFAULT_CONTEXT_GOVERNANCE_POLICY = ContextGovernancePolicy(rules=_default_rules())
+
+
+__all__ = [
+    "CONTEXT_GOVERNANCE_SCHEMA_VERSION",
+    "ContextGovernancePolicy",
+    "ContextProjection",
+    "ContextShareMode",
+    "ContextShareRule",
+    "DEFAULT_CONTEXT_GOVERNANCE_POLICY",
+    "project_context_for_agent",
+]

--- a/forma_core/workspaces/projects/objects.py
+++ b/forma_core/workspaces/projects/objects.py
@@ -630,6 +630,8 @@ def _namespace_names_for_ir(ir: HardwareIR, target_namespace: Optional[str] = No
 
 
 def build_project_object(ir: HardwareIR | dict[str, Any], *, target_namespace: Optional[str] = None) -> FormaProjectObject:
+    from forma_core.workspaces.projects.context_governance import DEFAULT_CONTEXT_GOVERNANCE_POLICY
+
     hardware_ir = coerce_hardware_ir(ir)
     namespace_names = _namespace_names_for_ir(hardware_ir, target_namespace=target_namespace)
     versions = _namespace_versions(hardware_ir, namespace_names)
@@ -659,6 +661,7 @@ def build_project_object(ir: HardwareIR | dict[str, Any], *, target_namespace: O
             "revision": project_object_version(hardware_ir),
             "updated_at": metadata.get("iterated_at") or metadata.get("generated_at") or utc_now(),
             "namespace_versions": versions,
+            "context_governance": DEFAULT_CONTEXT_GOVERNANCE_POLICY.model_dump(mode="json"),
         },
     )
 

--- a/tests/projects/test_context_governance.py
+++ b/tests/projects/test_context_governance.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import unittest
+
+from forma_core.agents.lattice import default_namespace_agent_cards
+from forma_core.workspaces.projects.context_governance import (
+    ContextGovernancePolicy,
+    ContextShareRule,
+    project_context_for_agent,
+)
+from forma_core.workspaces.projects.models import (
+    ComponentInstance,
+    ConnectionNet,
+    FunctionalRequirements,
+    HardwareIR,
+    MechanicalNotes,
+    PinDefinition,
+    PinReference,
+    ProjectOverview,
+)
+from forma_core.workspaces.projects.objects import build_project_object
+
+
+class ContextGovernanceTests(unittest.TestCase):
+    def setUp(self) -> None:
+        ir = HardwareIR(
+            overview=ProjectOverview(
+                title="Controller",
+                description="A low-voltage controller.",
+                difficulty="Beginner",
+                category="IoT",
+            ),
+            requirements=FunctionalRequirements(
+                requirements=["Read a button"],
+                power_needs="USB-C 5 V",
+            ),
+            components=[
+                ComponentInstance(
+                    ref_des="U1",
+                    part_number="MCU-1",
+                    name="Controller",
+                    category="Microcontroller",
+                    rationale="Runs the product.",
+                    pins=[PinDefinition(pin_id="GPIO1", name="Input", pin_type="Digital")],
+                )
+            ],
+            nets=[
+                ConnectionNet(
+                    net_id="NET_BUTTON",
+                    name="Button input",
+                    net_type="Digital",
+                    pins=[PinReference(ref_des="U1", pin_id="GPIO1")],
+                )
+            ],
+            mechanical=MechanicalNotes(
+                enclosure_type="3D Printed",
+                mounting_guidance="Use standoffs.",
+                manufacturability_rating="Easy",
+            ),
+            assembly_metadata={"project_id": "00000000-0000-0000-0000-000000000001"},
+        )
+        self.project_object = build_project_object(ir).model_dump(mode="json")
+
+    def test_mechanical_agent_receives_summary_without_pin_data(self) -> None:
+        context = project_context_for_agent(self.project_object, "product.mech")
+
+        electrical = context["namespaces"]["product.electrical"]
+        self.assertEqual(["U1"], [item["ref_des"] for item in electrical["components"]])
+        self.assertNotIn("pins", electrical["components"][0])
+        self.assertIn("components[].pins", context["omitted_attributes"]["product.electrical"])
+        self.assertNotIn("product.meta", context["namespaces"])
+        self.assertIn("project.meta", context["denied_sources"])
+
+    def test_assembly_receives_build_connectivity_without_pin_ids(self) -> None:
+        context = project_context_for_agent(self.project_object, "product.assembly")
+
+        electrical = context["namespaces"]["product.electrical"]
+        self.assertEqual(["NET_BUTTON"], [item["net_id"] for item in electrical["nets"]])
+        self.assertNotIn("pin_id", str(electrical))
+        self.assertIn("mechanical", context["namespaces"]["product.mech"])
+
+    def test_same_namespace_access_is_full_but_inline_data_is_sanitized(self) -> None:
+        context = project_context_for_agent(self.project_object, "product.mech")
+
+        mechanical = context["namespaces"]["product.mech"]["mechanical"]
+        self.assertEqual("3D Printed", mechanical["enclosure_type"])
+
+        mech_namespace = next(
+            item for item in self.project_object["namespaces"] if item["name"] == "product.mech"
+        )
+        mech_namespace["payload"]["token"] = "do-not-share"
+        mech_namespace["payload"]["inline"] = "data:text/plain;base64,secret"
+        context = project_context_for_agent(self.project_object, "product.mech")
+        own = context["namespaces"]["product.mech"]
+        self.assertNotIn("token", own)
+        self.assertEqual("<redacted inline data: 29 chars>", own["inline"])
+
+    def test_lattice_card_publishes_recipient_policy(self) -> None:
+        cards = {card.agent_id: card for card in default_namespace_agent_cards()}
+
+        manifest = cards["product.mech"].metadata["context_governance"]
+        self.assertEqual("none", manifest["default_mode"])
+        self.assertEqual("summary", manifest["grants"]["product.electrical"]["mode"])
+        self.assertNotIn("project.meta", manifest["grants"])
+
+    def test_project_object_records_the_policy_version(self) -> None:
+        governance = self.project_object["metadata"]["context_governance"]
+
+        self.assertEqual("1.0", governance["schema_version"])
+        self.assertEqual("none", governance["default_mode"])
+
+    def test_nested_secret_fields_are_removed_from_custom_grants(self) -> None:
+        source = {
+            "object_id": "project-1",
+            "version": 1,
+            "namespaces": [{"name": "product.source", "payload": {"record": {"token": "secret", "safe": "ok"}}}],
+        }
+        policy = ContextGovernancePolicy(rules=[ContextShareRule(
+            source_namespace="product.source",
+            recipient_namespace="product.target",
+            allowed_attributes={"record": ["token", "safe"]},
+            reason="Test grant",
+        )])
+
+        context = project_context_for_agent(source, "product.target", policy=policy)
+
+        self.assertEqual({"safe": "ok"}, context["namespaces"]["product.source"]["record"])
+        self.assertIn("record.token", context["omitted_attributes"]["product.source"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add a versioned, deny-by-default context governance policy for project namespaces.
- Project cross-domain handoffs use explicit attribute and nested-field allowlists.
- Emit auditable allowed, denied, and omitted context receipts with sanitization for secrets and inline data.
- Publish recipient policy manifests through project objects and Lattice agent cards.
- Document the relationship to issues #391 and #424 and add coverage for mechanical, electrical, assembly, and visual handoffs.

## Design

A project remains a set of typed, versioned namespaces. Agents may read their own namespace fully; cross-domain context is projected only when a source-to-recipient rule grants it. Electrical-to-mechanical handoffs receive component identity without pin definitions, while validation can receive the complete electrical state.

## Verification

- python -m unittest tests.projects.test_context_governance tests.agents.test_lattice tests.agents.test_system_architecture tests.projects.test_project_output (24 passed)
- python -m compileall -q forma_core tests/projects/test_context_governance.py
- git diff --check origin/main...HEAD

The full unittest discovery run completed with 742 tests, 2 skips, and 16 pre-existing environment/provider-related failures outside this change.