### PR TITLE
feat: route cli push through the delivery session (#431) (#432)

### DIFF
--- a/apps/api/cli_projects_api.py
+++ b/apps/api/cli_projects_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import uuid
 from datetime import datetime, timezone
 from typing import Any
@@ -47,6 +48,8 @@ router = APIRouter(prefix="/cli/projects", tags=["cli"])
 class ProjectPushRequest(BaseModel):
     manifest: dict[str, Any]
     parent_revision_id: str | None = Field(default=None, max_length=200)
+    idempotency_key: str | None = Field(default=None, min_length=1, max_length=200)
+    visibility: str | None = Field(default=None)
 
 
 class ProjectDeliverRequest(BaseModel):
@@ -84,6 +87,11 @@ def _delivery_visibility(value: str | None) -> str:
             detail="deliver visibility must be public or private.",
         )
     return normalized or "private"
+
+
+def _push_idempotency_key(manifest: dict[str, Any]) -> str:
+    canonical = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return f"push:{hashlib.sha256(canonical).hexdigest()}"
 
 
 def _artifact_declaration(artifact: dict[str, Any]) -> dict[str, Any]:
@@ -151,13 +159,21 @@ async def push_cli_project(
     user: UserContext = Depends(require_user_context),
 ) -> dict[str, Any]:
     owner = _owner(user)
+    manifest_document = dict(request.manifest or {})
+    if "owner_user_id" in manifest_document or "owner" in manifest_document:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Project ownership is derived from the authenticated user and cannot be supplied.",
+        )
+    project_id = str(manifest_document.get("project_id") or "").strip()
     try:
         compatibility = hosted_compatibility_metadata()
         ensure_supported_hardware_ir_version(
-            request.manifest,
+            manifest_document,
             supported_versions=compatibility.supported_hardware_ir_versions,
         )
-        manifest = ProjectManifest.from_document(request.manifest)
+        manifest_document["visibility"] = _delivery_visibility(request.visibility)
+        manifest = ProjectManifest.from_document(manifest_document)
         payload = manifest.upload_payload()
         payload["artifacts"] = validate_artifact_references(payload.get("artifacts"), require_integrity=True)
         if payload["artifacts"] and not ProjectArtifactStorage().config.get("enabled"):
@@ -165,16 +181,6 @@ async def push_cli_project(
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="CLI project artifact storage is not configured.",
             )
-        return insert_cli_project_revision(
-            payload,
-            owner,
-            expected_revision_id=request.parent_revision_id,
-        )
-    except CliProjectConflictError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=_revision_conflict_detail(str(request.manifest.get("project_id") or "").strip(), owner, exc),
-        ) from exc
     except UnsupportedHardwareIRVersion as exc:
         raise HTTPException(
             status_code=status.HTTP_426_UPGRADE_REQUIRED,
@@ -186,6 +192,40 @@ async def push_cli_project(
         ) from exc
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+
+    idempotency_key = request.idempotency_key or _push_idempotency_key(manifest_document)
+    existing = get_cli_project_delivery(project_id, owner, idempotency_key)
+    if existing is not None:
+        return _pending_delivery_response(existing)
+
+    try:
+        saved = insert_cli_project_revision(
+            payload,
+            owner,
+            expected_revision_id=request.parent_revision_id,
+        )
+    except CliProjectConflictError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=_revision_conflict_detail(project_id, owner, exc),
+        ) from exc
+
+    record = {
+        "delivery_id": str(uuid.uuid4()),
+        "project_id": saved["project_id"],
+        "owner_user_id": owner,
+        "idempotency_key": idempotency_key,
+        "revision_id": saved["revision_id"],
+        "revision": saved["revision"],
+        "parent_revision_id": saved["parent_revision_id"],
+        "manifest_json": payload,
+        "status": "pending",
+        "receipt_json": None,
+        "created_at": saved["created_at"],
+        "completed_at": None,
+    }
+    delivery = insert_cli_project_delivery(record)
+    return _pending_delivery_response(delivery)
 
 
 @router.post("/deliver")

