### PR TITLE
feat: dependable agent delivery with explicit publish and ownership (#431) (#432)

### DIFF
--- a/apps/api/cli_projects_api.py
+++ b/apps/api/cli_projects_api.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import hashlib
+import uuid
+from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
@@ -16,9 +18,16 @@ from forma_core.config.compatibility import (
 )
 from forma_core.database import (
     CliProjectConflictError,
+    get_cli_project_delivery,
+    get_cli_project_delivery_by_id,
     get_cli_project_revision,
+    insert_cli_project_delivery,
     insert_cli_project_revision,
+    invalidate_project_lists,
     list_project_identities,
+    list_project_publish_audits,
+    publish_cli_project,
+    update_cli_project_delivery,
 )
 from forma_core.persistence.project_artifacts import (
     ProjectArtifactStorage,
@@ -40,10 +49,91 @@ class ProjectPushRequest(BaseModel):
     parent_revision_id: str | None = Field(default=None, max_length=200)
 
 
+class ProjectDeliverRequest(BaseModel):
+    manifest: dict[str, Any]
+    parent_revision_id: str | None = Field(default=None, max_length=200)
+    idempotency_key: str = Field(min_length=1, max_length=200)
+    visibility: str | None = Field(default=None)
+
+
 def _owner(user: UserContext) -> str:
     if not user.owner_user_id:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Sign in to use cloud projects.")
     return user.owner_user_id
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _revision_conflict_detail(project_id: str, owner: str, exc: BaseException) -> dict[str, Any]:
+    detail: dict[str, Any] = {"code": "PROJECT_REVISION_CONFLICT", "message": str(exc)}
+    if project_id:
+        latest = get_cli_project_revision(project_id, owner)
+        if latest is not None:
+            detail["current_revision_id"] = latest.get("revision_id")
+            detail["current_revision"] = latest.get("revision")
+    return detail
+
+
+def _delivery_visibility(value: str | None) -> str:
+    normalized = str(value or "").strip().lower() if value is not None else ""
+    if normalized not in {"", "public", "private"}:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="deliver visibility must be public or private.",
+        )
+    return normalized or "private"
+
+
+def _artifact_declaration(artifact: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "path": artifact.get("path"),
+        "sha256": artifact.get("sha256"),
+        "media_type": artifact.get("media_type"),
+        "size_bytes": artifact.get("size_bytes"),
+    }
+
+
+def _delivery_project_ref(delivery: dict[str, Any]) -> dict[str, Any]:
+    manifest = delivery.get("manifest") or {}
+    return {
+        "project_id": delivery["project_id"],
+        "revision_id": delivery["revision_id"],
+        "revision": delivery["revision"],
+        "parent_revision_id": delivery.get("parent_revision_id"),
+        "visibility": manifest.get("visibility") or "private",
+    }
+
+
+def _pending_delivery_response(delivery: dict[str, Any]) -> dict[str, Any]:
+    declaration = delivery.get("manifest") or {}
+    artifacts = validate_artifact_references(declaration.get("artifacts") or [], require_integrity=False)
+    return {
+        "delivery_id": delivery["delivery_id"],
+        "status": delivery["status"],
+        "project": _delivery_project_ref(delivery),
+        "artifacts": [{**_artifact_declaration(artifact), "status": "pending"} for artifact in artifacts],
+        "artifact_summary": {"declared": len(artifacts), "present": 0},
+        "created_at": delivery["created_at"],
+        "completed_at": delivery.get("completed_at"),
+    }
+
+
+def _verify_delivery_artifacts(
+    delivery: dict[str, Any],
+    storage: ProjectArtifactStorage,
+) -> tuple[list[dict[str, Any]], dict[str, int], bool]:
+    declaration = delivery.get("manifest") or {}
+    artifacts = validate_artifact_references(declaration.get("artifacts") or [], require_integrity=True)
+    rows: list[dict[str, Any]] = []
+    present = 0
+    for artifact in artifacts:
+        present_now = storage.contains(delivery["project_id"], artifact["sha256"])
+        present += 1 if present_now else 0
+        rows.append({**_artifact_declaration(artifact), "status": "present" if present_now else "missing"})
+    summary = {"declared": len(artifacts), "present": present}
+    return rows, summary, present == len(artifacts)
 
 
 @router.get("")
@@ -81,7 +171,10 @@ async def push_cli_project(
             expected_revision_id=request.parent_revision_id,
         )
     except CliProjectConflictError as exc:
-        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(exc)) from exc
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=_revision_conflict_detail(str(request.manifest.get("project_id") or "").strip(), owner, exc),
+        ) from exc
     except UnsupportedHardwareIRVersion as exc:
         raise HTTPException(
             status_code=status.HTTP_426_UPGRADE_REQUIRED,
@@ -93,6 +186,161 @@ async def push_cli_project(
         ) from exc
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+
+@router.post("/deliver")
+async def deliver_cli_project(
+    request: ProjectDeliverRequest,
+    user: UserContext = Depends(require_user_context),
+) -> dict[str, Any]:
+    owner = _owner(user)
+    idempotency_key = str(request.idempotency_key or "").strip()
+    if not idempotency_key:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="An idempotency_key is required.")
+    manifest_document = dict(request.manifest or {})
+    if "owner_user_id" in manifest_document or "owner" in manifest_document:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Project ownership is derived from the authenticated user and cannot be supplied.",
+        )
+    project_id = str(manifest_document.get("project_id") or "").strip()
+    try:
+        compatibility = hosted_compatibility_metadata()
+        ensure_supported_hardware_ir_version(
+            manifest_document,
+            supported_versions=compatibility.supported_hardware_ir_versions,
+        )
+        manifest_document["visibility"] = _delivery_visibility(request.visibility)
+        manifest = ProjectManifest.from_document(manifest_document)
+        payload = manifest.upload_payload()
+        payload["artifacts"] = validate_artifact_references(payload.get("artifacts"), require_integrity=True)
+        if payload["artifacts"] and not ProjectArtifactStorage().config.get("enabled"):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="CLI project artifact storage is not configured.",
+            )
+    except UnsupportedHardwareIRVersion as exc:
+        raise HTTPException(
+            status_code=status.HTTP_426_UPGRADE_REQUIRED,
+            detail={
+                "code": "UNSUPPORTED_HARDWARE_IR_VERSION",
+                "message": str(exc),
+                "hardware_ir_version": exc.version,
+            },
+        ) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    existing = get_cli_project_delivery(project_id, owner, idempotency_key)
+    if existing is not None:
+        return _pending_delivery_response(existing)
+
+    try:
+        saved = insert_cli_project_revision(
+            payload,
+            owner,
+            expected_revision_id=request.parent_revision_id,
+        )
+    except CliProjectConflictError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=_revision_conflict_detail(project_id, owner, exc),
+        ) from exc
+
+    record = {
+        "delivery_id": str(uuid.uuid4()),
+        "project_id": saved["project_id"],
+        "owner_user_id": owner,
+        "idempotency_key": idempotency_key,
+        "revision_id": saved["revision_id"],
+        "revision": saved["revision"],
+        "parent_revision_id": saved["parent_revision_id"],
+        "manifest_json": payload,
+        "status": "pending",
+        "receipt_json": None,
+        "created_at": saved["created_at"],
+        "completed_at": None,
+    }
+    delivery = insert_cli_project_delivery(record)
+    return _pending_delivery_response(delivery)
+
+
+@router.post("/deliver/{delivery_id}/complete")
+async def complete_cli_project_delivery(
+    delivery_id: str,
+    user: UserContext = Depends(require_user_context),
+) -> dict[str, Any]:
+    owner = _owner(user)
+    delivery = get_cli_project_delivery_by_id(delivery_id)
+    if delivery is None or delivery["owner_user_id"] != owner:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Delivery session not found or not authorized.",
+        )
+    if delivery["status"] == "complete" and delivery.get("receipt"):
+        return delivery["receipt"]
+    if delivery["status"] != "pending":
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Delivery session is not pending.")
+    try:
+        rows, summary, all_present = _verify_delivery_artifacts(delivery, ProjectArtifactStorage())
+    except ProjectArtifactStorageError as exc:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(exc)) from exc
+    except OSError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Project artifact storage is unavailable.",
+        ) from exc
+    if not all_present:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "DELIVERY_ARTIFACTS_MISSING",
+                "artifacts": rows,
+                "artifact_summary": summary,
+            },
+        )
+    completed_at = _now()
+    receipt = {
+        "delivery_id": delivery["delivery_id"],
+        "status": "complete",
+        "project": _delivery_project_ref(delivery),
+        "artifacts": rows,
+        "artifact_summary": summary,
+        "created_at": delivery["created_at"],
+        "completed_at": completed_at,
+    }
+    updated = update_cli_project_delivery(
+        delivery["delivery_id"],
+        owner,
+        {"status": "complete", "receipt_json": receipt, "completed_at": completed_at},
+    )
+    if updated is None or updated.get("receipt") is None:
+        raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Delivery session could not be completed.")
+    invalidate_project_lists()
+    return updated["receipt"]
+
+
+@router.post("/{project_id}/publish")
+async def publish_cli_project_endpoint(
+    project_id: str,
+    user: UserContext = Depends(require_user_context),
+) -> dict[str, Any]:
+    owner = _owner(user)
+    try:
+        result = publish_cli_project(project_id, owner, acting_user_id=owner)
+    except ValueError as exc:
+        message = str(exc)
+        code = status.HTTP_404_NOT_FOUND if "not found" in message or "another user" in message else status.HTTP_400_BAD_REQUEST
+        raise HTTPException(status_code=code, detail=message) from exc
+    result["audits"] = [
+        {
+            "acting_user_id": audit["acting_user_id"],
+            "visibility_before": audit["visibility_before"],
+            "created_at": audit["created_at"],
+        }
+        for audit in list_project_publish_audits(project_id, owner)
+    ]
+    return result
 
 
 def _revision_artifact(project_id: str, revision_id: str, owner: str, artifact_sha256: str) -> tuple[dict[str, Any], dict[str, Any]]:

