### PR TITLE
docs(#443): define self-hosted FormaBackend service

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -147,6 +147,21 @@ To make backend logs visible in the local frontend LOGS tab when running uvicorn
 BACKEND_LOG_FILE=.logs/backend-dev.log uvicorn apps.api.main:app --reload --port 8000
 ```
 
+## Self-hosted tunnel origin
+
+The planned self-hosted production backend runs as a dedicated Windows service
+named `FormaBackend`, under a restricted non-interactive local account. It must
+bind only to `127.0.0.1:8000`; Cloudflare Tunnel is the only intended public
+ingress path. The service must use `FORMA_DEPLOYMENT_MODE=hosted`, production
+Supabase/Redis configuration, and must not set `FORMA_DEVELOPMENT_MODE=true`.
+
+Host service provisioning, account creation, ACLs, and tunnel configuration belong
+to `caid-technologies/local-server-config`. Keep passwords, tunnel tokens, and
+runtime environment values out of this repository. Verify the local backend before
+pointing tunnel ingress at it, then test `/`, `/api/runtime/config`, `/api/mcp`,
+A2A, WebSocket, request-body, and streamed-response paths without introducing an
+additional `/api` prefix.
+
 Run generation directly through the sole Forma Core CLI with `--llm provider/model`:
 
 ```bash


### PR DESCRIPTION
## Summary

Documents the self-hosted FastAPI deployment contract for the dedicated `FormaBackend` Windows service and Cloudflare Tunnel origin.

## Related issue

Related to #443

## Change type

- [ ] Bug fix
- [ ] Feature
- [x] Documentation
- [ ] Test
- [ ] Refactor
- [ ] Chore or maintenance

## Verification

```text
python -m compileall -q apps/api forma_core: passed on the current Forma-OSS worktree
Git diff check: passed
```

## Configuration or migration requirements

None. This documents configuration requirements only; it does not change runtime configuration, accounts, services, tunnel routes, or secrets.

## Visual changes

Not applicable.

## Safety and compatibility

The documented contract requires a restricted non-interactive `FormaBackend` account, loopback-only binding on `127.0.0.1:8000`, production persistence, and Cloudflare Tunnel as the intended public path. No credentials or tokens are included.

## AI assistance

Prepared with AI assistance and reviewed against the current repository deployment/runtime configuration.

## Checklist

- [x] This pull request targets `main`, the repository default branch.
- [x] The change addresses one logical concern and contains no unrelated cleanup.
- [x] No secrets, credentials, logs, databases, build artifacts, or generated temporary files were committed.
- [x] Documentation was updated when behavior changed.
- [x] Hardware safety implications were considered; this is deployment documentation only.
- [x] Breaking changes are clearly identified; none.