--- a/forma_cli/app.py
+++ b/forma_cli/app.py
@@ -554,6 +554,10 @@ def _download_parts(download: Any) -> tuple[bytes, str | None, str | None, int |
     )
 
 
+def _push_idempotency_key(upload_payload: dict[str, Any]) -> str:
+    return f"push:{_manifest_digest(upload_payload)}"
+
+
 def cmd_projects_push(args: argparse.Namespace) -> int:
     root = project_root(args.path)
     manifest = read_project(root)
@@ -565,12 +569,15 @@ def cmd_projects_push(args: argparse.Namespace) -> int:
             print("Upload cancelled.")
         return 1
     linkage = load_linkage(root)
+    idempotency_key = args.key or _push_idempotency_key(upload_payload)
     client = _client(args)
-    revision = client.push_project(
+    delivery = client.push_project(
         upload_payload,
+        idempotency_key=idempotency_key,
         parent_revision_id=linkage.get("revision_id"),
+        visibility=args.visibility,
     )
-    if revision.project_id != manifest.project_id:
+    if delivery.project.project_id != manifest.project_id:
         raise LocalProjectError("Cloud push returned a different project identity; refusing to update local linkage.")
     artifact_statuses: list[dict[str, Any]] = []
     for artifact in local_artifacts:
@@ -584,8 +591,8 @@ def cmd_projects_push(args: argparse.Namespace) -> int:
             )
         try:
             response = client.upload_project_artifact(
-                revision.project_id,
-                revision.revision_id,
+                delivery.project.project_id,
+                delivery.project.revision_id,
                 artifact.sha256,
                 content,
                 artifact.media_type,
@@ -616,6 +623,12 @@ def cmd_projects_push(args: argparse.Namespace) -> int:
                 "size_bytes": artifact.size_bytes,
             }
         )
+    try:
+        completed = client.complete_delivery(delivery.delivery_id)
+    except FormaAPIError as exc:
+        raise LocalProjectError(
+            f"Delivery session {delivery.delivery_id} could not be completed: {exc}"
+        ) from exc
     if local_artifacts:
         # Persist the same portable, secret-free shape that was committed remotely.
         write_project_manifest(root / "forma-project.json", ProjectManifest.model_validate(upload_payload))
@@ -623,26 +636,27 @@ def cmd_projects_push(args: argparse.Namespace) -> int:
         root,
         version=1,
         remote=args.api_url.rstrip("/") if args.api_url else api_url(),
-        remote_project_id=revision.project_id,
+        remote_project_id=completed.project.project_id,
         project_id=manifest.project_id,
-        revision_id=revision.revision_id,
-        parent_revision_id=revision.parent_revision_id,
+        revision_id=completed.project.revision_id,
+        parent_revision_id=completed.project.parent_revision_id,
         manifest_digest=_manifest_digest(upload_payload),
         artifact_digests=json.dumps(
             {artifact.path: artifact.sha256 for artifact in local_artifacts},
             sort_keys=True,
         ),
     )
-    payload = revision.model_dump(mode="json")
+    payload = completed.model_dump(mode="json")
     payload["operation"] = "push"
+    payload["idempotency_key"] = idempotency_key
     payload["artifacts"] = artifact_statuses
     payload["artifact_summary"] = _artifact_summary(artifact_statuses)
-    payload["project_url"] = _project_url(client.base_url or api_url(), revision.project_id)
+    payload["project_url"] = _project_url(client.base_url or api_url(), completed.project.project_id)
     if args.json:
         _print_json(payload)
     else:
-        print(f"Uploaded private project {revision.project_id} revision {revision.revision_id}")
-        print(f"Uploaded {len(artifact_statuses)} project artifact(s)")
+        print(f"Delivered project {completed.project.project_id} revision {completed.project.revision_id}")
+        print(f"Visibility: {completed.project.visibility}")
         print(f"Project URL: {payload['project_url']}")
     return 0
 