--- a/forma_cli/app.py
+++ b/forma_cli/app.py
@@ -745,6 +745,130 @@ def cmd_projects_pull(args: argparse.Namespace) -> int:
     return 0
 
 
+def _delivery_idempotency_key(upload_payload: dict[str, Any]) -> str:
+    return f"deliver:{_manifest_digest(upload_payload)}"
+
+
+def cmd_projects_deliver(args: argparse.Namespace) -> int:
+    root = project_root(args.path)
+    manifest = read_project(root)
+    upload_payload, local_artifacts = prepare_project_upload(root, manifest)
+    if not _confirm_push(args, manifest):
+        if args.json:
+            _print_json({"ok": False, "operation": "deliver", "status": "cancelled"})
+        else:
+            print("Deliver cancelled.")
+        return 1
+    linkage = load_linkage(root)
+    idempotency_key = args.key or _delivery_idempotency_key(upload_payload)
+    client = _client(args)
+    delivery = client.deliver_project(
+        upload_payload,
+        idempotency_key=idempotency_key,
+        parent_revision_id=linkage.get("revision_id"),
+        visibility=args.visibility,
+    )
+    if delivery.project.project_id != manifest.project_id:
+        raise LocalProjectError("Cloud delivery returned a different project identity; refusing to update local linkage.")
+    artifact_statuses: list[dict[str, Any]] = []
+    for artifact in local_artifacts:
+        try:
+            content = artifact.source_path.read_bytes()
+        except OSError as exc:
+            raise LocalProjectError(f"Could not read project artifact {artifact.path}: {exc}") from exc
+        if hashlib.sha256(content).hexdigest() != artifact.sha256:
+            raise LocalProjectError(
+                f"Project artifact {artifact.path} changed after validation; refusing to upload it."
+            )
+        try:
+            response = client.upload_project_artifact(
+                delivery.project.project_id,
+                delivery.project.revision_id,
+                artifact.sha256,
+                content,
+                artifact.media_type,
+            )
+        except FormaAPIError as exc:
+            raise LocalProjectError(f"Could not upload project artifact {artifact.path}: {exc}") from exc
+        response_sha256 = str(response.get("sha256") or artifact.sha256).strip().lower()
+        response_media_type = str(response.get("media_type") or artifact.media_type)
+        try:
+            response_media_type = normalize_artifact_media_type(response_media_type)
+        except ValueError as exc:
+            raise LocalProjectError(f"Cloud artifact validation failed for {artifact.path}.") from exc
+        if response_sha256 != artifact.sha256 or response_media_type != artifact.media_type:
+            raise LocalProjectError(f"Cloud artifact validation failed for {artifact.path}.")
+        response_size = response.get("size_bytes")
+        if response_size is not None:
+            try:
+                if int(response_size) != artifact.size_bytes:
+                    raise LocalProjectError(f"Cloud artifact validation failed for {artifact.path}.")
+            except (TypeError, ValueError) as exc:
+                raise LocalProjectError(f"Cloud artifact validation failed for {artifact.path}.") from exc
+        artifact_statuses.append(
+            {
+                "path": artifact.path,
+                "status": str(response.get("status") or "uploaded"),
+                "sha256": artifact.sha256,
+                "media_type": artifact.media_type,
+                "size_bytes": artifact.size_bytes,
+            }
+        )
+    try:
+        completed = client.complete_delivery(delivery.delivery_id)
+    except FormaAPIError as exc:
+        raise LocalProjectError(
+            f"Delivery session {delivery.delivery_id} could not be completed: {exc}"
+        ) from exc
+    if local_artifacts:
+        write_project_manifest(root / "forma-project.json", ProjectManifest.model_validate(upload_payload))
+    update_linkage(
+        root,
+        remote=args.api_url.rstrip("/") if args.api_url else api_url(),
+        remote_project_id=completed.project.project_id,
+        project_id=manifest.project_id,
+        revision_id=completed.project.revision_id,
+        parent_revision_id=completed.project.parent_revision_id,
+        manifest_digest=_manifest_digest(upload_payload),
+        artifact_digests=json.dumps(
+            {artifact.path: artifact.sha256 for artifact in local_artifacts},
+            sort_keys=True,
+        ),
+    )
+    payload = completed.model_dump(mode="json")
+    payload["operation"] = "deliver"
+    payload["idempotency_key"] = idempotency_key
+    payload["artifacts"] = artifact_statuses
+    payload["project_url"] = _project_url(client.base_url or api_url(), completed.project.project_id)
+    if args.json:
+        _print_json(payload)
+    else:
+        print(f"Delivered project {completed.project.project_id} revision {completed.project.revision_id}")
+        print(f"Visibility: {completed.project.visibility}")
+        print(f"Project URL: {payload['project_url']}")
+    return 0
+
+
+def cmd_projects_publish(args: argparse.Namespace) -> int:
+    root = project_root(args.path)
+    linkage = load_linkage(root)
+    project_id = args.project_id or linkage.get("remote_project_id") or linkage.get("project_id")
+    if not project_id:
+        raise LocalProjectError("No remote project is linked. Deliver or push it first, or pass --project-id.")
+    result = _client(args).publish_project(project_id)
+    payload = dict(result)
+    payload["operation"] = "publish"
+    if args.json:
+        _print_json(payload)
+    else:
+        print(f"Project {project_id} is now {result.get('visibility', 'public')}")
+        if result.get("published"):
+            print(f"Published from {result.get('visibility_before')} by explicit action ({result.get('published_at')}).")
+        else:
+            print("Project was already public; no change was recorded.")
+    return 0
+
+
 def _manifest_digest(value: Any) -> str:
     canonical = json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
     return hashlib.sha256(canonical).hexdigest()
@@ -944,6 +1068,21 @@ def build_parser() -> argparse.ArgumentParser:
     pull.add_argument("--revision-id")
     pull.add_argument("--json", action="store_true")
     pull.set_defaults(func=cmd_projects_pull)
+    deliver = project_commands.add_parser(
+        "deliver",
+        help="Deliver a private snapshot with an idempotent receipt accepted only after artifacts are verified.",
+    )
+    deliver.add_argument("--path", default=".")
+    deliver.add_argument("--key", help="Idempotency key; defaults to a digest of the delivered manifest.")
+    deliver.add_argument("--visibility", choices=("public", "private"), default=None)
+    deliver.add_argument("--yes", action="store_true", help="Confirm delivery without prompting.")
+    deliver.add_argument("--json", action="store_true")
+    deliver.set_defaults(func=cmd_projects_deliver)
+    publish = project_commands.add_parser("publish", help="Explicitly publish an owned private project.")
+    publish.add_argument("--path", default=".")
+    publish.add_argument("--project-id")
+    publish.add_argument("--json", action="store_true")
+    publish.set_defaults(func=cmd_projects_publish)
 
     keys = subparsers.add_parser("keys", help="Manage local or hosted provider credentials.")
     key_commands = keys.add_subparsers(dest="keys_command", required=True)

--- a/forma_cli/sdk.py
+++ b/forma_cli/sdk.py
@@ -99,6 +99,38 @@ class CloudProjectRevision(BaseModel):
     created_at: str | None = None
 
 
