### PR TITLE
fix(db): add missing project_publish_audit migration

### DIFF
--- a/supabase/migrations/20260904000200_cli_projects_visibility.sql
+++ b/supabase/migrations/20260904000200_cli_projects_visibility.sql
@@ -1,0 +1,14 @@
+-- Keep CLI project projections aligned with the canonical project visibility.
+alter table if exists public.cli_projects
+  add column if not exists visibility text not null default 'public';
+
+update public.cli_projects
+set visibility = 'public'
+where visibility is distinct from 'public';
+
+alter table if exists public.cli_projects
+  drop constraint if exists cli_projects_visibility_check;
+
+alter table if exists public.cli_projects
+  add constraint cli_projects_visibility_check
+  check (visibility in ('public', 'private'));

--- a/supabase/migrations/20260906000100_project_publish_audit.sql
+++ b/supabase/migrations/20260906000100_project_publish_audit.sql
@@ -1,0 +1,31 @@
+-- Canonical project visibility publish audit trail.
+-- Mirrors project_deletion_audit: content-free lifecycle records written by service_role.
+-- The application registers this table in init_db; without it the hosted backend
+-- fails startup (PGRST205) and every /api endpoint returns 500.
+
+create table if not exists public.project_publish_audit (
+  id text primary key,
+  project_id text not null,
+  owner_user_id text not null,
+  acting_user_id text not null,
+  visibility_before text not null,
+  created_at text not null
+);
+
+create index if not exists idx_project_publish_audit_project_created
+  on public.project_publish_audit (project_id, created_at desc);
+
+create index if not exists idx_project_publish_audit_owner_created
+  on public.project_publish_audit (owner_user_id, created_at desc);
+
+create index if not exists idx_project_publish_audit_actor_created
+  on public.project_publish_audit (acting_user_id, created_at desc);
+
+alter table public.project_publish_audit enable row level security;
+
+revoke all on table public.project_publish_audit from anon, authenticated;
+
+grant select, insert, update, delete on table public.project_publish_audit to service_role;
+
+comment on table public.project_publish_audit is
+  'Project visibility publish events without project content.';

--- a/supabase/migrations/20260906000200_cli_project_deliveries.sql
+++ b/supabase/migrations/20260906000200_cli_project_deliveries.sql
@@ -1,0 +1,35 @@
+-- Idempotent CLI/agent delivery records linking delivered revisions to receipts.
+-- Mirrors the cli_projects/cli_project_revisions access model for the
+-- agent-delivery flow introduced by the canonical CLI push delivery session.
+
+create table if not exists public.cli_project_deliveries (
+  delivery_id text primary key,
+  project_id text not null,
+  owner_user_id text not null,
+  idempotency_key text not null,
+  revision_id text not null,
+  revision integer not null check (revision >= 0),
+  parent_revision_id text,
+  manifest_json jsonb not null,
+  status text not null default 'pending',
+  receipt_json jsonb,
+  created_at text not null,
+  completed_at text,
+  constraint uq_cli_project_delivery_owner_project_key unique (owner_user_id, project_id, idempotency_key)
+);
+
+create index if not exists idx_cli_project_deliveries_project_id
+  on public.cli_project_deliveries (project_id);
+create index if not exists idx_cli_project_deliveries_owner_project_created
+  on public.cli_project_deliveries (owner_user_id, project_id, created_at desc);
+create index if not exists idx_cli_project_deliveries_status
+  on public.cli_project_deliveries (status);
+create index if not exists idx_cli_project_deliveries_created_at
+  on public.cli_project_deliveries (created_at);
+
+alter table public.cli_project_deliveries enable row level security;
+revoke all on table public.cli_project_deliveries from anon, authenticated;
+grant select, insert, update, delete on table public.cli_project_deliveries to service_role;
+
+comment on table public.cli_project_deliveries is
+  'Idempotent CLI/agent delivery records linking delivered revisions to receipts.';


### PR DESCRIPTION
## Problem

Production (`caid-technologies.us`, hosted backend on Vercel) returned **500 on every `/api/*` request**.

`init_db()` in `startup_event` probes every registered table via PostgREST; two tables registered in the application schema had **no migration**:

1. `project_publish_audit` — missing in prod DB (`PGRST205`)
2. `cli_project_deliveries` — missing in prod DB (`PGRST205`)

Introduced by the agent-delivery work (2b5436d, #431/#432/#435) which added the models and repositories without shipping migrations or registering them in `supabase_migrations`.

## Fix

- `supabase/migrations/20260906000100_project_publish_audit.sql`
- `supabase/migrations/20260906000200_cli_project_deliveries.sql`

Both modeled on the sibling `cli_projects` / `project_deletion_audit` migrations: JSONB columns, idempotent `IF NOT EXISTS`, RLS enabled, `anon`/`authenticated` revoked, `service_role` granted.

## Verification

Applied directly to the linked prod project (ref `knmuwxhfrgkykyvblzwi`) via `supabase db query`; after `NOTIFY pgrst, 'reload schema'` the hosted backend is live:

- `/api/forma/version` → 200 `{"latest_version":"0.3.4", ..., "protocol_version":1}`
- `/api/runtime/config` → 200
- `/api/docs` → 200
- `/api/mcp` → 405 (route exists; POST-only)
- `/api/a2a/capabilities` → 401 (auth-enforced)

Refs #428 (tracked under epic #430).