### PR TITLE
Fix project gallery pagination

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -8,7 +8,7 @@ import logging
 import sys
 import types
 import urllib.parse
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 from uuid import uuid4
 
 
@@ -2087,6 +2087,52 @@ def _gallery_inventory_cache_record(record: Any) -> Optional[Dict[str, Any]]:
     return cached
 
 
+def _paginated_gallery_summaries(
+    *,
+    owner_user_id: Optional[str],
+    visibility: Optional[str],
+    limit: int,
+    offset: int,
+    search: Optional[str],
+    summary_builder: Callable[[Any], Optional[Dict[str, Any]]],
+    on_page_records: Optional[Callable[[List[Any]], None]] = None,
+    include_search_in_page_call: bool = False,
+) -> tuple[List[Dict[str, Any]], int]:
+    """Return a page of valid summaries without letting bad rows consume slots."""
+    page_kwargs: Dict[str, Any] = {
+        "owner_user_id": owner_user_id,
+        "visibility": visibility,
+        "limit": limit,
+        "offset": offset,
+    }
+    if include_search_in_page_call or search is not None:
+        page_kwargs["search"] = search
+    records, total = list_project_gallery_inventory_page(
+        **page_kwargs,
+    )
+    if on_page_records:
+        on_page_records(records)
+    page_items = [
+        summary
+        for record in records
+        if (summary := summary_builder(record)) is not None
+    ]
+    if len(page_items) == len(records) and (records or total == 0):
+        return page_items, total
+
+    all_records = list_project_gallery_inventory(
+        owner_user_id=owner_user_id,
+        visibility=visibility,
+        search=search,
+    )
+    valid_items = [
+        summary
+        for record in all_records
+        if (summary := summary_builder(record)) is not None
+    ]
+    return valid_items[offset:offset + limit], len(valid_items)
+
+
 def _log_gallery_legacy_fallback(endpoint: str, records: List[Any]) -> None:
     count = sum(1 for record in records if str(getattr(record, "source", "") or "").lower() == "legacy")
     logger.info("project_gallery_legacy_fallback endpoint=%s count=%d", endpoint, count)