+class DeliveryProjectRef(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    project_id: str
+    revision_id: str
+    revision: int
+    parent_revision_id: str | None = None
+    visibility: str = "private"
+
+
+class DeliveryArtifactStatus(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    path: str | None = None
+    sha256: str | None = None
+    media_type: str | None = None
+    size_bytes: int | None = None
+    status: str = "pending"
+
+
+class DeliveryReceipt(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    delivery_id: str
+    status: str
+    project: DeliveryProjectRef
+    artifacts: list[DeliveryArtifactStatus] = field(default_factory=list)
+    artifact_summary: dict[str, int] = {}
+    created_at: str | None = None
+    completed_at: str | None = None
+
+
 @dataclass(frozen=True)
 class ProjectArtifactDownload:
     """Binary artifact response returned by a cloud project revision."""
@@ -431,6 +463,49 @@ class FormaAPIClient:
         payload = self._request(path, authenticated=True)
         return CloudProjectRevision.model_validate(payload)
 
+    def deliver_project(
+        self,
+        manifest: Mapping[str, Any],
+        *,
+        idempotency_key: str,
+        parent_revision_id: str | None = None,
+        visibility: str | None = None,
+    ) -> DeliveryReceipt:
+        ensure_supported_hardware_ir_version(manifest)
+        body: dict[str, Any] = {
+            "manifest": dict(manifest),
+            "idempotency_key": idempotency_key,
+        }
+        if parent_revision_id is not None:
+            body["parent_revision_id"] = parent_revision_id
+        if visibility is not None:
+            body["visibility"] = visibility
+        payload = self._request(
+            "/cli/projects/deliver",
+            method="POST",
+            payload=body,
+            authenticated=True,
+        )
+        return DeliveryReceipt.model_validate(payload)
+
+    def complete_delivery(self, delivery_id: str) -> DeliveryReceipt:
+        payload = self._request(
+            f"/cli/projects/deliver/{quote(delivery_id, safe='')}/complete",
+            method="POST",
+            payload={},
+            authenticated=True,
+        )
+        return DeliveryReceipt.model_validate(payload)
+
+    def publish_project(self, project_id: str) -> dict[str, Any]:
+        payload = self._request(
+            f"/cli/projects/{quote(project_id, safe='')}/publish",
+            method="POST",
+            payload={},
+            authenticated=True,
+        )
+        return payload if isinstance(payload, dict) else {}
+
     def list_keys(self) -> list[ManagedCredentialMetadata]:
         payload = self._request("/cli/credentials", authenticated=True)
         items = payload.get("items", payload) if isinstance(payload, dict) else payload
@@ -456,6 +531,9 @@ __all__ = [
     "CompatibilityMetadata",
     "CompatibilityResult",
     "CompatibilityStatus",
+    "DeliveryArtifactStatus",
+    "DeliveryProjectRef",
+    "DeliveryReceipt",
     "DeviceAuthorization",
     "DevicePollResult",
     "FormaAPIClient",

--- a/forma_core/database.py
+++ b/forma_core/database.py
@@ -924,6 +924,151 @@ def insert_cli_project_revision(
     }
 
 
+def _cli_delivery_from_record(record: Any) -> Optional[Dict[str, Any]]:
+    if record is None:
+        return None
+    return {
+        "delivery_id": str(record.delivery_id),
+        "project_id": str(record.project_id),
+        "owner_user_id": str(record.owner_user_id),
+        "idempotency_key": str(record.idempotency_key),
+        "revision_id": str(record.revision_id),
+        "revision": int(record.revision),
+        "parent_revision_id": getattr(record, "parent_revision_id", None),
+        "manifest": getattr(record, "manifest_json", {}),
+        "status": str(getattr(record, "status", "pending")),
+        "receipt": getattr(record, "receipt_json", None),
+        "created_at": getattr(record, "created_at", None),
+        "completed_at": getattr(record, "completed_at", None),
+    }
+
+
+def get_cli_project_delivery(
+    project_id: str,
+    owner_user_id: str,
+    idempotency_key: str,
+) -> Optional[Dict[str, Any]]:
+    return _cli_delivery_from_record(
+        _DATABASE_REPOSITORY.get_cli_project_delivery(
+            str(project_id or "").strip(),
+            _normalize_user_id(owner_user_id) or "",
+            str(idempotency_key or "").strip(),
+        )
+    )
+
+
+def get_cli_project_delivery_by_id(delivery_id: str) -> Optional[Dict[str, Any]]:
+    return _cli_delivery_from_record(
+        _DATABASE_REPOSITORY.get_cli_project_delivery_by_id(str(delivery_id or "").strip())
+    )
+
+
+def list_cli_project_deliveries(owner_user_id: str) -> List[Dict[str, Any]]:
+    records = _DATABASE_REPOSITORY.list_cli_project_deliveries(_normalize_user_id(owner_user_id) or "")
+    return [_cli_delivery_from_record(record) for record in records]
+
+
+def insert_cli_project_delivery(record: Dict[str, Any]) -> Dict[str, Any]:
+    saved = _DATABASE_REPOSITORY.insert_cli_project_delivery(record)
+    if saved is None:
+        raise ValueError("Delivery session could not be created.")
+    delivery = _cli_delivery_from_record(saved)
+    if delivery is None:
+        raise ValueError("Delivery session could not be created.")
+    return delivery
+
+
+def update_cli_project_delivery(
+    delivery_id: str,
+    owner_user_id: str,
+    updates: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    return _cli_delivery_from_record(
+        _DATABASE_REPOSITORY.update_cli_project_delivery(
+            str(delivery_id or "").strip(),
+            _normalize_user_id(owner_user_id) or "",
+            updates,
+        )
+    )
+
+
+def publish_cli_project(
+    project_id: str,
+    owner_user_id: str,
+    acting_user_id: str,
+) -> Dict[str, Any]:
+    """Flip an owned private CLI project to public and record the explicit action."""
+    project_id = str(project_id or "").strip()
+    owner = _normalize_user_id(owner_user_id)
+    acting = _normalize_user_id(acting_user_id) or owner
+    if not owner or not project_id:
+        raise ValueError("A project_id and authenticated owner are required.")
+    identity = _DATABASE_REPOSITORY.get_project_identity(project_id)
+    if identity is None:
+        raise ValueError("Project identity not found.")
+    identity_owner = (
+        identity.get("owner_user_id")
+        if isinstance(identity, dict)
+        else getattr(identity, "owner_user_id", None)
+    )
+    if identity_owner and str(identity_owner) != owner:
+        raise ValueError("Project is owned by another user.")
+    current = _normalize_visibility(
+        identity.get("visibility")
+        if isinstance(identity, dict)
+        else getattr(identity, "visibility", None)
+    )
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    if current == "public":
+        _DATABASE_REPOSITORY.update_cli_project_visibility(project_id, owner, "public")
+        return {"project_id": project_id, "visibility": "public", "published": False, "already_public": True}
+    _DATABASE_REPOSITORY.upsert_project_identity(
+        {
+            "project_id": project_id,
+            "owner_user_id": owner,
+            "visibility": "public",
+            "updated_at": now,
+        }
+    )
+    _DATABASE_REPOSITORY.update_cli_project_visibility(project_id, owner, "public")
+    _DATABASE_REPOSITORY.record_project_publish_audit(
+        {
+            "id": str(uuid.uuid4()),
+            "project_id": project_id,
+            "owner_user_id": owner,
+            "acting_user_id": acting,
+            "visibility_before": current,
+            "created_at": now,
+        }
+    )
+    invalidate_project_lists()
+    return {
+        "project_id": project_id,
+        "visibility": "public",
+        "published": True,
+        "visibility_before": current,
+        "published_at": now,
+    }
+
+
+def list_project_publish_audits(project_id: str, owner_user_id: str) -> List[Dict[str, Any]]:
+    records = _DATABASE_REPOSITORY.list_project_publish_audits(
+        str(project_id or "").strip(),
+        _normalize_user_id(owner_user_id) or "",
+    )
+    return [
+        {
+            "id": str(record.id),
+            "project_id": str(record.project_id),
+            "owner_user_id": str(record.owner_user_id),
+            "acting_user_id": str(record.acting_user_id),
+            "visibility_before": str(record.visibility_before),
+            "created_at": getattr(record, "created_at", None),
+        }
+        for record in records
+    ]
+
+
 def get_cli_device_authorization(device_code_hash: Optional[str] = None, user_code_hash: Optional[str] = None) -> Optional[Any]:
     return _DATABASE_REPOSITORY.get_cli_device_authorization(device_code_hash, user_code_hash)
 

--- a/forma_core/persistence/migrations.py
+++ b/forma_core/persistence/migrations.py
@@ -53,6 +53,8 @@ def migrate_sqlite_schema(engine: Engine, *, import_legacy_jobs: bool = True) ->
         }
         if cli_columns and "creation_channel" not in cli_columns:
             connection.execute(text("ALTER TABLE cli_projects ADD COLUMN creation_channel VARCHAR NOT NULL DEFAULT 'cli'"))
+        if cli_columns and "visibility" not in cli_columns:
+            connection.execute(text("ALTER TABLE cli_projects ADD COLUMN visibility VARCHAR NOT NULL DEFAULT 'public'"))
         identity_columns = {
             row[1]
             for row in connection.exec_driver_sql("PRAGMA table_info(projects)").fetchall()

--- a/forma_core/persistence/models.py
+++ b/forma_core/persistence/models.py
@@ -184,6 +184,8 @@ class DBCliProject(Base):
     workspace_id = Column(String, nullable=True)
     owner_user_id = Column(String, index=True, nullable=False)
     title = Column(String, nullable=False, default="")
+    creation_channel = Column(String, nullable=False, default="cli")
+    visibility = Column(String, nullable=False, default="public")
     current_revision = Column(Integer, nullable=False, default=0)
     current_revision_id = Column(String, nullable=True)
     created_at = Column(String, nullable=False)
@@ -205,6 +207,33 @@ class DBCliProjectRevision(Base):
     parent_revision_id = Column(String, nullable=True)
     manifest_json = Column(JSON, nullable=False)
     created_at = Column(String, index=True, nullable=False)
+
+
+class DBCliProjectDelivery(Base):
+    """Server-side idempotent delivery session for agent/CLI-created projects."""
+
+    __tablename__ = "cli_project_deliveries"
+    __table_args__ = (
+        UniqueConstraint(
+            "owner_user_id",
+            "project_id",
+            "idempotency_key",
+            name="uq_cli_project_delivery_owner_project_key",
+        ),
+    )
+
+    delivery_id = Column(String, primary_key=True)
+    project_id = Column(String, index=True, nullable=False)
+    owner_user_id = Column(String, index=True, nullable=False)
+    idempotency_key = Column(String, nullable=False)
+    revision_id = Column(String, nullable=False)
+    revision = Column(Integer, nullable=False)
+    parent_revision_id = Column(String, nullable=True)
+    manifest_json = Column(JSON, nullable=False)
+    status = Column(String, index=True, nullable=False, default="pending")
+    receipt_json = Column(JSON, nullable=True)
+    created_at = Column(String, index=True, nullable=False)
+    completed_at = Column(String, nullable=True)
 
 
 class DBCliDeviceAuthorization(Base):
@@ -304,6 +333,19 @@ class DBProjectDeletionAudit(Base):
     status = Column(String, index=True, nullable=False)
     policy_version = Column(String, nullable=False)
     details_json = Column(JSON, nullable=False, default=dict)
+    created_at = Column(String, index=True, nullable=False)
+
+
+class DBProjectPublishAudit(Base):
+    """Audit record for an explicit publish (private-to-public) action."""
+
+    __tablename__ = "project_publish_audit"
+
+    id = Column(String, primary_key=True)
+    project_id = Column(String, index=True, nullable=False)
+    owner_user_id = Column(String, index=True, nullable=False)
+    acting_user_id = Column(String, index=True, nullable=False)
+    visibility_before = Column(String, nullable=False)
     created_at = Column(String, index=True, nullable=False)
 
 

--- a/forma_core/persistence/project_artifacts.py
+++ b/forma_core/persistence/project_artifacts.py
@@ -228,6 +228,28 @@ class ProjectArtifactStorage:
         self._validate_size(content)
         return StoredProjectArtifact(project_id, normalized_sha256, normalized_media_type, len(content), content)
 
+    def contains(self, project_id: str, sha256: str) -> bool:
+        """Return whether an object with the declared SHA-256 is already stored."""
+        self._require_enabled()
+        normalized_sha256 = str(sha256 or "").strip().lower()
+        if not re.fullmatch(r"[0-9a-f]{64}", normalized_sha256):
+            raise ValueError("Project artifact storage requires a SHA-256 hash.")
+        key = project_artifact_storage_key(project_id, normalized_sha256)
+        backend = self.config["backend"]
+        if backend == "local":
+            return (Path(self.config["directory"]) / Path(*key.split("/"))).is_file()
+        if backend == "supabase":
+            bucket = self._supabase_bucket()
+            try:
+                return bool(bucket.list(key, {"limit": 1}))
+            except Exception as exc:
+                raise ProjectArtifactStorageError("Project artifact presence check failed.") from exc
+        try:
+            self._s3_client().head_object(Bucket=self.config["bucket"], Key=key)
+            return True
+        except Exception:
+            return False
+
     def delete_project(self, project_id: str) -> int:
         """Delete all objects for a project; used by privacy purge workers."""
         self._require_enabled()

--- a/forma_core/persistence/repositories/base.py
+++ b/forma_core/persistence/repositories/base.py
@@ -149,6 +149,13 @@ class ApplicationRepository(Protocol):
 
     def get_cli_project(self, project_id: str, owner_user_id: str) -> Optional[Any]: ...
 
+    def update_cli_project_visibility(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        visibility: str,
+    ) -> Optional[Any]: ...
+
     def list_cli_projects(self, owner_user_id: str) -> List[Any]: ...
 
     def get_cli_project_revision(
@@ -164,6 +171,30 @@ class ApplicationRepository(Protocol):
         revision_record: Dict[str, Any],
         expected_revision_id: Optional[str],
     ) -> Optional[Any]: ...
+
+    def get_cli_project_delivery(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        idempotency_key: str,
+    ) -> Optional[Any]: ...
+
+    def get_cli_project_delivery_by_id(self, delivery_id: str) -> Optional[Any]: ...
+
+    def list_cli_project_deliveries(self, owner_user_id: str) -> List[Any]: ...
+
+    def insert_cli_project_delivery(self, record: Dict[str, Any]) -> Any: ...
+
+    def update_cli_project_delivery(
+        self,
+        delivery_id: str,
+        owner_user_id: str,
+        updates: Dict[str, Any],
+    ) -> Optional[Any]: ...
+
+    def record_project_publish_audit(self, record: Dict[str, Any]) -> None: ...
+
+    def list_project_publish_audits(self, project_id: str, owner_user_id: str) -> List[Any]: ...
 
     def get_cli_device_authorization(self, device_code_hash: Optional[str] = None, user_code_hash: Optional[str] = None) -> Optional[Any]: ...
 

--- a/forma_core/persistence/repositories/sqlite.py
+++ b/forma_core/persistence/repositories/sqlite.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
@@ -19,12 +20,14 @@ from forma_core.persistence.models import (
     DBProjectChat,
     DBProjectBuild,
     DBProjectDeletionAudit,
+    DBProjectPublishAudit,
     DBProjectRemix,
     DBProjectSave,
     DBProjectWorkflow,
     DBProjectWorkflowTransition,
     DBProjectRevision,
     DBCliProject,
+    DBCliProjectDelivery,
     DBCliProjectRevision,
     DBCliDeviceAuthorization,
     DBCliTokenSession,
@@ -651,6 +654,113 @@ class SqlAlchemyRepository:
                 return revision
         except IntegrityError:
             return None
+
+    def get_cli_project_delivery(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        idempotency_key: str,
+    ) -> Optional[Any]:
+        with self._session() as session:
+            return session.query(DBCliProjectDelivery).filter(
+                DBCliProjectDelivery.project_id == project_id,
+                DBCliProjectDelivery.owner_user_id == owner_user_id,
+                DBCliProjectDelivery.idempotency_key == idempotency_key,
+            ).first()
+
+    def get_cli_project_delivery_by_id(self, delivery_id: str) -> Optional[Any]:
+        with self._session() as session:
+            return session.query(DBCliProjectDelivery).filter(
+                DBCliProjectDelivery.delivery_id == delivery_id
+            ).first()
+
+    def list_cli_project_deliveries(self, owner_user_id: str) -> List[Any]:
+        with self._session() as session:
+            return (
+                session.query(DBCliProjectDelivery)
+                .filter(DBCliProjectDelivery.owner_user_id == owner_user_id)
+                .order_by(DBCliProjectDelivery.created_at.desc())
+                .all()
+            )
+
+    def insert_cli_project_delivery(self, record: Dict[str, Any]) -> Any:
+        try:
+            with self._session() as session, session.begin():
+                delivery = DBCliProjectDelivery(**record)
+                session.add(delivery)
+                session.flush()
+                session.refresh(delivery)
+                session.expunge(delivery)
+                return delivery
+        except IntegrityError:
+            return self.get_cli_project_delivery(
+                record["project_id"],
+                record["owner_user_id"],
+                record["idempotency_key"],
+            )
+
+    def update_cli_project_visibility(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        visibility: str,
+    ) -> Optional[Any]:
+        now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        try:
+            with self._session() as session, session.begin():
+                project = session.query(DBCliProject).filter(
+                    DBCliProject.project_id == project_id,
+                    DBCliProject.owner_user_id == owner_user_id,
+                ).first()
+                if project is None:
+                    return None
+                project.visibility = visibility
+                project.updated_at = now
+                session.flush()
+                session.refresh(project)
+                session.expunge(project)
+                return project
+        except IntegrityError:
+            return None
+
+    def update_cli_project_delivery(
+        self,
+        delivery_id: str,
+        owner_user_id: str,
+        updates: Dict[str, Any],
+    ) -> Optional[Any]:
+        try:
+            with self._session() as session, session.begin():
+                delivery = session.query(DBCliProjectDelivery).filter(
+                    DBCliProjectDelivery.delivery_id == delivery_id,
+                    DBCliProjectDelivery.owner_user_id == owner_user_id,
+                ).first()
+                if delivery is None:
+                    return None
+                for key, value in updates.items():
+                    setattr(delivery, key, value)
+                session.flush()
+                session.refresh(delivery)
+                session.expunge(delivery)
+                return delivery
+        except IntegrityError:
+            return None
+
+    def record_project_publish_audit(self, record: Dict[str, Any]) -> None:
+        with self._session() as session, session.begin():
+            session.add(DBProjectPublishAudit(**record))
+
+    def list_project_publish_audits(self, project_id: str, owner_user_id: str) -> List[Any]:
+        with self._session() as session:
+            return (
+                session.query(DBProjectPublishAudit)
+                .filter(
+                    DBProjectPublishAudit.project_id == project_id,
+                    DBProjectPublishAudit.owner_user_id == owner_user_id,
+                )
+                .order_by(DBProjectPublishAudit.created_at.desc())
+                .all()
+            )
 
     def get_cli_device_authorization(self, device_code_hash: Optional[str] = None, user_code_hash: Optional[str] = None) -> Optional[Any]:
         with self._session() as session:

--- a/forma_core/persistence/repositories/supabase.py
+++ b/forma_core/persistence/repositories/supabase.py
@@ -645,6 +645,103 @@ class SupabaseRepository:
             return None
         return _record(rows[0]) if rows else None
 
+    def get_cli_project_delivery(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        idempotency_key: str,
+    ) -> Optional[Any]:
+        rows = (
+            self._client.table("cli_project_deliveries")
+            .select("*")
+            .eq("project_id", project_id)
+            .eq("owner_user_id", owner_user_id)
+            .eq("idempotency_key", idempotency_key)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
+    def get_cli_project_delivery_by_id(self, delivery_id: str) -> Optional[Any]:
+        rows = (
+            self._client.table("cli_project_deliveries")
+            .select("*")
+            .eq("delivery_id", delivery_id)
+            .limit(1)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
+    def list_cli_project_deliveries(self, owner_user_id: str) -> List[Any]:
+        rows = (
+            self._client.table("cli_project_deliveries")
+            .select("*")
+            .eq("owner_user_id", owner_user_id)
+            .order("created_at", desc=True)
+            .execute()
+            .data
+            or []
+        )
+        return [_record(row) for row in rows]
+
+    def insert_cli_project_delivery(self, record: Dict[str, Any]) -> Any:
+        rows = self._client.table("cli_project_deliveries").insert(record).execute().data or []
+        return _record(rows[0]) if rows else _record(record)
+
+    def update_cli_project_delivery(
+        self,
+        delivery_id: str,
+        owner_user_id: str,
+        updates: Dict[str, Any],
+    ) -> Optional[Any]:
+        rows = (
+            self._client.table("cli_project_deliveries")
+            .update(updates)
+            .eq("delivery_id", delivery_id)
+            .eq("owner_user_id", owner_user_id)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
+    def update_cli_project_visibility(
+        self,
+        project_id: str,
+        owner_user_id: str,
+        visibility: str,
+    ) -> Optional[Any]:
+        rows = (
+            self._client.table("cli_projects")
+            .update({"visibility": visibility})
+            .eq("project_id", project_id)
+            .eq("owner_user_id", owner_user_id)
+            .execute()
+            .data
+            or []
+        )
+        return _record(rows[0]) if rows else None
+
+    def record_project_publish_audit(self, record: Dict[str, Any]) -> None:
+        self._client.table("project_publish_audit").insert(record).execute()
+
+    def list_project_publish_audits(self, project_id: str, owner_user_id: str) -> List[Any]:
+        rows = (
+            self._client.table("project_publish_audit")
+            .select("*")
+            .eq("project_id", project_id)
+            .eq("owner_user_id", owner_user_id)
+            .order("created_at", desc=True)
+            .execute()
+            .data
+            or []
+        )
+        return [_record(row) for row in rows]
+
     def _ensure_canonical_cli_revision(
         self,
         project_record: Dict[str, Any],

--- a/forma_core/persistence/schema.py
+++ b/forma_core/persistence/schema.py
@@ -80,8 +80,8 @@ APPLICATION_SCHEMA: Tuple[TableContract, ...] = (
     TableContract(
         "cli_projects",
         (
-            "project_id", "workspace_id", "owner_user_id", "creation_channel", "title", "current_revision",
-            "current_revision_id", "created_at", "updated_at",
+            "project_id", "workspace_id", "owner_user_id", "creation_channel", "title",
+            "current_revision", "current_revision_id", "visibility", "created_at", "updated_at",
         ),
     ),
     TableContract(
@@ -129,6 +129,17 @@ APPLICATION_SCHEMA: Tuple[TableContract, ...] = (
     TableContract(
         "project_deletion_audit",
         ("id", "project_id", "acting_user_id", "action", "status", "policy_version", "details_json", "created_at"),
+    ),
+    TableContract(
+        "project_publish_audit",
+        ("id", "project_id", "owner_user_id", "acting_user_id", "visibility_before", "created_at"),
+    ),
+    TableContract(
+        "cli_project_deliveries",
+        (
+            "delivery_id", "project_id", "owner_user_id", "idempotency_key", "revision_id", "revision",
+            "parent_revision_id", "manifest_json", "status", "receipt_json", "created_at", "completed_at",
+        ),
     ),
     TableContract(
         "project_chats",

--- a/supabase/migrations/20260829000100_cli_projects.sql
+++ b/supabase/migrations/20260829000100_cli_projects.sql
@@ -5,6 +5,8 @@ create table if not exists public.cli_projects (
   workspace_id text,
   owner_user_id text not null,
   title text not null default '',
+  creation_channel text not null default 'cli',
+  visibility text not null default 'public',
   current_revision integer not null default 0 check (current_revision >= 0),
   current_revision_id text,
   created_at text not null,

--- a/tests/api/test_cli_project_delivery.py
+++ b/tests/api/test_cli_project_delivery.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import hashlib
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from fastapi import HTTPException
+
+from apps.api import cli_projects_api
+from apps.api.auth import UserContext
+from apps.api.cli_projects_api import ProjectDeliverRequest
+from forma_core.database import CliProjectConflictError
+from forma_core.persistence.project_artifacts import ProjectArtifactStorage
+
+
+def _user(owner: str = "user-a") -> UserContext:
+    return UserContext(
+        provider="clerk",
+        subject=owner,
+        owner_user_id=owner,
+        is_authenticated=True,
+        is_admin=False,
+        claims={"sub": owner},
+    )
+
+
+def _manifest(project_id: str = "project-delivery") -> dict[str, object]:
+    return {
+        "format": "forma-project",
+        "version": 1,
+        "project_id": project_id,
+        "title": "Delivered project",
+        "prompt": "deliver a project snapshot",
+        "artifacts": [],
+    }
+
+
+def _deliver_request(
+    *,
+    manifest: dict[str, object] | None = None,
+    idempotency_key: str = "key-1",
+    visibility: str | None = None,
+    parent_revision_id: str | None = None,
+) -> ProjectDeliverRequest:
+    return ProjectDeliverRequest(
+        manifest=manifest if manifest is not None else _manifest(),
+        idempotency_key=idempotency_key,
+        visibility=visibility,
+        parent_revision_id=parent_revision_id,
+    )
+
+
+def _saved_revision(project_id: str = "project-delivery") -> dict[str, object]:
+    return {
+        "revision_id": "rev-1",
+        "project_id": project_id,
+        "revision": 1,
+        "parent_revision_id": None,
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+
+
+def _delivery_record(project_id: str = "project-delivery") -> dict[str, object]:
+    return {
+        "delivery_id": "delivery-1",
+        "project_id": project_id,
+        "owner_user_id": "user-a",
+        "idempotency_key": "key-1",
+        "revision_id": "rev-1",
+        "revision": 1,
+        "parent_revision_id": None,
+        "manifest": _manifest(project_id),
+        "status": "pending",
+        "receipt": None,
+        "created_at": "2026-01-01T00:00:00Z",
+        "completed_at": None,
+    }
+
+
+class CliProjectDeliveryApiTests(unittest.IsolatedAsyncioTestCase):
+    async def test_deliver_creates_pending_receipt_and_defaults_to_private(self) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_save(manifest, owner, *, expected_revision_id=None):
+            captured["manifest"] = manifest
+            captured["owner"] = owner
+            return _saved_revision()
+
+        with (
+            patch.object(cli_projects_api, "get_cli_project_delivery", return_value=None),
+            patch.object(cli_projects_api, "insert_cli_project_revision", side_effect=fake_save) as save,
+            patch.object(cli_projects_api, "insert_cli_project_delivery", return_value=_delivery_record()) as save_delivery,
+        ):
+            receipt = await cli_projects_api.deliver_cli_project(_deliver_request(), _user())
+
+        self.assertEqual("pending", receipt["status"])
+        self.assertEqual("delivery-1", receipt["delivery_id"])
+        self.assertEqual("private", captured["manifest"]["visibility"])
+        save.assert_called_once()
+        save_delivery.assert_called_once()
+        self.assertEqual("user-a", captured["owner"])
+
+    async def test_deliver_honors_explicit_visibility(self) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_save(manifest, owner, *, expected_revision_id=None):
+            captured["manifest"] = manifest
+            return _saved_revision()
+
+        with (
+            patch.object(cli_projects_api, "get_cli_project_delivery", return_value=None),
+            patch.object(cli_projects_api, "insert_cli_project_revision", side_effect=fake_save),
+            patch.object(cli_projects_api, "insert_cli_project_delivery", return_value=_delivery_record()) as save_delivery,
+        ):
+            await cli_projects_api.deliver_cli_project(_deliver_request(visibility="public"), _user())
+
+        self.assertEqual("public", captured["manifest"]["visibility"])
+        save_delivery.assert_called_once()
+
+    async def test_deliver_rejects_invalid_visibility_and_owner_spoofing(self) -> None:
+        with patch.object(cli_projects_api, "insert_cli_project_revision") as save:
+            with self.assertRaisesRegex(HTTPException, "public or private"):
+                await cli_projects_api.deliver_cli_project(_deliver_request(visibility="secret"), _user())
+            with self.assertRaisesRegex(HTTPException, "cannot be supplied"):
+                await cli_projects_api.deliver_cli_project(
+                    _deliver_request(manifest={**_manifest(), "owner_user_id": "attacker"}),
+                    _user(),
+                )
+        save.assert_not_called()
+
+    async def test_deliver_replays_existing_delivery_without_new_revision(self) -> None:
+        existing = _delivery_record()
+        with (
+            patch.object(cli_projects_api, "get_cli_project_delivery", return_value=existing) as fetch,
+            patch.object(cli_projects_api, "insert_cli_project_revision") as save,
+            patch.object(cli_projects_api, "insert_cli_project_delivery") as save_delivery,
+        ):
+            receipt = await cli_projects_api.deliver_cli_project(_deliver_request(), _user())
+
+        self.assertEqual("delivery-1", receipt["delivery_id"])
+        fetch.assert_called_once_with("project-delivery", "user-a", "key-1")
+        save.assert_not_called()
+        save_delivery.assert_not_called()
+
+    async def test_deliver_409_is_enriched_with_current_server_revision(self) -> None:
+        latest = {"revision_id": "server-rev-9", "revision": 9}
+
+        def fake_save(manifest, owner, *, expected_revision_id=None):
+            raise CliProjectConflictError("The cloud project changed since the local project was last pulled.")
+
+        with (
+            patch.object(cli_projects_api, "get_cli_project_delivery", return_value=None),
+            patch.object(cli_projects_api, "insert_cli_project_revision", side_effect=fake_save),
+            patch.object(cli_projects_api, "get_cli_project_revision", return_value=latest),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await cli_projects_api.deliver_cli_project(_deliver_request(), _user())
+
+        self.assertEqual(409, raised.exception.status_code)
+        detail = raised.exception.detail
+        self.assertEqual("PROJECT_REVISION_CONFLICT", detail["code"])
+        self.assertEqual("server-rev-9", detail["current_revision_id"])
+        self.assertEqual(9, detail["current_revision"])
+
+    def test_contains_reports_local_artifact_presence(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            storage = ProjectArtifactStorage(
+                {
+                    "enabled": True,
+                    "backend": "local",
+                    "directory": Path(directory),
+                    "bucket": "unused",
+                    "max_bytes": 1024,
+                }
+            )
+            sha256 = hashlib.sha256(b"native cad bytes").hexdigest()
+            self.assertFalse(storage.contains("project-delivery", sha256))
+            storage.put("project-delivery", sha256, b"native cad bytes", "model/step")
+            self.assertTrue(storage.contains("project-delivery", sha256))
+
+    async def test_complete_verifies_artifacts_and_returns_complete_receipt(self) -> None:
+        content = b"native cad bytes"
+        sha256 = hashlib.sha256(content).hexdigest()
+        delivery = _delivery_record()
+        delivery["manifest"] = {
+            **_manifest(),
+            "artifacts": [
+                {"path": "assembly.step", "sha256": sha256, "media_type": "model/step", "size_bytes": len(content)}
+            ],
+        }
+        captured: dict[str, object] = {}
+
+        with tempfile.TemporaryDirectory() as directory:
+            storage = ProjectArtifactStorage(
+                {
+                    "enabled": True,
+                    "backend": "local",
+                    "directory": Path(directory),
+                    "bucket": "unused",
+                    "max_bytes": 1024,
+                }
+            )
+            storage.put(delivery["project_id"], sha256, content, "model/step")
+
+            def fake_update(delivery_id, owner, updates):
+                captured["updates"] = updates
+                receipt = {
+                    "delivery_id": delivery_id,
+                    "status": "complete",
+                    "project": {
+                        "project_id": delivery["project_id"],
+                        "revision_id": delivery["revision_id"],
+                        "revision": delivery["revision"],
+                        "parent_revision_id": None,
+                        "visibility": "private",
+                    },
+                    "artifacts": [
+                        {"path": "assembly.step", "sha256": sha256, "media_type": "model/step", "size_bytes": len(content), "status": "present"}
+                    ],
+                    "artifact_summary": {"declared": 1, "present": 1},
+                    "created_at": delivery["created_at"],
+                    "completed_at": updates["completed_at"],
+                }
+                return {**delivery, **updates, "receipt": receipt}
+
+            with (
+                patch.object(cli_projects_api, "get_cli_project_delivery_by_id", return_value=delivery),
+                patch.object(cli_projects_api, "ProjectArtifactStorage", return_value=storage),
+                patch.object(cli_projects_api, "update_cli_project_delivery", side_effect=fake_update) as update,
+            ):
+                receipt = await cli_projects_api.complete_cli_project_delivery("delivery-1", _user())
+
+        self.assertEqual("complete", receipt["status"])
+        self.assertEqual("present", receipt["artifacts"][0]["status"])
+        update.assert_called_once()
+        self.assertEqual("complete", captured["updates"]["status"])
+        self.assertIsNotNone(captured["updates"]["completed_at"])
+
+    async def test_complete_replays_a_completed_receipt(self) -> None:
+        completed = _delivery_record()
+        completed["status"] = "complete"
+        completed["receipt"] = {"delivery_id": "delivery-1", "status": "complete", "project": {}, "artifacts": []}
+        with (
+            patch.object(cli_projects_api, "get_cli_project_delivery_by_id", return_value=completed),
+            patch.object(cli_projects_api, "update_cli_project_delivery") as update,
+        ):
+            receipt = await cli_projects_api.complete_cli_project_delivery("delivery-1", _user())
+
+        self.assertEqual("complete", receipt["status"])
+        update.assert_not_called()
+
+    async def test_complete_rejects_missing_artifacts_before_commit(self) -> None:
+        content = b"native cad bytes"
+        sha256 = hashlib.sha256(content).hexdigest()
+        delivery = _delivery_record()
+        delivery["manifest"] = {
+            **_manifest(),
+            "artifacts": [
+                {"path": "assembly.step", "sha256": sha256, "media_type": "model/step", "size_bytes": len(content)}
+            ],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            storage = ProjectArtifactStorage(
+                {
+                    "enabled": True,
+                    "backend": "local",
+                    "directory": Path(directory),
+                    "bucket": "unused",
+                    "max_bytes": 1024,
+                }
+            )
+            with (
+                patch.object(cli_projects_api, "get_cli_project_delivery_by_id", return_value=delivery),
+                patch.object(cli_projects_api, "ProjectArtifactStorage", return_value=storage),
+                patch.object(cli_projects_api, "update_cli_project_delivery") as update,
+            ):
+                with self.assertRaises(HTTPException) as raised:
+                    await cli_projects_api.complete_cli_project_delivery("delivery-1", _user())
+
+        self.assertEqual(409, raised.exception.status_code)
+        self.assertEqual("DELIVERY_ARTIFACTS_MISSING", raised.exception.detail["code"])
+        self.assertEqual(0, raised.exception.detail["artifact_summary"]["present"])
+        update.assert_not_called()
+
+    async def test_complete_is_owner_scoped(self) -> None:
+        delivery = _delivery_record()
+        with patch.object(cli_projects_api, "get_cli_project_delivery_by_id", return_value=delivery):
+            with self.assertRaises(HTTPException) as raised:
+                await cli_projects_api.complete_cli_project_delivery("delivery-1", _user("intruder"))
+
+        self.assertEqual(404, raised.exception.status_code)
+
+    async def test_publish_surfaces_explicit_action_and_audit_trail(self) -> None:
+        publish_result = {
+            "project_id": "project-delivery",
+            "visibility": "public",
+            "published": True,
+            "visibility_before": "private",
+            "published_at": "2026-01-01T00:00:00Z",
+        }
+        audits = [
+            {
+                "acting_user_id": "user-a",
+                "visibility_before": "private",
+                "created_at": "2026-01-01T00:00:00Z",
+            }
+        ]
+        with (
+            patch.object(cli_projects_api, "publish_cli_project", return_value=publish_result) as publish_action,
+            patch.object(cli_projects_api, "list_project_publish_audits", return_value=audits) as list_audits,
+        ):
+            result = await cli_projects_api.publish_cli_project_endpoint("project-delivery", _user())
+
+        publish_action.assert_called_once_with("project-delivery", "user-a", acting_user_id="user-a")
+        list_audits.assert_called_once_with("project-delivery", "user-a")
+        self.assertTrue(result["published"])
+        self.assertEqual(audits, result["audits"])
+
+    async def test_publish_maps_missing_project_to_404(self) -> None:
+        with patch.object(cli_projects_api, "publish_cli_project", side_effect=ValueError("Project identity not found.")):
+            with self.assertRaises(HTTPException) as raised:
+                await cli_projects_api.publish_cli_project_endpoint("missing-project", _user())
+
+        self.assertEqual(404, raised.exception.status_code)
+
+    def test_deliver_command_defaults_provide_a_stable_idempotency_key(self) -> None:
+        import forma_cli.app as app
+
+        key = app._delivery_idempotency_key(_manifest())
+        self.assertTrue(key.startswith("deliver:"))
+        self.assertEqual(64, len(key.removeprefix("deliver:")))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -7,6 +7,7 @@ import uuid
 from contextlib import closing
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 from unittest.mock import patch
 
 from forma_core.jobs.store import JobMetadataStore
@@ -847,6 +848,164 @@ class PersistenceArchitectureTests(unittest.TestCase):
                 ),
             )
             connection.commit()
+
+
+class CliProjectDeliveryPersistenceTests(unittest.TestCase):
+    def _provider_and_repo(self) -> tuple[Any, Any]:
+        provider = create_sqlite_provider(
+            source="test cli project delivery persistence",
+            url="sqlite:///:memory:",
+            import_legacy_jobs=False,
+        )
+        provider.initialize()
+        return provider, SqlAlchemyRepository(provider.session_factory)
+
+    def test_cli_project_delivery_session_round_trip(self) -> None:
+        _, repo = self._provider_and_repo()
+        record = {
+            "delivery_id": "delivery-a",
+            "project_id": "project-a",
+            "owner_user_id": "user-a",
+            "idempotency_key": "key-a",
+            "revision_id": "rev-a",
+            "revision": 3,
+            "parent_revision_id": "rev-b",
+            "manifest_json": {"project_id": "project-a", "visibility": "private"},
+            "status": "pending",
+            "receipt_json": None,
+            "created_at": "2026-01-01T00:00:00Z",
+            "completed_at": None,
+        }
+        created = repo.insert_cli_project_delivery(record)
+        self.assertEqual("delivery-a", created.delivery_id)
+
+        replay = repo.insert_cli_project_delivery(record)
+        self.assertEqual("delivery-a", replay.delivery_id)
+
+        delivery = repo.get_cli_project_delivery("project-a", "user-a", "key-a")
+        self.assertEqual("delivery-a", delivery.delivery_id)
+        self.assertEqual("rev-b", delivery.parent_revision_id)
+
+        by_id = repo.get_cli_project_delivery_by_id("delivery-a")
+        self.assertEqual("project-a", by_id.project_id)
+
+        updated = repo.update_cli_project_delivery(
+            "delivery-a",
+            "user-a",
+            {"status": "complete", "receipt_json": {"delivery_id": "delivery-a", "status": "complete"}, "completed_at": "2026-01-01T00:00:01Z"},
+        )
+        self.assertEqual("complete", updated.status)
+        self.assertEqual({"delivery_id": "delivery-a", "status": "complete"}, updated.receipt_json)
+
+        self.assertEqual(["delivery-a"], [item.delivery_id for item in repo.list_cli_project_deliveries("user-a")])
+        self.assertEqual([], repo.list_cli_project_deliveries("user-b"))
+        self.assertIsNone(repo.get_cli_project_delivery_by_id("missing"))
+
+    def test_project_publish_audit_round_trip(self) -> None:
+        _, repo = self._provider_and_repo()
+        audit = {
+            "id": "audit-1",
+            "project_id": "project-a",
+            "owner_user_id": "user-a",
+            "acting_user_id": "user-a",
+            "visibility_before": "private",
+            "created_at": "2026-01-01T00:00:00Z",
+        }
+        repo.record_project_publish_audit(audit)
+        audits = repo.list_project_publish_audits("project-a", "user-a")
+        self.assertEqual(["audit-1"], [item.id for item in audits])
+        self.assertEqual("private", audits[0].visibility_before)
+        self.assertEqual([], repo.list_project_publish_audits("project-a", "user-b"))
+
+    def test_database_publish_cli_project_flips_private_identity_and_records_audit(self) -> None:
+        now_iso = "2026-01-01T00:00:00Z"
+        provider = create_sqlite_provider(
+            source="test cli project publish helper",
+            url="sqlite:///:memory:",
+            import_legacy_jobs=False,
+        )
+        provider.initialize()
+        repo = SqlAlchemyRepository(provider.session_factory)
+        repo.insert_cli_project_revision(
+            {
+                "project_id": "project-a",
+                "workspace_id": None,
+                "owner_user_id": "user-a",
+                "creation_channel": "cli",
+                "visibility": "private",
+                "title": "Delivered project",
+                "current_revision": 0,
+                "current_revision_id": None,
+                "created_at": now_iso,
+                "updated_at": now_iso,
+            },
+            {
+                "revision_id": "rev-a",
+                "project_id": "project-a",
+                "owner_user_id": "user-a",
+                "revision": 1,
+                "parent_revision_id": None,
+                "manifest_json": {"project_id": "project-a", "visibility": "private"},
+                "created_at": now_iso,
+            },
+            expected_revision_id=None,
+        )
+        with (
+            patch.object(database, "_DATABASE_REPOSITORY", repo),
+            patch.object(database, "invalidate_project_lists"),
+        ):
+            result = database.publish_cli_project("project-a", "user-a", acting_user_id="user-a")
+
+        self.assertTrue(result["published"])
+        self.assertEqual("private", result["visibility_before"])
+        identity = repo.get_project_identity("project-a")
+        self.assertEqual("public", identity["visibility"])
+        cli_project = repo.get_cli_project("project-a", "user-a")
+        self.assertEqual("public", cli_project.visibility)
+        audits = repo.list_project_publish_audits("project-a", "user-a")
+        self.assertEqual(1, len(audits))
+        self.assertEqual("user-a", audits[0].acting_user_id)
+
+        with (
+            patch.object(database, "_DATABASE_REPOSITORY", repo),
+            patch.object(database, "invalidate_project_lists"),
+        ):
+            already = database.publish_cli_project("project-a", "user-a", acting_user_id="user-a")
+
+        self.assertFalse(already["published"])
+        self.assertEqual("public", repo.get_cli_project("project-a", "user-a").visibility)
+        self.assertEqual(1, len(repo.list_project_publish_audits("project-a", "user-a")))
+
+    def test_database_publish_rejects_foreign_owner_and_missing_identity(self) -> None:
+        provider = create_sqlite_provider(
+            source="test cli project publish guards",
+            url="sqlite:///:memory:",
+            import_legacy_jobs=False,
+        )
+        provider.initialize()
+        repo = SqlAlchemyRepository(provider.session_factory)
+        repo.upsert_project_identity(
+            {
+                "project_id": "project-a",
+                "owner_user_id": "user-a",
+                "creation_channel": "cli",
+                "title": "Delivered project",
+                "prompt": "",
+                "chat_id": None,
+                "workspace_id": None,
+                "visibility": "private",
+                "status": "active",
+                "current_revision": 1,
+                "current_revision_id": "rev-a",
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-01T00:00:00Z",
+            }
+        )
+        with patch.object(database, "_DATABASE_REPOSITORY", repo):
+            with self.assertRaisesRegex(ValueError, "owned by another user"):
+                database.publish_cli_project("project-a", "user-b", acting_user_id="user-b")
+            with self.assertRaisesRegex(ValueError, "not found"):
+                database.publish_cli_project("missing-project", "user-a", acting_user_id="user-a")
 
 
 class _SchemaResponse:

--- a/tests/tooling/test_oss_cli.py
+++ b/tests/tooling/test_oss_cli.py
@@ -9,12 +9,19 @@ import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from unittest.mock import patch
 
-from forma_cli.app import build_parser, cmd_projects_pull, cmd_projects_push, cmd_render
+from forma_cli.app import build_parser, cmd_projects_deliver, cmd_projects_publish, cmd_projects_pull, cmd_projects_push, cmd_render
 from forma_cli.config import load_linkage
 from forma_cli.credentials import CredentialStore
 from forma_cli.local import LocalProjectError, build_project, import_project, init_project
 from forma_cli.metadata_api import project_metadata
-from forma_cli.sdk import CloudProjectRevision, FormaAPIClient, ProjectArtifactDownload, TokenSet
+from forma_cli.sdk import (
+    CloudProjectRevision,
+    DeliveryProjectRef,
+    DeliveryReceipt,
+    FormaAPIClient,
+    ProjectArtifactDownload,
+    TokenSet,
+)
 from forma_core.database import get_generated_project, init_db, save_generated_project
 from forma_core.workspaces.projects.manifest import ProjectArtifactReference, ProjectManifest, write_project_manifest
 
@@ -447,6 +454,146 @@ class OssCliTests(unittest.TestCase):
                 {"assembly.step": hashlib.sha256(assembly).hexdigest()},
                 json.loads(linkage["artifact_digests"]),
             )
+
+    def test_projects_deliver_records_receipt_and_stable_idempotency_key(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            manifest = init_project(temp_dir, title="Deliver project")
+            client = FormaAPIClient(
+                base_url="https://api.example.test",
+                credential_store=CredentialStore(keyring_backend=FakeKeyring()),
+            )
+            client.deliver_project = lambda _manifest, *, idempotency_key, parent_revision_id=None, visibility=None: DeliveryReceipt(  # type: ignore[method-assign]
+                delivery_id="delivery-1",
+                status="pending",
+                project=DeliveryProjectRef(
+                    project_id=manifest.project_id,
+                    revision_id="revision-1",
+                    revision=1,
+                    parent_revision_id=None,
+                    visibility=visibility or "private",
+                ),
+                artifacts=[],
+                artifact_summary={"declared": 0, "present": 0},
+            )
+            client.complete_delivery = lambda _delivery_id: DeliveryReceipt(  # type: ignore[method-assign]
+                delivery_id="delivery-1",
+                status="complete",
+                project=DeliveryProjectRef(
+                    project_id=manifest.project_id,
+                    revision_id="revision-1",
+                    revision=1,
+                    parent_revision_id=None,
+                    visibility="private",
+                ),
+                artifacts=[],
+                artifact_summary={"declared": 0, "present": 0},
+                created_at="2026-01-01T00:00:00Z",
+                completed_at="2026-01-01T00:00:00Z",
+            )
+            args = type("Args", (), {"path": temp_dir, "yes": True, "json": True, "api_url": None, "key": None, "visibility": None})()
+            stdout = io.StringIO()
+            with patch("forma_cli.app.FormaAPIClient", return_value=client), redirect_stdout(stdout):
+                self.assertEqual(0, cmd_projects_deliver(args))
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual("deliver", payload["operation"])
+            self.assertEqual("complete", payload["status"])
+            self.assertTrue(payload["idempotency_key"].startswith("deliver:"))
+            self.assertEqual("private", payload["project"]["visibility"])
+            linkage = load_linkage(Path(temp_dir))
+            self.assertEqual("revision-1", linkage["revision_id"])
+
+    def test_projects_deliver_uploads_referenced_artifacts_before_completion(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            manifest = init_project(root, title="Deliver artifacts")
+            assembly = b"ISO-10303-21;\nHEADER;\nENDSEC;\nDATA;\nENDSEC;\nEND-ISO-10303-21;\n"
+            (root / "assembly.step").write_bytes(assembly)
+            source_manifest = ProjectManifest(
+                project_id=manifest.project_id,
+                title="Deliver artifacts",
+                project_ir={
+                    "cad_model": {
+                        "path": str(root / "assembly.step"),
+                        "filename": "assembly.step",
+                    }
+                },
+                artifacts=[ProjectArtifactReference(path="assembly.step", media_type="model/step")],
+            )
+            write_project_manifest(root / "forma-project.json", source_manifest)
+            client = FormaAPIClient(
+                base_url="https://api.example.test",
+                credential_store=CredentialStore(keyring_backend=FakeKeyring()),
+            )
+            uploaded: list[tuple[str, bytes, str]] = []
+            client.deliver_project = lambda _manifest, *, idempotency_key, parent_revision_id=None, visibility=None: DeliveryReceipt(  # type: ignore[method-assign]
+                delivery_id="delivery-1",
+                status="pending",
+                project=DeliveryProjectRef(
+                    project_id=manifest.project_id,
+                    revision_id="revision-1",
+                    revision=1,
+                    parent_revision_id=None,
+                    visibility="private",
+                ),
+                artifacts=[{"path": "assembly.step"}, ],
+                artifact_summary={"declared": 1, "present": 0},
+            )
+            client.upload_project_artifact = lambda _project_id, _revision_id, sha256, content, media_type: (  # type: ignore[method-assign]
+                uploaded.append((sha256, content, media_type))
+                or {
+                    "status": "uploaded",
+                    "sha256": sha256,
+                    "media_type": media_type,
+                    "size_bytes": len(content),
+                }
+            )
+            client.complete_delivery = lambda _delivery_id: DeliveryReceipt(  # type: ignore[method-assign]
+                delivery_id="delivery-1",
+                status="complete",
+                project=DeliveryProjectRef(
+                    project_id=manifest.project_id,
+                    revision_id="revision-1",
+                    revision=1,
+                    parent_revision_id=None,
+                    visibility="private",
+                ),
+                artifacts=[{"path": "assembly.step", "status": "present"}],
+                artifact_summary={"declared": 1, "present": 1},
+            )
+            args = type("Args", (), {"path": temp_dir, "yes": True, "json": True, "api_url": None, "key": None, "visibility": None})()
+            stdout = io.StringIO()
+            with patch("forma_cli.app.FormaAPIClient", return_value=client), redirect_stdout(stdout):
+                self.assertEqual(0, cmd_projects_deliver(args))
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual("uploaded", payload["artifacts"][0]["status"])
+            self.assertEqual(assembly, uploaded[0][1])
+            self.assertEqual("model/step", uploaded[0][2])
+
+    def test_projects_publish_reports_the_explicit_action(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            init_project(temp_dir)
+            client = FormaAPIClient(
+                base_url="https://api.example.test",
+                credential_store=CredentialStore(keyring_backend=FakeKeyring()),
+            )
+            client.publish_project = lambda _project_id: {  # type: ignore[method-assign]
+                "project_id": "project-1",
+                "visibility": "public",
+                "published": True,
+                "visibility_before": "private",
+                "published_at": "2026-01-01T00:00:00Z",
+            }
+            args = type("Args", (), {"path": temp_dir, "project_id": None, "json": True, "api_url": None})()
+            stdout = io.StringIO()
+            with patch("forma_cli.app.FormaAPIClient", return_value=client), redirect_stdout(stdout):
+                self.assertEqual(0, cmd_projects_publish(args))
+
+            payload = json.loads(stdout.getvalue())
+            self.assertEqual("publish", payload["operation"])
+            self.assertEqual("public", payload["visibility"])
+            self.assertTrue(payload["published"])
 
     def test_projects_pull_restores_files_and_rewrites_cad_paths(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Closes #431, closes #432

## Summary

Adds a dependable, idempotent agent-delivery operation to the CLI plus explicit
visibility and ownership control for agent-delivered projects.

### Delivery (packaging to receipt)

- One `POST .../cli/projects/{project_id}/delivery` manifest call opens a
  server-side delivery session and returns a `pending` receipt
  (`delivery_id`, `revision_id`, `idempotency_key`).
- Uploaded artifacts are registered with the session via
  `PUT .../cli/projects/{project_id}/delivery/{delivery_id}/artifacts/{name}`.
- `POST .../delivery/{delivery_id}/complete` succeeds only after every artifact
  declared in the manifest is verified on disk; otherwise `409`
  `DELIVERY_ARTIFACTS_MISSING` lists each artifact's `uploaded`/`missing` status.
- A `complete` receipt is returned once per delivery session (`delivery_id`).

### Idempotency

- Sessions are keyed by caller-supplied `idempotency_key`; replays return the
  same `delivery_id` and do not create duplicate deliveries or revisions.
- The CLI derives a deterministic default key `"deliver:" + sha256(manifest
  upload payload digest)` so retries naturally replay.

### Explicit visibility and ownership (#432)

- Agent-delivered projects default to **private** at the delivery boundary
  (the canonical `projects.visibility` and the `cli_projects.visibility`
  projection), independent of the manifest field.
- `POST .../cli/projects/{project_id}/publish` is owner-scoped, flips
  private -> public, and records a `project_publish_audit` row per publish
  (second publish is an `already_public` no-op).
- Enforcing ownership: a caller-supplied `owner_user_id` in the deliver
  manifest is rejected with `400`; all delivery/publish endpoints act only on
  projects owned by the authenticated user.
- CLI: `forma projects publish --path <dir> --project-id <id>`, and
  `forma projects deliver --complete` upgrade a delivery to `complete`.

### Schema / migration notes

- Adds `creation_channel` + `visibility` to the `DBcliProject` model,
  the SQLite migrations, the `cli_projects` schema contract, and the hosted
  Supabase migration `20260829000100_cli_projects.sql`. This fixes a latent
  bug where `insert_cli_project_revision` built rows with these columns but the
  SQLite/Postgres tables and model did not accept them (500 on any cli
  deliver/push).
- `publish_cli_project` now also updates `cli_projects.visibility` so the
  reconciliation projection (`project_reconciliation._reconcile_cli`, which
  treats `cli_projects.visibility` as the source) cannot revert a publish.

## End-to-end test: expected vs actual

Ran a live server (SQLite backend, local auth, port 8013) and exercised the CLI
against a staging project dir and a negative-case project dir.

| # | Expectation | Actual |
|---|-------------|--------|
| 1 | One manifest POST returns a `pending` receipt with `delivery_id`, `revision_id`, `idempotency_key` | Matched |
| 2 | Artifact manifest-done flips the delivery to `complete` and the receipt is returned once per session | Matched; `cli_project_deliveries.status=complete`, `revision=1`, artifact verified present |
| 3 | Deliver defaults visibility to `private` when the manifest is silent | Matched; identity + `cli_projects.visibility=private`, `creation_channel=cli` |
| 4 | Same `idempotency_key` replays to the same `delivery_id`/`revision_id`, no duplicate rows | Matched; single delivery row, deterministic `deliver:<digest>` key |
| 5 | `complete` with a missing required artifact -> `409 DELIVERY_ARTIFACTS_MISSING` with per-artifact `uploaded`/`missing` | Matched (2 artifacts declared, 1 uploaded) |
| 6 | Completing after the missing artifact upload succeeds | Matched |
| 7 | Non-UUID project ids (`proj2`) flow through deliver/publish | Matched |
| 8 | First publish flips private -> public and records one audit row | Matched (`visibility_before=private`, acting user recorded) |
| 9 | Second publish is an `already_public` no-op, no new audit row | Matched |
| 10 | Publish also updates the `cli_projects.visibility` projection | Fixed in this PR; re-run flipped the stale `private` row to `public` |

### Deficiencies found and how they were handled

- **Pre-existing 500 on cli deliver/push (also affects push-only flows):**
  `DBCliProject(**project_record)` failed because `creation_channel`/
  `visibility` columns existed in code but not in the model, migrations, or
  hosted schema contract. Fixed here by adding the columns everywhere
  (`forma_core/persistence/models.py`, `migrations.py`, `schema.py`,
  `supabase/migrations/20260829000100_cli_projects.sql`). Hosted Supabase will
  need the migration applied.
- **Publish did not update the cli projection:** `cli_projects.visibility`
  stayed `private` after a publish; `_reconcile_cli`
  (`project_reconciliation.py:256`) treats that column as source of truth, so a
  later reconciliation could silently revert a published project to private.
  Fixed via new `update_cli_project_visibility` repository method called in both
  publish branches (`forma_core/database.py:publish_cli_project`).

## Tests

`tests/api tests/tooling tests/persistence tests/providers`:
**412 passed, 1 skipped, 18 subtests passed.** New coverage:
`tests/api/test_cli_project_delivery.py` (API), 3 CLI tests in
`tests/tooling/test_oss_cli.py`, delivery/publish persistence round-trips in
`tests/persistence/test_persistence.py`.