### PR TITLE
fix(security): make provider settings request scoped

### DIFF
--- a/apps/api/a2a.py
+++ b/apps/api/a2a.py
@@ -78,7 +78,7 @@ from forma_core.runtime import (
     ensure_hosted_chat_enabled,
     generation_unavailable_message,
 )
-from forma_core.user_integrations import UserIntegrationStore, apply_user_integrations_to_environment, default_integration_store
+from forma_core.user_integrations import UserIntegrationStore, default_integration_store, resolve_user_integration_settings, ResolvedIntegrationSettings
 from apps.api.storage import get_image_storage_config, upload_image_to_supabase_s3
 from apps.api.security import MAX_IMAGE_ENCODED_CHARS, consume_operation_limit, security_config, validate_image_limits
 from forma_core.utils import generate_mermaid_chart, generate_svg_schematic
@@ -510,8 +510,8 @@ def _safe_image_config(config: Dict[str, Any]) -> Dict[str, Any]:
     return safe
 
 
-def _attach_product_image(prompt_text: str, ir: Any, generate_image: bool = False) -> None:
-    image_provider = build_image_provider(force_enabled=generate_image)
+def _attach_product_image(prompt_text: str, ir: Any, generate_image: bool = False, settings: Optional[ResolvedIntegrationSettings] = None) -> None:
+    image_provider = build_image_provider(force_enabled=generate_image, settings=settings)
     image_config = _safe_image_config(image_provider.get_debug_config())
     visual_spec = build_project_visual_spec(prompt_text, ir)
     image_status = "pending" if generate_image else "not_requested"
