### PR TITLE
feat: authoring-mode UI wiring and state visibility (#433)

### DIFF
--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -12,7 +12,7 @@ import {
 } from "../lib/active-llms";
 import { buildProjectDocsMarkdown, docsExportFilename } from "../lib/docs-export";
 import { normalizeContextSuggestions } from "../lib/context-suggestions";
-import { usableRuntimeLlmOptions, webConfig, type RuntimeConfigContract } from "../lib/config";
+import { authoringModeEnabled, usableRuntimeLlmOptions, webConfig, type RuntimeConfigContract } from "../lib/config";
 import { calculateProjectCostMetrics, resolveProjectComponentInstances } from "../lib/project-cost-metrics";
 import { useFormaAuth } from "../lib/forma-auth";
 import {
@@ -62,6 +62,9 @@ import ConversationMessageList, {
   type ConversationMessage,
 } from "./forma-workspace/conversation-message-list";
 import HostedChatMaintenance, {
+  AUTHORING_MODE_ACTIVE_MESSAGE,
+  AUTHORING_MODE_HANDOFF_MESSAGE,
+  AuthoringModeBanner,
   HOSTED_CHAT_MAINTENANCE_MESSAGE,
 } from "./forma-workspace/hosted-chat-maintenance";
 import useChatAutoScroll from "./forma-workspace/use-chat-auto-scroll";
@@ -155,6 +158,8 @@ const PIPELINE_STALE_AFTER_MS = WORKSPACE_STATUS_STALE_AFTER_MS;
 const RECOVERY_JOB_BATCH_SIZE = 3;
 const RECOVERY_JOB_MAX_BACKOFF_MS = 60000;
 const LOG_POLL_INTERVAL_MS = 5000;
+const AUTHORING_DELIVERY_POLL_MS = 5000;
+const AUTHORING_DELIVERED_SIGNAL_MS = 8000;
 const CHAT_THREAD_STORAGE_PREFIX = "forma.chat.";
 const CHAT_INDEX_STORAGE_KEY = "forma.chatIndex";
 const PINNED_CHATS_STORAGE_KEY = "forma.pinnedChats";
@@ -211,7 +216,7 @@ type ChatMessage = {
   id: string;
   role: "assistant" | "user" | "system";
   content: string;
-  status?: "idle" | "loading" | "success" | "error" | "cancelled";
+  status?: "idle" | "loading" | "success" | "error" | "cancelled" | "handed-off";
   timestamp: string;
   projectId?: string | null;
   pipelineProgress?: AgentPipelineProgress | null;
@@ -1763,6 +1768,7 @@ export function FormaWorkspace({
   );
   const [authSecurityError, setAuthSecurityError] = useState(false);
   const [statusClockMs, setStatusClockMs] = useState(() => Date.now());
+  const [deliveredSignal, setDeliveredSignal] = useState(false);
   const [selectedImage, setSelectedImage] = useState<string | null>(null);
   const [selectedImageSource, setSelectedImageSource] = useState<"upload" | "clipboard">("upload");
   const [generationInputNotice, setGenerationInputNotice] = useState<string | null>(null);
@@ -1787,6 +1793,7 @@ export function FormaWorkspace({
     imageRequired: false,
   });
   const [formaDevMode, setFormaDevMode] = useState(false);
+  const [authoringMode, setAuthoringMode] = useState(false);
   const [generateProductImage, setGenerateProductImage] = useState(false);
   const [generationWorkflow, setGenerationWorkflow] = useState(DEFAULT_WORKFLOW_ID);
   const [generationWorkflows, setGenerationWorkflows] = useState<GenerationWorkflowOption[]>(defaultGenerationWorkflows);
@@ -1927,6 +1934,12 @@ export function FormaWorkspace({
       ? generationInputValidation.message
       : null);
   const hostedChatReadOnly = !hostedChatEnabled;
+  const chatReadOnly = hostedChatReadOnly || authoringMode;
+  const chatUnavailableReason = hostedChatReadOnly
+    ? HOSTED_CHAT_MAINTENANCE_MESSAGE
+    : authoringMode
+      ? AUTHORING_MODE_ACTIVE_MESSAGE
+      : undefined;
   const requireHostedChatEnabled = () => {
     if (hostedChatEnabled) return true;
     setGenerationInputNotice(HOSTED_CHAT_MAINTENANCE_MESSAGE);
@@ -2500,9 +2513,11 @@ export function FormaWorkspace({
             lastEventAt: lastEvent?.observed_at || progress?.uiUpdatedAt || null,
           }
         : null,
+      authoring: authoringMode,
+      delivered: deliveredSignal,
       nowMs: statusClockMs,
     });
-  }, [authSecurityError, latestAgentOperation, serverStatus, statusClockMs]);
+  }, [authSecurityError, authoringMode, deliveredSignal, latestAgentOperation, serverStatus, statusClockMs]);
 
 
   const persistChatThread = (chatId: string | null, messages: ChatMessage[], explicitTitle?: string | null) => {
@@ -2825,6 +2840,7 @@ export function FormaWorkspace({
       if (typeof config.deployment?.hosted_chat_enabled === "boolean") {
         setHostedChatEnabled(config.deployment.hosted_chat_enabled);
       }
+      setAuthoringMode(authoringModeEnabled(config));
       setFormaDevMode(config.forma_dev_mode === true);
       const activeLlms = usableRuntimeLlmOptions(config);
       const selectedLlm = config.generation.selected_llm;
@@ -3739,6 +3755,10 @@ export function FormaWorkspace({
 
   const submitGatherContext = async (answer?: string) => {
     if (!requireHostedChatEnabled()) return;
+    if (authoringMode) {
+      setGenerationInputNotice(AUTHORING_MODE_ACTIVE_MESSAGE);
+      return;
+    }
     if (contextSubmitting || activeGenerationRef.current) return;
     if (!(await requireSignedInForGeneration())) return;
 
@@ -3895,6 +3915,10 @@ export function FormaWorkspace({
 
   const handleBuildNow = async () => {
     if (!requireHostedChatEnabled()) return;
+    if (authoringMode) {
+      setGenerationInputNotice(AUTHORING_MODE_ACTIVE_MESSAGE);
+      return;
+    }
     if (contextBuildStarting || contextSubmitting || activeGenerationRef.current) return;
     const requestChatId = activeChatId;
     const availableMessages = requestChatId
@@ -4373,6 +4397,29 @@ export function FormaWorkspace({
   const handleProjectChatGenerate = async (event: React.FormEvent) => {
     event.preventDefault();
     if (!requireHostedChatEnabled()) return;
+    if (authoringMode) {
+      const handoffProjectId = currentProjectId;
+      const handoffMessage = projectChatInput.trim();
+      if (!handoffProjectId || !projectIR || !handoffMessage) return;
+      const sourceChatId = currentProjectChatId || activeChatId || newBuildChatId();
+      setActiveChatId(sourceChatId);
+      appendThreadMessage(sourceChatId, {
+        role: "user",
+        content: handoffMessage,
+        status: "idle",
+        projectId: handoffProjectId,
+      });
+      appendThreadMessage(sourceChatId, {
+        role: "assistant",
+        content: AUTHORING_MODE_HANDOFF_MESSAGE,
+        status: "handed-off",
+        projectId: handoffProjectId,
+      });
+      setProjectChatInput("");
+      setGenerationInputNotice(null);
+      checkServerStatus();
+      return;
+    }
     if (activeGenerationRef.current) return;
     if (!(await requireSignedInForGeneration())) return;
     if (!currentUserOwnsProject) {
@@ -5070,7 +5117,7 @@ export function FormaWorkspace({
       goHome();
     }
   };
-  const newChatDisabled = hostedChatReadOnly || (homeView === "chat" && !routedProjectId && !activeSidebarChatStarted);
+  const newChatDisabled = chatReadOnly || (homeView === "chat" && !routedProjectId && !activeSidebarChatStarted);
   const homeChromeRef = useRef<HTMLDivElement>(null);
   const { headerAway: homeHeaderAway, bindCapture: bindHomeChromeScroll } = useChromeHeaderScroll(
     `${homeView}:${activeChatId || ""}:${activeSidebarChatStarted ? "started" : "new"}`
@@ -5199,6 +5246,63 @@ export function FormaWorkspace({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [routedProjectId, currentUserOwnsProject, currentProjectId, currentProjectChatMessages.length, projectIR]);
 
+  const deliverySignatureRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!authoringMode || !currentProjectId) {
+      setDeliveredSignal(false);
+      return;
+    }
+    const token = currentProjectId;
+    let cancelled = false;
+    let pending = false;
+    deliverySignatureRef.current = null;
+
+    const signatureOf = (record: Record<string, unknown>) => {
+      const updatedAt = typeof record?.updated_at === "string" ? record.updated_at : "";
+      const contentUpdatedAt = typeof record?.content_updated_at === "string" ? record.content_updated_at : "";
+      return `${contentUpdatedAt || updatedAt}`;
+    };
+
+    const poll = async () => {
+      if (cancelled || pending) return;
+      pending = true;
+      try {
+        const response = await fetch(`${API_URL}/projects/${encodeURIComponent(token)}`, {
+          cache: "no-store",
+          headers: await optionalAuthHeaders(),
+        });
+        if (cancelled) return;
+        if (!response.ok) return;
+        const data = await response.json();
+        const signature = signatureOf(data);
+        if (!deliverySignatureRef.current) {
+          deliverySignatureRef.current = signature;
+          return;
+        }
+        if (signature && signature !== deliverySignatureRef.current) {
+          deliverySignatureRef.current = signature;
+          refreshProjectAndChatLists();
+          setDeliveredSignal(true);
+          window.setTimeout(() => {
+            if (!cancelled) setDeliveredSignal(false);
+          }, AUTHORING_DELIVERED_SIGNAL_MS);
+        }
+      } catch {
+        // Transient polling errors must not clear the tracked delivery signature.
+      } finally {
+        pending = false;
+      }
+    };
+
+    void poll();
+    const intervalId = window.setInterval(poll, AUTHORING_DELIVERY_POLL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(intervalId);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- refreshProjectAndChatLists is intentionally excluded for parity with the other polling effects.
+  }, [authoringMode, currentProjectId, optionalAuthHeaders]);
+
   const implicitChatRouteTransition: ChatRouteTransition | null = routedChatId && (
     activeChatId !== routedChatId ||
     !chatIndexLoaded ||
@@ -5251,7 +5355,7 @@ export function FormaWorkspace({
             activeChatId={visibleChatRouteTransition.chatId}
             onNewChat={startNewProjectChat}
             newChatDisabled={newChatDisabled}
-            newChatDisabledReason={hostedChatReadOnly ? HOSTED_CHAT_MAINTENANCE_MESSAGE : undefined}
+            newChatDisabledReason={chatUnavailableReason}
             readOnly={hostedChatReadOnly}
             onOpenChat={openChatItem}
             onRenameChat={renameSidebarChat}
@@ -5274,7 +5378,7 @@ export function FormaWorkspace({
             activeChatId={visibleChatRouteTransition.chatId}
             onNewChat={startNewProjectChat}
             newChatDisabled={newChatDisabled}
-            newChatDisabledReason={hostedChatReadOnly ? HOSTED_CHAT_MAINTENANCE_MESSAGE : undefined}
+            newChatDisabledReason={chatUnavailableReason}
             readOnly={hostedChatReadOnly}
             onOpenChat={openChatItem}
             onRenameChat={renameSidebarChat}
@@ -5325,7 +5429,7 @@ export function FormaWorkspace({
             activeChatId={null}
             onNewChat={startNewProjectChat}
             newChatDisabled={newChatDisabled}
-            newChatDisabledReason={hostedChatReadOnly ? HOSTED_CHAT_MAINTENANCE_MESSAGE : undefined}
+            newChatDisabledReason={chatUnavailableReason}
             readOnly={hostedChatReadOnly}
             onOpenChat={openChatItem}
             onRenameChat={renameSidebarChat}
@@ -5348,7 +5452,7 @@ export function FormaWorkspace({
             activeChatId={null}
             onNewChat={startNewProjectChat}
             newChatDisabled={newChatDisabled}
-            newChatDisabledReason={hostedChatReadOnly ? HOSTED_CHAT_MAINTENANCE_MESSAGE : undefined}
+            newChatDisabledReason={chatUnavailableReason}
             readOnly={hostedChatReadOnly}
             onOpenChat={openChatItem}
             onRenameChat={renameSidebarChat}
@@ -5401,7 +5505,7 @@ export function FormaWorkspace({
             activeChatId={activeChatId}
             onNewChat={startNewProjectChat}
             newChatDisabled={newChatDisabled}
-            newChatDisabledReason={hostedChatReadOnly ? HOSTED_CHAT_MAINTENANCE_MESSAGE : undefined}
+            newChatDisabledReason={chatUnavailableReason}
             readOnly={hostedChatReadOnly}
             onOpenChat={openChatItem}
             onRenameChat={renameSidebarChat}
@@ -5424,7 +5528,7 @@ export function FormaWorkspace({
             activeChatId={activeChatId}
             onNewChat={startNewProjectChat}
             newChatDisabled={newChatDisabled}
-            newChatDisabledReason={hostedChatReadOnly ? HOSTED_CHAT_MAINTENANCE_MESSAGE : undefined}
+            newChatDisabledReason={chatUnavailableReason}
             readOnly={hostedChatReadOnly}
             onOpenChat={openChatItem}
             onRenameChat={renameSidebarChat}
@@ -5591,6 +5695,7 @@ export function FormaWorkspace({
             <HomeChatView
               started={activeSidebarChatStarted}
               readOnly={hostedChatReadOnly}
+              authoringActive={authoringMode}
               conversationKey={activeChatId || "new-chat"}
               workspaceTitle={
                 activeSidebarChatStarted ? (
@@ -5708,7 +5813,7 @@ export function FormaWorkspace({
           activeChatId={activeSidebarChatId}
           onNewChat={startNewProjectChat}
           newChatDisabled={newChatDisabled}
-          newChatDisabledReason={hostedChatReadOnly ? HOSTED_CHAT_MAINTENANCE_MESSAGE : undefined}
+          newChatDisabledReason={chatUnavailableReason}
           readOnly={hostedChatReadOnly}
           onOpenChat={openChatItem}
           onRenameChat={renameSidebarChat}
@@ -5731,7 +5836,7 @@ export function FormaWorkspace({
           activeChatId={activeSidebarChatId}
           onNewChat={startNewProjectChat}
           newChatDisabled={newChatDisabled}
-          newChatDisabledReason={hostedChatReadOnly ? HOSTED_CHAT_MAINTENANCE_MESSAGE : undefined}
+          newChatDisabledReason={chatUnavailableReason}
           readOnly={hostedChatReadOnly}
           onOpenChat={openChatItem}
           onRenameChat={renameSidebarChat}
@@ -5791,6 +5896,7 @@ export function FormaWorkspace({
                 }}
                 canChat={hostedChatEnabled && currentUserOwnsProject}
                 readOnly={hostedChatReadOnly}
+                authoringActive={authoringMode}
                 namespaceTabs={visibleWorkspaceTabs}
                 activeNamespace={activeWorkspaceTab.id}
                 activeNamespaceLabel={activeWorkspaceTab.label}
@@ -7153,6 +7259,7 @@ function ChatWorkspace({
   onRetryFailedBuild,
   canChat,
   readOnly,
+  authoringActive = false,
   namespaceTabs,
   activeNamespace,
   activeNamespaceLabel,
@@ -7178,6 +7285,7 @@ function ChatWorkspace({
   onRetryFailedBuild: () => void;
   canChat: boolean;
   readOnly: boolean;
+  authoringActive?: boolean;
   namespaceTabs: typeof workspaceTabs;
   activeNamespace: string;
   activeNamespaceLabel: string;
@@ -7215,7 +7323,13 @@ function ChatWorkspace({
           <div className="flex min-w-0 items-center gap-2">
             <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-[rgb(var(--forma-green-rgb)/0.12)] px-2 py-0.5 text-[10px] font-medium text-[rgb(var(--forma-green-rgb))]">
               {chatAvailable ? <MessageSquare className="h-3 w-3" /> : <Eye className="h-3 w-3" />}
-              {chatAvailable ? "Project chat" : readOnly ? "Read-only during maintenance" : "Read-only project"}
+              {authoringActive
+                ? "OpenCode authoring"
+                : chatAvailable
+                  ? "Project chat"
+                  : readOnly
+                    ? "Read-only during maintenance"
+                    : "Read-only project"}
             </span>
             <EditableWorkspaceTitle
               value={projectTitle}
@@ -7237,6 +7351,7 @@ function ChatWorkspace({
             >
               <div className="mx-auto flex w-full min-w-0 max-w-6xl flex-col gap-3">
                 {readOnly && <HostedChatMaintenance compact />}
+                {authoringActive && <AuthoringModeBanner compact />}
                 <ConversationMessageList
                   messages={messages}
                   renderPipelineProgress={renderPipelineProgress}

--- a/apps/web/app/forma-workspace/conversation-message-list.tsx
+++ b/apps/web/app/forma-workspace/conversation-message-list.tsx
@@ -17,7 +17,7 @@ export type ConversationMessage = {
   id: string;
   role: "assistant" | "user" | "system";
   content: string;
-  status?: "idle" | "loading" | "success" | "error" | "cancelled";
+  status?: "idle" | "loading" | "success" | "error" | "cancelled" | "handed-off";
   timestamp: string;
   projectId?: string | null;
   pipelineProgress?: unknown;

--- a/apps/web/app/forma-workspace/home-chat-view.tsx
+++ b/apps/web/app/forma-workspace/home-chat-view.tsx
@@ -18,7 +18,7 @@ import {
 
 import { shouldOfferFailedBuildRetry } from "../../lib/conversation-build-state";
 import ConversationMessageList, { type ConversationMessage } from "./conversation-message-list";
-import HostedChatMaintenance from "./hosted-chat-maintenance";
+import HostedChatMaintenance, { AuthoringModeBanner } from "./hosted-chat-maintenance";
 import useChatAutoScroll from "./use-chat-auto-scroll";
 
 type HomeChatViewProps = {
@@ -55,6 +55,7 @@ type HomeChatViewProps = {
   onImageChange: ChangeEventHandler<HTMLInputElement>;
   onImagePaste: ClipboardEventHandler<HTMLTextAreaElement>;
   readOnly: boolean;
+  authoringActive?: boolean;
 };
 
 export default function HomeChatView({
@@ -91,6 +92,7 @@ export default function HomeChatView({
   onImageChange,
   onImagePaste,
   readOnly,
+  authoringActive = false,
 }: HomeChatViewProps) {
   const { containerRef, endRef, handleScroll } = useChatAutoScroll(conversationKey, messages);
   const promptRef = useRef<HTMLTextAreaElement>(null);
@@ -131,9 +133,9 @@ export default function HomeChatView({
           </p>
         </div>
       )}
-      {readOnly && !started && (
+      {(readOnly || authoringActive) && !started && (
         <div className="mx-auto w-full max-w-2xl px-3 sm:px-4 md:px-0">
-          <HostedChatMaintenance />
+          {authoringActive ? <AuthoringModeBanner /> : <HostedChatMaintenance />}
         </div>
       )}
 
@@ -156,6 +158,7 @@ export default function HomeChatView({
             className="min-h-0 flex-1 space-y-4 overflow-x-hidden overflow-y-auto px-3 pb-5 pt-16 sm:px-4 sm:pb-6 md:pt-5"
           >
             {readOnly && <HostedChatMaintenance compact />}
+            {authoringActive && <AuthoringModeBanner compact />}
             <ConversationMessageList
               messages={messages}
               renderPipelineProgress={renderPipelineProgress}

--- a/apps/web/app/forma-workspace/hosted-chat-maintenance.tsx
+++ b/apps/web/app/forma-workspace/hosted-chat-maintenance.tsx
@@ -5,6 +5,11 @@ import { ArrowRight, Eye, Terminal } from "lucide-react";
 
 export const HOSTED_CHAT_MAINTENANCE_MESSAGE = "Forma hosted chat is temporarily under maintenance.";
 
+export const AUTHORING_MODE_ACTIVE_MESSAGE = "OpenCode is authoring this workspace.";
+
+export const AUTHORING_MODE_HANDOFF_MESSAGE =
+  "Routed to OpenCode — this change is being authored in your local session and will appear here when delivered.";
+
 const LOCAL_WORKFLOW_COMMANDS = `forma-oss init <local-project-directory>
 forma-oss build "<your hardware prompt>" --path <local-project-directory>
 
@@ -51,6 +56,31 @@ export default function HostedChatMaintenance({ compact = false }: { compact?: b
         <pre className="overflow-x-auto whitespace-pre-wrap break-words px-3 py-3 font-mono text-[11px] leading-5 text-cyan-100">
           <code>{LOCAL_WORKFLOW_COMMANDS}</code>
         </pre>
+      </div>
+    </section>
+  );
+}
+
+export function AuthoringModeBanner({ compact = false }: { compact?: boolean }) {
+  return (
+    <section
+      role="status"
+      aria-label={AUTHORING_MODE_ACTIVE_MESSAGE}
+      className={`rounded-xl border border-violet-400/20 bg-[linear-gradient(135deg,rgba(167,139,250,0.09),rgba(34,211,238,0.06)),#181b22] text-left ${
+        compact ? "p-4" : "p-5 sm:p-6"
+      }`}
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 rounded-lg border border-violet-300/20 bg-violet-300/10 p-2 text-violet-200">
+          <Terminal className="h-4 w-4" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <h2 className="text-sm font-semibold text-zinc-100">{AUTHORING_MODE_ACTIVE_MESSAGE}</h2>
+          <p className="mt-1.5 text-xs leading-5 text-zinc-400">
+            Forma keeps this workspace read-only while the OpenCode agent authors hardware locally. Change
+            requests are routed back to OpenCode, and the updated project will appear here after delivery.
+          </p>
+        </div>
       </div>
     </section>
   );

--- a/apps/web/app/forma-workspace/sidebar.tsx
+++ b/apps/web/app/forma-workspace/sidebar.tsx
@@ -24,7 +24,10 @@ import {
 
 import CaidLogo from "../../components/caid-logo";
 import { FormaUserButton, useFormaAuth } from "../../lib/forma-auth";
-import { type WorkspaceStatusPresentation } from "../../lib/connection-status";
+import {
+  type WorkspaceStatusPresentation,
+  type WorkspaceStatusTone,
+} from "../../lib/connection-status";
 
 export type ChatListItem = {
   chatId: string;
@@ -111,10 +114,17 @@ function formatSidebarDate(value: string | null) {
   return date.toLocaleDateString([], { month: "short", day: "numeric" });
 }
 
+const STATUS_BADGE_TONE_CLASS: Record<WorkspaceStatusTone, string> = {
+  ok: "status-badge-ok",
+  authoring: "status-badge-authoring",
+  delivered: "status-badge-delivered",
+  error: "status-badge-error",
+};
+
 function ApiConnectionStatus({ status }: { status: WorkspaceStatusPresentation }) {
   return (
     <span
-      className={`status-badge ${status.tone === "error" ? "status-badge-error" : "status-badge-ok"} ${
+      className={`status-badge ${STATUS_BADGE_TONE_CLASS[status.tone]} ${
         status.pulse ? "status-badge-pulse" : "status-badge-idle"
       }`}
       role="status"

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -942,6 +942,14 @@ html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark
   color: rgb(var(--forma-green-rgb));
 }
 
+html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark"]) .status-badge-authoring {
+  color: rgb(var(--forma-cyan-rgb));
+}
+
+html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark"]) .status-badge-delivered {
+  color: rgb(var(--forma-violet-rgb));
+}
+
 html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark"]) .status-badge-error {
   color: rgb(var(--forma-red-rgb));
 }
@@ -1147,6 +1155,14 @@ html:is([data-theme="light"], [data-theme="arctic"], [data-theme="solarized-dark
 
 .status-badge-ok {
   color: #34d399;
+}
+
+.status-badge-authoring {
+  color: #22d3ee;
+}
+
+.status-badge-delivered {
+  color: #a78bfa;
 }
 
 .status-badge-error {

--- a/apps/web/lib/config/index.ts
+++ b/apps/web/lib/config/index.ts
@@ -1,5 +1,6 @@
 export { webConfig } from "./environment";
 export {
+  authoringModeEnabled,
   usableRuntimeLlmOptions,
   type RuntimeConfigContract,
   type RuntimeWorkflowOption,

--- a/apps/web/lib/config/runtime.ts
+++ b/apps/web/lib/config/runtime.ts
@@ -41,6 +41,7 @@ export type RuntimeConfigContract = {
   };
   deployment?: {
     hosted_chat_enabled?: boolean;
+    authoring_mode_enabled?: boolean;
   };
   video?: {
     generation?: { configured?: boolean; reason?: string | null };
@@ -52,4 +53,8 @@ export function usableRuntimeLlmOptions(contract: RuntimeConfigContract): Genera
   return Array.isArray(contract.generation.llm_options)
     ? contract.generation.llm_options.filter((option) => option.configured !== false && option.provider && option.model)
     : [];
+}
+
+export function authoringModeEnabled(contract: RuntimeConfigContract): boolean {
+  return contract.deployment?.authoring_mode_enabled === true;
 }

--- a/apps/web/lib/connection-status.ts
+++ b/apps/web/lib/connection-status.ts
@@ -1,15 +1,17 @@
 export type ServerConnectionStatus = "connected" | "disconnected";
 
-export type WorkspaceStatusTone = "ok" | "error";
+export type WorkspaceStatusTone = "ok" | "authoring" | "delivered" | "error";
 
 export type WorkspaceStatusReason =
   | "stable"
+  | "authoring"
+  | "delivered"
   | "disconnected"
   | "auth"
   | "run-failure"
   | "timeout";
 
-export type AgentOperationStatus = "idle" | "loading" | "success" | "error" | "cancelled";
+export type AgentOperationStatus = "idle" | "loading" | "success" | "error" | "cancelled" | "handed-off";
 
 export type AgentOperationSignal = {
   status?: AgentOperationStatus;
@@ -22,6 +24,8 @@ export type WorkspaceStatusSignals = {
   connection: ServerConnectionStatus;
   authError?: boolean;
   agent?: AgentOperationSignal | null;
+  authoring?: boolean;
+  delivered?: boolean;
   nowMs?: number;
   staleAfterMs?: number;
 };
@@ -75,6 +79,8 @@ export function workspaceStatusBadge({
   connection,
   authError = false,
   agent = null,
+  authoring = false,
+  delivered = false,
   nowMs = Date.now(),
   staleAfterMs = WORKSPACE_STATUS_STALE_AFTER_MS,
 }: WorkspaceStatusSignals): WorkspaceStatusPresentation {
@@ -95,6 +101,12 @@ export function workspaceStatusBadge({
   }
   if (connection !== "connected") {
     return present("error", "disconnected", "Disconnected", true);
+  }
+  if (authoring && delivered) {
+    return present("delivered", "delivered", "Delivered — agent work is on-chain", false);
+  }
+  if (authoring) {
+    return present("authoring", "authoring", "Authoring — OpenCode is building this project", true);
   }
 
   return present(

--- a/apps/web/lib/conversation-build-state.ts
+++ b/apps/web/lib/conversation-build-state.ts
@@ -1,5 +1,5 @@
 export type ConversationBuildMessage = {
-  status?: "idle" | "loading" | "success" | "error" | "cancelled";
+  status?: "idle" | "loading" | "success" | "error" | "cancelled" | "handed-off";
   projectId?: string | null;
   contextProjectId?: string | null;
   buildPlanId?: string | null;

--- a/apps/web/test/connection-status.test.ts
+++ b/apps/web/test/connection-status.test.ts
@@ -107,3 +107,57 @@ test("a dropped API connection is not treated as healthy", () => {
   assert.equal(badge.tone, "error");
   assert.equal(badge.reason, "disconnected");
 });
+
+test("an active OpenCode authoring session is distinct from a stable ready badge", () => {
+  const badge = workspaceStatusBadge({
+    connection: "connected",
+    agent: { status: "success", content: "Project is ready." },
+    authoring: true,
+  });
+
+  assert.equal(badge.tone, "authoring");
+  assert.equal(badge.reason, "authoring");
+  assert.match(badge.label, /OpenCode/);
+  assert.equal(badge.pulse, true);
+});
+
+test("a delivered OpenCode result is distinct from authoring and ready", () => {
+  const badge = workspaceStatusBadge({
+    connection: "connected",
+    authoring: true,
+    delivered: true,
+  });
+
+  assert.equal(badge.tone, "delivered");
+  assert.equal(badge.reason, "delivered");
+  assert.match(badge.label, /Delivered/);
+  assert.equal(badge.pulse, false);
+});
+
+test("delivery is only claimed while authoring is active", () => {
+  const badge = workspaceStatusBadge({
+    connection: "connected",
+    delivered: true,
+    authoring: false,
+  });
+
+  assert.equal(badge.reason, "stable");
+  assert.equal(badge.tone, "ok");
+});
+
+test("connection and auth failures still outrank an authoring session", () => {
+  const disconnected = workspaceStatusBadge({
+    connection: "disconnected",
+    authoring: true,
+  });
+  const authFailed = workspaceStatusBadge({
+    connection: "connected",
+    authError: true,
+    authoring: true,
+  });
+
+  assert.equal(disconnected.tone, "error");
+  assert.equal(disconnected.reason, "disconnected");
+  assert.equal(authFailed.tone, "error");
+  assert.equal(authFailed.reason, "auth");
+});

--- a/apps/web/test/runtime-config.test.ts
+++ b/apps/web/test/runtime-config.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { test } from "node:test";
 
 import { generationLlmImageSupport, shouldShowProductImageSection } from "../lib/active-llms";
-import { usableRuntimeLlmOptions, type RuntimeConfigContract } from "../lib/config";
+import { authoringModeEnabled, usableRuntimeLlmOptions, type RuntimeConfigContract } from "../lib/config";
 
 function contract(): RuntimeConfigContract {
   return {
@@ -89,4 +89,19 @@ test("an existing or requested product image still appears even without image-ca
     llms: [{ provider: "cloudflare", model: "nvidia/nemotron-3-super-120b-a12b" }],
     metadata: { image_output_status: "failed" },
   }), true);
+});
+
+test("authoring mode is disabled unless the backend explicitly enables it", () => {
+  assert.equal(authoringModeEnabled(contract()), false);
+  assert.equal(authoringModeEnabled({ ...contract(), deployment: { hosted_chat_enabled: true } }), false);
+  assert.equal(authoringModeEnabled({ ...contract(), deployment: { authoring_mode_enabled: false } }), false);
+});
+
+test("the runtime contract surfaces an enabled authoring mode", () => {
+  const enabled = authoringModeEnabled({
+    ...contract(),
+    deployment: { authoring_mode_enabled: true },
+  });
+
+  assert.equal(enabled, true);
 });

--- a/forma_core/config/runtime.py
+++ b/forma_core/config/runtime.py
@@ -29,6 +29,7 @@ DEPLOYMENT_MODE_ENV = "FORMA_DEPLOYMENT_MODE"
 DEVELOPMENT_MODE_ENV = "FORMA_DEVELOPMENT_MODE"
 LEGACY_DEVELOPMENT_MODE_ENV = "FORMA_DEV_MODE"
 HOSTED_CHAT_ENABLED_ENV = "FORMA_HOSTED_CHAT_ENABLED"
+AUTHORING_MODE_ENABLED_ENV = "FORMA_AUTHORING_MODE_ENABLED"
 DEPLOYMENT_MODES = {"local", "hosted"}
 BOOLEAN_VALUES = {"true": True, "false": False}
 
@@ -148,6 +149,11 @@ def hosted_chat_enabled() -> bool:
     return env_bool(HOSTED_CHAT_ENABLED_ENV, default=not deployment_mode_enabled())
 
 
+def authoring_mode_enabled() -> bool:
+    """Resolve external OpenCode authoring mode, disabled by default."""
+    return env_bool(AUTHORING_MODE_ENABLED_ENV, default=False)
+
+
 class HostedChatUnavailableError(RuntimeError):
     """Raised when hosted chat is disabled by deployment configuration."""
 
@@ -170,6 +176,7 @@ def deployment_runtime_config(
         "mode": state["deployment_mode"],
         "development_mode": state["development_mode"],
         "hosted_chat_enabled": hosted_chat_enabled(),
+        "authoring_mode_enabled": authoring_mode_enabled(),
         "alpha_generation_gate_active": deployment_enabled and not live_generation_enabled,
         "generation_available": (not deployment_enabled) or live_generation_enabled,
     }
@@ -227,6 +234,7 @@ def generation_unavailable_detail(llm_config: Dict[str, Any]) -> Dict[str, Any]:
 __all__ = [
     "ALPHA_GENERATION_UNAVAILABLE_MESSAGE",
     "AlphaGenerationUnavailableError",
+    "AUTHORING_MODE_ENABLED_ENV",
     "BOOLEAN_VALUES",
     "DEPLOYMENT_MODE_ENV",
     "DEVELOPMENT_MODE_ENV",
@@ -236,6 +244,7 @@ __all__ = [
     "HostedChatUnavailableError",
     "LEGACY_DEVELOPMENT_MODE_ENV",
     "RuntimeConfigurationError",
+    "authoring_mode_enabled",
     "deployment_mode",
     "deployment_mode_enabled",
     "deployment_runtime_config",

--- a/tests/providers/test_runtime_contract.py
+++ b/tests/providers/test_runtime_contract.py
@@ -40,6 +40,7 @@ class RuntimeContractTests(unittest.TestCase):
         self.assertTrue(contract["images"]["generate_by_default"])
         self.assertFalse(contract["provider_setup"]["required"])
         self.assertTrue(contract["deployment"]["hosted_chat_enabled"])
+        self.assertFalse(contract["deployment"]["authoring_mode_enabled"])
         self.assertEqual(
             ("cloudflare", "@cf/google/gemma-4-26b-a4b-it"),
             (
@@ -94,6 +95,17 @@ class RuntimeContractTests(unittest.TestCase):
             )
 
         self.assertFalse(contract["deployment"]["hosted_chat_enabled"])
+        self.assertFalse(contract["deployment"]["authoring_mode_enabled"])
+
+    def test_authoring_mode_surfaces_in_the_runtime_contract(self) -> None:
+        with patch.dict(os.environ, {"FORMA_AUTHORING_MODE_ENABLED": "true"}, clear=True):
+            contract = resolve_runtime_contract(
+                llm_config={"live_generation_enabled": False, "validation_error": "Unavailable."},
+                image_config={"request_capable": False},
+                workflows=[{"id": "default", "label": "Catalog", "description": "Catalog"}],
+            )
+
+        self.assertTrue(contract["deployment"]["authoring_mode_enabled"])
 
     def test_config_can_select_catalog_as_the_default_workflow(self) -> None:
         with patch.dict(os.environ, {"FORMA_DEFAULT_GENERATION_WORKFLOW": "default"}, clear=True):

--- a/tests/providers/test_runtime_state.py
+++ b/tests/providers/test_runtime_state.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from forma_core.config.runtime import (
     RuntimeConfigurationError,
+    authoring_mode_enabled,
     deployment_mode,
     development_mode_enabled,
     hosted_chat_enabled,
@@ -77,6 +78,14 @@ class RuntimeStateTests(unittest.TestCase):
             clear=True,
         ):
             self.assertTrue(hosted_chat_enabled())
+
+    def test_authoring_mode_defaults_to_disabled(self) -> None:
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertFalse(authoring_mode_enabled())
+
+    def test_authoring_mode_flag_can_be_enabled_explicitly(self) -> None:
+        with patch.dict(os.environ, {"FORMA_AUTHORING_MODE_ENABLED": "true"}, clear=True):
+            self.assertTrue(authoring_mode_enabled())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Wires #433 into the web GUI. When OpenCode authoring mode is active (`FORMA_AUTHORING_MODE_ENABLED=true`, surfaced as `deployment.authoring_mode_enabled` in the runtime contract, default `false`), the Forma GUI no longer runs a competing generation pipeline and instead surfaces distinct authoring / delivered / error states with automatic refresh on delivery and change-request handoff back to OpenCode.

## Changes

**Backend** (`forma_core/config/runtime.py`)
- New `AUTHORING_MODE_ENABLED_ENV = "FORMA_AUTHORING_MODE_ENABLED"` flag, `authoring_mode_enabled()` helper (env bool, default `false`), surfaced inside the `deployment` sub-contract (flows via `deployment_runtime_config()`).
- Backend tests: default-disabled and explicit-enable coverage in `tests/providers/test_runtime_state.py`; default-false asserts + `test_authoring_mode_surfaces_in_the_runtime_contract` in `tests/providers/test_runtime_contract.py`.

**Frontend contract** (`apps/web/lib/config/runtime.ts`, `apps/web/lib/config/index.ts`)
- `deployment.authoring_mode_enabled?: boolean` on `RuntimeConfigContract` plus pure `authoringModeEnabled(contract)` helper (re-exported). Consumed in `fetchRuntimeConfig`.

**Frontend UI** (`apps/web/app/forma-workspace.tsx` + components/styles)
- `ChatMessage.status` extended with `"handed-off"`; `AgentOperationStatus`, `ConversationBuildMessage.status` unions widened to match.
- `WorkspaceStatusTone` gains `authoring`/`delivered`; badge now prefers `authoring && delivered` -> "Delivered — agent work is on-chain", then `authoring` -> pulsed "Authoring — OpenCode is building this project", still outranked by errors/auth failures. New `.status-badge-authoring` (`#22d3ee`) and `.status-badge-delivered` (`#a78bfa`) tones in `globals.css`.
- `AuthoringModeBanner` (full + compact) in `hosted-chat-maintenance.tsx`; `HomeChatView`/`ChatWorkspace` render it via `authoringActive` while keeping the composer available so change requests can be handed off.
- Guards: `submitGatherContext` and `handleBuildNow` early-return with an authoring notice (no competing generation); `handleProjectChatGenerate` routes submissions to OpenCode (user message + `"handed-off"` assistant message) and never calls `POST /iterate` while authoring.
- Delivery poller: while authoring and a project is current, polls `GET /projects/{id}` every 5s; on an `updated_at`/`content_updated_at` change it refreshes project/chat lists and flashes the delivered badge for 8s (no manual refresh needed).
- `newChatDisabled` + sidebar `newChatDisabledReason` now use the authoring message; sidebar rename/pin/delete remain available (kept on `hostedChatReadOnly`).

**Tests** (web, `tsx --test`): `test/connection-status.test.ts` (authoring/delivered tones, delivered-outranks-authoring, error precedence) and `test/runtime-config.test.ts` (default-false when absent/explicit-false, true when enabled). Web suite: 71/71 pass; `tsc --noEmit` and eslint clean.

## Verification

- Backend: `python -m pytest tests/providers/test_runtime_state.py tests/providers/test_runtime_contract.py -q` green; full suite 771 passed / 2 skipped (3 pre-existing Windows-only failures confirmed identical on `origin/main` worktree `64fc464` — file-mode `0o600` and a 13-vs-14 checksum count, unrelated to this change).
- Web: 71/71 tests, `npx tsc --noEmit` clean, eslint clean.

Closes #433