### PR TITLE
fix(cli): make project delivery interruption safe

### DIFF
--- a/apps/api/cli_projects_api.py
+++ b/apps/api/cli_projects_api.py
@@ -94,6 +94,110 @@ def _push_idempotency_key(manifest: dict[str, Any]) -> str:
     return f"push:{hashlib.sha256(canonical).hexdigest()}"
 
 
+def _manifest_digest(manifest: dict[str, Any]) -> str:
+    canonical = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def _delivery_manifest_digest(delivery: dict[str, Any]) -> str:
+    return str(delivery.get("manifest_digest") or "").strip()
+
+
+def _ensure_delivery_key_matches(delivery: dict[str, Any], manifest: dict[str, Any]) -> None:
+    stored_digest = _delivery_manifest_digest(delivery)
+    # Rows created before manifest_digest was introduced cannot be compared
+    # safely after normalization, so preserve their existing replay behavior.
+    if not stored_digest or stored_digest == _manifest_digest(manifest):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "code": "IDEMPOTENCY_KEY_REUSE",
+            "message": "The idempotency_key was already used for different project content.",
+        },
+    )
+
+
+def _delivery_plan(project_id: str, owner: str) -> tuple[int, str]:
+    latest = get_cli_project_revision(project_id, owner)
+    latest_revision = int((latest or {}).get("revision") or 0)
+    return latest_revision + 1, str(uuid.uuid4())
+
+
+def _reserve_and_materialize_delivery(
+    payload: dict[str, Any],
+    owner: str,
+    idempotency_key: str,
+    expected_revision_id: str | None,
+) -> dict[str, Any]:
+    project_id = str(payload.get("project_id") or "").strip()
+    digest = _manifest_digest(payload)
+    delivery = get_cli_project_delivery(project_id, owner, idempotency_key)
+    if delivery is None:
+        planned_revision, planned_revision_id = _delivery_plan(project_id, owner)
+        delivery = insert_cli_project_delivery(
+            {
+                "delivery_id": str(uuid.uuid4()),
+                "project_id": project_id,
+                "owner_user_id": owner,
+                "idempotency_key": idempotency_key,
+                "revision_id": planned_revision_id,
+                "revision": planned_revision,
+                "parent_revision_id": expected_revision_id,
+                "manifest_json": payload,
+                "manifest_digest": digest,
+                "status": "pending",
+                "receipt_json": None,
+                "created_at": _now(),
+                "completed_at": None,
+            }
+        )
+    _ensure_delivery_key_matches(delivery, payload)
+    if delivery.get("status") == "complete" and delivery.get("receipt"):
+        return delivery
+    if delivery.get("revision_id") and get_cli_project_revision(
+        project_id,
+        owner,
+        delivery["revision_id"],
+    ) is not None:
+        return delivery
+
+    try:
+        saved = insert_cli_project_revision(
+            payload,
+            owner,
+            expected_revision_id=delivery.get("parent_revision_id"),
+            revision_id=delivery.get("revision_id"),
+            revision=delivery.get("revision"),
+        )
+    except CliProjectConflictError as exc:
+        current = get_cli_project_delivery(project_id, owner, idempotency_key)
+        if current is not None:
+            _ensure_delivery_key_matches(current, payload)
+            if current.get("revision_id") and get_cli_project_revision(
+                project_id,
+                owner,
+                current["revision_id"],
+            ) is not None:
+                return current
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=_revision_conflict_detail(project_id, owner, exc),
+        ) from exc
+    if (
+        saved.get("revision_id") != delivery.get("revision_id")
+        or saved.get("revision") != delivery.get("revision")
+    ):
+        updated = update_cli_project_delivery(
+            delivery["delivery_id"],
+            owner,
+            {"revision_id": saved["revision_id"], "revision": saved["revision"]},
+        )
+        if updated is not None:
+            delivery = updated
+    return delivery
+
+
 def _artifact_declaration(artifact: dict[str, Any]) -> dict[str, Any]:
     return {
         "path": artifact.get("path"),
@@ -194,37 +298,7 @@ async def push_cli_project(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
     idempotency_key = request.idempotency_key or _push_idempotency_key(manifest_document)
-    existing = get_cli_project_delivery(project_id, owner, idempotency_key)
-    if existing is not None:
-        return _pending_delivery_response(existing)
-
-    try:
-        saved = insert_cli_project_revision(
-            payload,
-            owner,
-            expected_revision_id=request.parent_revision_id,
-        )
-    except CliProjectConflictError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=_revision_conflict_detail(project_id, owner, exc),
-        ) from exc
-
-    record = {
-        "delivery_id": str(uuid.uuid4()),
-        "project_id": saved["project_id"],
-        "owner_user_id": owner,
-        "idempotency_key": idempotency_key,
-        "revision_id": saved["revision_id"],
-        "revision": saved["revision"],
-        "parent_revision_id": saved["parent_revision_id"],
-        "manifest_json": payload,
-        "status": "pending",
-        "receipt_json": None,
-        "created_at": saved["created_at"],
-        "completed_at": None,
-    }
-    delivery = insert_cli_project_delivery(record)
+    delivery = _reserve_and_materialize_delivery(payload, owner, idempotency_key, request.parent_revision_id)
     return _pending_delivery_response(delivery)
 
 
@@ -271,37 +345,7 @@ async def deliver_cli_project(
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
 
-    existing = get_cli_project_delivery(project_id, owner, idempotency_key)
-    if existing is not None:
-        return _pending_delivery_response(existing)
-
-    try:
-        saved = insert_cli_project_revision(
-            payload,
-            owner,
-            expected_revision_id=request.parent_revision_id,
-        )
-    except CliProjectConflictError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=_revision_conflict_detail(project_id, owner, exc),
-        ) from exc
-
-    record = {
-        "delivery_id": str(uuid.uuid4()),
-        "project_id": saved["project_id"],
-        "owner_user_id": owner,
-        "idempotency_key": idempotency_key,
-        "revision_id": saved["revision_id"],
-        "revision": saved["revision"],
-        "parent_revision_id": saved["parent_revision_id"],
-        "manifest_json": payload,
-        "status": "pending",
-        "receipt_json": None,
-        "created_at": saved["created_at"],
-        "completed_at": None,
-    }
-    delivery = insert_cli_project_delivery(record)
+    delivery = _reserve_and_materialize_delivery(payload, owner, idempotency_key, request.parent_revision_id)
     return _pending_delivery_response(delivery)
 
 

--- a/forma_core/database.py
+++ b/forma_core/database.py
@@ -868,6 +868,8 @@ def insert_cli_project_revision(
     owner_user_id: str,
     *,
     expected_revision_id: Optional[str] = None,
+    revision_id: Optional[str] = None,
+    revision: Optional[int] = None,
 ) -> Dict[str, Any]:
     """Create one public-by-default project revision with compare-and-swap ancestry."""
     owner = _normalize_user_id(owner_user_id)
@@ -883,11 +885,28 @@ def insert_cli_project_revision(
             or (existing_identity.get("visibility") if isinstance(existing_identity, dict) else None)
             or requested_visibility
         )
-    next_revision = int(getattr(existing, "current_revision", 0)) + 1 if existing else 1
+    next_revision = int(revision) if revision is not None else (
+        int(getattr(existing, "current_revision", 0)) + 1 if existing else 1
+    )
     now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
-    revision_id = str(uuid.uuid4())
+    requested_revision_id = str(revision_id or uuid.uuid4())
+    latest = _DATABASE_REPOSITORY.get_cli_project_revision(project_id, owner)
+    if (
+        latest is not None
+        and int(getattr(latest, "revision", 0)) == next_revision
+        and str(getattr(latest, "parent_revision_id", "") or "") == str(expected_revision_id or "")
+        and getattr(latest, "manifest_json", None) == manifest
+    ):
+        return {
+            "revision_id": str(latest.revision_id),
+            "project_id": project_id,
+            "revision": int(latest.revision),
+            "parent_revision_id": getattr(latest, "parent_revision_id", None),
+            "manifest": getattr(latest, "manifest_json", manifest),
+            "created_at": getattr(latest, "created_at", None),
+        }
     revision_record = {
-        "revision_id": revision_id,
+        "revision_id": requested_revision_id,
         "project_id": project_id,
         "owner_user_id": owner,
         "revision": next_revision,
@@ -915,12 +934,12 @@ def insert_cli_project_revision(
     if saved is None:
         raise CliProjectConflictError("The cloud project changed since the local project was last pulled.")
     return {
-        "revision_id": revision_id,
+        "revision_id": str(getattr(saved, "revision_id", requested_revision_id)),
         "project_id": project_id,
-        "revision": next_revision,
-        "parent_revision_id": expected_revision_id,
-        "manifest": manifest,
-        "created_at": now,
+        "revision": int(getattr(saved, "revision", next_revision)),
+        "parent_revision_id": getattr(saved, "parent_revision_id", expected_revision_id),
+        "manifest": getattr(saved, "manifest_json", manifest),
+        "created_at": getattr(saved, "created_at", now),
     }
 
 
@@ -936,6 +955,7 @@ def _cli_delivery_from_record(record: Any) -> Optional[Dict[str, Any]]:
         "revision": int(record.revision),
         "parent_revision_id": getattr(record, "parent_revision_id", None),
         "manifest": getattr(record, "manifest_json", {}),
+        "manifest_digest": getattr(record, "manifest_digest", "") or "",
         "status": str(getattr(record, "status", "pending")),
         "receipt": getattr(record, "receipt_json", None),
         "created_at": getattr(record, "created_at", None),

--- a/forma_core/persistence/models.py
+++ b/forma_core/persistence/models.py
@@ -230,6 +230,7 @@ class DBCliProjectDelivery(Base):
     revision = Column(Integer, nullable=False)
     parent_revision_id = Column(String, nullable=True)
     manifest_json = Column(JSON, nullable=False)
+    manifest_digest = Column(String, nullable=False, default="")
     status = Column(String, index=True, nullable=False, default="pending")
     receipt_json = Column(JSON, nullable=True)
     created_at = Column(String, index=True, nullable=False)

--- a/forma_core/persistence/repositories/supabase.py
+++ b/forma_core/persistence/repositories/supabase.py
@@ -689,7 +689,17 @@ class SupabaseRepository:
         return [_record(row) for row in rows]
 
     def insert_cli_project_delivery(self, record: Dict[str, Any]) -> Any:
-        rows = self._client.table("cli_project_deliveries").insert(record).execute().data or []
+        try:
+            rows = self._client.table("cli_project_deliveries").insert(record).execute().data or []
+        except Exception:
+            existing = self.get_cli_project_delivery(
+                record["project_id"],
+                record["owner_user_id"],
+                record["idempotency_key"],
+            )
+            if existing is None:
+                raise
+            return existing
         return _record(rows[0]) if rows else _record(record)
 
     def update_cli_project_delivery(

--- a/supabase/migrations/20260903000400_gallery_legacy_projection_payload.sql
+++ b/supabase/migrations/20260903000400_gallery_legacy_projection_payload.sql
@@ -3,23 +3,23 @@
 create or replace view public.project_gallery_inventory as
 with hosted_latest as (
   select distinct on (project_id)
-    id as revision_id,
+    coalesce(to_jsonb(r)->>'revision_id', to_jsonb(r)->>'id') as revision_id,
     project_id,
     owner_user_id,
     revision,
     payload_json as revision_payload_json,
     created_at as revision_created_at
-  from public.project_revisions
+  from public.project_revisions r
   order by project_id, revision desc
 ), cli_latest as (
   select distinct on (project_id)
-    id as revision_id,
+    coalesce(to_jsonb(r)->>'revision_id', to_jsonb(r)->>'id') as revision_id,
     project_id,
     owner_user_id,
     revision,
     manifest_json as revision_payload_json,
     created_at as revision_created_at
-  from public.cli_project_revisions
+  from public.cli_project_revisions r
   order by project_id, revision desc
 )
 select

--- a/supabase/migrations/20260906000200_cli_project_deliveries.sql
+++ b/supabase/migrations/20260906000200_cli_project_deliveries.sql
@@ -11,7 +11,6 @@ create table if not exists public.cli_project_deliveries (
   revision integer not null check (revision >= 0),
   parent_revision_id text,
   manifest_json jsonb not null,
-  manifest_digest text not null default '',
   status text not null default 'pending',
   receipt_json jsonb,
   created_at text not null,
@@ -34,6 +33,3 @@ grant select, insert, update, delete on table public.cli_project_deliveries to s
 
 comment on table public.cli_project_deliveries is
   'Idempotent CLI/agent delivery records linking delivered revisions to receipts.';
-
-alter table public.cli_project_deliveries
-  add column if not exists manifest_digest text not null default '';

--- a/supabase/migrations/20260906000200_cli_project_deliveries.sql
+++ b/supabase/migrations/20260906000200_cli_project_deliveries.sql
@@ -11,6 +11,7 @@ create table if not exists public.cli_project_deliveries (
   revision integer not null check (revision >= 0),
   parent_revision_id text,
   manifest_json jsonb not null,
+  manifest_digest text not null default '',
   status text not null default 'pending',
   receipt_json jsonb,
   created_at text not null,
@@ -33,3 +34,6 @@ grant select, insert, update, delete on table public.cli_project_deliveries to s
 
 comment on table public.cli_project_deliveries is
   'Idempotent CLI/agent delivery records linking delivered revisions to receipts.';
+
+alter table public.cli_project_deliveries
+  add column if not exists manifest_digest text not null default '';

--- a/supabase/migrations/20260908000100_cli_project_delivery_manifest_digest.sql
+++ b/supabase/migrations/20260908000100_cli_project_delivery_manifest_digest.sql
@@ -1,0 +1,5 @@
+-- Persist the canonical payload digest without rewriting the already-applied
+-- CLI delivery table migration.
+
+alter table public.cli_project_deliveries
+  add column if not exists manifest_digest text not null default '';

--- a/tests/api/test_cli_project_delivery.py
+++ b/tests/api/test_cli_project_delivery.py
@@ -83,13 +83,14 @@ class CliProjectDeliveryApiTests(unittest.IsolatedAsyncioTestCase):
     async def test_deliver_creates_pending_receipt_and_defaults_to_private(self) -> None:
         captured: dict[str, object] = {}
 
-        def fake_save(manifest, owner, *, expected_revision_id=None):
+        def fake_save(manifest, owner, *, expected_revision_id=None, revision_id=None, revision=None):
             captured["manifest"] = manifest
             captured["owner"] = owner
             return _saved_revision()
 
         with (
             patch.object(cli_projects_api, "get_cli_project_delivery", return_value=None),
+            patch.object(cli_projects_api, "get_cli_project_revision", return_value=None),
             patch.object(cli_projects_api, "insert_cli_project_revision", side_effect=fake_save) as save,
             patch.object(cli_projects_api, "insert_cli_project_delivery", return_value=_delivery_record()) as save_delivery,
         ):
@@ -105,12 +106,13 @@ class CliProjectDeliveryApiTests(unittest.IsolatedAsyncioTestCase):
     async def test_deliver_honors_explicit_visibility(self) -> None:
         captured: dict[str, object] = {}
 
-        def fake_save(manifest, owner, *, expected_revision_id=None):
+        def fake_save(manifest, owner, *, expected_revision_id=None, revision_id=None, revision=None):
             captured["manifest"] = manifest
             return _saved_revision()
 
         with (
             patch.object(cli_projects_api, "get_cli_project_delivery", return_value=None),
+            patch.object(cli_projects_api, "get_cli_project_revision", return_value=None),
             patch.object(cli_projects_api, "insert_cli_project_revision", side_effect=fake_save),
             patch.object(cli_projects_api, "insert_cli_project_delivery", return_value=_delivery_record()) as save_delivery,
         ):
@@ -134,6 +136,7 @@ class CliProjectDeliveryApiTests(unittest.IsolatedAsyncioTestCase):
         existing = _delivery_record()
         with (
             patch.object(cli_projects_api, "get_cli_project_delivery", return_value=existing) as fetch,
+            patch.object(cli_projects_api, "get_cli_project_revision", return_value=_saved_revision()),
             patch.object(cli_projects_api, "insert_cli_project_revision") as save,
             patch.object(cli_projects_api, "insert_cli_project_delivery") as save_delivery,
         ):
@@ -144,16 +147,60 @@ class CliProjectDeliveryApiTests(unittest.IsolatedAsyncioTestCase):
         save.assert_not_called()
         save_delivery.assert_not_called()
 
+    async def test_deliver_rejects_idempotency_key_reuse_with_different_content(self) -> None:
+        existing = _delivery_record()
+        existing["manifest_digest"] = "different-content"
+        with (
+            patch.object(cli_projects_api, "get_cli_project_delivery", return_value=existing),
+            patch.object(cli_projects_api, "insert_cli_project_revision") as save,
+        ):
+            with self.assertRaises(HTTPException) as raised:
+                await cli_projects_api.deliver_cli_project(_deliver_request(), _user())
+
+        self.assertEqual(409, raised.exception.status_code)
+        self.assertEqual("IDEMPOTENCY_KEY_REUSE", raised.exception.detail["code"])
+        save.assert_not_called()
+
+    async def test_deliver_reserves_before_materializing_revision(self) -> None:
+        events: list[str] = []
+
+        def fake_insert_delivery(record):
+            events.append("reserve")
+            return {
+                **_delivery_record(),
+                "project_id": record["project_id"],
+                "idempotency_key": record["idempotency_key"],
+                "revision_id": record["revision_id"],
+                "revision": record["revision"],
+                "manifest": record["manifest_json"],
+                "manifest_digest": record["manifest_digest"],
+            }
+
+        def fake_save(manifest, owner, *, expected_revision_id=None, revision_id=None, revision=None):
+            events.append("revision")
+            return {**_saved_revision(), "revision_id": revision_id, "revision": revision}
+
+        with (
+            patch.object(cli_projects_api, "get_cli_project_delivery", return_value=None),
+            patch.object(cli_projects_api, "get_cli_project_revision", return_value=None),
+            patch.object(cli_projects_api, "insert_cli_project_delivery", side_effect=fake_insert_delivery),
+            patch.object(cli_projects_api, "insert_cli_project_revision", side_effect=fake_save),
+        ):
+            await cli_projects_api.deliver_cli_project(_deliver_request(), _user())
+
+        self.assertEqual(["reserve", "revision"], events)
+
     async def test_deliver_409_is_enriched_with_current_server_revision(self) -> None:
         latest = {"revision_id": "server-rev-9", "revision": 9}
 
-        def fake_save(manifest, owner, *, expected_revision_id=None):
+        def fake_save(manifest, owner, *, expected_revision_id=None, revision_id=None, revision=None):
             raise CliProjectConflictError("The cloud project changed since the local project was last pulled.")
 
         with (
             patch.object(cli_projects_api, "get_cli_project_delivery", return_value=None),
+            patch.object(cli_projects_api, "get_cli_project_revision", side_effect=[None, None, latest]),
             patch.object(cli_projects_api, "insert_cli_project_revision", side_effect=fake_save),
-            patch.object(cli_projects_api, "get_cli_project_revision", return_value=latest),
+            patch.object(cli_projects_api, "insert_cli_project_delivery", return_value=_delivery_record()),
         ):
             with self.assertRaises(HTTPException) as raised:
                 await cli_projects_api.deliver_cli_project(_deliver_request(), _user())
@@ -345,7 +392,7 @@ class PushApiTests(unittest.IsolatedAsyncioTestCase):
         captured: dict[str, object] = {}
         captured_keys: list[str] = []
 
-        def fake_save(manifest, owner, *, expected_revision_id=None):
+        def fake_save(manifest, owner, *, expected_revision_id=None, revision_id=None, revision=None):
             captured["manifest"] = manifest
             captured["owner"] = owner
             return _saved_revision()
@@ -357,6 +404,7 @@ class PushApiTests(unittest.IsolatedAsyncioTestCase):
         request = cli_projects_api.ProjectPushRequest(manifest=_manifest())
         with (
             patch.object(cli_projects_api, "get_cli_project_delivery", return_value=None),
+            patch.object(cli_projects_api, "get_cli_project_revision", return_value=None),
             patch.object(cli_projects_api, "insert_cli_project_revision", side_effect=fake_save) as save,
             patch.object(cli_projects_api, "insert_cli_project_delivery", side_effect=fake_insert_delivery) as save_delivery,
         ):
@@ -373,7 +421,7 @@ class PushApiTests(unittest.IsolatedAsyncioTestCase):
     async def test_push_honors_explicit_visibility_and_key(self) -> None:
         captured: dict[str, object] = {}
 
-        def fake_save(manifest, owner, *, expected_revision_id=None):
+        def fake_save(manifest, owner, *, expected_revision_id=None, revision_id=None, revision=None):
             captured["manifest"] = manifest
             return _saved_revision()
 
@@ -382,6 +430,7 @@ class PushApiTests(unittest.IsolatedAsyncioTestCase):
         )
         with (
             patch.object(cli_projects_api, "get_cli_project_delivery", return_value=None),
+            patch.object(cli_projects_api, "get_cli_project_revision", return_value=None),
             patch.object(cli_projects_api, "insert_cli_project_revision", side_effect=fake_save),
             patch.object(cli_projects_api, "insert_cli_project_delivery", return_value=_delivery_record()),
         ):
@@ -406,6 +455,7 @@ class PushApiTests(unittest.IsolatedAsyncioTestCase):
         request = cli_projects_api.ProjectPushRequest(manifest=_manifest(), idempotency_key="key-1")
         with (
             patch.object(cli_projects_api, "get_cli_project_delivery", return_value=existing) as fetch,
+            patch.object(cli_projects_api, "get_cli_project_revision", return_value=_saved_revision()),
             patch.object(cli_projects_api, "insert_cli_project_revision") as save,
             patch.object(cli_projects_api, "insert_cli_project_delivery") as save_delivery,
         ):
@@ -427,6 +477,7 @@ class PushApiTests(unittest.IsolatedAsyncioTestCase):
         request = cli_projects_api.ProjectPushRequest(manifest=_manifest())
         with (
             patch.object(cli_projects_api, "get_cli_project_delivery", return_value=None),
+            patch.object(cli_projects_api, "get_cli_project_revision", return_value=None),
             patch.object(cli_projects_api, "insert_cli_project_revision", return_value=_saved_revision()),
             patch.object(cli_projects_api, "insert_cli_project_delivery", side_effect=fake_insert_delivery),
         ):
@@ -437,15 +488,16 @@ class PushApiTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(64, len(captured_key[0].removeprefix("push:")))
 
     async def test_push_409_is_enriched_with_current_server_revision(self) -> None:
-        def fake_save(manifest, owner, *, expected_revision_id=None):
+        def fake_save(manifest, owner, *, expected_revision_id=None, revision_id=None, revision=None):
             raise CliProjectConflictError("The cloud project changed since the local project was last pulled.")
 
         latest = {"revision_id": "server-rev-9", "revision": 9}
         request = cli_projects_api.ProjectPushRequest(manifest=_manifest(), parent_revision_id="stale")
         with (
             patch.object(cli_projects_api, "get_cli_project_delivery", return_value=None),
+            patch.object(cli_projects_api, "get_cli_project_revision", side_effect=[None, None, latest]),
             patch.object(cli_projects_api, "insert_cli_project_revision", side_effect=fake_save),
-            patch.object(cli_projects_api, "get_cli_project_revision", return_value=latest),
+            patch.object(cli_projects_api, "insert_cli_project_delivery", return_value=_delivery_record()),
         ):
             with self.assertRaises(HTTPException) as raised:
                 await cli_projects_api.push_cli_project(request, _user())

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -871,6 +871,7 @@ class CliProjectDeliveryPersistenceTests(unittest.TestCase):
             "revision": 3,
             "parent_revision_id": "rev-b",
             "manifest_json": {"project_id": "project-a", "visibility": "private"},
+            "manifest_digest": "digest-a",
             "status": "pending",
             "receipt_json": None,
             "created_at": "2026-01-01T00:00:00Z",
@@ -885,6 +886,7 @@ class CliProjectDeliveryPersistenceTests(unittest.TestCase):
         delivery = repo.get_cli_project_delivery("project-a", "user-a", "key-a")
         self.assertEqual("delivery-a", delivery.delivery_id)
         self.assertEqual("rev-b", delivery.parent_revision_id)
+        self.assertEqual("digest-a", delivery.manifest_digest)
 
         by_id = repo.get_cli_project_delivery_by_id("delivery-a")
         self.assertEqual("project-a", by_id.project_id)


### PR DESCRIPTION
## Summary

- Reserve CLI project deliveries before materializing revisions.
- Persist manifest digests and reject changed payloads for reused idempotency keys.
- Recover safely from interrupted or concurrent same-key delivery attempts.

## Related issue

Closes #447

## Change type

- [x] Bug fix
- [x] Feature

## Verification

- pytest tests/api/test_cli_project_delivery.py tests/persistence/test_persistence.py -q: 45 passed.
- python -m compileall -q apps/api forma_core tests/api/test_cli_project_delivery.py tests/persistence/test_persistence.py: passed.
- pytest -q: 779 passed, 2 skipped, 3 known unrelated Windows-only baseline failures.
  - Hugging Face fixture assumes LF byte count while Windows writes CRLF.
  - Two encrypted-file tests assert POSIX 0600 permissions unavailable on Windows.
- git diff --check origin/main...HEAD: passed.

## Configuration or migration requirements

Apply the Supabase delivery migration adding manifest_digest.

## Visual changes

Not applicable.

## Safety and compatibility

Delivery reservations preserve idempotent retries and prevent duplicate revision materialization. Existing delivery rows without a digest retain replay compatibility. No hardware behavior changes.

## AI assistance

Implementation and tests were prepared with AI assistance.

## Checklist

- [x] The change addresses one logical concern.
- [x] Relevant deterministic tests were added or updated.
- [x] No secrets or generated artifacts were committed.
- [x] Migration requirements are documented.
- [x] Known platform-specific test failures are explained above.