@@ -1059,6 +1073,8 @@ def build_parser() -> argparse.ArgumentParser:
     projects_list.set_defaults(func=cmd_projects_list)
     push = project_commands.add_parser("push", help="Upload the canonical manifest and referenced artifacts explicitly.")
     push.add_argument("--path", default=".")
+    push.add_argument("--key", help="Idempotency key; defaults to a digest of the pushed manifest.")
+    push.add_argument("--visibility", choices=("public", "private"), default=None)
     push.add_argument("--yes", action="store_true", help="Confirm upload without prompting.")
     push.add_argument("--json", action="store_true")
     push.set_defaults(func=cmd_projects_push)

--- a/forma_cli/sdk.py
+++ b/forma_cli/sdk.py
@@ -412,15 +412,24 @@ class FormaAPIClient:
         manifest: Mapping[str, Any],
         *,
         parent_revision_id: str | None = None,
-    ) -> CloudProjectRevision:
+        idempotency_key: str | None = None,
+        visibility: str | None = None,
+    ) -> DeliveryReceipt:
         ensure_supported_hardware_ir_version(manifest)
+        body: dict[str, Any] = {"manifest": dict(manifest)}
+        if parent_revision_id is not None:
+            body["parent_revision_id"] = parent_revision_id
+        if idempotency_key is not None:
+            body["idempotency_key"] = idempotency_key
+        if visibility is not None:
+            body["visibility"] = visibility
         payload = self._request(
             "/cli/projects/push",
             method="POST",
-            payload={"manifest": dict(manifest), "parent_revision_id": parent_revision_id},
+            payload=body,
             authenticated=True,
         )
