### PR TITLE
docs(#434): state the shared OpenCode/Forma ownership boundary

### DIFF
--- a/.agents/skills/forma-hardware/SKILL.md
+++ b/.agents/skills/forma-hardware/SKILL.md
@@ -5,7 +5,7 @@ description: Compile, validate, inspect, or generate safe low-voltage maker-elec
 
 # Forma Hardware
 
-Use the host agent to author the design and Forma to normalize Hardware IR, apply deterministic electrical checks, and render diagrams. For CAD-capable workflows, use the Forma-owned OpenCAD adapter described in [references/cad.md](references/cad.md). Never replace a failed live generation with simulated output unless the user explicitly requests simulation.
+Use the host agent to author the design and Forma to normalize Hardware IR, apply deterministic electrical checks, and render diagrams. The host agent owns the conversation and the working project state; Forma owns accepted snapshots, deterministic validation, persistence, and display. None of the compile, validate, or render steps below transfer authoring ownership back to Forma — Forma never directs the agent's internal authoring steps. For CAD-capable workflows, use the Forma-owned OpenCAD adapter described in [references/cad.md](references/cad.md). Never replace a failed live generation with simulated output unless the user explicitly requests simulation.
 
 ## CAD dependency
 

--- a/docs/agent-clients.md
+++ b/docs/agent-clients.md
@@ -5,6 +5,30 @@ Forma supports these clients through two portable surfaces:
 - A shared Agent Skill at `.agents/skills/forma-hardware/SKILL.md`.
 - An MCP Streamable HTTP endpoint at `http://127.0.0.1:8000/mcp` (or `/api/mcp` when the deployment adds an `/api` prefix).
 
+## Ownership boundary
+
+This is the canonical ownership statement shared with the OpenCode extension
+repository (`caid-technologies/local-server-config`).
+
+- **The host agent owns the conversation and the working project state.** It
+  runs clarify → plan → author → compile → repair → iterate → validate →
+  deliver. The agent writes the Hardware IR with its own model and keeps that
+  working state in its own workspace.
+- **Forma owns accepted snapshots, deterministic validation, persistence, and
+  display.** Forma receives, stores, and shows delivered results as project
+  revisions. It does not run a parallel authoring agent.
+- **Deterministic validation and compiler tools are utilities, not ownership.**
+  `forma.compile_project` and `forma.validate_circuit` normalize and check what
+  the agent authored; calling them does not transfer authoring ownership back to
+  Forma.
+- **Working state lives with the agent; delivered state lives in Forma
+  revisions.** The undelivered draft belongs to the agent's workspace; delivering
+  publishes an accepted snapshot into Forma.
+
+Both repositories must state this same boundary. When in doubt, the visible
+component identifier (OpenCode conversation, Forma project/revision) tells you
+which side owns it.
+
 Start the backend in local authentication mode:
 
 ```bash


### PR DESCRIPTION
Closes #434 (child of #430).

## What this does

Establishes one shared ownership boundary between Forma-OSS and the OpenCode extension repository (`caid-technologies/local-server-config`), so the two repos cannot drift:

- **`docs/agent-clients.md`** — new canonical **Ownership boundary** section, placed at the top so it is the first thing a client/host integration reads:
  - The host agent owns the conversation and the working project state (clarify → plan → author → compile → repair → iterate → validate → deliver).
  - Forma owns accepted snapshots, deterministic validation, persistence, and display; it does not run a parallel authoring agent.
  - Deterministic validation/compiler tools are utilities, not ownership — `forma.compile_project` / `forma.validate_circuit` never transfer authoring ownership back to Forma.
  - Working state lives with the agent; delivered state lives in Forma revisions.
- **`.agents/skills/forma-hardware/SKILL.md`** — intro tightened to state the same boundary inline and explicitly note that compile/validate/render steps never direct the agent's internal authoring steps.

## Same boundary on the extension side

`caid-technologies/local-server-config` states the identical boundary (paraphrase + pointer back to the canonical `#ownership-boundary` section) in `docs/authoring.md` §1 and `docs/agent-integration.md`, landing via PR caid-technologies/local-server-config#7.

## Acceptance criteria

- [x] Both repositories state the same boundary in their setup/architecture docs (`docs/agent-clients.md` here; `docs/authoring.md` + `docs/agent-integration.md` in the extension repo).
- [x] Skill wording no longer implies Forma directs OpenCode's internal authoring steps (`Use the host agent to author the design` intro + explicit "never directs the agent's internal authoring steps").
- [x] A reader can identify which repo owns each component (visible identifier rule: OpenCode conversation ↔ Forma project/revision).

## Verification

- Extension: `npm test` 21/21; `git diff` doc-only.
- This PR: doc-only, no code/tests affected.
- Related: coordinates with #337/#338 (canonical skill source) and #342 (skill versioning) — no skill behavior change, wording only.