@@ -892,12 +892,17 @@ def _persist_updated_project_ir(
         logger.warning("Failed to persist updated project metadata for %s: %s", project_id, exc)
 
 
-def _apply_owner_user_integrations(owner_user_id: Optional[str]) -> None:
+def _resolve_owner_user_integrations(owner_user_id: Optional[str]) -> ResolvedIntegrationSettings:
     if not clerk_auth_required():
-        apply_user_integrations_to_environment(default_integration_store())
-        return
+        return resolve_user_integration_settings(default_integration_store())
     if isinstance(owner_user_id, str) and owner_user_id.strip():
-        apply_user_integrations_to_environment(UserIntegrationStore.for_user(owner_user_id.strip()))
+        return resolve_user_integration_settings(UserIntegrationStore.for_user(owner_user_id.strip()))
+    return resolve_user_integration_settings()
+
+
+def _apply_owner_user_integrations(owner_user_id: Optional[str]) -> ResolvedIntegrationSettings:
+    """Compatibility shim for callers that previously requested environment mutation."""
+    return _resolve_owner_user_integrations(owner_user_id)
 
 
 def _context_owner_user_id(user_context: Optional[UserContext]) -> Optional[str]:
@@ -945,9 +950,10 @@ def build_generation_response(
     past_job_context: Optional[PastJobContext] = None,
     project_id: Optional[str] = None,
     retry_stage: Optional[str] = None,
+    settings: Optional[ResolvedIntegrationSettings] = None,
 ) -> Dict[str, Any]:
     ensure_hosted_chat_enabled()
-    _apply_owner_user_integrations(owner_user_id)
+    settings = settings or _resolve_owner_user_integrations(owner_user_id)
 
     prompt_text = (prompt or "").strip()
     try:
@@ -1021,6 +1027,7 @@ def build_generation_response(
         provider_name=provider,
         model_name=model,
         external_source_provider=external_source_provider,
+        settings=settings,
     )
     if deployment_runtime_config(llm_config)["alpha_generation_gate_active"]:
         raise AlphaGenerationUnavailableError(generation_unavailable_message(llm_config))
@@ -1070,6 +1077,7 @@ def build_generation_response(
                 provider_name=provider,
                 model_name=model,
                 external_source_provider=external_source_provider,
+                settings=settings,
                 generation_metadata={
                     "project_id": project_id,
                     "chat_id": chat_id,
@@ -1130,8 +1138,7 @@ def build_generation_response(
 
             if generate_image:
                 emit_agent_pipeline_event(workflow_id, "image_generation", "started")
-                _apply_owner_user_integrations(owner_user_id)
-            _attach_product_image(prompt_text, ir, generate_image=generate_image)
+            _attach_product_image(prompt_text, ir, generate_image=generate_image, settings=settings)
             if generate_image:
                 image_status = (ir.assembly_metadata or {}).get("image_output_status")
                 emit_agent_pipeline_event(
@@ -1219,7 +1226,7 @@ async def call_forma_action(
             require_workflow=normalized == "generate_project",
         )
 
-    _apply_owner_user_integrations(owner_user_id if isinstance(owner_user_id, str) else None)
+    settings = _resolve_owner_user_integrations(owner_user_id if isinstance(owner_user_id, str) else None)
 
     if normalized == "generate_project":
         data_sources = normalize_generation_data_sources(payload.get("data_sources") or [])
@@ -1254,16 +1261,18 @@ async def call_forma_action(
             past_job_context,
             payload.get("project_id"),
             payload.get("retry_stage"),
+            settings=settings,
         )
 
     if normalized == "debug_config":
         orchestrator = HardwarePipelineOrchestrator(
             provider_name=payload.get("provider"),
             model_name=payload.get("model"),
+            settings=settings,
         )
         return {
             **orchestrator.get_debug_config(),
-            "image_output": get_image_output_debug_config(),
+            "image_output": get_image_output_debug_config(settings=settings),
             "image_storage": get_image_storage_config(),
             "observability": get_langfuse_debug_config(),
             "workflows": list_workflows(),

--- a/apps/api/context_gathering_api.py
+++ b/apps/api/context_gathering_api.py
@@ -23,7 +23,7 @@ from forma_core.database import (
     upsert_project_chat,
 )
 from forma_core.llm import build_llm_provider
-from forma_core.user_integrations import UserIntegrationStore, apply_user_integrations_to_environment
+from forma_core.user_integrations import UserIntegrationStore, resolve_user_integration_settings
 from forma_core.workspaces.context import (
     ContextBuildExecution,
     ContextGatheringRequest,
@@ -94,10 +94,10 @@ def context_gathering_agent(
     user: UserContext = Depends(require_user_context),
 ) -> ContextGatheringAgent:
     if user.owner_user_id:
-        apply_user_integrations_to_environment(UserIntegrationStore.for_user(user.owner_user_id))
+        settings = resolve_user_integration_settings(UserIntegrationStore.for_user(user.owner_user_id))
     else:
-        apply_user_integrations_to_environment()
-    return ContextGatheringAgent(llm_provider=build_llm_provider())
+        settings = resolve_user_integration_settings()
+    return ContextGatheringAgent(llm_provider=build_llm_provider(settings=settings))
 
 
 @router.post("/messages", response_model=ContextGatheringResponse, status_code=status.HTTP_201_CREATED)

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -64,10 +64,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 load_dotenv(REPO_ROOT / ".env")
 load_dotenv(Path(__file__).resolve().parent / ".env", override=False)
 
-from forma_core.user_integrations import UserIntegrationStore, apply_user_integrations_to_environment, require_user_secrets_key
+from forma_core.user_integrations import UserIntegrationStore, require_user_secrets_key, resolve_user_integration_settings, ResolvedIntegrationSettings
 from forma_core.vertex_auth import VercelOidcContextMiddleware
-
-apply_user_integrations_to_environment()
 
 from apps.api.logging_config import configure_backend_logging
 
@@ -373,28 +371,35 @@ def _deployment_runtime_config(llm_config: Dict[str, Any]) -> Dict[str, Any]:
     return deployment_runtime_config(llm_config, signup_storage=get_database_config()["client"])
 
 
-def _resolved_client_runtime_config() -> tuple[Dict[str, Any], Dict[str, Any]]:
-    llm_config = HardwarePipelineOrchestrator().get_debug_config()
-    image_config = get_image_output_debug_config()
+def _resolved_client_runtime_config(settings: Optional[ResolvedIntegrationSettings] = None) -> tuple[Dict[str, Any], Dict[str, Any]]:
+    llm_config = HardwarePipelineOrchestrator(settings=settings).get_debug_config()
+    image_config = get_image_output_debug_config(settings=settings)
     contract = resolve_runtime_contract(
         llm_config=llm_config,
         image_config=image_config,
         workflows=list_workflows(),
         signup_storage=get_database_config()["client"],
+        settings=settings,
     )
     contract["video"] = {
-        "generation": GMICloudProvider().get_debug_config(),
+        "generation": GMICloudProvider(settings=settings).get_debug_config(),
         "self_correction": FireworksVideoReviewClient().get_debug_config(),
     }
     return llm_config, contract
 
 
-def _apply_user_integrations(user: UserContext) -> None:
-    """Load provider settings only for operations that consume them."""
-    if user.provider == "local":
-        apply_user_integrations_to_environment()
-    elif user.owner_user_id:
-        apply_user_integrations_to_environment(UserIntegrationStore.for_user(user.owner_user_id))
+def _resolve_user_integrations(user: Optional[UserContext]) -> ResolvedIntegrationSettings:
+    """Snapshot provider settings for this request without mutating the process environment."""
+    if user is None or user.provider == "local":
+        return resolve_user_integration_settings()
+    if user.owner_user_id:
+        return resolve_user_integration_settings(UserIntegrationStore.for_user(user.owner_user_id))
+    return resolve_user_integration_settings()
+
+
+def _apply_user_integrations(user: UserContext) -> ResolvedIntegrationSettings:
+    """Compatibility shim for callers that previously requested environment mutation."""
+    return _resolve_user_integrations(user)
 
 
 def _job_owner_user_id(job: Optional[Dict[str, Any]]) -> Optional[str]:
@@ -578,9 +583,9 @@ def debug_config_endpoint(
     """
     Reports LLM provider and model resolution state without exposing credentials.
     """
-    _apply_user_integrations(user)
+    settings = _resolve_user_integrations(user)
     try:
-        orchestrator = HardwarePipelineOrchestrator(provider_name=provider, model_name=model)
+        orchestrator = HardwarePipelineOrchestrator(provider_name=provider, model_name=model, settings=settings)
         llm_config = orchestrator.get_debug_config()
         return {
             **llm_config,
@@ -588,11 +593,11 @@ def debug_config_endpoint(
             "deployment": _deployment_runtime_config(llm_config),
             "database": get_database_config(),
             "job_metadata": JOB_STORE.get_config(),
-            "image_output": get_image_output_debug_config(),
+            "image_output": get_image_output_debug_config(settings=settings),
             "image_storage": get_image_storage_config(),
             "observability": get_langfuse_debug_config(),
             "debug": get_debug_mode_config(),
-            "video_generation": GMICloudProvider().get_debug_config(),
+            "video_generation": GMICloudProvider(settings=settings).get_debug_config(),
             "video_self_correction": FireworksVideoReviewClient().get_debug_config(),
             "video_storage": get_video_storage_config(),
             "security": security_config(),
@@ -631,9 +636,9 @@ def debug_config_endpoint(
 @app.get("/runtime/config")
 def runtime_config_endpoint(user: UserContext = Depends(optional_user_context)):
     """Return the canonical, credential-safe runtime contract for this user."""
-    _apply_user_integrations(user)
+    settings = _resolve_user_integrations(user)
     try:
-        _, contract = _resolved_client_runtime_config()
+        _, contract = _resolved_client_runtime_config(settings)
         return contract
     except LLMProviderConfigError as e:
         correlation_id = new_error_correlation_id()
@@ -674,13 +679,14 @@ async def generate_project_endpoint(request: GenerateProjectRequest, user: UserC
         except WorkflowStateError as exc:
             status_code = status.HTTP_404_NOT_FOUND if exc.code == "workflow_not_found" else status.HTTP_409_CONFLICT
             raise HTTPException(status_code=status_code, detail=exc.as_dict()) from exc
-    _apply_user_integrations(user)
+    settings = _resolve_user_integrations(user)
     try:
         llm_config = get_workflow_debug_config(
             request.workflow,
             provider_name=request.provider,
             model_name=request.model,
             external_source_provider=request.external_source_provider,
+            settings=settings,
         )
     except LLMProviderConfigError as e:
         raise HTTPException(
@@ -1057,20 +1063,20 @@ VIDEO_FAILED_STATUSES = {"failed", "failure", "error", "cancelled", "canceled"}
 VIDEO_SUCCESS_STATUSES = {"success", "succeeded", "completed", "complete", "done"}
 
 
-def _normalize_video_model(model: str | None, mode: str = VIDEO_MODE_IMAGE_TO_VIDEO) -> str:
+def _normalize_video_model(model: str | None, mode: str = VIDEO_MODE_IMAGE_TO_VIDEO, settings: Optional[ResolvedIntegrationSettings] = None) -> str:
     normalized_mode = normalize_video_mode(mode)
-    normalized = (model or get_default_video_model(normalized_mode)).strip()
+    normalized = (model or get_default_video_model(normalized_mode, settings)).strip()
     if not normalized:
         raise HTTPException(status_code=400, detail="Video model is required.")
-    allowed_models = get_available_video_models(normalized_mode)
+    allowed_models = get_available_video_models(normalized_mode, settings)
     if normalized not in allowed_models:
         raise HTTPException(status_code=400, detail=f"Unsupported {normalized_mode} model '{normalized}'.")
     return normalized
 
 
-def _normalize_video_request_aspect_ratio(aspect_ratio: str | None) -> str:
+def _normalize_video_request_aspect_ratio(aspect_ratio: str | None, settings: Optional[ResolvedIntegrationSettings] = None) -> str:
     try:
-        return normalize_video_aspect_ratio(aspect_ratio)
+        return normalize_video_aspect_ratio(aspect_ratio, settings)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
@@ -1231,20 +1237,21 @@ def _video_route_response(
 
 
 @app.get("/video/models")
-def list_video_models_endpoint():
+def list_video_models_endpoint(user: UserContext = Depends(optional_user_context)):
     """Returns the backend-approved video generation models."""
-    models = get_available_video_model_options()
-    default_model = get_default_video_model(VIDEO_MODE_IMAGE_TO_VIDEO)
-    default_video_to_video_model = get_default_video_model(VIDEO_MODE_VIDEO_TO_VIDEO)
-    provider_config = GMICloudProvider().get_debug_config()
+    settings = _resolve_user_integrations(user)
+    models = get_available_video_model_options(settings=settings)
+    default_model = get_default_video_model(VIDEO_MODE_IMAGE_TO_VIDEO, settings)
+    default_video_to_video_model = get_default_video_model(VIDEO_MODE_VIDEO_TO_VIDEO, settings)
+    provider_config = GMICloudProvider(settings=settings).get_debug_config()
     return {
         "models": [model.response_metadata() for model in models],
         "defaultModel": default_model,
         "default_model": default_model,
         "defaultVideoToVideoModel": default_video_to_video_model,
         "default_video_to_video_model": default_video_to_video_model,
-        "aspectRatioOptions": get_available_video_aspect_ratios(),
-        "aspect_ratio_options": get_available_video_aspect_ratios(),
+        "aspectRatioOptions": get_available_video_aspect_ratios(settings),
+        "aspect_ratio_options": get_available_video_aspect_ratios(settings),
         "generationConfigured": provider_config["configured"],
         "generation_configured": provider_config["configured"],
         "reason": provider_config.get("reason"),
@@ -1271,13 +1278,14 @@ def list_project_videos_endpoint(project_id: str, user: UserContext = Depends(re
 def create_image_to_video_endpoint(request: VideoImageToVideoRequest, user: UserContext = Depends(require_user_context)):
     """Queues a backend-only GMI Cloud image-to-video generation request."""
     require_hosted_chat_enabled()
+    settings = _resolve_user_integrations(user)
     project_id = _require_non_empty(request.projectId, "projectId is required.")
     project = _resolve_project_owner(project_id, user)
     image = _require_non_empty(request.image, "image is required.")
     prompt = _require_non_empty(request.prompt, "prompt is required.")
-    model = _normalize_video_model(request.model, VIDEO_MODE_IMAGE_TO_VIDEO)
+    model = _normalize_video_model(request.model, VIDEO_MODE_IMAGE_TO_VIDEO, settings)
     duration = _require_non_empty(request.duration, "duration is required.")
-    aspect_ratio = _normalize_video_request_aspect_ratio(request.aspectRatio or request.aspect_ratio)
+    aspect_ratio = _normalize_video_request_aspect_ratio(request.aspectRatio or request.aspect_ratio, settings)
     sound = "on" if (request.sound or "").strip().lower() == "on" else "off"
 
     try:
@@ -1285,7 +1293,7 @@ def create_image_to_video_endpoint(request: VideoImageToVideoRequest, user: User
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    provider = GMICloudProvider()
+    provider = GMICloudProvider(settings=settings)
     try:
         result = provider.create_image_to_video(
             image=image,
@@ -1328,13 +1336,14 @@ def create_image_to_video_endpoint(request: VideoImageToVideoRequest, user: User
 def create_video_to_video_endpoint(request: VideoToVideoRequest, user: UserContext = Depends(require_user_context)):
     """Queues a backend-only GMI Cloud video-to-video generation request."""
     require_hosted_chat_enabled()
+    settings = _resolve_user_integrations(user)
     project_id = _require_non_empty(request.projectId, "projectId is required.")
     project = _resolve_project_owner(project_id, user)
     video = _require_non_empty(request.video, "video is required.")
     prompt = _require_non_empty(request.prompt, "prompt is required.")
-    model = _normalize_video_model(request.model, VIDEO_MODE_VIDEO_TO_VIDEO)
+    model = _normalize_video_model(request.model, VIDEO_MODE_VIDEO_TO_VIDEO, settings)
     duration = _require_non_empty(request.duration, "duration is required.")
-    aspect_ratio = _normalize_video_request_aspect_ratio(request.aspectRatio or request.aspect_ratio)
+    aspect_ratio = _normalize_video_request_aspect_ratio(request.aspectRatio or request.aspect_ratio, settings)
     sound = "on" if (request.sound or "").strip().lower() == "on" else "off"
 
     try:
@@ -1342,7 +1351,7 @@ def create_video_to_video_endpoint(request: VideoToVideoRequest, user: UserConte
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-    provider = GMICloudProvider()
+    provider = GMICloudProvider(settings=settings)
     try:
         result = provider.create_video_to_video(
             video=video,
@@ -1396,11 +1405,12 @@ def get_image_to_video_status_endpoint(
     request_id = _require_non_empty(request_id, "requestId is required.")
     project_id = _require_non_empty(projectId, "projectId is required.")
     project = _resolve_project_owner(project_id, user)
+    settings = _resolve_user_integrations(user)
     normalized_mode = normalize_video_mode(mode)
-    model = _normalize_video_model(model, normalized_mode)
-    aspect_ratio = _normalize_video_request_aspect_ratio(aspectRatio) if aspectRatio else None
+    model = _normalize_video_model(model, normalized_mode, settings)
+    aspect_ratio = _normalize_video_request_aspect_ratio(aspectRatio, settings) if aspectRatio else None
 
-    provider = GMICloudProvider()
+    provider = GMICloudProvider(settings=settings)
     try:
         result = provider.get_request_status(request_id)
     except Exception as exc:
@@ -1445,7 +1455,7 @@ def alpha_signup_endpoint(request: AlphaSignupRequest):
     Captures alpha access interest while deployed generation is unavailable.
     """
     try:
-        llm_config = HardwarePipelineOrchestrator().get_debug_config()
+        llm_config = HardwarePipelineOrchestrator(settings=_resolve_user_integrations(None)).get_debug_config()
         deployment_config = _deployment_runtime_config(llm_config)
         save_alpha_signup(
             name=request.name,
@@ -2944,7 +2954,7 @@ def iterate_project_endpoint(
 ):
     """Applies an iteration instruction to an existing project through forma_core."""
     require_hosted_chat_enabled()
-    _apply_user_integrations(user)
+    settings = _resolve_user_integrations(user)
     try:
         project = resolve_project_for_read(project_id, user.owner_user_id).project
     except ProjectReadError:
@@ -2991,7 +3001,7 @@ def iterate_project_endpoint(
             raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=exc.as_dict()) from exc
 
     try:
-        iterator = ProjectIterator(provider_name=request.provider, model_name=request.model)
+        iterator = ProjectIterator(provider_name=request.provider, model_name=request.model, settings=settings)
         revised_ir = iterator.iterate_project(
             current_ir,
             request.instruction,
@@ -3165,7 +3175,7 @@ def video_self_correct_project_endpoint(
 ):
     """Reviews a generated project video with a Fireworks native video model and applies a corrective iteration."""
     require_hosted_chat_enabled()
-    _apply_user_integrations(user)
+    settings = _resolve_user_integrations(user)
     project = _resolve_project_owner(project_id, user)
     owner_user_id = user.owner_user_id
     try:
@@ -3178,7 +3188,7 @@ def video_self_correct_project_endpoint(
         review_video_url = _resolve_stored_video_review_target(project.project_id, request)
         agent = FireworksVideoSelfCorrectionAgent(
             review_client=FireworksVideoReviewClient(model=request.review_model),
-            iterator=ProjectIterator(provider_name=request.provider, model_name=request.model),
+            iterator=ProjectIterator(provider_name=request.provider, model_name=request.model, settings=settings),
         )
         revised_ir, review = agent.correct_project_from_video(
             current_ir,

--- a/apps/api/user_integrations_api.py
+++ b/apps/api/user_integrations_api.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel, Field
 
 from forma_core.user_integrations import (
     UserIntegrationStore,
-    apply_user_integrations_to_environment,
+    resolve_user_integration_settings,
     default_integration_store,
     integration_status_payload,
 )
@@ -244,7 +244,7 @@ def test_image_model(
 
     store = _store_for_context(user_context)
     try:
-        apply_user_integrations_to_environment(store, fail_open=False)
+        settings = resolve_user_integration_settings(store, fail_open=False)
     except Exception as exc:
         raise _unexpected_storage_error(
             operation="image_model_test_load",
@@ -253,7 +253,7 @@ def test_image_model(
             exc=exc,
         ) from exc
 
-    provider = build_image_provider(force_enabled=True)
+    provider = build_image_provider(force_enabled=True, settings=settings)
     config = redact_debug_value(provider.get_debug_config())
     actual_provider = str(getattr(provider, "provider_name", "") or "")
     actual_model = str(getattr(provider, "model_name", "") or "")

--- a/apps/api/video_providers.py
+++ b/apps/api/video_providers.py
@@ -5,7 +5,7 @@ import urllib.error
 import urllib.request
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 from dotenv import load_dotenv
 
@@ -13,6 +13,7 @@ load_dotenv(Path(__file__).resolve().parents[2] / ".env")
 load_dotenv(Path(__file__).resolve().parent / ".env", override=False)
 
 logger = logging.getLogger(__name__)
+Settings = Mapping[str, str]
 
 DEFAULT_GMI_BASE_URL = "https://console.gmicloud.ai"
 VIDEO_MODE_IMAGE_TO_VIDEO = "image-to-video"
@@ -101,24 +102,24 @@ class VideoGenerationResult:
         }
 
 
-def _env(name: str, default: Optional[str] = None) -> Optional[str]:
-    value = config.get(name)
+def _env(name: str, default: Optional[str] = None, settings: Optional[Settings] = None) -> Optional[str]:
+    value = settings.get(name) if settings is not None else config.get(name)
     if value is None:
         return default
     stripped = value.strip()
     return stripped if stripped else default
 
 
-def _first_env(names: List[str], default: Optional[str] = None) -> Optional[str]:
+def _first_env(names: List[str], default: Optional[str] = None, settings: Optional[Settings] = None) -> Optional[str]:
     for name in names:
-        value = _env(name)
+        value = _env(name, settings=settings)
         if value is not None:
             return value
     return default
 
 
-def _env_float(name: str, default: float) -> float:
-    raw_value = _env(name)
+def _env_float(name: str, default: float, settings: Optional[Settings] = None) -> float:
+    raw_value = _env(name, settings=settings)
     if raw_value is None:
         return default
     try:
@@ -175,24 +176,24 @@ def normalize_video_mode(mode: Optional[str]) -> str:
     return VIDEO_MODE_IMAGE_TO_VIDEO
 
 
-def get_default_video_model(mode: str = VIDEO_MODE_IMAGE_TO_VIDEO) -> str:
+def get_default_video_model(mode: str = VIDEO_MODE_IMAGE_TO_VIDEO, settings: Optional[Settings] = None) -> str:
     normalized_mode = normalize_video_mode(mode)
     if normalized_mode == VIDEO_MODE_VIDEO_TO_VIDEO:
-        return _env("GMI_CLOUD_VIDEO_TO_VIDEO_MODEL", DEFAULT_GMI_VIDEO_TO_VIDEO_MODEL) or DEFAULT_GMI_VIDEO_TO_VIDEO_MODEL
-    return _env("GMI_CLOUD_IMAGE_TO_VIDEO_MODEL", DEFAULT_GMI_IMAGE_TO_VIDEO_MODEL) or DEFAULT_GMI_IMAGE_TO_VIDEO_MODEL
+        return _env("GMI_CLOUD_VIDEO_TO_VIDEO_MODEL", DEFAULT_GMI_VIDEO_TO_VIDEO_MODEL, settings) or DEFAULT_GMI_VIDEO_TO_VIDEO_MODEL
+    return _env("GMI_CLOUD_IMAGE_TO_VIDEO_MODEL", DEFAULT_GMI_IMAGE_TO_VIDEO_MODEL, settings) or DEFAULT_GMI_IMAGE_TO_VIDEO_MODEL
 
 
-def get_available_video_model_options(mode: Optional[str] = None) -> List[VideoModelDefinition]:
+def get_available_video_model_options(mode: Optional[str] = None, settings: Optional[Settings] = None) -> List[VideoModelDefinition]:
     image_models = [
-        get_default_video_model(VIDEO_MODE_IMAGE_TO_VIDEO),
+        get_default_video_model(VIDEO_MODE_IMAGE_TO_VIDEO, settings),
         *DEFAULT_GMI_IMAGE_TO_VIDEO_MODELS,
-        *_parse_model_list(_env("GMI_CLOUD_IMAGE_TO_VIDEO_MODELS")),
-        *_parse_model_list(_env("GMI_CLOUD_VIDEO_MODELS")),
+        *_parse_model_list(_env("GMI_CLOUD_IMAGE_TO_VIDEO_MODELS", settings=settings)),
+        *_parse_model_list(_env("GMI_CLOUD_VIDEO_MODELS", settings=settings)),
     ]
     video_models = [
-        get_default_video_model(VIDEO_MODE_VIDEO_TO_VIDEO),
+        get_default_video_model(VIDEO_MODE_VIDEO_TO_VIDEO, settings),
         *DEFAULT_GMI_VIDEO_TO_VIDEO_MODELS,
-        *_parse_model_list(_env("GMI_CLOUD_VIDEO_TO_VIDEO_MODELS")),
+        *_parse_model_list(_env("GMI_CLOUD_VIDEO_TO_VIDEO_MODELS", settings=settings)),
     ]
 
     definitions = [
@@ -205,17 +206,17 @@ def get_available_video_model_options(mode: Optional[str] = None) -> List[VideoM
     return _dedupe_definitions(definitions)
 
 
-def get_available_video_models(mode: Optional[str] = None) -> List[str]:
-    return [definition.id for definition in get_available_video_model_options(mode)]
+def get_available_video_models(mode: Optional[str] = None, settings: Optional[Settings] = None) -> List[str]:
+    return [definition.id for definition in get_available_video_model_options(mode, settings)]
 
 
-def get_available_video_aspect_ratios() -> List[str]:
-    configured = _parse_model_list(_env("GMI_CLOUD_VIDEO_ASPECT_RATIOS"))
+def get_available_video_aspect_ratios(settings: Optional[Settings] = None) -> List[str]:
+    configured = _parse_model_list(_env("GMI_CLOUD_VIDEO_ASPECT_RATIOS", settings=settings))
     ratios = [*DEFAULT_VIDEO_ASPECT_RATIOS, *configured]
     return list(dict.fromkeys(ratio for ratio in ratios if ratio))
 
 
-def normalize_video_aspect_ratio(value: Optional[str]) -> str:
+def normalize_video_aspect_ratio(value: Optional[str], settings: Optional[Settings] = None) -> str:
     raw_value = (value or DEFAULT_VIDEO_ASPECT_RATIO).strip().lower()
     aliases = {
         "landscape": "16:9",
@@ -226,7 +227,7 @@ def normalize_video_aspect_ratio(value: Optional[str]) -> str:
         "square": "1:1",
     }
     normalized = aliases.get(raw_value, raw_value)
-    allowed = get_available_video_aspect_ratios()
+    allowed = get_available_video_aspect_ratios(settings)
     if normalized not in allowed:
         raise ValueError(f"Unsupported video aspect ratio '{value}'. Valid ratios: {', '.join(allowed)}.")
     return normalized
@@ -290,12 +291,13 @@ def _collect_video_urls(value: Any) -> List[str]:
 class GMICloudProvider:
     provider_name = "gmi-cloud"
 
-    def __init__(self) -> None:
-        self.api_key = _first_env(["GMI_CLOUD_API_KEY", "GMICLOUD_API_KEY", "GMI_API_KEY"])
-        self.base_url = (_env("GMI_CLOUD_BASE_URL", DEFAULT_GMI_BASE_URL) or DEFAULT_GMI_BASE_URL).rstrip("/")
-        self.default_model = get_default_video_model()
-        self.requests_path = _env("GMI_CLOUD_REQUESTS_PATH", DEFAULT_GMI_REQUESTS_PATH) or DEFAULT_GMI_REQUESTS_PATH
-        self.timeout_seconds = _env_float("GMI_CLOUD_TIMEOUT_SECONDS", DEFAULT_GMI_TIMEOUT_SECONDS)
+    def __init__(self, settings: Optional[Settings] = None) -> None:
+        self.settings = settings
+        self.api_key = _first_env(["GMI_CLOUD_API_KEY", "GMICLOUD_API_KEY", "GMI_API_KEY"], settings=settings)
+        self.base_url = (_env("GMI_CLOUD_BASE_URL", DEFAULT_GMI_BASE_URL, settings) or DEFAULT_GMI_BASE_URL).rstrip("/")
+        self.default_model = get_default_video_model(settings=settings)
+        self.requests_path = _env("GMI_CLOUD_REQUESTS_PATH", DEFAULT_GMI_REQUESTS_PATH, settings) or DEFAULT_GMI_REQUESTS_PATH
+        self.timeout_seconds = _env_float("GMI_CLOUD_TIMEOUT_SECONDS", DEFAULT_GMI_TIMEOUT_SECONDS, settings)
 
     @property
     def is_configured(self) -> bool:
@@ -312,10 +314,10 @@ class GMICloudProvider:
             "configured": self.is_configured,
             "base_url": self.base_url,
             "default_model": self.default_model,
-            "default_video_to_video_model": get_default_video_model(VIDEO_MODE_VIDEO_TO_VIDEO),
-            "models": get_available_video_models(),
-            "model_options": [model.response_metadata() for model in get_available_video_model_options()],
-            "aspect_ratios": get_available_video_aspect_ratios(),
+            "default_video_to_video_model": get_default_video_model(VIDEO_MODE_VIDEO_TO_VIDEO, self.settings),
+            "models": get_available_video_models(settings=self.settings),
+            "model_options": [model.response_metadata() for model in get_available_video_model_options(settings=self.settings)],
+            "aspect_ratios": get_available_video_aspect_ratios(self.settings),
             "default_aspect_ratio": DEFAULT_VIDEO_ASPECT_RATIO,
             "reason": reason,
         }
@@ -394,7 +396,7 @@ class GMICloudProvider:
                 image_key: image,
                 "prompt": prompt,
                 "duration": str(duration),
-                "aspect_ratio": normalize_video_aspect_ratio(aspect_ratio),
+                "aspect_ratio": normalize_video_aspect_ratio(aspect_ratio, self.settings),
                 "sound": sound or "off",
             },
         }
@@ -417,7 +419,7 @@ class GMICloudProvider:
                 "reference_videos": [video],
                 "prompt": prompt,
                 "duration": str(duration),
-                "aspect_ratio": normalize_video_aspect_ratio(aspect_ratio),
+                "aspect_ratio": normalize_video_aspect_ratio(aspect_ratio, self.settings),
                 "sound": sound or "off",
             }
             payload = {
@@ -432,7 +434,7 @@ class GMICloudProvider:
             source_key: video,
             "prompt": prompt,
             "duration": str(duration),
-            "aspect_ratio": normalize_video_aspect_ratio(aspect_ratio),
+            "aspect_ratio": normalize_video_aspect_ratio(aspect_ratio, self.settings),
             "sound": sound or "off",
         }
 

--- a/forma_core/agents/firecrawl_mcp.py
+++ b/forma_core/agents/firecrawl_mcp.py
@@ -10,21 +10,22 @@ import subprocess
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Mapping, Optional
 
 
 DEFAULT_FIRECRAWL_MCP_COMMAND = "npx -y firecrawl-mcp"
+Settings = Mapping[str, str]
 
 
-def _env_bool(name: str, default: bool = False) -> bool:
-    value = config.get(name)
+def _env_bool(name: str, default: bool = False, settings: Optional[Settings] = None) -> bool:
+    value = settings.get(name) if settings is not None else config.get(name)
     if value is None:
         return default
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _env_int(name: str, default: int, minimum: int, maximum: int) -> int:
-    raw = config.get(name)
+def _env_int(name: str, default: int, minimum: int, maximum: int, settings: Optional[Settings] = None) -> int:
+    raw = settings.get(name) if settings is not None else config.get(name)
     if raw is None:
         return default
     try:
@@ -42,12 +43,12 @@ class FirecrawlMCPConfig:
     reason: Optional[str] = None
 
     @classmethod
-    def from_env(cls) -> "FirecrawlMCPConfig":
-        if _env_bool("FIRECRAWL_MCP_DISABLED", False):
+    def from_env(cls, settings: Optional[Settings] = None) -> "FirecrawlMCPConfig":
+        if _env_bool("FIRECRAWL_MCP_DISABLED", False, settings):
             return cls(enabled=False, reason="FIRECRAWL_MCP_DISABLED is true.")
 
-        configured_command = config.get("FIRECRAWL_MCP_COMMAND")
-        api_key = config.get("FIRECRAWL_API_KEY")
+        configured_command = settings.get("FIRECRAWL_MCP_COMMAND") if settings is not None else config.get("FIRECRAWL_MCP_COMMAND")
+        api_key = settings.get("FIRECRAWL_API_KEY") if settings is not None else config.get("FIRECRAWL_API_KEY")
         if configured_command:
             command = shlex.split(configured_command)
         elif api_key:
@@ -61,8 +62,8 @@ class FirecrawlMCPConfig:
         if not command:
             return cls(enabled=False, reason="FIRECRAWL_MCP_COMMAND resolved to an empty command.")
 
-        timeout = float(_env_int("FIRECRAWL_MCP_TIMEOUT_SECONDS", 45, 5, 180))
-        search_limit = _env_int("FIRECRAWL_SEARCH_LIMIT", 3, 1, 8)
+        timeout = float(_env_int("FIRECRAWL_MCP_TIMEOUT_SECONDS", 45, 5, 180, settings))
+        search_limit = _env_int("FIRECRAWL_SEARCH_LIMIT", 3, 1, 8, settings)
         return cls(enabled=True, command=command, timeout_seconds=timeout, search_limit=search_limit)
 
 
@@ -146,16 +147,17 @@ class FirecrawlResearchResult:
 
 
 class _MCPStdioSession:
-    def __init__(self, command: List[str], timeout_seconds: float):
+    def __init__(self, command: List[str], timeout_seconds: float, settings: Optional[Settings] = None):
         self.command = command
         self.timeout_seconds = timeout_seconds
+        self.settings = settings
         self._next_id = 1
         self._responses: "queue.Queue[Dict[str, Any]]" = queue.Queue()
         self._stderr_lines: "queue.Queue[str]" = queue.Queue()
         self.process: Optional[subprocess.Popen[bytes]] = None
 
     def __enter__(self) -> "_MCPStdioSession":
-        env = config.snapshot()
+        env = dict(self.settings) if self.settings is not None else config.snapshot()
         self.process = subprocess.Popen(
             self.command,
             stdin=subprocess.PIPE,
@@ -396,8 +398,9 @@ def _flatten_firecrawl_hits(value: Any) -> List[FirecrawlSearchHit]:
 
 
 class FirecrawlMCPResearchClient:
-    def __init__(self, config: Optional[FirecrawlMCPConfig] = None):
-        self.config = config or FirecrawlMCPConfig.from_env()
+    def __init__(self, config: Optional[FirecrawlMCPConfig] = None, settings: Optional[Settings] = None):
+        self.settings = settings
+        self.config = config or FirecrawlMCPConfig.from_env(settings)
 
     def research(self, queries: Iterable[str]) -> FirecrawlResearchResult:
         if not self.config.enabled:
@@ -408,7 +411,7 @@ class FirecrawlMCPResearchClient:
             return FirecrawlResearchResult(configured=True, error="No research queries were provided.")
 
         try:
-            with _MCPStdioSession(self.config.command, self.config.timeout_seconds) as session:
+            with _MCPStdioSession(self.config.command, self.config.timeout_seconds, self.settings) as session:
                 tools_result = session.request("tools/list")
                 tools = tools_result.get("tools") or []
                 tool_names = [tool.get("name") for tool in tools if isinstance(tool, dict)]

--- a/forma_core/agents/orchestrator.py
+++ b/forma_core/agents/orchestrator.py
@@ -53,6 +53,7 @@ from forma_core.runtime import (
     deployment_mode_enabled,
     generation_unavailable_message,
 )
+from forma_core.user_integrations import ResolvedIntegrationSettings
 from forma_core.workspaces.projects.models import (
     HardwareIR, ProjectOverview, FunctionalRequirements, 
     ComponentInstance, ConnectionNet, PinReference, AssemblyStep, 
@@ -656,13 +657,15 @@ class HardwarePipelineOrchestrator:
         provider_name: Optional[str] = None,
         model_name: Optional[str] = None,
         runtime_config: Optional[LLMRuntimeConfig] = None,
+        settings: Optional[ResolvedIntegrationSettings] = None,
         persist_project: bool = True,
     ):
         self.runtime_config = runtime_config or resolve_llm_runtime_config(
             provider_name=provider_name,
             model_name=model_name,
+            settings=settings,
         )
-        self.llm_provider = build_llm_provider(runtime_config=self.runtime_config)
+        self.llm_provider = build_llm_provider(runtime_config=self.runtime_config, settings=settings)
         self.use_simulation = use_simulation or not self.llm_provider.is_configured
         self.model_name = self.llm_provider.model_name
         self.persist_project = persist_project

--- a/forma_core/agents/web_research_workflow.py
+++ b/forma_core/agents/web_research_workflow.py
@@ -62,6 +62,7 @@ from forma_core.runtime import (
     deployment_mode_enabled,
     generation_unavailable_message,
 )
+from forma_core.user_integrations import ResolvedIntegrationSettings
 from forma_core.validation import (
     build_validation_summary,
     check_safety_violations,
@@ -150,19 +151,22 @@ class WebResearchHardwarePipeline:
         provider_name: Optional[str] = None,
         model_name: Optional[str] = None,
         runtime_config: Optional[LLMRuntimeConfig] = None,
+        settings: Optional[ResolvedIntegrationSettings] = None,
         external_source_provider: Optional[str] = None,
         persist_project: bool = True,
     ):
+        self.settings = settings
         self.runtime_config = runtime_config or resolve_llm_runtime_config(
             provider_name=provider_name,
             model_name=model_name,
+            settings=settings,
         )
-        self.llm_provider = build_llm_provider(runtime_config=self.runtime_config)
+        self.llm_provider = build_llm_provider(runtime_config=self.runtime_config, settings=settings)
         self.use_simulation = not self.llm_provider.is_configured
         self.model_name = self.llm_provider.model_name
         self.external_source_provider = external_source_provider
         self.persist_project = persist_project
-        self.research_client = build_external_source_provider(provider=external_source_provider)
+        self.research_client = build_external_source_provider(provider=external_source_provider, settings=settings)
         self._active_generation_metadata: Dict[str, Any] = {}
 
     def get_debug_config(self) -> Dict[str, Any]:
@@ -286,7 +290,7 @@ class WebResearchHardwarePipeline:
         if safety_error:
             emit_agent_pipeline_event(self.workflow_id, "safety_guardrail", "failed", details={"reason": safety_error})
             logger.info("Web research workflow safety guardrail blocked request; delegating to safety response.")
-            return HardwarePipelineOrchestrator(runtime_config=self.runtime_config).generate_project(
+            return HardwarePipelineOrchestrator(runtime_config=self.runtime_config, settings=self.settings).generate_project(
                 user_prompt,
                 image_bytes=image_bytes,
                 image_mime_type=image_mime_type,
@@ -298,7 +302,7 @@ class WebResearchHardwarePipeline:
                 raise AlphaGenerationUnavailableError(generation_unavailable_message(self.get_debug_config()))
             logger.info("Web research workflow is using simulation fallback because external generation is unavailable.")
             emit_agent_pipeline_event(self.workflow_id, "external_research", "skipped", details={"reason": self.research_client.config.reason})
-            ir = HardwarePipelineOrchestrator(use_simulation=True, runtime_config=self.runtime_config).generate_project(
+            ir = HardwarePipelineOrchestrator(use_simulation=True, runtime_config=self.runtime_config, settings=self.settings).generate_project(
                 user_prompt,
                 image_bytes=image_bytes,
                 image_mime_type=image_mime_type,

--- a/forma_core/agents/workflows.py
+++ b/forma_core/agents/workflows.py
@@ -13,6 +13,7 @@ from forma_core.jobs.source_usage import (
 )
 from forma_core.workspaces.projects.cad_generation import ensure_native_cad_model
 from forma_core.workspaces.projects.models import HardwareIR
+from forma_core.user_integrations import ResolvedIntegrationSettings
 
 
 @dataclass(frozen=True)
@@ -58,6 +59,7 @@ def get_workflow_debug_config(
     provider_name: Optional[str] = None,
     model_name: Optional[str] = None,
     external_source_provider: Optional[str] = None,
+    settings: Optional[ResolvedIntegrationSettings] = None,
 ) -> Dict[str, Any]:
     normalized = normalize_workflow_id(workflow_id)
     if normalized == WEB_RESEARCH_WORKFLOW_ID:
@@ -65,9 +67,10 @@ def get_workflow_debug_config(
             provider_name=provider_name,
             model_name=model_name,
             external_source_provider=external_source_provider,
+            settings=settings,
         ).get_debug_config()
     return {
-        **HardwarePipelineOrchestrator(provider_name=provider_name, model_name=model_name).get_debug_config(),
+        **HardwarePipelineOrchestrator(provider_name=provider_name, model_name=model_name, settings=settings).get_debug_config(),
         "workflow": DEFAULT_WORKFLOW_ID,
     }
 
@@ -81,6 +84,7 @@ def generate_project_with_workflow(
     provider_name: Optional[str] = None,
     model_name: Optional[str] = None,
     external_source_provider: Optional[str] = None,
+    settings: Optional[ResolvedIntegrationSettings] = None,
     generation_metadata: Optional[Dict[str, Any]] = None,
     persist_project: bool = True,
 ) -> HardwareIR:
@@ -91,6 +95,7 @@ def generate_project_with_workflow(
             provider_name=provider_name,
             model_name=model_name,
             external_source_provider=external_source_provider,
+            settings=settings,
             persist_project=persist_project,
         ).generate_project(
             prompt,
@@ -103,6 +108,7 @@ def generate_project_with_workflow(
             provider_name=provider_name,
             model_name=model_name,
             persist_project=persist_project,
+            settings=settings,
         ).generate_project(
             prompt,
             image_bytes=image_bytes,

--- a/forma_core/config/contract.py
+++ b/forma_core/config/contract.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Mapping, Optional
 
 from forma_core.agents.orchestrator import HardwarePipelineOrchestrator
 from forma_core.agents.workflows import list_workflows
@@ -79,7 +79,10 @@ def _llm_option(provider: str, model: str, selected: LLMRuntimeConfig) -> Dict[s
     }
 
 
-def _resolved_llm_options(runtime: LLMRuntimeConfig) -> list[Dict[str, Any]]:
+def _resolved_llm_options(
+    runtime: LLMRuntimeConfig,
+    settings: Optional[Mapping[str, str]] = None,
+) -> list[Dict[str, Any]]:
     configured = set(runtime.configured_providers or [])
     allowed = set(runtime.allowed_providers or configured)
     providers = _ordered_unique([runtime.provider, *sorted(configured)])
@@ -89,7 +92,7 @@ def _resolved_llm_options(runtime: LLMRuntimeConfig) -> list[Dict[str, Any]]:
         if provider == "simulation" or provider not in configured or provider not in allowed:
             continue
         try:
-            provider_runtime = resolve_llm_runtime_config(provider_name=provider)
+            provider_runtime = resolve_llm_runtime_config(provider_name=provider, settings=settings)
         except LLMProviderConfigError:
             continue
         models = _ordered_unique([
@@ -108,16 +111,17 @@ def resolve_runtime_contract(
     image_config: Optional[Dict[str, Any]] = None,
     workflows: Optional[list[Dict[str, Any]]] = None,
     signup_storage: Optional[str] = None,
+    settings: Optional[Mapping[str, str]] = None,
 ) -> Dict[str, Any]:
     """Resolve all client-facing generation decisions from the active environment."""
-    resolved_llm_config = llm_config or HardwarePipelineOrchestrator().get_debug_config()
-    runtime = resolve_llm_runtime_config()
-    llm_options = _resolved_llm_options(runtime)
+    resolved_llm_config = llm_config or HardwarePipelineOrchestrator(settings=settings).get_debug_config()
+    runtime = resolve_llm_runtime_config(settings=settings)
+    llm_options = _resolved_llm_options(runtime, settings=settings)
     selected_llm = next((option for option in llm_options if option["selected"]), None)
     if selected_llm is None and runtime.provider != "simulation":
         selected_llm = _llm_option(runtime.provider, runtime.model, runtime)
 
-    resolved_image = image_config or get_image_output_debug_config()
+    resolved_image = image_config or get_image_output_debug_config(settings=settings)
     image_capable = bool(resolved_image.get("request_capable"))
     resolved_workflows = workflows if workflows is not None else list_workflows()
     workflow_ids = {str(item.get("id")) for item in resolved_workflows if isinstance(item, dict)}

--- a/forma_core/config/environment.py
+++ b/forma_core/config/environment.py
@@ -2,8 +2,9 @@
 
 Application code imports :data:`config` instead of reading ``os.getenv``
 directly. The object intentionally remains live: user-scoped integration
-settings are applied to the process environment before a request is resolved,
-and tests commonly patch the environment within a context manager.
+settings are resolved into explicit request snapshots by the hosted API, while
+tests and local CLI flows may still patch the environment within a context
+manager.
 """
 
 from __future__ import annotations

--- a/forma_core/external_sources.py
+++ b/forma_core/external_sources.py
@@ -14,15 +14,15 @@ DEFAULT_EXTERNAL_SOURCE_PROVIDER = "firecrawl"
 SUPPORTED_EXTERNAL_SOURCE_PROVIDERS = {"auto", "none", "disabled", "off", "tavily", "firecrawl"}
 
 
-def _env_bool(name: str, default: bool = False) -> bool:
-    value = config.get(name)
+def _env_bool(name: str, default: bool = False, settings: Optional[Mapping[str, str]] = None) -> bool:
+    value = settings.get(name) if settings is not None else config.get(name)
     if value is None:
         return default
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _env_int(name: str, default: int, minimum: int, maximum: int) -> int:
-    raw = config.get(name)
+def _env_int(name: str, default: int, minimum: int, maximum: int, settings: Optional[Mapping[str, str]] = None) -> int:
+    raw = settings.get(name) if settings is not None else config.get(name)
     if raw is None:
         return default
     try:
@@ -31,8 +31,8 @@ def _env_int(name: str, default: int, minimum: int, maximum: int) -> int:
         return default
 
 
-def _env_float(name: str, default: float, minimum: float, maximum: float) -> float:
-    raw = config.get(name)
+def _env_float(name: str, default: float, minimum: float, maximum: float, settings: Optional[Mapping[str, str]] = None) -> float:
+    raw = settings.get(name) if settings is not None else config.get(name)
     if raw is None:
         return default
     try:
@@ -41,9 +41,9 @@ def _env_float(name: str, default: float, minimum: float, maximum: float) -> flo
         return default
 
 
-def _first_env(names: Iterable[str]) -> Optional[str]:
+def _first_env(names: Iterable[str], settings: Optional[Mapping[str, str]] = None) -> Optional[str]:
     for name in names:
-        value = config.get(name)
+        value = settings.get(name) if settings is not None else config.get(name)
         if value and value.strip():
             return value.strip()
     return None
@@ -178,14 +178,14 @@ class ExternalSourceProviderConfig:
     research_output_length: str = "standard"
 
     @classmethod
-    def from_env(cls, provider_override: Optional[str] = None) -> "ExternalSourceProviderConfig":
-        if _env_bool("EXTERNAL_SOURCE_DISABLED", False) or _env_bool("WEB_RESEARCH_DISABLED", False):
+    def from_env(cls, provider_override: Optional[str] = None, settings: Optional[Mapping[str, str]] = None) -> "ExternalSourceProviderConfig":
+        if _env_bool("EXTERNAL_SOURCE_DISABLED", False, settings) or _env_bool("WEB_RESEARCH_DISABLED", False, settings):
             return cls(provider="none", enabled=False, reason="EXTERNAL_SOURCE_DISABLED or WEB_RESEARCH_DISABLED is true.")
 
         requested = (
             provider_override
-            or config.get("EXTERNAL_SOURCE_PROVIDER")
-            or config.get("WEB_RESEARCH_PROVIDER")
+            or (settings.get("EXTERNAL_SOURCE_PROVIDER") if settings is not None else config.get("EXTERNAL_SOURCE_PROVIDER"))
+            or (settings.get("WEB_RESEARCH_PROVIDER") if settings is not None else config.get("WEB_RESEARCH_PROVIDER"))
             or DEFAULT_EXTERNAL_SOURCE_PROVIDER
         ).strip().lower().replace("_", "-")
         if requested not in SUPPORTED_EXTERNAL_SOURCE_PROVIDERS:
@@ -193,36 +193,39 @@ class ExternalSourceProviderConfig:
 
         search_limit = _env_int(
             "EXTERNAL_SOURCE_SEARCH_LIMIT",
-            _env_int("TAVILY_SEARCH_LIMIT", _env_int("FIRECRAWL_SEARCH_LIMIT", 3, 1, 8), 1, 20),
+            _env_int("TAVILY_SEARCH_LIMIT", _env_int("FIRECRAWL_SEARCH_LIMIT", 3, 1, 8, settings), 1, 20, settings),
             1,
             20,
+            settings,
         )
         timeout = _env_float(
             "EXTERNAL_SOURCE_TIMEOUT_SECONDS",
-            _env_float("TAVILY_TIMEOUT_SECONDS", _env_float("FIRECRAWL_MCP_TIMEOUT_SECONDS", 45.0, 5.0, 180.0), 5.0, 180.0),
+            _env_float("TAVILY_TIMEOUT_SECONDS", _env_float("FIRECRAWL_MCP_TIMEOUT_SECONDS", 45.0, 5.0, 180.0, settings), 5.0, 180.0, settings),
             5.0,
             180.0,
+            settings,
         )
-        search_depth = (config.get("TAVILY_SEARCH_DEPTH") or "basic").strip().lower() or "basic"
-        include_answer = _env_bool("TAVILY_INCLUDE_ANSWER", True)
-        include_raw_content = _env_bool("TAVILY_INCLUDE_RAW_CONTENT", False)
+        get_value = lambda name: settings.get(name) if settings is not None else config.get(name)
+        search_depth = (get_value("TAVILY_SEARCH_DEPTH") or "basic").strip().lower() or "basic"
+        include_answer = _env_bool("TAVILY_INCLUDE_ANSWER", True, settings)
+        include_raw_content = _env_bool("TAVILY_INCLUDE_RAW_CONTENT", False, settings)
         tavily_kwargs = {
             "search_limit": search_limit,
             "timeout_seconds": timeout,
             "search_depth": search_depth,
             "include_answer": include_answer,
             "include_raw_content": include_raw_content,
-            "crawl_max_depth": _env_int("TAVILY_CRAWL_MAX_DEPTH", 1, 1, 5),
-            "crawl_limit": _env_int("TAVILY_CRAWL_LIMIT", 20, 1, 50),
-            "crawl_extract_depth": (config.get("TAVILY_CRAWL_EXTRACT_DEPTH") or "basic").strip().lower() or "basic",
-            "research_model": (config.get("TAVILY_RESEARCH_MODEL") or "auto").strip().lower() or "auto",
-            "research_output_length": (config.get("TAVILY_RESEARCH_OUTPUT_LENGTH") or "standard").strip().lower() or "standard",
+            "crawl_max_depth": _env_int("TAVILY_CRAWL_MAX_DEPTH", 1, 1, 5, settings),
+            "crawl_limit": _env_int("TAVILY_CRAWL_LIMIT", 20, 1, 50, settings),
+            "crawl_extract_depth": (get_value("TAVILY_CRAWL_EXTRACT_DEPTH") or "basic").strip().lower() or "basic",
+            "research_model": (get_value("TAVILY_RESEARCH_MODEL") or "auto").strip().lower() or "auto",
+            "research_output_length": (get_value("TAVILY_RESEARCH_OUTPUT_LENGTH") or "standard").strip().lower() or "standard",
         }
 
         if requested in {"none", "disabled", "off"}:
             return cls(provider="none", enabled=False, reason="External source research is disabled.")
         if requested == "tavily":
-            has_key = bool(_first_env(["TAVILY_API_KEY"]))
+            has_key = bool(_first_env(["TAVILY_API_KEY"], settings))
             return cls(
                 provider="tavily",
                 enabled=has_key,
@@ -230,7 +233,7 @@ class ExternalSourceProviderConfig:
                 **tavily_kwargs,
             )
 
-        firecrawl_config = FirecrawlMCPResearchClient().config
+        firecrawl_config = FirecrawlMCPResearchClient(settings=settings).config
         if requested in {"auto", "firecrawl"} and (requested == "firecrawl" or firecrawl_config.enabled):
             return cls(
                 provider="firecrawl",
@@ -239,7 +242,7 @@ class ExternalSourceProviderConfig:
                 search_limit=firecrawl_config.search_limit or search_limit,
                 timeout_seconds=firecrawl_config.timeout_seconds or timeout,
             )
-        if requested == "auto" and _first_env(["TAVILY_API_KEY"]):
+        if requested == "auto" and _first_env(["TAVILY_API_KEY"], settings):
             return cls(provider="tavily", enabled=True, **tavily_kwargs)
 
         if requested == "firecrawl":
@@ -305,9 +308,9 @@ class NoExternalSourceProvider(ExternalSourceProvider):
 
 
 class FirecrawlExternalSourceProvider(ExternalSourceProvider):
-    def __init__(self, config: Optional[ExternalSourceProviderConfig] = None) -> None:
+    def __init__(self, config: Optional[ExternalSourceProviderConfig] = None, settings: Optional[Mapping[str, str]] = None) -> None:
         super().__init__(config)
-        self.client = FirecrawlMCPResearchClient()
+        self.client = FirecrawlMCPResearchClient(settings=settings)
 
     def research(self, queries: Iterable[str]) -> ExternalSourceLibrary:
         result = self.client.research(queries)
@@ -363,11 +366,15 @@ def _tavily_source_record(value: Mapping[str, Any], *, source_type: str = "web")
 
 
 class TavilyExternalSourceProvider(ExternalSourceProvider):
+    def __init__(self, config: Optional[ExternalSourceProviderConfig] = None, settings: Optional[Mapping[str, str]] = None) -> None:
+        super().__init__(config)
+        self.settings = settings
+
     def research(self, queries: Iterable[str]) -> ExternalSourceLibrary:
         if not self.config.enabled:
             return ExternalSourceLibrary(provider="tavily", configured=False, error=self.config.reason)
 
-        api_key = _first_env(["TAVILY_API_KEY"])
+        api_key = _first_env(["TAVILY_API_KEY"], self.settings)
         if not api_key:
             return ExternalSourceLibrary(provider="tavily", configured=False, error="Set TAVILY_API_KEY to enable Tavily research.")
 
@@ -465,14 +472,15 @@ def build_external_source_provider(
     config: Optional[ExternalSourceProviderConfig] = None,
     *,
     provider: Optional[str] = None,
+    settings: Optional[Mapping[str, str]] = None,
 ) -> ExternalSourceProvider:
-    resolved = config or ExternalSourceProviderConfig.from_env(provider_override=provider)
+    resolved = config or ExternalSourceProviderConfig.from_env(provider_override=provider, settings=settings)
     if not resolved.enabled:
         return NoExternalSourceProvider(resolved)
     if resolved.provider == "tavily":
-        return TavilyExternalSourceProvider(resolved)
+        return TavilyExternalSourceProvider(resolved, settings=settings)
     if resolved.provider == "firecrawl":
-        return FirecrawlExternalSourceProvider(resolved)
+        return FirecrawlExternalSourceProvider(resolved, settings=settings)
     return NoExternalSourceProvider(resolved)
 
 

--- a/forma_core/image_providers.py
+++ b/forma_core/image_providers.py
@@ -11,7 +11,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from dotenv import load_dotenv
 
@@ -32,6 +32,8 @@ from forma_core.agents.prompt_compaction import (
 load_dotenv()
 
 logger = logging.getLogger(__name__)
+
+Settings = Mapping[str, str]
 
 DEFAULT_OPENAI_IMAGE_MODEL = "gpt-image-2"
 DEFAULT_VERTEX_IMAGE_MODEL = "gemini-3.1-flash-image"
@@ -77,38 +79,38 @@ class GeneratedImage:
     model_license: Optional[str] = None
 
 
-def _env(name: str, default: Optional[str] = None) -> Optional[str]:
-    value = config.get(name)
+def _env(name: str, default: Optional[str] = None, settings: Optional[Settings] = None) -> Optional[str]:
+    value = settings.get(name) if settings is not None else config.get(name)
     if value is None:
         return default
     stripped = value.strip()
     return stripped if stripped else default
 
 
-def _first_env(names: List[str], default: Optional[str] = None) -> Optional[str]:
+def _first_env(names: List[str], default: Optional[str] = None, settings: Optional[Settings] = None) -> Optional[str]:
     for name in names:
-        value = _env(name)
+        value = _env(name, settings=settings)
         if value is not None:
             return value
     return default
 
 
-def _env_bool(name: str, default: bool = False) -> bool:
-    value = config.get(name)
+def _env_bool(name: str, default: bool = False, settings: Optional[Settings] = None) -> bool:
+    value = settings.get(name) if settings is not None else config.get(name)
     if value is None:
         return default
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _first_env_bool(names: List[str], default: bool = False) -> bool:
+def _first_env_bool(names: List[str], default: bool = False, settings: Optional[Settings] = None) -> bool:
     for name in names:
-        if config.get(name) is not None:
-            return _env_bool(name, default)
+        if (settings is not None and name in settings) or (settings is None and config.get(name) is not None):
+            return _env_bool(name, default, settings=settings)
     return default
 
 
-def _first_env_float(names: List[str], default: float) -> float:
-    raw_value = _first_env(names)
+def _first_env_float(names: List[str], default: float, settings: Optional[Settings] = None) -> float:
+    raw_value = _first_env(names, settings=settings)
     if raw_value is None:
         return default
     try:
@@ -118,8 +120,8 @@ def _first_env_float(names: List[str], default: float) -> float:
         return default
 
 
-def _first_env_int(names: List[str], default: int) -> int:
-    raw_value = _first_env(names)
+def _first_env_int(names: List[str], default: int, settings: Optional[Settings] = None) -> int:
+    raw_value = _first_env(names, settings=settings)
     if raw_value is None:
         return default
     try:
@@ -129,10 +131,11 @@ def _first_env_int(names: List[str], default: int) -> int:
         return default
 
 
-def _first_env_optional_int(names: List[str]) -> Optional[int]:
-    raw_value = _first_env(names)
+def _first_env_optional_int(names: List[str], settings: Optional[Settings] = None) -> Optional[int]:
+    raw_value = _first_env(names, settings=settings)
     if raw_value is None:
         return None
+
     try:
         return int(raw_value)
     except ValueError:
@@ -140,6 +143,15 @@ def _first_env_optional_int(names: List[str]) -> Optional[int]:
         return None
 
 
+def _scoped_image_env_helpers(settings: Optional[Settings]):
+    return (
+        lambda name, default=None: _env(name, default, settings),
+        lambda names, default=None: _first_env(names, default, settings),
+        lambda names, default=False: _first_env_bool(names, default, settings),
+        lambda names, default=0.0: _first_env_float(names, default, settings),
+        lambda names, default=0: _first_env_int(names, default, settings),
+        lambda names: _first_env_optional_int(names, settings),
+    )
 def _truncate(value: Any, limit: int) -> str:
     text = str(value or "").strip()
     if len(text) <= limit:
@@ -232,7 +244,8 @@ class NoImageProvider(ImageProvider):
 
 
 class OpenAIImageProvider(ImageProvider):
-    def __init__(self, provider_name: str = "openai", enabled: bool = True, force_enabled: bool = False) -> None:
+    def __init__(self, provider_name: str = "openai", enabled: bool = True, force_enabled: bool = False, settings: Optional[Settings] = None) -> None:
+        _env, _first_env, _first_env_bool, _first_env_float, _first_env_int, _first_env_optional_int = _scoped_image_env_helpers(settings)
         normalized_provider = provider_name.strip().lower().replace("_", "-")
         self.provider_name = "openai-compatible" if normalized_provider != "openai" else "openai"
         self.enabled = enabled or force_enabled
@@ -565,7 +578,8 @@ class OpenAIImageProvider(ImageProvider):
 class VertexAIImageProvider(OpenAIImageProvider):
     """Nano Banana image generation on Vertex AI using Application Default Credentials."""
 
-    def __init__(self, enabled: bool = True, force_enabled: bool = False) -> None:
+    def __init__(self, enabled: bool = True, force_enabled: bool = False, settings: Optional[Settings] = None) -> None:
+        _env, _first_env, _first_env_bool, _first_env_float, _first_env_int, _first_env_optional_int = _scoped_image_env_helpers(settings)
         ImageProvider.__init__(self)
         self.provider_name = "vertex"
         self.enabled = enabled or force_enabled
@@ -749,7 +763,8 @@ class VertexAIImageProvider(OpenAIImageProvider):
 
 
 class GMIImageProvider(OpenAIImageProvider):
-    def __init__(self, enabled: bool = True, force_enabled: bool = False) -> None:
+    def __init__(self, enabled: bool = True, force_enabled: bool = False, settings: Optional[Settings] = None) -> None:
+        _env, _first_env, _first_env_bool, _first_env_float, _first_env_int, _first_env_optional_int = _scoped_image_env_helpers(settings)
         ImageProvider.__init__(self)
         self.provider_name = "gmi"
         self.enabled = enabled or force_enabled
@@ -1009,7 +1024,8 @@ class GMIImageProvider(OpenAIImageProvider):
 
 
 class TogetherImageProvider(OpenAIImageProvider):
-    def __init__(self, enabled: bool = True, force_enabled: bool = False) -> None:
+    def __init__(self, enabled: bool = True, force_enabled: bool = False, settings: Optional[Settings] = None) -> None:
+        _env, _first_env, _first_env_bool, _first_env_float, _first_env_int, _first_env_optional_int = _scoped_image_env_helpers(settings)
         ImageProvider.__init__(self)
         self.provider_name = "together"
         self.enabled = enabled or force_enabled
@@ -1146,7 +1162,8 @@ class TogetherImageProvider(OpenAIImageProvider):
 class HuggingFaceImageProvider(ImageProvider):
     provider_name = "huggingface"
 
-    def __init__(self, enabled: bool = True, force_enabled: bool = False) -> None:
+    def __init__(self, enabled: bool = True, force_enabled: bool = False, settings: Optional[Settings] = None) -> None:
+        _env, _first_env, _first_env_bool, _first_env_float, _first_env_int, _first_env_optional_int = _scoped_image_env_helpers(settings)
         self.enabled = enabled or force_enabled
         self.api_key = _first_env(["HUGGINGFACE_IMAGE_API_KEY", "HF_IMAGE_TOKEN", "HF_TOKEN", "HUGGINGFACE_API_KEY", "HUGGINGFACE_HUB_TOKEN", "HF_API_TOKEN"])
         self.model_name = _first_env(["HUGGINGFACE_IMAGE_MODEL", "HF_IMAGE_MODEL", "IMAGE_MODEL"], "black-forest-labs/FLUX.1-schnell") or "black-forest-labs/FLUX.1-schnell"
@@ -2951,7 +2968,8 @@ def build_project_layout_diagram_image(
     )
 
 
-def build_image_provider(force_enabled: bool = False) -> ImageProvider:
+def build_image_provider(force_enabled: bool = False, settings: Optional[Settings] = None) -> ImageProvider:
+    _env, _first_env, _first_env_bool, _first_env_float, _first_env_int, _first_env_optional_int = _scoped_image_env_helpers(settings)
     provider_name = (_env("IMAGE_PROVIDER") or "").strip().lower().replace("_", "-")
     enabled_default = bool(provider_name and provider_name not in {"none", "disabled", "off", "false", "simulation", "mock"})
     enabled = _first_env_bool(["IMAGE_OUTPUT_ENABLED", "OPENAI_IMAGE_OUTPUT_ENABLED"], default=enabled_default)
@@ -2978,15 +2996,15 @@ def build_image_provider(force_enabled: bool = False) -> ImageProvider:
     if provider_name in {"none", "disabled", "off", "false", "simulation", "mock"}:
         return NoImageProvider()
     if provider_name in {"openai", "openai-compatible", "compatible"}:
-        return OpenAIImageProvider(provider_name=provider_name, enabled=enabled, force_enabled=force_enabled)
+        return OpenAIImageProvider(provider_name=provider_name, enabled=enabled, force_enabled=force_enabled, settings=settings)
     if provider_name in {"gmi", "gmi-cloud", "gmicloud", "gemicloud"}:
-        return GMIImageProvider(enabled=enabled, force_enabled=force_enabled)
+        return GMIImageProvider(enabled=enabled, force_enabled=force_enabled, settings=settings)
     if provider_name in {"together", "together-ai", "togetherai"}:
-        return TogetherImageProvider(enabled=enabled, force_enabled=force_enabled)
+        return TogetherImageProvider(enabled=enabled, force_enabled=force_enabled, settings=settings)
     if provider_name in {"vertex", "vertex-ai", "google-vertex", "google-vertex-ai", "nano-banana"}:
-        return VertexAIImageProvider(enabled=enabled, force_enabled=force_enabled)
+        return VertexAIImageProvider(enabled=enabled, force_enabled=force_enabled, settings=settings)
     if provider_name in {"huggingface", "hugging-face", "hf"}:
-        return HuggingFaceImageProvider(enabled=enabled, force_enabled=force_enabled)
+        return HuggingFaceImageProvider(enabled=enabled, force_enabled=force_enabled, settings=settings)
 
     logger.warning("Unsupported IMAGE_PROVIDER %r; image output is disabled.", provider_name)
     return NoImageProvider(
@@ -2995,9 +3013,9 @@ def build_image_provider(force_enabled: bool = False) -> ImageProvider:
     )
 
 
-def get_image_output_debug_config() -> Dict[str, Any]:
-    default_config = build_image_provider().get_debug_config()
-    request_config = build_image_provider(force_enabled=True).get_debug_config()
+def get_image_output_debug_config(settings: Optional[Settings] = None) -> Dict[str, Any]:
+    default_config = build_image_provider(settings=settings).get_debug_config()
+    request_config = build_image_provider(force_enabled=True, settings=settings).get_debug_config()
     return {
         **default_config,
         "default_enabled": default_config.get("enabled", False),

--- a/forma_core/llm_providers.py
+++ b/forma_core/llm_providers.py
@@ -9,11 +9,13 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 from dotenv import load_dotenv
 
 from forma_core.runtime import forma_dev_mode_enabled, deployment_mode_enabled
+
+Settings = Mapping[str, str]
 
 load_dotenv()
 
@@ -279,43 +281,43 @@ class LLMRuntimeConfig:
         }
 
 
-def _env(name: str, default: Optional[str] = None) -> Optional[str]:
-    value = config.get(name)
+def _env(name: str, default: Optional[str] = None, settings: Optional[Settings] = None) -> Optional[str]:
+    value = settings.get(name) if settings is not None else config.get(name)
     if value is None:
         return default
     stripped = value.strip()
     return stripped if stripped else default
 
 
-def _first_env(names: List[str], default: Optional[str] = None) -> Optional[str]:
+def _first_env(names: List[str], default: Optional[str] = None, settings: Optional[Settings] = None) -> Optional[str]:
     for name in names:
-        value = _env(name)
+        value = _env(name, settings=settings)
         if value is not None:
             return value
     return default
 
 
-def _cloudflare_base_url_from_env() -> Optional[str]:
-    configured = _first_env(["CLOUDFLARE_BASE_URL"])
+def _cloudflare_base_url_from_env(settings: Optional[Settings] = None) -> Optional[str]:
+    configured = _first_env(["CLOUDFLARE_BASE_URL"], settings=settings)
     if configured:
         return configured.rstrip("/")
-    account_id = _first_env(["CLOUDFLARE_ACCOUNT_ID"])
+    account_id = _first_env(["CLOUDFLARE_ACCOUNT_ID"], settings=settings)
     if not account_id:
         return None
     encoded_account_id = urllib.parse.quote(account_id, safe="")
     return f"https://api.cloudflare.com/client/v4/accounts/{encoded_account_id}/ai/v1"
 
 
-def _parse_csv_env(names: List[str]) -> Optional[List[str]]:
-    raw_value = _first_env(names)
+def _parse_csv_env(names: List[str], settings: Optional[Settings] = None) -> Optional[List[str]]:
+    raw_value = _first_env(names, settings=settings)
     if raw_value is None:
         return None
     values = [item.strip() for item in raw_value.split(",") if item.strip()]
     return values
 
 
-def _parse_json_mapping_env(names: List[str]) -> Dict[str, Any]:
-    raw_value = _first_env(names)
+def _parse_json_mapping_env(names: List[str], settings: Optional[Settings] = None) -> Dict[str, Any]:
+    raw_value = _first_env(names, settings=settings)
     if raw_value is None:
         return {}
     try:
@@ -350,29 +352,29 @@ def _runpod_base_url_env_names(*, include_generic: bool) -> List[str]:
     return names
 
 
-def _runpod_serverless_endpoint_url_from_env(*, include_generic: bool = True) -> Optional[str]:
-    endpoint_url = _first_env(["RUNPOD_ENDPOINT_URL"])
+def _runpod_serverless_endpoint_url_from_env(*, include_generic: bool = True, settings: Optional[Settings] = None) -> Optional[str]:
+    endpoint_url = _first_env(["RUNPOD_ENDPOINT_URL"], settings=settings)
     if endpoint_url:
         return endpoint_url
 
     for name in _runpod_base_url_env_names(include_generic=include_generic):
-        value = _env(name)
+        value = _env(name, settings=settings)
         if _is_runpod_serverless_endpoint_url(value):
             return value
     return None
 
 
-def _runpod_openai_base_url_from_env(*, include_generic: bool = True) -> Optional[str]:
+def _runpod_openai_base_url_from_env(*, include_generic: bool = True, settings: Optional[Settings] = None) -> Optional[str]:
     for name in _runpod_base_url_env_names(include_generic=include_generic):
-        value = _env(name)
+        value = _env(name, settings=settings)
         if value and not _is_runpod_serverless_endpoint_url(value):
             return value
     return None
 
 
-def _runpod_serverless_url_env_name(*, include_generic: bool = True) -> Optional[str]:
+def _runpod_serverless_url_env_name(*, include_generic: bool = True, settings: Optional[Settings] = None) -> Optional[str]:
     for name in _runpod_base_url_env_names(include_generic=include_generic):
-        if _is_runpod_serverless_endpoint_url(_env(name)):
+        if _is_runpod_serverless_endpoint_url(_env(name, settings=settings)):
             return name
     return None
 
@@ -395,22 +397,22 @@ def normalize_llm_provider_name(value: Optional[str]) -> Optional[str]:
     return PROVIDER_ALIASES.get(normalized, normalized)
 
 
-def _env_bool(name: str, default: bool = False) -> bool:
-    value = config.get(name)
+def _env_bool(name: str, default: bool = False, settings: Optional[Settings] = None) -> bool:
+    value = settings.get(name) if settings is not None else config.get(name)
     if value is None:
         return default
     return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _first_env_bool(names: List[str], default: bool = False) -> bool:
+def _first_env_bool(names: List[str], default: bool = False, settings: Optional[Settings] = None) -> bool:
     for name in names:
-        if config.get(name) is not None:
-            return _env_bool(name, default)
+        if (settings is not None and name in settings) or (settings is None and config.get(name) is not None):
+            return _env_bool(name, default, settings=settings)
     return default
 
 
-def _first_env_float(names: List[str], default: float) -> float:
-    raw_value = _first_env(names)
+def _first_env_float(names: List[str], default: float, settings: Optional[Settings] = None) -> float:
+    raw_value = _first_env(names, settings=settings)
     if raw_value is None:
         return default
     try:
@@ -420,8 +422,8 @@ def _first_env_float(names: List[str], default: float) -> float:
         return default
 
 
-def _first_env_optional_float(names: List[str], default: Optional[float] = None) -> Optional[float]:
-    raw_value = _first_env(names)
+def _first_env_optional_float(names: List[str], default: Optional[float] = None, settings: Optional[Settings] = None) -> Optional[float]:
+    raw_value = _first_env(names, settings=settings)
     if raw_value is None:
         return default
 
@@ -439,8 +441,9 @@ def _first_env_optional_string(
     names: List[str],
     default: Optional[str] = None,
     omit_values: Optional[List[str]] = None,
+    settings: Optional[Settings] = None,
 ) -> Optional[str]:
-    raw_value = _first_env(names)
+    raw_value = _first_env(names, settings=settings)
     if raw_value is None:
         return default
 
@@ -450,10 +453,11 @@ def _first_env_optional_string(
     return value
 
 
-def _first_env_int(names: List[str]) -> Optional[int]:
-    raw_value = _first_env(names)
+def _first_env_int(names: List[str], settings: Optional[Settings] = None) -> Optional[int]:
+    raw_value = _first_env(names, settings=settings)
     if raw_value is None:
         return None
+
     try:
         return int(raw_value)
     except ValueError:
@@ -461,107 +465,131 @@ def _first_env_int(names: List[str]) -> Optional[int]:
         return None
 
 
-def _default_provider_name() -> str:
-    provider_name = normalize_llm_provider_name(_env("LLM_PROVIDER"))
+def _scoped_env_helpers(settings: Optional[Settings]):
+    """Bind all constructor reads to one explicit settings snapshot."""
+    return (
+        lambda name, default=None: _env(name, default, settings),
+        lambda names, default=None: _first_env(names, default, settings),
+        lambda names, default=False: _first_env_bool(names, default, settings),
+        lambda names, default=0.0: _first_env_float(names, default, settings),
+        lambda names, default=None: _first_env_optional_float(names, default, settings),
+        lambda names: _first_env_int(names, settings),
+        lambda names, default=None, omit_values=None: _first_env_optional_string(names, default, omit_values, settings),
+        lambda include_generic=True: _runpod_openai_base_url_from_env(include_generic=include_generic, settings=settings),
+        lambda include_generic=True: _runpod_serverless_endpoint_url_from_env(include_generic=include_generic, settings=settings),
+        lambda include_generic=True: _runpod_serverless_url_env_name(include_generic=include_generic, settings=settings),
+        lambda: _model_endpoint_map(settings),
+        lambda: _cloudflare_base_url_from_env(settings),
+    )
+def _default_provider_name(settings: Optional[Settings] = None) -> str:
+    provider_name = normalize_llm_provider_name(_env("LLM_PROVIDER", settings=settings))
     if provider_name:
         return provider_name
-    runpod_api_key = _first_env(["RUNPOD_API_KEY"])
-    runpod_openai_base_url = _runpod_openai_base_url_from_env(include_generic=False)
-    runpod_serverless_endpoint = _first_env(["RUNPOD_ENDPOINT_ID"]) or _runpod_serverless_endpoint_url_from_env(include_generic=False)
+    runpod_api_key = _first_env(["RUNPOD_API_KEY"], settings=settings)
+    runpod_openai_base_url = _runpod_openai_base_url_from_env(include_generic=False, settings=settings)
+    runpod_serverless_endpoint = _first_env(["RUNPOD_ENDPOINT_ID"], settings=settings) or _runpod_serverless_endpoint_url_from_env(include_generic=False, settings=settings)
     if runpod_api_key and runpod_serverless_endpoint and not runpod_openai_base_url:
         return "runpod-serverless"
     if runpod_api_key and runpod_openai_base_url:
         return "runpod"
     if runpod_api_key and runpod_serverless_endpoint:
         return "runpod-serverless"
-    if _first_env(["VERTEX_AI_PROJECT", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID", "GCLOUD_PROJECT"]):
+    if _first_env(["VERTEX_AI_PROJECT", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID", "GCLOUD_PROJECT"], settings=settings):
         return "vertex"
-    if _first_env(["GEMINI_API_KEY", "GOOGLE_API_KEY"]):
+    if _first_env(["GEMINI_API_KEY", "GOOGLE_API_KEY"], settings=settings):
         return "gemini"
-    if _first_env(["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"]):
+    if _first_env(["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"], settings=settings):
         return "anthropic"
-    if _first_env(["LLM_BASE_URL", "OPENAI_BASE_URL"]):
+    if _first_env(["LLM_BASE_URL", "OPENAI_BASE_URL"], settings=settings):
         return "openai-compatible"
-    if _first_env(["OPENAI_API_KEY", "LLM_API_KEY"]):
+    if _first_env(["OPENAI_API_KEY", "LLM_API_KEY"], settings=settings):
         return "openai"
-    if _first_env(["BASETEN_API_KEY"]) and _first_env(["BASETEN_BASE_URL"], DEFAULT_BASETEN_BASE_URL):
+    if _first_env(["BASETEN_API_KEY"], settings=settings) and _first_env(["BASETEN_BASE_URL"], DEFAULT_BASETEN_BASE_URL, settings=settings):
         return "baseten"
-    if _first_env(["GMI_API_KEY", "GMI_CLOUD_API_KEY", "GMICLOUD_API_KEY"]) and _first_env(
+    if _first_env(["GMI_API_KEY", "GMI_CLOUD_API_KEY", "GMICLOUD_API_KEY"], settings=settings) and _first_env(
         ["GMI_BASE_URL", "GMI_CLOUD_BASE_URL", "GMICLOUD_BASE_URL"],
         DEFAULT_GMI_BASE_URL,
+        settings=settings,
     ):
         return "gmi"
-    if _first_env(["HUGGINGFACE_API_KEY", "HUGGINGFACE_HUB_TOKEN", "HF_TOKEN", "HF_API_TOKEN"]) and _first_env(
+    if _first_env(["HUGGINGFACE_API_KEY", "HUGGINGFACE_HUB_TOKEN", "HF_TOKEN", "HF_API_TOKEN"], settings=settings) and _first_env(
         ["HUGGINGFACE_BASE_URL", "HF_BASE_URL"],
         DEFAULT_HUGGINGFACE_BASE_URL,
+        settings=settings,
     ):
         return "huggingface"
-    if _first_env(["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_AI_API_KEY", "CLOUDFLARE_API_KEY"]) and _cloudflare_base_url_from_env():
+    if _first_env(["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_AI_API_KEY", "CLOUDFLARE_API_KEY"], settings=settings) and _cloudflare_base_url_from_env(settings):
         return "cloudflare"
-    if _first_env(["NVIDIA_API_KEY", "NVIDIA_NIM_API_KEY", "NIM_API_KEY"]) and _first_env(
+    if _first_env(["NVIDIA_API_KEY", "NVIDIA_NIM_API_KEY", "NIM_API_KEY"], settings=settings) and _first_env(
         ["NVIDIA_BASE_URL", "NVIDIA_NIM_BASE_URL", "NIM_BASE_URL"],
         DEFAULT_NVIDIA_BASE_URL,
+        settings=settings,
     ):
         return "nvidia"
-    if _first_env(["XAI_API_KEY", "GROK_API_KEY"]) and _first_env(
+    if _first_env(["XAI_API_KEY", "GROK_API_KEY"], settings=settings) and _first_env(
         ["XAI_BASE_URL", "GROK_BASE_URL"],
         DEFAULT_XAI_BASE_URL,
+        settings=settings,
     ):
         return "xai"
-    if _first_env(["TOGETHER_MODEL", "TOGETHER_LLM_BASE_URL"]) and _first_env(["TOGETHER_API_KEY", "TOGETHER_IMAGE_API_KEY"]):
+    if _first_env(["TOGETHER_MODEL", "TOGETHER_LLM_BASE_URL"], settings=settings) and _first_env(["TOGETHER_API_KEY", "TOGETHER_IMAGE_API_KEY"], settings=settings):
         return "together"
     return "simulation"
 
 
-def _configured_provider_names(default_provider: str) -> List[str]:
+def _configured_provider_names(default_provider: str, settings: Optional[Settings] = None) -> List[str]:
     providers = {default_provider, "simulation"}
-    if _first_env(["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"]):
+    if _first_env(["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"], settings=settings):
         providers.add("anthropic")
-    if _first_env(["BASETEN_API_KEY"]) and _first_env(["BASETEN_BASE_URL", "LLM_BASE_URL"], DEFAULT_BASETEN_BASE_URL):
+    if _first_env(["BASETEN_API_KEY"], settings=settings) and _first_env(["BASETEN_BASE_URL", "LLM_BASE_URL"], DEFAULT_BASETEN_BASE_URL, settings=settings):
         providers.add("baseten")
-    if _first_env(["GMI_API_KEY", "GMI_CLOUD_API_KEY", "GMICLOUD_API_KEY"]) and _first_env(
+    if _first_env(["GMI_API_KEY", "GMI_CLOUD_API_KEY", "GMICLOUD_API_KEY"], settings=settings) and _first_env(
         ["GMI_BASE_URL", "GMI_CLOUD_BASE_URL", "GMICLOUD_BASE_URL"],
         DEFAULT_GMI_BASE_URL,
+        settings=settings,
     ):
         providers.add("gmi")
-    if _first_env(["HUGGINGFACE_API_KEY", "HUGGINGFACE_HUB_TOKEN", "HF_TOKEN", "HF_API_TOKEN"]) and _first_env(
+    if _first_env(["HUGGINGFACE_API_KEY", "HUGGINGFACE_HUB_TOKEN", "HF_TOKEN", "HF_API_TOKEN"], settings=settings) and _first_env(
         ["HUGGINGFACE_BASE_URL", "HF_BASE_URL"],
         DEFAULT_HUGGINGFACE_BASE_URL,
+        settings=settings,
     ):
         providers.add("huggingface")
-    if _first_env(["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_AI_API_KEY", "CLOUDFLARE_API_KEY"]) and _cloudflare_base_url_from_env():
+    if _first_env(["CLOUDFLARE_API_TOKEN", "CLOUDFLARE_AI_API_KEY", "CLOUDFLARE_API_KEY"], settings=settings) and _cloudflare_base_url_from_env(settings):
         providers.add("cloudflare")
-    if _first_env(["NVIDIA_API_KEY", "NVIDIA_NIM_API_KEY", "NIM_API_KEY"]) and _first_env(
+    if _first_env(["NVIDIA_API_KEY", "NVIDIA_NIM_API_KEY", "NIM_API_KEY"], settings=settings) and _first_env(
         ["NVIDIA_BASE_URL", "NVIDIA_NIM_BASE_URL", "NIM_BASE_URL", "LLM_BASE_URL"],
         DEFAULT_NVIDIA_BASE_URL,
+        settings=settings,
     ):
         providers.add("nvidia")
-    if _first_env(["XAI_API_KEY", "GROK_API_KEY"]) and _first_env(
+    if _first_env(["XAI_API_KEY", "GROK_API_KEY"], settings=settings) and _first_env(
         ["XAI_BASE_URL", "GROK_BASE_URL", "LLM_BASE_URL"],
         DEFAULT_XAI_BASE_URL,
+        settings=settings,
     ):
         providers.add("xai")
-    if _first_env(["TOGETHER_API_KEY", "TOGETHER_IMAGE_API_KEY"]) and _first_env(["TOGETHER_MODEL", "TOGETHER_LLM_BASE_URL"]):
+    if _first_env(["TOGETHER_API_KEY", "TOGETHER_IMAGE_API_KEY"], settings=settings) and _first_env(["TOGETHER_MODEL", "TOGETHER_LLM_BASE_URL"], settings=settings):
         providers.add("together")
-    if _first_env(["RUNPOD_API_KEY"]) and _runpod_openai_base_url_from_env():
+    if _first_env(["RUNPOD_API_KEY"], settings=settings) and _runpod_openai_base_url_from_env(settings=settings):
         providers.add("runpod")
-    if _first_env(["RUNPOD_API_KEY"]) and (_first_env(["RUNPOD_ENDPOINT_ID"]) or _runpod_serverless_endpoint_url_from_env()):
+    if _first_env(["RUNPOD_API_KEY"], settings=settings) and (_first_env(["RUNPOD_ENDPOINT_ID"], settings=settings) or _runpod_serverless_endpoint_url_from_env(settings=settings)):
         providers.add("runpod-serverless")
-    if _first_env(["GEMINI_API_KEY", "GOOGLE_API_KEY"]):
+    if _first_env(["GEMINI_API_KEY", "GOOGLE_API_KEY"], settings=settings):
         providers.add("gemini")
-    if _first_env(["VERTEX_AI_PROJECT", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID", "GCLOUD_PROJECT"]):
+    if _first_env(["VERTEX_AI_PROJECT", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID", "GCLOUD_PROJECT"], settings=settings):
         providers.add("vertex")
-    if _first_env(["OPENAI_API_KEY", "LLM_API_KEY"]):
+    if _first_env(["OPENAI_API_KEY", "LLM_API_KEY"], settings=settings):
         providers.add("openai")
-    if _first_env(["LLM_BASE_URL", "OPENAI_BASE_URL"]):
+    if _first_env(["LLM_BASE_URL", "OPENAI_BASE_URL"], settings=settings):
         providers.add("openai-compatible")
     return sorted(provider for provider in providers if provider in SUPPORTED_LLM_PROVIDERS)
 
 
-def _allowed_provider_names(default_provider: str) -> Optional[List[str]]:
-    configured = _parse_csv_env(["LLM_ALLOWED_PROVIDERS", "ALLOWED_LLM_PROVIDERS"])
+def _allowed_provider_names(default_provider: str, settings: Optional[Settings] = None) -> Optional[List[str]]:
+    configured = _parse_csv_env(["LLM_ALLOWED_PROVIDERS", "ALLOWED_LLM_PROVIDERS"], settings=settings)
     if configured is None:
-        return _configured_provider_names(default_provider)
+        return _configured_provider_names(default_provider, settings)
     allowed: List[str] = []
     for provider in configured:
         normalized = normalize_llm_provider_name(provider)
@@ -570,83 +598,84 @@ def _allowed_provider_names(default_provider: str) -> Optional[List[str]]:
     return sorted(set(allowed))
 
 
-def _default_model_for_provider(provider_name: str, *, include_runtime_override: bool = True) -> str:
+def _default_model_for_provider(provider_name: str, *, include_runtime_override: bool = True, settings: Optional[Settings] = None) -> str:
     runtime_model = ["LLM_MODEL"] if include_runtime_override else []
     if provider_name == "anthropic":
-        return _first_env(["ANTHROPIC_MODEL", "CLAUDE_MODEL", *runtime_model], DEFAULT_ANTHROPIC_MODEL) or DEFAULT_ANTHROPIC_MODEL
+        return _first_env(["ANTHROPIC_MODEL", "CLAUDE_MODEL", *runtime_model], DEFAULT_ANTHROPIC_MODEL, settings=settings) or DEFAULT_ANTHROPIC_MODEL
     if provider_name == "baseten":
-        return _first_env(["BASETEN_MODEL", *runtime_model], DEFAULT_BASETEN_MODEL) or DEFAULT_BASETEN_MODEL
+        return _first_env(["BASETEN_MODEL", *runtime_model], DEFAULT_BASETEN_MODEL, settings=settings) or DEFAULT_BASETEN_MODEL
     if provider_name == "gemini":
-        return _first_env([*runtime_model, "GEMINI_MODEL"], DEFAULT_GEMINI_MODEL) or DEFAULT_GEMINI_MODEL
+        return _first_env([*runtime_model, "GEMINI_MODEL"], DEFAULT_GEMINI_MODEL, settings=settings) or DEFAULT_GEMINI_MODEL
     if provider_name == "vertex":
-        return _first_env([*runtime_model, "VERTEX_AI_MODEL", "VERTEX_MODEL"], DEFAULT_VERTEX_MODEL) or DEFAULT_VERTEX_MODEL
+        return _first_env([*runtime_model, "VERTEX_AI_MODEL", "VERTEX_MODEL"], DEFAULT_VERTEX_MODEL, settings=settings) or DEFAULT_VERTEX_MODEL
     if provider_name == "gmi":
         return _normalize_model_for_provider(
             provider_name,
-            _first_env(["GMI_MODEL", "GMI_CLOUD_MODEL", "GMICLOUD_MODEL", *runtime_model], DEFAULT_GMI_MODEL) or DEFAULT_GMI_MODEL,
+            _first_env(["GMI_MODEL", "GMI_CLOUD_MODEL", "GMICLOUD_MODEL", *runtime_model], DEFAULT_GMI_MODEL, settings=settings) or DEFAULT_GMI_MODEL,
         )
     if provider_name == "huggingface":
-        return _first_env(["HUGGINGFACE_MODEL", "HF_MODEL"], DEFAULT_HUGGINGFACE_MODEL) or DEFAULT_HUGGINGFACE_MODEL
+        return _first_env(["HUGGINGFACE_MODEL", "HF_MODEL"], DEFAULT_HUGGINGFACE_MODEL, settings=settings) or DEFAULT_HUGGINGFACE_MODEL
     if provider_name == "cloudflare":
-        return _first_env(["CLOUDFLARE_MODEL", *runtime_model], DEFAULT_CLOUDFLARE_MODEL) or DEFAULT_CLOUDFLARE_MODEL
+        return _first_env(["CLOUDFLARE_MODEL", *runtime_model], DEFAULT_CLOUDFLARE_MODEL, settings=settings) or DEFAULT_CLOUDFLARE_MODEL
     if provider_name == "nvidia":
-        return _first_env(["NVIDIA_MODEL", "NVIDIA_NIM_MODEL", "NIM_MODEL", *runtime_model], DEFAULT_NVIDIA_MODEL) or DEFAULT_NVIDIA_MODEL
+        return _first_env(["NVIDIA_MODEL", "NVIDIA_NIM_MODEL", "NIM_MODEL", *runtime_model], DEFAULT_NVIDIA_MODEL, settings=settings) or DEFAULT_NVIDIA_MODEL
     if provider_name == "xai":
-        return _first_env(["XAI_MODEL", "GROK_MODEL", *runtime_model], DEFAULT_XAI_MODEL) or DEFAULT_XAI_MODEL
+        return _first_env(["XAI_MODEL", "GROK_MODEL", *runtime_model], DEFAULT_XAI_MODEL, settings=settings) or DEFAULT_XAI_MODEL
     if provider_name == "together":
-        return _first_env(["TOGETHER_MODEL", *runtime_model], DEFAULT_TOGETHER_MODEL) or DEFAULT_TOGETHER_MODEL
+        return _first_env(["TOGETHER_MODEL", *runtime_model], DEFAULT_TOGETHER_MODEL, settings=settings) or DEFAULT_TOGETHER_MODEL
     if provider_name == "openai":
-        return _first_env(["OPENAI_MODEL", *runtime_model], DEFAULT_OPENAI_MODEL) or DEFAULT_OPENAI_MODEL
+        return _first_env(["OPENAI_MODEL", *runtime_model], DEFAULT_OPENAI_MODEL, settings=settings) or DEFAULT_OPENAI_MODEL
     if provider_name == "openai-compatible":
-        return _first_env([*runtime_model, "OPENAI_MODEL"], DEFAULT_OPENAI_MODEL) or DEFAULT_OPENAI_MODEL
+        return _first_env([*runtime_model, "OPENAI_MODEL"], DEFAULT_OPENAI_MODEL, settings=settings) or DEFAULT_OPENAI_MODEL
     if provider_name == "runpod":
-        return _first_env(["RUNPOD_OPENAI_MODEL", *runtime_model, "RUNPOD_MODEL"], "runpod-default") or "runpod-default"
+        return _first_env(["RUNPOD_OPENAI_MODEL", *runtime_model, "RUNPOD_MODEL"], "runpod-default", settings=settings) or "runpod-default"
     if provider_name == "runpod-serverless":
         return (
-            _first_env(["RUNPOD_SERVERLESS_MODEL", "RUNPOD_MODEL", "RUNPOD_OPENAI_MODEL", *runtime_model], "runpod-serverless")
+            _first_env(["RUNPOD_SERVERLESS_MODEL", "RUNPOD_MODEL", "RUNPOD_OPENAI_MODEL", *runtime_model], "runpod-serverless", settings=settings)
             or "runpod-serverless"
         )
     return "simulation"
 
 
-def _fallback_model_for_provider(provider_name: str) -> Optional[str]:
+def _fallback_model_for_provider(provider_name: str, settings: Optional[Settings] = None) -> Optional[str]:
     if provider_name == "anthropic":
-        return _first_env(["ANTHROPIC_FALLBACK_MODEL", "CLAUDE_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"])
+        return _first_env(["ANTHROPIC_FALLBACK_MODEL", "CLAUDE_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"], settings=settings)
     if provider_name == "baseten":
-        return _first_env(["BASETEN_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"])
+        return _first_env(["BASETEN_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"], settings=settings)
     if provider_name == "gemini":
-        return _first_env(["LLM_FALLBACK_MODEL", "GEMINI_FALLBACK_MODEL"], DEFAULT_GEMINI_FALLBACK_MODEL)
+        return _first_env(["LLM_FALLBACK_MODEL", "GEMINI_FALLBACK_MODEL"], DEFAULT_GEMINI_FALLBACK_MODEL, settings=settings)
     if provider_name == "vertex":
         return _first_env(
             ["LLM_FALLBACK_MODEL", "VERTEX_AI_FALLBACK_MODEL", "VERTEX_FALLBACK_MODEL"],
             DEFAULT_VERTEX_FALLBACK_MODEL,
+            settings=settings,
         )
     if provider_name == "gmi":
-        fallback = _first_env(["GMI_FALLBACK_MODEL", "GMI_CLOUD_FALLBACK_MODEL", "GMICLOUD_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"])
+        fallback = _first_env(["GMI_FALLBACK_MODEL", "GMI_CLOUD_FALLBACK_MODEL", "GMICLOUD_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"], settings=settings)
         return _normalize_model_for_provider(provider_name, fallback) if fallback else None
     if provider_name == "huggingface":
-        return _first_env(["HUGGINGFACE_FALLBACK_MODEL", "HF_FALLBACK_MODEL"])
+        return _first_env(["HUGGINGFACE_FALLBACK_MODEL", "HF_FALLBACK_MODEL"], settings=settings)
     if provider_name == "cloudflare":
-        return _first_env(["CLOUDFLARE_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"])
+        return _first_env(["CLOUDFLARE_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"], settings=settings)
     if provider_name == "nvidia":
-        return _first_env(["NVIDIA_FALLBACK_MODEL", "NVIDIA_NIM_FALLBACK_MODEL", "NIM_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"])
+        return _first_env(["NVIDIA_FALLBACK_MODEL", "NVIDIA_NIM_FALLBACK_MODEL", "NIM_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"], settings=settings)
     if provider_name == "xai":
-        return _first_env(["XAI_FALLBACK_MODEL", "GROK_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"])
+        return _first_env(["XAI_FALLBACK_MODEL", "GROK_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"], settings=settings)
     if provider_name == "together":
-        return _first_env(["TOGETHER_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"])
+        return _first_env(["TOGETHER_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"], settings=settings)
     if provider_name == "openai":
-        return _first_env(["OPENAI_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"])
+        return _first_env(["OPENAI_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"], settings=settings)
     if provider_name == "openai-compatible":
-        return _first_env(["LLM_FALLBACK_MODEL", "OPENAI_FALLBACK_MODEL"])
+        return _first_env(["LLM_FALLBACK_MODEL", "OPENAI_FALLBACK_MODEL"], settings=settings)
     if provider_name == "runpod":
-        return _first_env(["RUNPOD_OPENAI_FALLBACK_MODEL", "RUNPOD_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"])
+        return _first_env(["RUNPOD_OPENAI_FALLBACK_MODEL", "RUNPOD_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"], settings=settings)
     if provider_name == "runpod-serverless":
-        return _first_env(["RUNPOD_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"])
+        return _first_env(["RUNPOD_FALLBACK_MODEL", "LLM_FALLBACK_MODEL"], settings=settings)
     return None
 
 
-def _model_endpoint_map() -> Dict[str, Any]:
-    return _parse_json_mapping_env(["RUNPOD_MODEL_ENDPOINTS", "RUNPOD_ENDPOINTS_BY_MODEL"])
+def _model_endpoint_map(settings: Optional[Settings] = None) -> Dict[str, Any]:
+    return _parse_json_mapping_env(["RUNPOD_MODEL_ENDPOINTS", "RUNPOD_ENDPOINTS_BY_MODEL"], settings=settings)
 
 
 def _normalize_model_for_provider(provider_name: str, model_name: Optional[str]) -> str:
@@ -669,7 +698,7 @@ def _normalize_model_for_provider(provider_name: str, model_name: Optional[str])
     return aliases.get(lowered, model)
 
 
-def _allowed_model_names(provider_name: str, default_model: str) -> Optional[List[str]]:
+def _allowed_model_names(provider_name: str, default_model: str, settings: Optional[Settings] = None) -> Optional[List[str]]:
     env_names = ["LLM_ALLOWED_MODELS", "ALLOWED_LLM_MODELS"]
     if provider_name == "anthropic":
         env_names = ["ANTHROPIC_ALLOWED_MODELS", "CLAUDE_ALLOWED_MODELS", "ALLOWED_ANTHROPIC_MODELS", *env_names]
@@ -703,24 +732,25 @@ def _allowed_model_names(provider_name: str, default_model: str) -> Optional[Lis
     elif provider_name in {"runpod", "runpod-serverless"}:
         env_names = ["RUNPOD_ALLOWED_MODELS", "ALLOWED_RUNPOD_MODELS", *env_names]
 
-    configured = _parse_csv_env(env_names)
+    configured = _parse_csv_env(env_names, settings=settings)
     if configured is not None:
         return sorted(set(_normalize_model_for_provider(provider_name, model) for model in configured))
 
     defaults = {default_model}
-    fallback = _fallback_model_for_provider(provider_name)
+    fallback = _fallback_model_for_provider(provider_name, settings)
     if fallback:
         defaults.add(fallback)
     if provider_name == "runpod-serverless":
-        defaults.update(str(model_name) for model_name in _model_endpoint_map().keys())
+        defaults.update(str(model_name) for model_name in _model_endpoint_map(settings).keys())
     return sorted(model for model in defaults if model)
 
 
 def resolve_llm_runtime_config(
     provider_name: Optional[str] = None,
     model_name: Optional[str] = None,
+    settings: Optional[Settings] = None,
 ) -> LLMRuntimeConfig:
-    default_provider = _default_provider_name()
+    default_provider = _default_provider_name(settings)
     provider_requested = bool(provider_name and provider_name.strip())
     provider = normalize_llm_provider_name(provider_name) or default_provider
     if provider not in SUPPORTED_LLM_PROVIDERS:
@@ -729,8 +759,8 @@ def resolve_llm_runtime_config(
             f"{', '.join(sorted(SUPPORTED_LLM_PROVIDERS))}."
         )
 
-    configured_providers = _configured_provider_names(default_provider)
-    allowed_providers = _allowed_provider_names(default_provider)
+    configured_providers = _configured_provider_names(default_provider, settings)
+    allowed_providers = _allowed_provider_names(default_provider, settings)
     if allowed_providers is not None and provider not in allowed_providers:
         if provider_requested:
             allowed_providers = sorted({*allowed_providers, provider})
@@ -743,11 +773,12 @@ def resolve_llm_runtime_config(
     default_model = _default_model_for_provider(
         provider,
         include_runtime_override=provider == default_provider,
+        settings=settings,
     )
     requested_model = model_name.strip() if isinstance(model_name, str) else None
     requested_model = requested_model or None
     model = _normalize_model_for_provider(provider, requested_model or default_model)
-    allowed_models = _allowed_model_names(provider, default_model)
+    allowed_models = _allowed_model_names(provider, default_model, settings)
     if (
         requested_model
         and allowed_models is not None
@@ -774,8 +805,8 @@ def resolve_llm_runtime_config(
     )
 
 
-def get_llm_runtime_debug_config() -> Dict[str, Any]:
-    return resolve_llm_runtime_config().as_debug_dict()
+def get_llm_runtime_debug_config(settings: Optional[Settings] = None) -> Dict[str, Any]:
+    return resolve_llm_runtime_config(settings=settings).as_debug_dict()
 
 
 def _normalize_model_name(model_name: str) -> str:
@@ -1011,7 +1042,11 @@ class GeminiProvider(StructuredLLMProvider):
     provider_name = "gemini"
     provider_label = "Gemini"
 
-    def __init__(self, model_name: Optional[str] = None):
+    def __init__(self, model_name: Optional[str] = None, settings: Optional[Settings] = None):
+        self.settings = settings
+        (_env, _first_env, _first_env_bool, _first_env_float, _first_env_optional_float, _first_env_int,
+         _first_env_optional_string, _runpod_openai_base_url_from_env, _runpod_serverless_endpoint_url_from_env,
+         _runpod_serverless_url_env_name, _model_endpoint_map, _cloudflare_base_url_from_env) = _scoped_env_helpers(settings)
         self.api_key = _first_env(["GEMINI_API_KEY", "GOOGLE_API_KEY", "LLM_API_KEY"])
         self.requested_model = model_name or _first_env(["LLM_MODEL", "GEMINI_MODEL"], DEFAULT_GEMINI_MODEL) or DEFAULT_GEMINI_MODEL
         self.fallback_model = (
@@ -1213,7 +1248,10 @@ class VertexAIProvider(GeminiProvider):
     provider_name = "vertex"
     provider_label = "Vertex AI"
 
-    def __init__(self, model_name: Optional[str] = None):
+    def __init__(self, model_name: Optional[str] = None, settings: Optional[Settings] = None):
+        (_env, _first_env, _first_env_bool, _first_env_float, _first_env_optional_float, _first_env_int,
+         _first_env_optional_string, _runpod_openai_base_url_from_env, _runpod_serverless_endpoint_url_from_env,
+         _runpod_serverless_url_env_name, _model_endpoint_map, _cloudflare_base_url_from_env) = _scoped_env_helpers(settings)
         self.project = _first_env(
             ["VERTEX_AI_PROJECT", "GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID", "GCLOUD_PROJECT"]
         )
@@ -1282,7 +1320,10 @@ class VertexAIProvider(GeminiProvider):
 class AnthropicProvider(StructuredLLMProvider):
     provider_name = "anthropic"
 
-    def __init__(self, model_name: Optional[str] = None):
+    def __init__(self, model_name: Optional[str] = None, settings: Optional[Settings] = None):
+        (_env, _first_env, _first_env_bool, _first_env_float, _first_env_optional_float, _first_env_int,
+         _first_env_optional_string, _runpod_openai_base_url_from_env, _runpod_serverless_endpoint_url_from_env,
+         _runpod_serverless_url_env_name, _model_endpoint_map, _cloudflare_base_url_from_env) = _scoped_env_helpers(settings)
         self.api_key = _first_env(["ANTHROPIC_API_KEY", "CLAUDE_API_KEY"])
         self.base_url = (
             _first_env(["ANTHROPIC_BASE_URL", "CLAUDE_BASE_URL"], DEFAULT_ANTHROPIC_BASE_URL)
@@ -1302,6 +1343,7 @@ class AnthropicProvider(StructuredLLMProvider):
         self.max_tokens = _first_env_int(["ANTHROPIC_MAX_TOKENS", "CLAUDE_MAX_TOKENS", "LLM_MAX_TOKENS"])
         self.temperature = _first_env_optional_float(["ANTHROPIC_TEMPERATURE", "CLAUDE_TEMPERATURE", "LLM_TEMPERATURE"], default=None)
         self.anthropic_version = _first_env(["ANTHROPIC_VERSION", "CLAUDE_API_VERSION"], DEFAULT_ANTHROPIC_VERSION) or DEFAULT_ANTHROPIC_VERSION
+        self.user_agent = _env("LLM_USER_AGENT", DEFAULT_HTTP_USER_AGENT) or DEFAULT_HTTP_USER_AGENT
         self.use_output_config = _first_env_bool(["ANTHROPIC_JSON_SCHEMA_OUTPUT", "CLAUDE_JSON_SCHEMA_OUTPUT"], default=True)
         self.model_name = self.requested_model
         self._validation: Optional[LLMProviderValidation] = None
@@ -1315,7 +1357,7 @@ class AnthropicProvider(StructuredLLMProvider):
         return {
             "Accept": "application/json",
             "Content-Type": "application/json",
-            "User-Agent": config.get("LLM_USER_AGENT", DEFAULT_HTTP_USER_AGENT),
+            "User-Agent": self.user_agent,
             "x-api-key": self.api_key or "",
             "anthropic-version": self.anthropic_version,
         }
@@ -1607,7 +1649,10 @@ class AnthropicProvider(StructuredLLMProvider):
 
 
 class OpenAICompatibleProvider(StructuredLLMProvider):
-    def __init__(self, provider_name: str = "openai", model_name: Optional[str] = None):
+    def __init__(self, provider_name: str = "openai", model_name: Optional[str] = None, settings: Optional[Settings] = None):
+        (_env, _first_env, _first_env_bool, _first_env_float, _first_env_optional_float, _first_env_int,
+         _first_env_optional_string, _runpod_openai_base_url_from_env, _runpod_serverless_endpoint_url_from_env,
+         _runpod_serverless_url_env_name, _model_endpoint_map, _cloudflare_base_url_from_env) = _scoped_env_helpers(settings)
         normalized_provider = normalize_llm_provider_name(provider_name) or "openai"
         if normalized_provider in {"baseten", "gmi", "huggingface", "cloudflare", "nvidia", "openai", "runpod", "together", "xai"}:
             self.provider_name = normalized_provider
@@ -1828,8 +1873,9 @@ class OpenAICompatibleProvider(StructuredLLMProvider):
             omit_values=["default", "omit"],
         )
         self.cloudflare_enable_thinking = (
-            config.cloudflare_enable_thinking if self.provider_name == "cloudflare" else None
+            _first_env_bool(["CLOUDFLARE_ENABLE_THINKING"], default=False) if self.provider_name == "cloudflare" else None
         )
+        self.user_agent = _env("LLM_USER_AGENT", DEFAULT_HTTP_USER_AGENT) or DEFAULT_HTTP_USER_AGENT
         self.allow_no_api_key = _first_env_bool(
             allow_no_api_key_names,
             default=self.provider_name == "openai-compatible" and configured_base_url is not None,
@@ -1847,7 +1893,7 @@ class OpenAICompatibleProvider(StructuredLLMProvider):
         headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",
-            "User-Agent": config.get("LLM_USER_AGENT", DEFAULT_HTTP_USER_AGENT),
+            "User-Agent": self.user_agent,
         }
         if self.api_key:
             headers["Authorization"] = f"Bearer {self.api_key}"
@@ -2349,7 +2395,11 @@ class OpenAICompatibleProvider(StructuredLLMProvider):
 class RunpodServerlessProvider(StructuredLLMProvider):
     provider_name = "runpod-serverless"
 
-    def __init__(self, model_name: Optional[str] = None):
+    def __init__(self, model_name: Optional[str] = None, settings: Optional[Settings] = None):
+        self.settings = settings
+        (_env, _first_env, _first_env_bool, _first_env_float, _first_env_optional_float, _first_env_int,
+         _first_env_optional_string, _runpod_openai_base_url_from_env, _runpod_serverless_endpoint_url_from_env,
+         _runpod_serverless_url_env_name, _model_endpoint_map, _cloudflare_base_url_from_env) = _scoped_env_helpers(settings)
         self.api_key = _first_env(["RUNPOD_API_KEY"])
         self.requested_model = (
             model_name
@@ -2391,8 +2441,8 @@ class RunpodServerlessProvider(StructuredLLMProvider):
             endpoint_url = str(raw_url) if raw_url else None
             endpoint_id = str(raw_id) if raw_id else None
 
-        endpoint_url = endpoint_url or _runpod_serverless_endpoint_url_from_env()
-        endpoint_id = endpoint_id or _first_env(["RUNPOD_ENDPOINT_ID"])
+        endpoint_url = endpoint_url or _runpod_serverless_endpoint_url_from_env(settings=self.settings)
+        endpoint_id = endpoint_id or _first_env(["RUNPOD_ENDPOINT_ID"], settings=self.settings)
 
         if endpoint_url:
             parsed = urllib.parse.urlparse(endpoint_url)
@@ -2601,20 +2651,21 @@ def build_llm_provider(
     provider_name: Optional[str] = None,
     model_name: Optional[str] = None,
     runtime_config: Optional[LLMRuntimeConfig] = None,
+    settings: Optional[Settings] = None,
 ) -> StructuredLLMProvider:
-    runtime = runtime_config or resolve_llm_runtime_config(provider_name=provider_name, model_name=model_name)
+    runtime = runtime_config or resolve_llm_runtime_config(provider_name=provider_name, model_name=model_name, settings=settings)
     if runtime.provider == "anthropic":
-        return AnthropicProvider(model_name=runtime.model)
+        return AnthropicProvider(model_name=runtime.model, settings=settings)
     if runtime.provider == "gemini":
-        return GeminiProvider(model_name=runtime.model)
+        return GeminiProvider(model_name=runtime.model, settings=settings)
     if runtime.provider == "vertex":
-        return VertexAIProvider(model_name=runtime.model)
+        return VertexAIProvider(model_name=runtime.model, settings=settings)
     if runtime.provider in {"baseten", "gmi", "huggingface", "cloudflare", "nvidia", "openai", "openai-compatible", "together", "xai"}:
-        return OpenAICompatibleProvider(provider_name=runtime.provider, model_name=runtime.model)
+        return OpenAICompatibleProvider(provider_name=runtime.provider, model_name=runtime.model, settings=settings)
     if runtime.provider == "runpod":
-        return OpenAICompatibleProvider(provider_name="runpod", model_name=runtime.model)
+        return OpenAICompatibleProvider(provider_name="runpod", model_name=runtime.model, settings=settings)
     if runtime.provider == "runpod-serverless":
-        return RunpodServerlessProvider(model_name=runtime.model)
+        return RunpodServerlessProvider(model_name=runtime.model, settings=settings)
     if runtime.provider == "simulation":
         return SimulationProvider()
 

--- a/forma_core/user_integrations.py
+++ b/forma_core/user_integrations.py
@@ -13,7 +13,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Iterable, Optional
+from types import MappingProxyType
+from typing import Any, Iterable, Mapping, Optional
 
 from cryptography.fernet import Fernet, InvalidToken
 
@@ -187,6 +188,32 @@ class UserIntegrationConfig:
             "updated_at": self.updated_at,
             "integrations": [integration.as_json() for integration in self.integrations],
         }
+
+
+@dataclass(frozen=True)
+class ResolvedIntegrationSettings(Mapping[str, str]):
+    """Immutable process-environment snapshot plus one integration overlay."""
+
+    values: Mapping[str, str]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "values", MappingProxyType(dict(self.values)))
+
+    def __getitem__(self, key: str) -> str:
+        return self.values[key]
+
+    def __iter__(self):
+        return iter(self.values)
+
+    def __len__(self) -> int:
+        return len(self.values)
+
+    def get(self, key: str, default: Optional[str] = None) -> Optional[str]:
+        return self.values.get(key, default)
+
+    def as_env(self) -> dict[str, str]:
+        """Return a subprocess-safe copy without exposing it in metadata/logs."""
+        return dict(self.values)
 
 
 INTEGRATION_DEFINITIONS: tuple[IntegrationDefinition, ...] = (
@@ -1557,12 +1584,19 @@ def _capture_original_environment(env_names: Iterable[str]) -> None:
             _ORIGINAL_ENV_VALUES[env_name] = env_config.get(env_name)
 
 
-def _original_environment_value(env_names: Iterable[str]) -> Optional[str]:
+def _environment_value(
+    env_names: Iterable[str],
+    environment: Mapping[str, Optional[str]],
+) -> Optional[str]:
     for env_name in env_names:
-        value = _ORIGINAL_ENV_VALUES.get(env_name)
+        value = environment.get(env_name)
         if value and value.strip():
             return value.strip()
     return None
+
+
+def _original_environment_value(env_names: Iterable[str]) -> Optional[str]:
+    return _environment_value(env_names, _ORIGINAL_ENV_VALUES)
 
 
 def _disabled_flag(value: Optional[str]) -> bool:
@@ -1619,17 +1653,21 @@ def _values_configure_integration(
     return runtime_provider == definition.id and bool((generic_key or "").strip())
 
 
-def _environment_configures_integration(definition: IntegrationDefinition) -> bool:
+def _environment_configures_integration(
+    definition: IntegrationDefinition,
+    environment: Optional[Mapping[str, Optional[str]]] = None,
+) -> bool:
+    source = environment if environment is not None else _ORIGINAL_ENV_VALUES
     values = {
         field.id: value
         for field in definition.fields
-        if (value := (_original_environment_value(field.env_names) or "").strip())
+        if (value := (_environment_value(field.env_names, source) or "").strip())
     }
     return _values_configure_integration(
         definition,
         values,
-        runtime_provider=_normalize_provider_id(_ORIGINAL_ENV_VALUES.get("LLM_PROVIDER") or ""),
-        generic_key=_ORIGINAL_ENV_VALUES.get("LLM_API_KEY"),
+        runtime_provider=_normalize_provider_id(source.get("LLM_PROVIDER") or ""),
+        generic_key=source.get("LLM_API_KEY"),
     )
 
 
@@ -1703,7 +1741,11 @@ def _merge_csv_value(existing: Optional[str], values: Iterable[str]) -> str:
     return ",".join(merged)
 
 
-def _desired_environment(config: UserIntegrationConfig) -> dict[str, str]:
+def _desired_environment(
+    config: UserIntegrationConfig,
+    *,
+    environment: Optional[Mapping[str, str]] = None,
+) -> dict[str, str]:
     desired: dict[str, str] = {}
     allowed_providers: set[str] = set()
     allowed_models_by_provider: dict[str, set[str]] = {}
@@ -1786,7 +1828,7 @@ def _desired_environment(config: UserIntegrationConfig) -> dict[str, str]:
     elif (
         inferred_image_provider
         and not desired.get("IMAGE_PROVIDER")
-        and not _ORIGINAL_ENV_VALUES.get("IMAGE_PROVIDER")
+        and not (environment or _ORIGINAL_ENV_VALUES).get("IMAGE_PROVIDER")
     ):
         desired["IMAGE_PROVIDER"] = inferred_image_provider
 
@@ -1800,6 +1842,36 @@ def _desired_environment(config: UserIntegrationConfig) -> dict[str, str]:
         if env_name and models:
             desired[env_name] = _merge_csv_value(desired.get(env_name), sorted(models))
     return desired
+
+
+def resolve_user_integration_settings(
+    store: Optional[UserIntegrationStore] = None,
+    *,
+    fail_open: bool = True,
+) -> ResolvedIntegrationSettings:
+    """Resolve one request's provider settings without mutating the process environment."""
+    resolved_store = store or default_integration_store()
+    try:
+        integration_config = resolved_store.load()
+    except Exception as exc:
+        if not fail_open or deployment_mode_enabled():
+            raise
+        logger.warning(
+            "Integration config load failed from %s; using empty runtime config: %s",
+            getattr(resolved_store, "storage_label", getattr(resolved_store, "path", "unknown")),
+            exc,
+        )
+        integration_config = UserIntegrationConfig()
+
+    environment = env_config.snapshot()
+    desired = _desired_environment(integration_config, environment=environment)
+    additive_env_names = {"LLM_ALLOWED_PROVIDERS", *PROVIDER_ALLOWED_MODEL_ENV.values()}
+    for env_name in additive_env_names:
+        desired_value = desired.get(env_name)
+        if desired_value:
+            desired[env_name] = _merge_csv_value(environment.get(env_name), desired_value.split(","))
+    environment.update(desired)
+    return ResolvedIntegrationSettings(environment)
 
 
 def apply_user_integrations_to_environment(
@@ -1859,10 +1931,14 @@ def _field_status_payload(
     *,
     integration_id: str,
     hosted_user_store: bool = False,
+    environment: Optional[Mapping[str, Optional[str]]] = None,
 ) -> dict[str, object]:
     stored_value = integration.field_value(field_definition.id) if integration else None
     saved_value = stored_value if integration and integration.enabled else None
-    environment_value = _original_environment_value(field_definition.env_names)
+    environment_value = _environment_value(
+        field_definition.env_names,
+        environment if environment is not None else _ORIGINAL_ENV_VALUES,
+    )
     policy = _active_hosted_byok_policy(integration_id) if hosted_user_store else None
     blocked_by_policy = bool(policy and field_definition.id in policy.blocked_secret_fields)
     conditional_by_policy = bool(policy and field_definition.id in policy.conditional_secret_fields)
@@ -1897,20 +1973,22 @@ def _field_status_payload(
 
 def integration_status_payload(store: Optional[UserIntegrationStore] = None) -> dict[str, object]:
     resolved_store = store or default_integration_store()
-    config = apply_user_integrations_to_environment(resolved_store, fail_open=False)
+    config = resolved_store.load()
+    environment = env_config.snapshot()
     hosted_user_store = isinstance(resolved_store, SupabaseUserIntegrationStore) or bool(
         getattr(resolved_store, "user_scoped", False)
     )
     integrations: list[dict[str, object]] = []
     for definition in INTEGRATION_DEFINITIONS:
         stored = config.integration_by_id(definition.id)
-        environment_configured = _environment_configures_integration(definition)
+        environment_configured = _environment_configures_integration(definition, environment)
         configured_fields = [
             _field_status_payload(
                 stored,
                 field_definition,
                 integration_id=definition.id,
                 hosted_user_store=hosted_user_store,
+                environment=environment,
             )
             for field_definition in definition.fields
         ]
@@ -1949,11 +2027,13 @@ __all__ = [
     "IntegrationFieldDefinition",
     "StoredIntegration",
     "StoredIntegrationField",
+    "ResolvedIntegrationSettings",
     "SupabaseUserIntegrationStore",
     "SupabaseWorkspaceIntegrationStore",
     "UserIntegrationConfig",
     "UserIntegrationStore",
     "apply_user_integrations_to_environment",
+    "resolve_user_integration_settings",
     "default_integration_store",
     "default_user_integrations_path",
     "encrypted_user_integrations_path",

--- a/forma_core/workers/generation.py
+++ b/forma_core/workers/generation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import inspect
 import logging
 from typing import Any, Awaitable, Callable, Protocol
@@ -40,6 +41,11 @@ from forma_core.workspaces.projects.cad_generation import (
     cad_project_artifact,
 )
 from forma_core.workspaces.projects.output import attach_hardware_reference_image, attach_product_image
+from forma_core.user_integrations import (
+    ResolvedIntegrationSettings,
+    UserIntegrationStore,
+    resolve_user_integration_settings,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -73,11 +79,13 @@ class HardwareIRGenerationEngine:
         model_name: str | None = None,
         use_simulation: bool = False,
         generate_image: bool = True,
+        settings: ResolvedIntegrationSettings | None = None,
     ) -> None:
         self.provider_name = provider_name
         self.model_name = model_name
         self.use_simulation = use_simulation
         self.generate_image = generate_image
+        self.settings = settings
 
     def generate(
         self,
@@ -95,6 +103,7 @@ class HardwareIRGenerationEngine:
             provider_name=self.provider_name,
             model_name=self.model_name,
             persist_project=False,
+            settings=self.settings,
         )
         state = orchestrator.generate_project(
             prompt,
@@ -119,7 +128,7 @@ class HardwareIRGenerationEngine:
         generate_product_image = self.generate_image and generation_status == "succeeded"
         if generate_product_image:
             emit_agent_pipeline_event("default", "image_generation", "started")
-        attach_product_image(prompt, state, generate_image=generate_product_image)
+        attach_product_image(prompt, state, generate_image=generate_product_image, settings=self.settings)
         if image_data:
             attach_hardware_reference_image(state, image_data, media_type=decoded_media_type or image_media_type)
         if generate_product_image:
@@ -370,6 +379,15 @@ class GenerationWorker:
             cancellation_check = None
 
         try:
+            generation_engine = self._engine
+            if isinstance(self._engine, HardwareIRGenerationEngine):
+                settings = await asyncio.to_thread(
+                    resolve_user_integration_settings,
+                    UserIntegrationStore.for_user(owner_user_id),
+                    fail_open=False,
+                )
+                generation_engine = copy.copy(self._engine)
+                generation_engine.settings = settings
             if cancellation_check is not None and cancellation_check():
                 return _cancelled_result(request)
             progress_sequence = max(0, int(request.metadata.get("progress_sequence_start") or 0)) + 1
@@ -380,7 +398,7 @@ class GenerationWorker:
                 percent_complete=10,
                 message="Generating structured project state from the frozen DesignBrief.",
             ))
-            if isinstance(self._engine, HardwareIRGenerationEngine):
+            if isinstance(generation_engine, HardwareIRGenerationEngine):
                 event_loop = asyncio.get_running_loop()
 
                 prior_generation_run = request.metadata.get("prior_generation_run")
@@ -436,10 +454,10 @@ class GenerationWorker:
                         future.result()
 
                     with observe_agent_pipeline(record_pipeline_event, cancellation_check=cancellation_check):
-                        generation_parameters = inspect.signature(self._engine.generate).parameters
+                        generation_parameters = inspect.signature(generation_engine.generate).parameters
                         if "generation_metadata" not in generation_parameters:
-                            return self._engine.generate(payload.design_brief)
-                        return self._engine.generate(
+                            return generation_engine.generate(payload.design_brief)
+                        return generation_engine.generate(
                             payload.design_brief,
                             generation_metadata={
                                 "prior_generation_run": prior_generation_run,

--- a/forma_core/workspaces/projects/iteration.py
+++ b/forma_core/workspaces/projects/iteration.py
@@ -25,6 +25,7 @@ from forma_core.workspaces.projects.objects import (
     namespace_payload,
 )
 from forma_core.validation import build_validation_summary, validate_circuit
+from forma_core.user_integrations import ResolvedIntegrationSettings
 
 
 logger = logging.getLogger(__name__)
@@ -545,6 +546,7 @@ class ProjectIterator:
         provider_name: Optional[str] = None,
         model_name: Optional[str] = None,
         runtime_config: Optional[LLMRuntimeConfig] = None,
+        settings: Optional[ResolvedIntegrationSettings] = None,
         llm_provider: Optional[StructuredLLMProvider] = None,
         use_simulation: bool = False,
         require_live_generation: bool = False,
@@ -552,8 +554,9 @@ class ProjectIterator:
         self.runtime_config = runtime_config or resolve_llm_runtime_config(
             provider_name=provider_name,
             model_name=model_name,
+            settings=settings,
         )
-        self.llm_provider = llm_provider or build_llm_provider(runtime_config=self.runtime_config)
+        self.llm_provider = llm_provider or build_llm_provider(runtime_config=self.runtime_config, settings=settings)
         self.use_simulation = use_simulation or not self.llm_provider.is_configured
         self.require_live_generation = require_live_generation
 
@@ -639,6 +642,7 @@ def iterate_project(
     provider_name: Optional[str] = None,
     model_name: Optional[str] = None,
     runtime_config: Optional[LLMRuntimeConfig] = None,
+    settings: Optional[ResolvedIntegrationSettings] = None,
     llm_provider: Optional[StructuredLLMProvider] = None,
     use_simulation: bool = False,
     require_live_generation: bool = False,
@@ -647,6 +651,7 @@ def iterate_project(
         provider_name=provider_name,
         model_name=model_name,
         runtime_config=runtime_config,
+        settings=settings,
         llm_provider=llm_provider,
         use_simulation=use_simulation,
         require_live_generation=require_live_generation,

--- a/forma_core/workspaces/projects/output.py
+++ b/forma_core/workspaces/projects/output.py
@@ -18,6 +18,7 @@ from forma_core.database import (
 )
 from forma_core.images import build_image_provider, build_project_visual_spec
 from forma_core.persistence.images import get_image_storage_config, upload_image_to_supabase_s3
+from forma_core.user_integrations import ResolvedIntegrationSettings
 
 
 logger = logging.getLogger(__name__)
@@ -143,9 +144,15 @@ def attach_product_image(
     generate_image: bool = False,
     provider_factory: ImageProviderFactory = build_image_provider,
     storage_handler: ImageStorageHandler = store_project_image,
+    settings: Optional[ResolvedIntegrationSettings] = None,
 ) -> None:
     """Generate product visuals and attach UI-compatible metadata to a HardwareIR."""
-    image_provider = provider_factory(force_enabled=generate_image)
+    try:
+        image_provider = provider_factory(force_enabled=generate_image, settings=settings)
+    except TypeError as exc:
+        if "settings" not in str(exc):
+            raise
+        image_provider = provider_factory(force_enabled=generate_image)
     image_config = _safe_image_config(image_provider.get_debug_config())
     status = "pending" if generate_image else "not_requested"
     ir.assembly_metadata = {

--- a/tests/api/test_a2a_user_integrations.py
+++ b/tests/api/test_a2a_user_integrations.py
@@ -69,7 +69,7 @@ class A2AUserIntegrationTests(unittest.TestCase):
             )
 
         def fake_attach_product_image(*_args, **_kwargs):
-            provider = build_image_provider(force_enabled=True)
+            provider = build_image_provider(force_enabled=True, settings=_kwargs["settings"])
             observed.update(provider.get_debug_config())
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -121,7 +121,6 @@ class A2AUserIntegrationTests(unittest.TestCase):
 
         def fake_generate_project_with_workflow(*_args, **_kwargs):
             self.assertFalse(_kwargs["persist_project"])
-            user_integrations.apply_user_integrations_to_environment()
             return SimpleNamespace(
                 assembly_metadata={},
                 constraints=[],
@@ -140,7 +139,7 @@ class A2AUserIntegrationTests(unittest.TestCase):
             )
 
         def fake_attach_product_image(*_args, **_kwargs):
-            provider = build_image_provider(force_enabled=True)
+            provider = build_image_provider(force_enabled=True, settings=_kwargs["settings"])
             observed.update(provider.get_debug_config())
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -191,7 +190,7 @@ class A2AUserIntegrationTests(unittest.TestCase):
         )
 
         def fake_build_generation_response(*_args, **_kwargs):
-            provider = build_image_provider(force_enabled=True)
+            provider = build_image_provider(force_enabled=True, settings=_kwargs["settings"])
             observed.update(provider.get_debug_config())
             return {"ok": True}
 

--- a/tests/api/test_user_integrations_api.py
+++ b/tests/api/test_user_integrations_api.py
@@ -169,7 +169,7 @@ class UserIntegrationsApiAuthTests(unittest.TestCase):
         request = ImageModelTestRequest(provider="gmi", model="seedream-5.0-pro", prompt="  test render  ")
         with patch.dict(os.environ, {}, clear=True), patch(
             "apps.api.user_integrations_api._store_for_context", return_value=object()
-        ), patch("apps.api.user_integrations_api.apply_user_integrations_to_environment"), patch(
+        ), patch("apps.api.user_integrations_api.resolve_user_integration_settings", return_value={}), patch(
             "apps.api.user_integrations_api.build_image_provider", return_value=provider
         ):
             response = run_image_model_test(request, HOSTED_CONTEXT)

--- a/tests/integrations/test_user_integrations.py
+++ b/tests/integrations/test_user_integrations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import stat
 import tempfile
@@ -18,8 +19,9 @@ from forma_core.user_integrations import (
     apply_user_integrations_to_environment,
     default_integration_store,
     integration_status_payload,
+    resolve_user_integration_settings,
 )
-from forma_core.llm_providers import resolve_llm_runtime_config
+from forma_core.llm_providers import build_llm_provider, resolve_llm_runtime_config
 
 
 TEST_ENV_KEYS = (
@@ -266,12 +268,44 @@ class UserIntegrationTests(unittest.TestCase):
             self.assertNotIn("OPENAI_MODEL", os.environ)
             self.assertNotIn("OPENAI_STREAM_MODEL", os.environ)
 
+    def test_request_scoped_settings_isolate_concurrent_provider_credentials(self) -> None:
+        with isolated_integration_env(), tempfile.TemporaryDirectory() as tmpdir:
+            store_a = UserIntegrationStore(Path(tmpdir) / "user-a.json")
+            store_b = UserIntegrationStore(Path(tmpdir) / "user-b.json")
+            store_a.update_integration(
+                "openai",
+                field_values={"api_key": "sk-user-a", "model": "gpt-user-a"},
+            )
+            store_b.update_integration(
+                "anthropic",
+                field_values={"api_key": "sk-user-b", "model": "claude-user-b"},
+            )
+            environment_before = dict(os.environ)
+
+            async def resolve_provider(store: UserIntegrationStore):
+                settings = await asyncio.to_thread(resolve_user_integration_settings, store)
+                runtime = resolve_llm_runtime_config(settings=settings)
+                provider = build_llm_provider(runtime_config=runtime, settings=settings)
+                return runtime.provider, runtime.model, provider.api_key
+
+            async def resolve_both():
+                return await asyncio.gather(resolve_provider(store_a), resolve_provider(store_b))
+
+            resolved = asyncio.run(resolve_both())
+
+            self.assertEqual(
+                [("openai", "gpt-user-a", "sk-user-a"), ("anthropic", "claude-user-b", "sk-user-b")],
+                resolved,
+            )
+            self.assertEqual(environment_before, dict(os.environ))
+
     def test_status_payload_reports_environment_as_configured_fallback(self) -> None:
         with isolated_integration_env(), tempfile.TemporaryDirectory() as tmpdir:
             os.environ["OPENAI_API_KEY"] = "sk-env-original"
             os.environ["IMAGE_PROVIDER"] = "openai"
             os.environ["OPENAI_IMAGE_MODEL"] = "gpt-image-2"
             store = UserIntegrationStore(Path(tmpdir) / "integrations.json")
+            environment_before = dict(os.environ)
 
             payload = integration_status_payload(store)
             openai = integration_by_id(payload, "openai")
@@ -282,6 +316,7 @@ class UserIntegrationTests(unittest.TestCase):
             self.assertTrue(field_by_id(openai, "api_key")["configured"])
             self.assertEqual("environment", field_by_id(runtime, "image_provider")["source"])
             self.assertTrue(field_by_id(runtime, "image_provider")["configured"])
+            self.assertEqual(environment_before, dict(os.environ))
 
     def test_image_env_defaults_do_not_mark_openai_or_custom_image_configured(self) -> None:
         with isolated_integration_env(), tempfile.TemporaryDirectory() as tmpdir:
@@ -341,7 +376,7 @@ class UserIntegrationTests(unittest.TestCase):
             self.assertEqual("2", os.environ["TAVILY_CRAWL_MAX_DEPTH"])
             self.assertEqual("mini", os.environ["TAVILY_RESEARCH_MODEL"])
 
-    def test_saved_byok_overrides_environment_without_hiding_other_env_providers(self) -> None:
+    def test_saved_byok_is_request_scoped_without_hiding_other_env_providers(self) -> None:
         with isolated_integration_env(), tempfile.TemporaryDirectory() as tmpdir:
             os.environ["OPENAI_API_KEY"] = "sk-platform"
             os.environ["OPENAI_MODEL"] = "gpt-platform"
@@ -359,10 +394,17 @@ class UserIntegrationTests(unittest.TestCase):
 
             payload = integration_status_payload(store)
 
-            self.assertEqual("sk-user", os.environ["OPENAI_API_KEY"])
-            self.assertEqual("gpt-user", os.environ["OPENAI_MODEL"])
-            self.assertEqual("openai,baseten", os.environ["LLM_ALLOWED_PROVIDERS"])
-            self.assertEqual("gpt-platform,gpt-user", os.environ["OPENAI_ALLOWED_MODELS"])
+            self.assertEqual("sk-platform", os.environ["OPENAI_API_KEY"])
+            self.assertEqual("gpt-platform", os.environ["OPENAI_MODEL"])
+            self.assertEqual("openai", os.environ["LLM_ALLOWED_PROVIDERS"])
+            self.assertEqual("gpt-platform", os.environ["OPENAI_ALLOWED_MODELS"])
+            settings = resolve_user_integration_settings(store)
+            runtime = resolve_llm_runtime_config(settings=settings)
+            provider = build_llm_provider(runtime_config=runtime, settings=settings)
+            self.assertEqual("openai", runtime.provider)
+            self.assertEqual("gpt-user", runtime.model)
+            self.assertEqual("sk-user", provider.api_key)
+            self.assertIn("baseten", runtime.allowed_providers or [])
             openai = integration_by_id(payload, "openai")
             self.assertEqual("saved", field_by_id(openai, "api_key")["source"])
             self.assertEqual("saved", field_by_id(openai, "model")["source"])


### PR DESCRIPTION
## Summary
- replace hosted process-global integration mutation with immutable request-scoped settings
- propagate settings through LLM, image, external research, video, workflow, A2A, and generation-worker paths
- preserve local environment fallback and retain the legacy mutating bridge only for local compatibility
- add concurrent credential-isolation coverage and keep credentials out of diagnostics and persisted metadata

## Validation
- python -m unittest tests.api.test_a2a_user_integrations tests.api.test_user_integrations_api tests.api.test_user_context tests.api.test_user_settings_api tests.api.test_a2a_image_logging tests.agents.test_generation_worker (51 passed)
- python -m compileall -q forma_core apps/api tests (passed)
- git diff --check origin/main...HEAD (passed)
- Full unittest discovery ran 787 tests; remaining failures are environment or pre-existing suite issues involving Vertex mocks, Windows file modes, debug-mode ordering, and production-preflight expectations.

Closes #333