-        return CloudProjectRevision.model_validate(payload)
+        return DeliveryReceipt.model_validate(payload)
 
     def upload_project_artifact(
         self,

--- a/tests/api/test_cli_project_delivery.py
+++ b/tests/api/test_cli_project_delivery.py
@@ -332,6 +332,130 @@ class CliProjectDeliveryApiTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(key.startswith("deliver:"))
         self.assertEqual(64, len(key.removeprefix("deliver:")))
 
+    def test_push_command_defaults_provide_a_stable_idempotency_key(self) -> None:
+        import forma_cli.app as app
+
+        key = app._push_idempotency_key(_manifest())
+        self.assertTrue(key.startswith("push:"))
+        self.assertEqual(64, len(key.removeprefix("push:")))
+
+
+class PushApiTests(unittest.IsolatedAsyncioTestCase):
+    async def test_push_creates_pending_receipt_and_defaults_to_private(self) -> None:
+        captured: dict[str, object] = {}
+        captured_keys: list[str] = []
+
+        def fake_save(manifest, owner, *, expected_revision_id=None):
+            captured["manifest"] = manifest
+            captured["owner"] = owner
+            return _saved_revision()
+
+        def fake_insert_delivery(record):
+            captured_keys.append(record["idempotency_key"])
+            return _delivery_record()
+
+        request = cli_projects_api.ProjectPushRequest(manifest=_manifest())
+        with (
+            patch.object(cli_projects_api, "get_cli_project_delivery", return_value=None),
+            patch.object(cli_projects_api, "insert_cli_project_revision", side_effect=fake_save) as save,
+            patch.object(cli_projects_api, "insert_cli_project_delivery", side_effect=fake_insert_delivery) as save_delivery,
+        ):
+            receipt = await cli_projects_api.push_cli_project(request, _user())
+
+        self.assertEqual("pending", receipt["status"])
+        self.assertEqual("delivery-1", receipt["delivery_id"])
+        self.assertEqual("private", captured["manifest"]["visibility"])
+        self.assertTrue(captured_keys[0].startswith("push:"))
+        save.assert_called_once()
+        save_delivery.assert_called_once()
+        self.assertEqual("user-a", captured["owner"])
+
+    async def test_push_honors_explicit_visibility_and_key(self) -> None:
+        captured: dict[str, object] = {}
+
+        def fake_save(manifest, owner, *, expected_revision_id=None):
+            captured["manifest"] = manifest
+            return _saved_revision()
+
+        request = cli_projects_api.ProjectPushRequest(
+            manifest=_manifest(), visibility="public", idempotency_key="explicit-key"
+        )
+        with (
+            patch.object(cli_projects_api, "get_cli_project_delivery", return_value=None),
+            patch.object(cli_projects_api, "insert_cli_project_revision", side_effect=fake_save),
+            patch.object(cli_projects_api, "insert_cli_project_delivery", return_value=_delivery_record()),
+        ):
+            await cli_projects_api.push_cli_project(request, _user())
+
+        self.assertEqual("public", captured["manifest"]["visibility"])
+
+    async def test_push_rejects_invalid_visibility_and_owner_spoofing(self) -> None:
+        request_bad_vis = cli_projects_api.ProjectPushRequest(manifest=_manifest(), visibility="secret")
+        request_spoofed = cli_projects_api.ProjectPushRequest(
+            manifest={**_manifest(), "owner_user_id": "attacker"}
+        )
+        with patch.object(cli_projects_api, "insert_cli_project_revision") as save:
+            with self.assertRaisesRegex(HTTPException, "public or private"):
+                await cli_projects_api.push_cli_project(request_bad_vis, _user())
+            with self.assertRaisesRegex(HTTPException, "cannot be supplied"):
+                await cli_projects_api.push_cli_project(request_spoofed, _user())
+        save.assert_not_called()
+
+    async def test_push_replays_existing_delivery_without_new_revision(self) -> None:
+        existing = _delivery_record()
+        request = cli_projects_api.ProjectPushRequest(manifest=_manifest(), idempotency_key="key-1")
+        with (
+            patch.object(cli_projects_api, "get_cli_project_delivery", return_value=existing) as fetch,
+            patch.object(cli_projects_api, "insert_cli_project_revision") as save,
+            patch.object(cli_projects_api, "insert_cli_project_delivery") as save_delivery,
+        ):
+            receipt = await cli_projects_api.push_cli_project(request, _user())
+
+        self.assertEqual("delivery-1", receipt["delivery_id"])
+        self.assertEqual("pending", receipt["status"])
+        fetch.assert_called_once_with("project-delivery", "user-a", "key-1")
+        save.assert_not_called()
+        save_delivery.assert_not_called()
+
+    async def test_push_derives_key_when_not_supplied(self) -> None:
+        captured_key: list[str] = []
+
+        def fake_insert_delivery(record):
+            captured_key.append(record["idempotency_key"])
+            return _delivery_record()
+
+        request = cli_projects_api.ProjectPushRequest(manifest=_manifest())
+        with (
+            patch.object(cli_projects_api, "get_cli_project_delivery", return_value=None),
+            patch.object(cli_projects_api, "insert_cli_project_revision", return_value=_saved_revision()),
+            patch.object(cli_projects_api, "insert_cli_project_delivery", side_effect=fake_insert_delivery),
+        ):
+            await cli_projects_api.push_cli_project(request, _user())
+
+        self.assertEqual(1, len(captured_key))
+        self.assertTrue(captured_key[0].startswith("push:"))
+        self.assertEqual(64, len(captured_key[0].removeprefix("push:")))
+
+    async def test_push_409_is_enriched_with_current_server_revision(self) -> None:
+        def fake_save(manifest, owner, *, expected_revision_id=None):
+            raise CliProjectConflictError("The cloud project changed since the local project was last pulled.")
+
+        latest = {"revision_id": "server-rev-9", "revision": 9}
+        request = cli_projects_api.ProjectPushRequest(manifest=_manifest(), parent_revision_id="stale")
+        with (
+            patch.object(cli_projects_api, "get_cli_project_delivery", return_value=None),
+            patch.object(cli_projects_api, "insert_cli_project_revision", side_effect=fake_save),
+            patch.object(cli_projects_api, "get_cli_project_revision", return_value=latest),
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await cli_projects_api.push_cli_project(request, _user())
+
+        self.assertEqual(409, raised.exception.status_code)
+        detail = raised.exception.detail
+        self.assertEqual("PROJECT_REVISION_CONFLICT", detail["code"])
+        self.assertEqual("server-rev-9", detail["current_revision_id"])
+        self.assertEqual(9, detail["current_revision"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tooling/test_oss_cli.py
+++ b/tests/tooling/test_oss_cli.py
@@ -363,22 +363,39 @@ class OssCliTests(unittest.TestCase):
     def test_projects_push_json_keeps_stdout_machine_readable(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             manifest = init_project(temp_dir, title="Upload project")
-            revision = CloudProjectRevision(
-                revision_id="revision-1",
-                project_id=manifest.project_id,
-                revision=1,
-                manifest=manifest.upload_payload(),
+            delivery_id = "delivery-push-1"
+            pending = DeliveryReceipt(
+                delivery_id=delivery_id,
+                status="pending",
+                project=DeliveryProjectRef(
+                    project_id=manifest.project_id,
+                    revision_id="revision-1",
+                    revision=1,
+                ),
+            )
+            completed = DeliveryReceipt(
+                delivery_id=delivery_id,
+                status="complete",
+                project=DeliveryProjectRef(
+                    project_id=manifest.project_id,
+                    revision_id="revision-1",
+                    revision=1,
+                    visibility="private",
+                ),
             )
             client = FormaAPIClient(
                 base_url="https://api.example.test",
                 credential_store=CredentialStore(keyring_backend=FakeKeyring()),
             )
-            client.push_project = lambda _manifest, parent_revision_id=None: revision  # type: ignore[method-assign]
+            client.push_project = lambda _manifest, **kwargs: pending  # type: ignore[method-assign]
+            client.complete_delivery = lambda _delivery_id: completed  # type: ignore[method-assign]
             args = type("Args", (), {
                 "path": temp_dir,
                 "yes": True,
                 "json": True,
                 "api_url": None,
+                "key": None,
+                "visibility": None,
             })()
             stdout = io.StringIO()
             stderr = io.StringIO()
@@ -386,7 +403,8 @@ class OssCliTests(unittest.TestCase):
                 self.assertEqual(0, cmd_projects_push(args))
 
             payload = json.loads(stdout.getvalue())
-            self.assertEqual("revision-1", payload["revision_id"])
+            self.assertEqual("revision-1", payload["project"]["revision_id"])
+            self.assertEqual("push", payload["operation"])
             self.assertEqual(
                 f"https://api.example.test/project/{manifest.project_id}",
                 payload["project_url"],
@@ -411,18 +429,33 @@ class OssCliTests(unittest.TestCase):
                 artifacts=[ProjectArtifactReference(path="assembly.step", media_type="model/step")],
             )
             write_project_manifest(root / "forma-project.json", source_manifest)
-            revision = CloudProjectRevision(
-                revision_id="revision-1",
-                project_id=manifest.project_id,
-                revision=1,
-                manifest={},
+            delivery_id = "delivery-push-1"
+            pending = DeliveryReceipt(
+                delivery_id=delivery_id,
+                status="pending",
+                project=DeliveryProjectRef(
+                    project_id=manifest.project_id,
+                    revision_id="revision-1",
+                    revision=1,
+                ),
+            )
+            completed = DeliveryReceipt(
+                delivery_id=delivery_id,
+                status="complete",
+                project=DeliveryProjectRef(
+                    project_id=manifest.project_id,
+                    revision_id="revision-1",
+                    revision=1,
+                    visibility="private",
+                ),
             )
             client = FormaAPIClient(
                 base_url="https://api.example.test",
                 credential_store=CredentialStore(keyring_backend=FakeKeyring()),
             )
             uploaded: list[tuple[str, bytes, str]] = []
-            client.push_project = lambda _manifest, parent_revision_id=None: revision  # type: ignore[method-assign]
+            client.push_project = lambda _manifest, **kwargs: pending  # type: ignore[method-assign]
+            client.complete_delivery = lambda _delivery_id: completed  # type: ignore[method-assign]
             client.upload_project_artifact = lambda _project_id, _revision_id, sha256, content, media_type: (  # type: ignore[method-assign]
                 uploaded.append((sha256, content, media_type))
                 or {
@@ -432,7 +465,7 @@ class OssCliTests(unittest.TestCase):
                     "size_bytes": len(content),
                 }
             )
-            args = type("Args", (), {"path": temp_dir, "yes": True, "json": True, "api_url": None})()
+            args = type("Args", (), {"path": temp_dir, "yes": True, "json": True, "api_url": None, "key": None, "visibility": None})()
             stdout = io.StringIO()
             with patch("forma_cli.app.FormaAPIClient", return_value=client), redirect_stdout(stdout):
                 self.assertEqual(0, cmd_projects_push(args))


### PR DESCRIPTION
## Follow-up to #435 (review-resolution)

Resolves the code-review comments posted on #435. #435 was merged as `2b5436d`; this branch is based on the freshly-fetched `origin/main` and carries the review follow-up only.

### What changed

**1. `POST /cli/projects/{project_id}/push` now routes through the delivery session** (review comment 3, `apps/api/cli_projects_api.py:148`).

Previously push inserted a revision immediately with manifest-default visibility and returned the revision dict with no session/receipt. Now push mirrors the deliver flow:

- Defaults visibility to `private` at the delivery boundary (`_delivery_visibility`), unless the caller passes `visibility: "public"`.
- Derives a deterministic `idempotency_key` (`push:<sha256>` of the manifest) when the caller doesn't supply one, so replays are idempotent.
- Rejects caller-supplied ownership (`owner_user_id`/`owner`) with `400`.
- Creates a `cli_project_deliveries` row (`status=pending`) and returns a pending receipt with `delivery_id`, `idempotency_key`, and `project.visibility=private`.
- Replays return the existing delivery without inserting a new revision.
- Preserves 409 `PROJECT_REVISION_CONFLICT` enrichment and 426 `UNSUPPORTED_HARDWARE_IR_VERSION` handling.

**2. SDK `push_project` returns a `DeliveryReceipt`** (`forma_cli/sdk.py:410`) and accepts `idempotency_key` + `visibility`.

**3. CLI `projects push` uploads artifacts and completes the session** (`forma_cli/app.py`):

- Sends manifest via `push_project` (returns pending receipt), uploads referenced artifacts, then calls `complete_delivery` — the receipt is honored only after every declared artifact is verified.
- Prints the completed receipt (`op: push`, `visibility`, `project_url`); `--key` and `--visibility` mirror deliver.

### Tests

- New `PushApiTests` in `tests/api/test_cli_project_delivery.py`: pending receipt + default-private, explicit visibility/key, rejects invalid visibility + owner spoofing, idempotent replay, derived `push:` key, enriched 409.
- CLI push tests in `tests/tooling/test_oss_cli.py` updated to receipt shape.
- Full affected suites: **419 passed, 1 skipped, 18 subtests**.
- E2E against a local server (SQLite): push → complete receipt (`visibility: private`), replay returns the same `delivery_id`, publish flips both identity and `cli_projects.visibility` to `public`.

### Notes

- Review comment 1 (reconciliation source of truth) was resolved by keeping the current lock-step sync: publish updates `projects.visibility` and `cli_projects.visibility` together (`forma_core/database.py:publish_cli_project`), so `_reconcile_cli` has no drift to revert. No reconciliation change needed.
- Review comment 2 (hosted Supabase migration for `creation_channel`/`visibility`) was already delivered in #435; still requires applying the migration on the hosted `cli_projects` table.