@@ -2294,19 +2340,16 @@ def list_projects_endpoint(
     """Lists public compiled hardware projects."""
     try:
         if limit is not None:
-            projects, total = list_project_gallery_inventory_page(
+            items, total = _paginated_gallery_summaries(
                 owner_user_id=None,
                 visibility="public",
                 limit=limit,
                 offset=offset,
                 search=q,
+                summary_builder=_gallery_inventory_cache_record,
+                on_page_records=lambda records: _log_gallery_legacy_fallback("public", records),
+                include_search_in_page_call=True,
             )
-            _log_gallery_legacy_fallback("public", projects)
-            items = [
-                cached
-                for project in projects
-                if (cached := _gallery_inventory_cache_record(project)) is not None
-            ]
             return {
                 "items": _with_project_engagement(
                     _personalize_public_project_records(items, user.owner_user_id),
@@ -2346,23 +2389,25 @@ def list_my_projects_endpoint(
     user: UserContext = Depends(require_user_context),
     limit: Optional[int] = None,
     offset: int = 0,
+    q: Optional[str] = None,
 ):
     """Lists projects owned by the signed-in user."""
     owner_user_id = _require_authenticated_user(user)
     try:
         if limit is not None:
-            projects, total = list_project_gallery_inventory_page(
+            items, total = _paginated_gallery_summaries(
                 owner_user_id=owner_user_id,
                 visibility=None,
                 limit=limit,
                 offset=offset,
+                search=q,
+                summary_builder=lambda project: (
+                    summary.model_dump(mode="json")
+                    if (summary := _gallery_inventory_summary(project, current_user_id=owner_user_id)) is not None
+                    else None
+                ),
+                on_page_records=lambda records: _log_gallery_legacy_fallback("mine", records),
             )
-            _log_gallery_legacy_fallback("mine", projects)
-            items = [
-                summary.model_dump(mode="json")
-                for project in projects
-                if (summary := _gallery_inventory_summary(project, current_user_id=owner_user_id)) is not None
-            ]
             return {
                 "items": _with_project_engagement(items, owner_user_id),
                 "total": total,

--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -1732,6 +1732,8 @@ export function FormaWorkspace({
   const [myProjectHistoryError, setMyProjectHistoryError] = useState<Error | null>(null);
   const [projectSearchInput, setProjectSearchInput] = useState("");
   const [projectSearchQuery, setProjectSearchQuery] = useState("");
+  const [myProjectSearchInput, setMyProjectSearchInput] = useState("");
+  const [myProjectSearchQuery, setMyProjectSearchQuery] = useState("");
   const [localChatItems, setLocalChatItems] = useState<ChatListItem[]>([]);
   const [privateChatItems, setPrivateChatItems] = useState<ChatListItem[]>([]);
   const [privateChatsLoaded, setPrivateChatsLoaded] = useState(false);
@@ -2689,6 +2691,18 @@ export function FormaWorkspace({
     return () => window.clearTimeout(timeout);
   }, [projectSearchInput, projectSearchQuery]);
 
+  useEffect(() => {
+    const timeout = window.setTimeout(() => {
+      const nextQuery = myProjectSearchInput.trim();
+      if (nextQuery === myProjectSearchQuery) return;
+      setMyProjectHistoryLoaded(false);
+      setVisibleProjectGalleryIds([]);
+      setMyProjectHistoryPage(0);
+      setMyProjectSearchQuery(nextQuery);
+    }, 300);
+    return () => window.clearTimeout(timeout);
+  }, [myProjectSearchInput, myProjectSearchQuery]);
+
   useDeferredTask(() => {
     if (!projectHistoryLoaded) void fetchProjectHistory(projectHistoryPage, projectSearchQuery);
   }, {
@@ -2747,7 +2761,7 @@ export function FormaWorkspace({
     }
     void fetchMyProjectHistory(myProjectHistoryPage);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [authIdentityKey, authLoaded, authRequired, isSignedIn, myProjectHistoryPage]);
+  }, [authIdentityKey, authLoaded, authRequired, isSignedIn, myProjectHistoryPage, myProjectSearchQuery]);
 
   useDeferredTask(() => {
     void fetchAgentPipelineSteps(generationWorkflow);
@@ -2929,7 +2943,10 @@ export function FormaWorkspace({
     }
   };
 
-  const fetchMyProjectHistory = async (page: number = myProjectHistoryPage) => {
+  const fetchMyProjectHistory = async (
+    page: number = myProjectHistoryPage,
+    search: string = myProjectSearchQuery,
+  ) => {
     const requestId = myProjectHistoryRequestIdRef.current + 1;
     myProjectHistoryRequestIdRef.current = requestId;
     if (authRequired && !authLoaded) {
@@ -2951,6 +2968,8 @@ export function FormaWorkspace({
         limit: String(PROJECT_GALLERY_PAGE_SIZE),
         offset: String(Math.max(0, page) * PROJECT_GALLERY_PAGE_SIZE),
       });
+      const normalizedSearch = search.trim();
+      if (normalizedSearch) params.set("q", normalizedSearch);
       const res = await fetch(`${API_URL}/my/projects?${params.toString()}`, {
         headers: await generationRequestHeaders(),
       });
@@ -5466,6 +5485,7 @@ export function FormaWorkspace({
                 sectionRef={projectsSectionRef}
                 projects={projectBrowserItems}
                 title="Community"
+                pageSize={PROJECT_GALLERY_PAGE_SIZE}
                 loading={projectsPageLoading}
                 onOpenProject={(projectId) => router.push(projectRoute(projectId))}
                 onToggleSave={canInteractWithGallery ? (project) => {
@@ -5488,6 +5508,7 @@ export function FormaWorkspace({
                 sectionRef={projectsSectionRef}
                 projects={myProjectBrowserItems}
                 title="My projects"
+                pageSize={PROJECT_GALLERY_PAGE_SIZE}
                 loading={myProjectsPageLoading}
                 onOpenProject={(projectId) => router.push(projectRoute(projectId))}
                 onToggleSave={canInteractWithGallery ? (project) => {
@@ -5502,6 +5523,8 @@ export function FormaWorkspace({
                 totalItems={myProjectHistoryTotal}
                 currentPage={myProjectHistoryPage}
                 onPageChange={handleMyProjectHistoryPageChange}
+                searchValue={myProjectSearchInput}
+                onSearchValueChange={setMyProjectSearchInput}
                 error={myProjectHistoryError}
               />
           ) : homeView === "jobs" ? (

--- a/apps/web/e2e/project-pagination.spec.ts
+++ b/apps/web/e2e/project-pagination.spec.ts
@@ -1,0 +1,85 @@
+import { expect, test, type Page } from "@playwright/test";
+
+type Project = {
+  project_id: string;
+  title: string;
+  description: string;
+};
+
+const projects: Project[] = Array.from({ length: 7 }, (_, index) => ({
+  project_id: `project-${index + 1}`,
+  title: `Project ${index + 1}`,
+  description: "A test project",
+}));
+
+function pageResponse(url: URL) {
+  const offset = Number(url.searchParams.get("offset") || 0);
+  const limit = Number(url.searchParams.get("limit") || 6);
+  return {
+    items: projects.slice(offset, offset + limit),
+    total: projects.length,
+    limit,
+    offset,
+    has_more: offset + limit < projects.length,
+  };
+}
+
+async function mockProjectList(page: Page, path: string) {
+  const endpoint = new RegExp(
+    `^https?://(?:localhost|127\\.0\\.0\\.1):8000/(?:api/)?${path}(?:\\?|$)`,
+  );
+  await page.route(endpoint, async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(pageResponse(new URL(route.request().url()))),
+    });
+  });
+}
+
+async function openRoute(page: Page, path: string) {
+  try {
+    await page.goto(path, { waitUntil: "domcontentloaded", timeout: 120_000 });
+  } catch (error) {
+    // Next dev can detach a frame while compiling a freshly requested route.
+    if (!String(error).includes("ERR_ABORTED")) throw error;
+    await page.goto(path, { waitUntil: "domcontentloaded", timeout: 120_000 });
+  }
+}
+
+function projectCards(page: Page) {
+  return page.locator("section.forma-gui-browser[aria-busy='false'] .forma-gui-card:not(.forma-gui-card-skeleton)");
+}
+
+test.describe("project pagination", () => {
+  test("community keeps six fetched projects per page", async ({ page }) => {
+    await mockProjectList(page, "projects");
+    await openRoute(page, "/projects");
+
+    await expect(page.getByRole("main").getByRole("heading", { name: "Community" })).toBeVisible();
+    await expect(projectCards(page)).toHaveCount(6);
+    await expect(page.getByText("Page 1 of 2")).toBeVisible();
+
+    await page.getByRole("button", { name: "Next", exact: true }).click();
+    await expect(projectCards(page)).toHaveCount(1);
+    await expect(page.getByText("Page 2 of 2")).toBeVisible();
+  });
+
+  test("my projects uses the same page size and search contract", async ({ page }) => {
+    const requests: string[] = [];
+    await page.route(/^https?:\/\/(?:localhost|127\.0\.0\.1):8000\/(?:api\/)?my\/projects(?:\?|$)/, async (route) => {
+      requests.push(route.request().url());
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify(pageResponse(new URL(route.request().url()))),
+      });
+    });
+    await openRoute(page, "/my-projects");
+
+    await expect(page.getByRole("main").getByRole("heading", { name: "My projects" })).toBeVisible();
+    await expect(projectCards(page)).toHaveCount(6);
+    await expect(page.getByText("Page 1 of 2")).toBeVisible();
+
+    await page.getByPlaceholder("Search projects").fill("controller");
+    await expect.poll(() => requests.some((url) => url.includes("q=controller"))).toBe(true);
+  });
+});

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "3.3.6",
+        "@playwright/test": "^1.63.0",
         "@types/node": "25.9.1",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.4",
@@ -3744,6 +3745,22 @@
         "rclone.js": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.63.0.tgz",
+      "integrity": "sha512-oxMK4vllB9RK5NQ2l1pq1IfOf2AvnEuj/vYGDj0H2nMtmtZpKtCwt/l00GEO6xjGfpBNAvjovvYdCm50dRQkpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@poppinss/colors": {
@@ -10925,6 +10942,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.63.0.tgz",
+      "integrity": "sha512-+7ziBLidS4NaNCdt57SUDT+wYmmd5fmiQejUic/kb+YsYSCPyOOE9sebzMjNmQrsnNpDJqd4WHvV/8lfKfUDUg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.63.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.63.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.63.0.tgz",
+      "integrity": "sha512-rYCsBF/M5HjUch52bbtVONEFjv6Xu8sm8h72dNlR5bzIE1fvC/bxgspzkjSfU+MweEMmPM8KJebG6nnyxo5mCg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "rm -rf .next && next build",
     "start": "next start",
     "lint": "eslint .",
+    "test:e2e": "playwright test",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
     "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
@@ -30,6 +31,7 @@
   },
   "devDependencies": {
     "@eslint/eslintrc": "3.3.6",
+    "@playwright/test": "^1.63.0",
     "@types/node": "25.9.1",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  reporter: process.env.CI ? "github" : "list",
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: process.env.PLAYWRIGHT_BASE_URL
+    ? undefined
+    : {
+        command: "npm run dev -- --hostname 127.0.0.1 --port 3000",
+        cwd: ".",
+        url: "http://127.0.0.1:3000",
+        reuseExistingServer: !process.env.CI,
+        timeout: 120_000,
+      },
+});

--- a/tests/api/test_project_access.py
+++ b/tests/api/test_project_access.py
@@ -194,6 +194,48 @@ class ProjectReadAccessTests(unittest.TestCase):
         self.assertFalse(response["items"][0]["can_chat"])
         self.assertTrue(response["items"][1]["can_chat"])
 
+    def test_public_list_repaginates_when_invalid_rows_would_underfill_page(self) -> None:
+        invalid = SimpleNamespace(
+            source="legacy",
+            project_id="invalid-project",
+            owner_user_id="user-b",
+            creation_channel="hosted",
+            chat_id=None,
+            visibility="public",
+            title="Invalid project",
+            prompt="",
+            created_at="2026-07-25T12:00:00Z",
+            updated_at="2026-07-25T12:00:00Z",
+            legacy_hardware_ir={},
+        )
+        valid_projects = [
+            _legacy_inventory(_project(f"public-project-{index}", owner_user_id="user-b", visibility="public"))
+            for index in range(1, 7)
+        ]
+
+        with self._summary_dependencies(), patch.object(
+            main,
+            "list_project_gallery_inventory_page",
+            return_value=([invalid, valid_projects[0], valid_projects[1]], 7),
+        ) as list_page, patch.object(
+            main,
+            "list_project_gallery_inventory",
+            return_value=[invalid, *valid_projects],
+        ) as list_all:
+            response = main.list_projects_endpoint(_anonymous_context(), limit=6, offset=0)
+
+        list_page.assert_called_once_with(
+            owner_user_id=None,
+            visibility="public",
+            limit=6,
+            offset=0,
+            search=None,
+        )
+        list_all.assert_called_once_with(owner_user_id=None, visibility="public", search=None)
+        self.assertEqual(6, len(response["items"]))
+        self.assertEqual(6, response["total"])
+        self.assertFalse(response["has_more"])
+
     def test_public_list_passes_search_to_the_paginated_query(self) -> None:
         with self._summary_dependencies(), patch.object(
             main,
@@ -213,6 +255,29 @@ class ProjectReadAccessTests(unittest.TestCase):
             limit=6,
             offset=0,
             search="motor controller",
+        )
+        self.assertEqual([], response["items"])
+        self.assertEqual(0, response["total"])
+
+    def test_owner_list_passes_search_to_the_paginated_query(self) -> None:
+        with self._summary_dependencies(), patch.object(
+            main,
+            "list_project_gallery_inventory_page",
+            return_value=([], 0),
+        ) as list_page:
+            response = main.list_my_projects_endpoint(
+                _user_context("user-a"),
+                limit=6,
+                offset=0,
+                q="controller",
+            )
+
+        list_page.assert_called_once_with(
+            owner_user_id="user-a",
+            visibility=None,
+            limit=6,
+            offset=0,
+            search="controller",
         )
         self.assertEqual([], response["items"])
         self.assertEqual(0, response["total"])


### PR DESCRIPTION
## Summary
- keep public and owned project gallery pages filled when invalid inventory rows are skipped
- add owned-project search propagation and use the shared six-item page size
- add Playwright coverage for pagination and search request behavior

## Verification
- python -m unittest tests.api.test_project_access
- 
px tsc --noEmit
- 
pm run lint -- --no-cache
- PLAYWRIGHT_BASE_URL=http://127.0.0.1:3002 npx playwright test e2e/project-pagination.spec.ts --workers=1