### PR TITLE
docs(#443): clarify cloud and worker boundary

### DIFF
--- a/docs/agent-clients.md
+++ b/docs/agent-clients.md
@@ -5,6 +5,19 @@ Forma supports these clients through two portable surfaces:
 - A shared Agent Skill at `.agents/skills/forma-hardware/SKILL.md`.
 - An MCP Streamable HTTP endpoint at `http://127.0.0.1:8000/mcp` (or `/api/mcp` when the deployment adds an `/api` prefix).
 
+## Cloud and local worker boundary
+
+Cloud Forma remains the public browser API, chat/persistence authority, and project
+viewer. A Mini-PC may run the same backend code as a local execution worker for
+OpenCode-owned conversations, compilation, deterministic validation, and generation
+when explicitly configured. The worker delivers accepted snapshots and revisions
+back to cloud Forma through authenticated outbound HTTPS/CLI delivery.
+
+The local worker is not a second hosted Forma deployment. Do not point the Vercel
+browser API at it, copy production Supabase/Clerk/Redis state to it, or publish its
+loopback MCP/API port through a tunnel for normal operation. A narrowly scoped
+remote worker-control endpoint would require separate security review.
+
 Start the backend in local authentication mode:
 
 ```bash
@@ -92,7 +105,7 @@ Verify it with:
 opencode mcp list
 ```
 
-## Protected deployments
+## Protected cloud deployments
 
 The MCP route accepts either a Clerk administrator session or the dedicated `FORMA_MCP_API_KEY`. The API key must contain at least 32 characters. Pass the selected credential as an `Authorization: Bearer ...` header and keep it in an environment variable rather than committing it.
 

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -147,6 +147,21 @@ To make backend logs visible in the local frontend LOGS tab when running uvicorn
 BACKEND_LOG_FILE=.logs/backend-dev.log uvicorn apps.api.main:app --reload --port 8000
 ```
 
+## Self-hosted tunnel origin
+
+The planned self-hosted production backend runs as a dedicated Windows service
+named `FormaBackend`, under a restricted non-interactive local account. It must
+bind only to `127.0.0.1:8000`; Cloudflare Tunnel is the only intended public
+ingress path. The service must use `FORMA_DEPLOYMENT_MODE=hosted`, production
+Supabase/Redis configuration, and must not set `FORMA_DEVELOPMENT_MODE=true`.
+
+Host service provisioning, account creation, ACLs, and tunnel configuration belong
+to `caid-technologies/local-server-config`. Keep passwords, tunnel tokens, and
+runtime environment values out of this repository. Verify the local backend before
+pointing tunnel ingress at it, then test `/`, `/api/runtime/config`, `/api/mcp`,
+A2A, WebSocket, request-body, and streamed-response paths without introducing an
+additional `/api` prefix.
+
 Run generation directly through the sole Forma Core CLI with `--llm provider/model`:
 
 ```bash

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -147,20 +147,20 @@ To make backend logs visible in the local frontend LOGS tab when running uvicorn
 BACKEND_LOG_FILE=.logs/backend-dev.log uvicorn apps.api.main:app --reload --port 8000
 ```
 
-## Self-hosted tunnel origin
+## Local execution worker
 
-The planned self-hosted production backend runs as a dedicated Windows service
-named `FormaBackend`, under a restricted non-interactive local account. It must
-bind only to `127.0.0.1:8000`; Cloudflare Tunnel is the only intended public
-ingress path. The service must use `FORMA_DEPLOYMENT_MODE=hosted`, production
-Supabase/Redis configuration, and must not set `FORMA_DEVELOPMENT_MODE=true`.
+The planned Mini-PC runtime is a local execution worker, not a second public Forma
+deployment. It runs the backend code locally for OpenCode-owned conversations,
+project compilation, deterministic validation, and delivery back to cloud Forma.
+It may bind to `127.0.0.1:8000` for local MCP use, but it must not become the
+browser API origin or a public Cloudflare Tunnel upstream.
 
-Host service provisioning, account creation, ACLs, and tunnel configuration belong
-to `caid-technologies/local-server-config`. Keep passwords, tunnel tokens, and
-runtime environment values out of this repository. Verify the local backend before
-pointing tunnel ingress at it, then test `/`, `/api/runtime/config`, `/api/mcp`,
-A2A, WebSocket, request-body, and streamed-response paths without introducing an
-additional `/api` prefix.
+Use `FORMA_DEPLOYMENT_MODE=local` for the worker and keep local execution state
+separate from cloud production persistence. Cloud delivery uses the approved
+outbound Forma CLI/API credential. Host service provisioning, account creation,
+ACLs, and local MCP setup belong to `caid-technologies/local-server-config`.
+Keep passwords, service credentials, tunnel tokens, and runtime environment values
+out of this repository.
 
 Run generation directly through the sole Forma Core CLI with `--llm provider/model`:
 


### PR DESCRIPTION
## Summary

Corrects Forma documentation to distinguish cloud Forma from a local Mini-PC execution worker.

Cloud Forma remains the browser/API/chat/persistence authority. The local worker performs OpenCode-owned execution, compilation, deterministic validation, and delivery through authenticated outbound requests.

## Related issue

Related to #443 and #428

## Change type

- [ ] Bug fix
- [ ] Feature
- [x] Documentation
- [ ] Test
- [ ] Refactor
- [ ] Chore or maintenance

## Verification

```text
python -m compileall -q apps/api forma_core: passed
git diff --check: passed
```

## Configuration or migration requirements

None. Documentation only; no runtime, account, tunnel, persistence, or secret changes.

## Visual changes

Not applicable.

## Safety and compatibility

Clarifies that the worker must not be the Vercel browser API origin or a public tunnel upstream, preventing duplicate production persistence and public exposure.

## AI assistance

Prepared with AI assistance and reviewed against the current cloud/worker ownership boundary.

## Checklist

- [x] Targets the repository default `main` branch.
- [x] One logical documentation correction.
- [x] No secrets, credentials, logs, databases, or generated artifacts committed.
- [x] Documentation updated.
- [x] No breaking runtime changes.
