### PR TITLE
feat(opencode): add hosted authoring bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,13 @@ FORMA_AUTH_MODE=local
 # Optional dedicated bearer credential for the authenticated A2A REST, WebSocket,
 # TCP, and A2A/MCP transports. Use at least 32 random characters.
 # FORMA_A2A_API_KEY=
+# Hosted OpenCode pilot access is an exact server-side Clerk primary-email
+# allowlist. Unset means deny all; do not use an admin or service key here.
+# FORMA_OPENCODE_ALLOWED_EMAILS=isayahculbertson@gmail.com
+# Connector-only HMAC/bootstrap secrets; never expose these to the browser.
+# FORMA_OPENCODE_CAPABILITY_SECRET=
+# FORMA_OPENCODE_CONNECTOR_BOOTSTRAP_TOKEN=
+# FORMA_OPENCODE_CONNECTOR_ID=mini-pc-1
 
 # Runtime state. Local is the safe default; hosted deployments must disable
 # development mode before startup.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -25,6 +25,12 @@ FORMA_AUTH_MODE=local
 # compatibility.
 # FORMA_A2A_API_KEY=
 # FORMA_MCP_API_KEY=
+# Hosted OpenCode pilot access is an exact server-side Clerk primary-email
+# allowlist. Unset means deny all.
+# FORMA_OPENCODE_ALLOWED_EMAILS=isayahculbertson@gmail.com
+# FORMA_OPENCODE_CAPABILITY_SECRET=
+# FORMA_OPENCODE_CONNECTOR_BOOTSTRAP_TOKEN=
+# FORMA_OPENCODE_CONNECTOR_ID=mini-pc-1
 # Runtime state. Valid deployment modes are local and hosted.
 FORMA_DEPLOYMENT_MODE=local
 FORMA_DEVELOPMENT_MODE=false

--- a/apps/api/a2a.py
+++ b/apps/api/a2a.py
@@ -2328,6 +2328,7 @@ def _persist_mcp_compile(
         "source_prompt": prompt,
     }
     hardware_ir = project.model_dump(mode="json")
+    source_job_id = str(arguments.get("source_job_id") or f"compile-{uuid.uuid4().hex}")
     if existing is not None:
         if not owner_user_id:
             raise ValueError("An authenticated owner is required to update a compiled project.")
@@ -2335,7 +2336,7 @@ def _persist_mcp_compile(
             project_id,
             owner_user_id,
             project,
-            source_job_id=f"compile-{uuid.uuid4().hex}",
+            source_job_id=source_job_id,
             prompt=prompt,
             chat_id=chat_id,
             visibility=visibility,
@@ -2345,7 +2346,7 @@ def _persist_mcp_compile(
             project_id,
             owner_user_id,
             project,
-            source_job_id=f"compile-{uuid.uuid4().hex}",
+            source_job_id=source_job_id,
             prompt=prompt,
             chat_id=chat_id,
             visibility=visibility,

--- a/apps/api/auth.py
+++ b/apps/api/auth.py
@@ -18,6 +18,7 @@ from jwt import PyJWKClient
 from apps.api.auth_mode import clerk_auth_required
 from apps.api.cli_auth_store import is_cli_access_token, resolve_access_token
 from forma_core.config import config
+from forma_core.debug import new_error_correlation_id
 
 
 LOCAL_USER_ID = "local-dev-user"
@@ -235,6 +236,46 @@ def clerk_user_image_url(user_id: str) -> Optional[str]:
 def clerk_user_email(user_id: str) -> Optional[str]:
     profile = clerk_user_profile(user_id)
     return profile.get("email") if profile else None
+
+
+def opencode_allowed_emails() -> frozenset[str]:
+    """Return the exact server-configured allowlist for hosted OpenCode."""
+    return frozenset(email.strip().lower() for email in _csv_env("FORMA_OPENCODE_ALLOWED_EMAILS") if "@" in email)
+
+
+async def require_opencode_authoring_access(request: Request) -> UserContext:
+    """Require a hosted Clerk user whose primary email is explicitly allowed.
+
+    This intentionally does not use admin status or either service API key. The
+    email is resolved from Clerk by the server, never accepted from the caller.
+    """
+    deployment = (config.get("FORMA_DEPLOYMENT_MODE") or "").strip().lower()
+    try:
+        clerk_required = deployed_auth_required()
+    except RuntimeError:
+        clerk_required = False
+    if deployment not in {"hosted", "production", "prod"} or not clerk_required:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=_opencode_auth_error("opencode_hosted_only", "Hosted OpenCode access is unavailable."),
+        )
+    context = await require_user_context(request)
+    if context.provider != "clerk" or not context.owner_user_id:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=_opencode_auth_error("opencode_clerk_required", "A Clerk user session is required."),
+        )
+    email = clerk_user_email(context.owner_user_id)
+    if not email or email.strip().lower() not in opencode_allowed_emails():
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=_opencode_auth_error("opencode_email_not_allowed", "This account is not enabled for hosted OpenCode."),
+        )
+    return context
+
+
+def _opencode_auth_error(code: str, message: str) -> Dict[str, str]:
+    return {"code": code, "message": message, "correlation_id": new_error_correlation_id()}
 
 
 def _request_bearer_token(request: Any) -> Optional[str]:

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -166,6 +166,7 @@ from apps.api.cli_credentials_api import router as cli_credentials_router
 from apps.api.compatibility import require_client_compatibility
 from apps.api.version_api import router as version_router
 from apps.api.hosted_chat import require_hosted_chat_enabled
+from apps.api.opencode_api import router as opencode_router
 from apps.api.auth import (
     UserContext,
     require_a2a_admin_user_context,
@@ -365,6 +366,7 @@ app.include_router(cli_auth_router, dependencies=[Depends(require_client_compati
 app.include_router(cli_projects_router, dependencies=[Depends(require_client_compatibility)])
 app.include_router(cli_credentials_router, dependencies=[Depends(require_client_compatibility)])
 app.include_router(version_router)
+app.include_router(opencode_router)
 
 
 def _deployment_runtime_config(llm_config: Dict[str, Any]) -> Dict[str, Any]:

--- a/apps/api/opencode_api.py
+++ b/apps/api/opencode_api.py
@@ -1,0 +1,390 @@
+"""Hosted OpenCode gateway and connector protocol endpoints."""
+
+from __future__ import annotations
+
+import hmac
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+from fastapi import APIRouter, Body, Depends, Header, HTTPException, Query, Response, status
+
+from apps.api.auth import UserContext, require_opencode_authoring_access
+from apps.api.opencode_mcp import handle_opencode_mcp_json_rpc
+from forma_core.config import config
+from forma_core.debug import new_error_correlation_id
+from forma_core.opencode.capabilities import CapabilityError, ConnectorCapability, issue_capability, verify_capability
+from forma_core.opencode.models import (
+    CommandResponse,
+    ConnectorCapabilityResponse,
+    ConnectorCapabilityRequest,
+    ConnectorCommand,
+    ConnectorCompletion,
+    ConnectorEventInput,
+    ConnectorHeartbeat,
+    ConnectorLeaseResponse,
+    ConnectorSession,
+    ConnectorSessionPage,
+    CreateSessionRequest,
+    EventPage,
+    OpenCodeCommandStatus,
+    OpenCodeEventKind,
+    OpenCodeOperation,
+    OpenCodeSessionStatus,
+    PublicEvent,
+    SessionResponse,
+    SubmitCommandRequest,
+    McpJsonRpcRequest,
+)
+from forma_core.opencode.public_events import project_public_event
+from forma_core.opencode.store import OpenCodeStore, StoredCommand, StoredSession
+from forma_core.database import get_project_identity
+
+
+router = APIRouter(prefix="/opencode", tags=["opencode"])
+OPENCODE_STORE = OpenCodeStore()
+
+
+@router.post("/sessions", response_model=SessionResponse, status_code=status.HTTP_201_CREATED)
+def create_opencode_session(
+    request: CreateSessionRequest,
+    user: UserContext = Depends(require_opencode_authoring_access),
+) -> SessionResponse:
+    owner = _owner(user)
+    project_id = request.project_id or UUID(str(uuid4()))
+    if request.project_id:
+        _require_owned_project(str(project_id), owner)
+    session = OPENCODE_STORE.create_session(
+        session_id=f"ocs_{uuid4().hex}",
+        connector_id=request.connector_id.strip(),
+        owner_user_id=owner,
+        project_id=str(project_id),
+    )
+    return _session_response(session)
+
+
+@router.get("/sessions/{session_id}", response_model=SessionResponse)
+def get_opencode_session(
+    session_id: str,
+    user: UserContext = Depends(require_opencode_authoring_access),
+) -> SessionResponse:
+    session = _owned_session(session_id, _owner(user))
+    return _session_response(session)
+
+
+@router.post("/sessions/{session_id}/commands", response_model=CommandResponse, status_code=status.HTTP_201_CREATED)
+def submit_opencode_command(
+    session_id: str,
+    request: SubmitCommandRequest,
+    user: UserContext = Depends(require_opencode_authoring_access),
+) -> CommandResponse:
+    session = _owned_session(session_id, _owner(user))
+    if session.status != OpenCodeSessionStatus.ACTIVE:
+        raise _http_error(409, "opencode_session_closed", "The OpenCode session is no longer active.")
+    command = OPENCODE_STORE.create_command(
+        command_id=f"occ_{uuid4().hex}",
+        session=session,
+        operation=OpenCodeOperation.PROJECT_MESSAGE,
+        idempotency_key=request.idempotency_key,
+        message=request.message,
+    )
+    _store_event(
+        session,
+        ConnectorEventInput(
+            event_id=f"queued_{command.command_id}",
+            kind=OpenCodeEventKind.QUEUED.value,
+            status=OpenCodeCommandStatus.QUEUED,
+        ),
+    )
+    return _command_response(command)
+
+
+@router.get("/sessions/{session_id}/events", response_model=EventPage)
+def list_opencode_events(
+    session_id: str,
+    cursor: int = Query(0, ge=0),
+    limit: int = Query(50, ge=1, le=200),
+    user: UserContext = Depends(require_opencode_authoring_access),
+) -> EventPage:
+    session = _owned_session(session_id, _owner(user))
+    _record_connector_unavailable_if_stale(session)
+    events = tuple(OPENCODE_STORE.list_events(session.session_id, cursor, limit))
+    next_cursor = events[-1].sequence if events else cursor
+    return EventPage(events=events, next_cursor=next_cursor)
+
+
+@router.post("/sessions/{session_id}/cancel", response_model=SessionResponse)
+def cancel_opencode_session(
+    session_id: str,
+    user: UserContext = Depends(require_opencode_authoring_access),
+) -> SessionResponse:
+    session = _owned_session(session_id, _owner(user))
+    if session.status == OpenCodeSessionStatus.ACTIVE:
+        _set_session_status(session, OpenCodeSessionStatus.CANCELLED)
+        OPENCODE_STORE.cancel_session_commands(session.session_id)
+        _store_event(
+            session,
+            ConnectorEventInput(event_id=f"cancelled_{session.session_id}", kind=OpenCodeEventKind.CANCELLED.value, status=OpenCodeCommandStatus.CANCELLED),
+        )
+        session = OPENCODE_STORE.get_session(session.session_id) or session
+    return _session_response(session)
+
+
+@router.post("/connector/capability")
+def issue_opencode_connector_capability(
+    request: ConnectorCapabilityRequest,
+    bootstrap: str | None = Header(default=None, alias="X-Forma-OpenCode-Bootstrap"),
+) -> ConnectorCapabilityResponse:
+    _require_connector_bootstrap(bootstrap)
+    session = OPENCODE_STORE.get_session(request.session_id)
+    if session is None or session.connector_id != request.connector_id or session.status != OpenCodeSessionStatus.ACTIVE:
+        raise _http_error(404, "opencode_session_not_found", "The OpenCode session was not found.")
+    token = issue_capability(
+        connector_id=session.connector_id,
+        session_id=session.session_id,
+        project_id=session.project_id,
+        owner_user_id=session.owner_user_id,
+        scopes=frozenset({"poll", "heartbeat", "events", "complete", "mcp"}),
+    )
+    return ConnectorCapabilityResponse(capability=token)
+
+
+@router.get("/connector/sessions", response_model=ConnectorSessionPage)
+def list_opencode_connector_sessions(
+    connector_id: str = Query(..., min_length=1, max_length=120),
+    bootstrap: str | None = Header(default=None, alias="X-Forma-OpenCode-Bootstrap"),
+) -> ConnectorSessionPage:
+    _require_connector_bootstrap(bootstrap)
+    sessions = OPENCODE_STORE.list_connector_sessions(connector_id.strip())
+    return ConnectorSessionPage(
+        sessions=tuple(
+            ConnectorSession(session_id=session.session_id, connector_id=session.connector_id, project_id=UUID(session.project_id))
+            for session in sessions
+        )
+    )
+
+
+@router.get("/connector/commands", response_model=ConnectorCommand | None)
+def poll_opencode_command(
+    session_id: str,
+    capability: str | None = Header(default=None, alias="X-Forma-OpenCode-Capability"),
+    authorization: str | None = Header(default=None),
+    lease_seconds: int = Query(60, ge=15, le=300),
+) -> ConnectorCommand | Response:
+    cap = _connector_capability(capability or _bearer(authorization), session_id=session_id, scope="poll")
+    session = _scoped_connector_session(cap)
+    OPENCODE_STORE.touch_session(session.session_id)
+    configured_lease_seconds = lease_seconds if isinstance(lease_seconds, int) else 60
+    if session.status != OpenCodeSessionStatus.ACTIVE:
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    command = OPENCODE_STORE.claim_next(connector_id=session.connector_id, session_id=session.session_id, lease_seconds=configured_lease_seconds)
+    if command is None:
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+    return command
+
+
+@router.post("/connector/sessions/{session_id}/heartbeat")
+def heartbeat_opencode_session(
+    session_id: str,
+    capability: str | None = Header(default=None, alias="X-Forma-OpenCode-Capability"),
+    authorization: str | None = Header(default=None),
+) -> dict[str, str]:
+    cap = _connector_capability(capability or _bearer(authorization), session_id=session_id, scope="heartbeat")
+    session = _scoped_connector_session(cap)
+    OPENCODE_STORE.touch_session(session.session_id)
+    return {"status": "ok"}
+
+
+@router.post("/connector/commands/{command_id}/heartbeat", response_model=ConnectorLeaseResponse)
+def heartbeat_opencode_command(
+    command_id: str,
+    request: ConnectorHeartbeat,
+    capability: str | None = Header(default=None, alias="X-Forma-OpenCode-Capability"),
+    authorization: str | None = Header(default=None),
+) -> ConnectorLeaseResponse:
+    command = _connector_command(command_id, capability or _bearer(authorization), "heartbeat")
+    try:
+        updated = OPENCODE_STORE.heartbeat(command, request.lease_token)
+    except PermissionError as exc:
+        raise _http_error(403, "opencode_lease_invalid", "The command lease is invalid or expired.") from exc
+    return ConnectorLeaseResponse(
+        command_id=updated.command_id,
+        status=updated.status,
+        lease_expires_at=_datetime(updated.lease_expires_at or ""),
+    )
+
+
+@router.post("/connector/commands/{command_id}/events", response_model=PublicEvent)
+def ingest_opencode_event(
+    command_id: str,
+    event: ConnectorEventInput,
+    capability: str | None = Header(default=None, alias="X-Forma-OpenCode-Capability"),
+    authorization: str | None = Header(default=None),
+    lease_token: str | None = Header(default=None, alias="X-Forma-OpenCode-Lease"),
+) -> PublicEvent:
+    resolved_capability = capability or _bearer(authorization)
+    command = _connector_command(command_id, resolved_capability, "events")
+    if not lease_token:
+        raise _http_error(401, "opencode_lease_required", "The command lease is required for event delivery.")
+    try:
+        OPENCODE_STORE.validate_lease(command, lease_token)
+    except PermissionError as exc:
+        raise _http_error(403, "opencode_lease_invalid", "The command lease is invalid or expired.") from exc
+    if event.project_id is not None and str(event.project_id) != command.project_id:
+        raise _http_error(403, "opencode_scope_mismatch", "The event is outside the command project scope.")
+    session = _scoped_connector_session(verify_capability(resolved_capability or "", session_id=command.session_id, project_id=command.project_id, owner_user_id=command.owner_user_id, scope="events"))
+    return _store_event(session, event)
+
+
+@router.post("/connector/commands/{command_id}/complete", response_model=CommandResponse)
+def complete_opencode_command(
+    command_id: str,
+    request: ConnectorCompletion,
+    capability: str | None = Header(default=None, alias="X-Forma-OpenCode-Capability"),
+    authorization: str | None = Header(default=None),
+) -> CommandResponse:
+    command = _connector_command(command_id, capability or _bearer(authorization), "complete")
+    try:
+        updated = OPENCODE_STORE.complete(command, request.lease_token, request.status)
+    except PermissionError as exc:
+        raise _http_error(403, "opencode_lease_invalid", "The command lease is invalid or expired.") from exc
+    return _command_response(updated)
+
+
+@router.post("/mcp", response_model=None)
+async def opencode_mcp_endpoint(
+    payload: McpJsonRpcRequest | list[McpJsonRpcRequest] = Body(...),
+    capability: str | None = Header(default=None, alias="X-Forma-OpenCode-Capability"),
+    authorization: str | None = Header(default=None),
+) -> dict[str, object] | list[dict[str, object]] | Response:
+    cap = _connector_capability(capability or _bearer(authorization), scope="mcp")
+    response = await handle_opencode_mcp_json_rpc(payload, cap)
+    return Response(status_code=status.HTTP_202_ACCEPTED) if response is None else response
+
+
+def _owner(user: UserContext) -> str:
+    owner = str(user.owner_user_id or "").strip()
+    if not owner:
+        raise _http_error(401, "authentication_required", "A signed-in owner is required.")
+    return owner
+
+
+def _require_owned_project(project_id: str, owner_user_id: str) -> None:
+    identity = get_project_identity(project_id)
+    if identity is None or str(identity.get("owner_user_id") or "") != owner_user_id or identity.get("status", "active") != "active":
+        raise _http_error(404, "opencode_project_not_found", "The project is not available to this account.")
+
+
+def _owned_session(session_id: str, owner_user_id: str) -> StoredSession:
+    session = OPENCODE_STORE.get_session(session_id)
+    if session is None or session.owner_user_id != owner_user_id:
+        raise _http_error(404, "opencode_session_not_found", "The OpenCode session was not found.")
+    return session
+
+
+def _session_response(session: StoredSession) -> SessionResponse:
+    return SessionResponse(
+        session_id=session.session_id, connector_id=session.connector_id, project_id=session.project_id,
+        owner_user_id=session.owner_user_id, status=session.status, created_at=_datetime(session.created_at), updated_at=_datetime(session.updated_at),
+    )
+
+
+def _command_response(command: StoredCommand) -> CommandResponse:
+    return CommandResponse(
+        command_id=command.command_id, session_id=command.session_id, project_id=command.project_id,
+        operation=command.operation, status=command.status, attempt_count=command.attempt_count,
+        created_at=_datetime(command.created_at), updated_at=_datetime(command.updated_at),
+    )
+
+
+def _datetime(value: str) -> datetime:
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    return datetime.fromisoformat(normalized).astimezone(timezone.utc)
+
+
+def _store_event(session: StoredSession, event: ConnectorEventInput) -> PublicEvent:
+    public_event = project_public_event(
+        event,
+        sequence=OPENCODE_STORE.next_event_sequence(session.session_id),
+        session_id=session.session_id,
+        project_id=UUID(session.project_id),
+    )
+    return OPENCODE_STORE.add_event(public_event)
+
+
+def _record_connector_unavailable_if_stale(session: StoredSession) -> None:
+    heartbeat = session.last_heartbeat_at
+    if heartbeat:
+        normalized = heartbeat[:-1] + "+00:00" if heartbeat.endswith("Z") else heartbeat
+        try:
+            age = (datetime.now(timezone.utc) - datetime.fromisoformat(normalized).astimezone(timezone.utc)).total_seconds()
+        except ValueError:
+            age = 0
+    else:
+        age = 10**9
+    if age < 120 or session.status != OpenCodeSessionStatus.ACTIVE:
+        return
+    _store_event(
+        session,
+        ConnectorEventInput(
+            event_id=f"connector_unavailable_{session.session_id}",
+            kind=OpenCodeEventKind.CONNECTOR_UNAVAILABLE.value,
+        ),
+    )
+
+
+def _set_session_status(session: StoredSession, new_status: OpenCodeSessionStatus) -> None:
+    provider = OPENCODE_STORE.provider
+    now = _timestamp()
+    if hasattr(provider, "client"):
+        provider.client.table("opencode_sessions").update({"status": new_status.value, "updated_at": now}).eq("session_id", session.session_id).execute()
+    else:
+        with OPENCODE_STORE._connection() as connection:
+            connection.execute("UPDATE opencode_sessions SET status = ?, updated_at = ? WHERE session_id = ?", (new_status.value, now, session.session_id))
+
+
+def _connector_capability(token: str | None, *, session_id: str | None = None, scope: str) -> ConnectorCapability:
+    if not token:
+        raise _http_error(401, "opencode_capability_required", "A connector capability is required.")
+    try:
+        return verify_capability(token, session_id=session_id, scope=scope)
+    except CapabilityError as exc:
+        raise _http_error(403, "opencode_capability_invalid", "The connector capability is invalid or out of scope.") from exc
+
+
+def _bearer(value: str | None) -> str | None:
+    if not value:
+        return None
+    scheme, _, token = value.partition(" ")
+    return token.strip() if scheme.lower() == "bearer" and token.strip() else None
+
+
+def _scoped_connector_session(capability: ConnectorCapability) -> StoredSession:
+    session = OPENCODE_STORE.get_session(capability.session_id)
+    if session is None or session.connector_id != capability.connector_id or session.project_id != capability.project_id or session.owner_user_id != capability.owner_user_id:
+        raise _http_error(403, "opencode_scope_mismatch", "The connector capability does not match the session.")
+    return session
+
+
+def _connector_command(command_id: str, token: str | None, scope: str) -> StoredCommand:
+    cap = _connector_capability(token, scope=scope)
+    command = OPENCODE_STORE.get_command(command_id)
+    if command is None or command.session_id != cap.session_id or command.connector_id != cap.connector_id or command.project_id != cap.project_id or command.owner_user_id != cap.owner_user_id:
+        raise _http_error(403, "opencode_scope_mismatch", "The connector capability does not match the command.")
+    return command
+
+
+def _require_connector_bootstrap(value: str | None) -> None:
+    configured = (config.get("FORMA_OPENCODE_CONNECTOR_BOOTSTRAP_TOKEN") or "").strip()
+    if len(configured) < 32 or not value or not hmac.compare_digest(value, configured):
+        raise _http_error(401, "opencode_connector_auth_required", "The connector bootstrap credential is invalid.")
+
+
+def _timestamp() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _http_error(code: int, error_code: str, message: str) -> HTTPException:
+    return HTTPException(
+        status_code=code,
+        detail={"code": error_code, "message": message, "correlation_id": new_error_correlation_id()},
+    )

--- a/apps/api/opencode_mcp.py
+++ b/apps/api/opencode_mcp.py
@@ -1,0 +1,180 @@
+"""Restricted MCP tools for one authenticated OpenCode project session."""
+
+from __future__ import annotations
+
+import json
+import hashlib
+import logging
+
+from apps.api.a2a import _persist_mcp_compile
+from apps.api.auth import UserContext
+from forma_core.workspaces.projects.cad_generation import ensure_native_cad_model
+from forma_core.debug import new_error_correlation_id
+from forma_core.opencode.capabilities import ConnectorCapability
+from forma_core.opencode.models import (
+    McpJsonRpcRequest,
+    McpToolArguments,
+    ProjectToolResult,
+)
+from forma_core.database import get_latest_project_revision, get_project_revision_by_source_job
+from forma_core.validation import build_validation_summary, validate_circuit
+from forma_core.workspaces.projects.models import HardwareIR
+from forma_core.utils import generate_mermaid_chart, generate_svg_schematic
+
+
+logger = logging.getLogger(__name__)
+
+
+def opencode_mcp_tools() -> list[dict[str, object]]:
+    """Return only project authoring tools, never the broad Forma MCP registry."""
+    project_ir_schema = {"type": "object", "description": "Forma Hardware IR for this session project."}
+    return [
+        {
+            "name": "forma.opencode.create_project",
+            "description": "Create the private project bound to the current OpenCode session.",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+        {
+            "name": "forma.opencode.read_project",
+            "description": "Read the current private project bound to the current OpenCode session.",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+        {
+            "name": "forma.opencode.update_project",
+            "description": "Validate and persist a new revision of the current session project.",
+            "inputSchema": {"type": "object", "properties": {"project_ir": project_ir_schema}, "required": ["project_ir"]},
+        },
+        {
+            "name": "forma.opencode.compile_project",
+            "description": "Compile and persist Hardware IR for the current private project.",
+            "inputSchema": {"type": "object", "properties": {"project_ir": project_ir_schema}, "required": ["project_ir"]},
+        },
+        {
+            "name": "forma.opencode.validate_project",
+            "description": "Run deterministic Forma electrical validation for the session project.",
+            "inputSchema": {"type": "object", "properties": {"project_ir": project_ir_schema}, "required": ["project_ir"]},
+        },
+    ]
+
+
+async def handle_opencode_mcp_json_rpc(
+    payload: McpJsonRpcRequest | list[McpJsonRpcRequest],
+    capability: ConnectorCapability,
+) -> dict[str, object] | list[dict[str, object]] | None:
+    if isinstance(payload, list):
+        responses = [await _handle_request(item, capability) for item in payload]
+        return [response for response in responses if response is not None] or None
+    return await _handle_request(payload, capability)
+
+
+async def _handle_request(request: McpJsonRpcRequest, capability: ConnectorCapability) -> dict[str, object] | None:
+    request_id = request.id
+    if "id" not in request.model_fields_set:
+        return None
+    method = request.method
+    params = request.params
+    if method == "initialize":
+        return _result(request_id, {"protocolVersion": "2025-06-18", "serverInfo": {"name": "forma-opencode", "version": "1.0.0"}, "capabilities": {"tools": {}}})
+    if method == "notifications/initialized":
+        return None
+    if method == "ping":
+        return _result(request_id, {})
+    if method == "tools/list":
+        return _result(request_id, {"tools": opencode_mcp_tools()})
+    if method != "tools/call":
+        return _error(request_id, -32601, "The requested MCP method was not found.", "mcp_method_not_found")
+    tool_name = params.name
+    arguments = params.arguments
+    if not tool_name:
+        return _error(request_id, -32602, "Request parameters are invalid.", "mcp_invalid_params")
+    try:
+        result = await _call_tool(tool_name, arguments, capability)
+    except PermissionError:
+        return _error(request_id, -32003, "The OpenCode tool is outside the session scope.", "authorization_required")
+    except (TypeError, ValueError, KeyError):
+        return _error(request_id, -32602, "The project tool parameters are invalid.", "mcp_invalid_params")
+    except Exception:
+        logger.warning("Restricted OpenCode MCP tool failed")
+        return _error(request_id, -32000, "The OpenCode project tool could not complete.", "mcp_tool_failed")
+    return _result(request_id, {"content": [{"type": "text", "text": json.dumps(result)}], "structuredContent": result})
+
+
+async def _call_tool(name: str, arguments: McpToolArguments, capability: ConnectorCapability) -> dict[str, object]:
+    allowed = {tool["name"] for tool in opencode_mcp_tools()}
+    if name not in allowed:
+        raise PermissionError("The requested tool is not part of the project-only surface.")
+    project_id = capability.project_id
+    owner_user_id = capability.owner_user_id
+    user_context = UserContext(
+        provider="opencode-connector",
+        subject=owner_user_id,
+        owner_user_id=owner_user_id,
+        is_authenticated=True,
+        is_admin=False,
+    )
+    if name == "forma.opencode.create_project":
+        project = HardwareIR.model_validate({"components": [], "nets": []})
+        result = _compile(project, project_id, user_context)
+        return ProjectToolResult.model_validate(result).model_dump(mode="json")
+    if name == "forma.opencode.read_project":
+        revision = get_latest_project_revision(project_id, owner_user_id)
+        if revision is None:
+            raise ValueError("The session project has not been created.")
+        project = revision.state
+        return _tool_result(project, project_id, str(getattr(revision, "id", "")) or None)
+    if arguments.project_ir is None:
+        raise ValueError("project_ir is required")
+    project = arguments.project_ir
+    if name == "forma.opencode.validate_project":
+        return _validation_result(project)
+    if name in {"forma.opencode.compile_project", "forma.opencode.update_project"}:
+        result = _compile(project, project_id, user_context)
+        return ProjectToolResult.model_validate(result).model_dump(mode="json")
+    raise PermissionError("The requested tool is not part of the project-only surface.")
+
+
+def _compile(project: HardwareIR, project_id: str, user_context: UserContext) -> dict[str, object]:
+    metadata = dict(project.assembly_metadata or {})
+    metadata.update({"project_id": project_id, "authoring_agent": "opencode"})
+    project.assembly_metadata = metadata
+    issues = validate_circuit(project.components, project.nets, project.requirements)
+    project.validation = build_validation_summary(issues)
+    project.is_valid = not project.validation.critical
+    ensure_native_cad_model(project, project_id=project_id, required=False, authoring_agent="opencode", workflow="default")
+    source_job_id = "opencode-" + hashlib.sha256(
+        json.dumps(project.model_dump(mode="json"), sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()[:32]
+    existing = get_project_revision_by_source_job(project_id, user_context.owner_user_id or "", source_job_id)
+    if existing is not None:
+        return _tool_result(existing.state, project_id, str(getattr(existing, "id", "")) or None)
+    _persist_mcp_compile(
+        project,
+        {"project_id": project_id, "prompt": "OpenCode project", "visibility": "private", "authoring_agent": "opencode", "source_job_id": source_job_id},
+        user_context,
+    )
+    revision = get_latest_project_revision(project_id, user_context.owner_user_id or "")
+    return _tool_result(project, project_id, str(getattr(revision, "id", "")) or None if revision else None)
+
+
+def _tool_result(project: HardwareIR, project_id: str, revision_id: str | None) -> dict[str, object]:
+    return {
+        "project_id": project_id,
+        "revision_id": revision_id,
+        "project_ir": project.model_dump(mode="json"),
+        "validation": {"is_valid": project.is_valid, "issues": [issue.model_dump(mode="json") for issue in [*project.validation.critical, *project.validation.warning, *project.validation.info]]},
+        "mermaid_code": generate_mermaid_chart(project),
+        "svg_schematic": generate_svg_schematic(project),
+    }
+
+
+def _validation_result(project: HardwareIR) -> dict[str, object]:
+    issues = validate_circuit(project.components, project.nets, project.requirements)
+    return {"is_valid": not any(issue.severity.upper() == "CRITICAL" for issue in issues), "issues": [issue.model_dump(mode="json") for issue in issues]}
+
+
+def _result(request_id: object, result: object) -> dict[str, object]:
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}
+
+
+def _error(request_id: object, code: int, message: str, error_code: str) -> dict[str, object]:
+    return {"jsonrpc": "2.0", "id": request_id, "error": {"code": code, "message": message, "data": {"code": error_code, "correlation_id": new_error_correlation_id()}}}

--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -12,6 +12,13 @@ import {
 } from "../lib/active-llms";
 import { buildProjectDocsMarkdown, docsExportFilename } from "../lib/docs-export";
 import { normalizeContextSuggestions } from "../lib/context-suggestions";
+import {
+  cancelOpenCodeSession,
+  createOpenCodeSession,
+  listOpenCodeEvents,
+  submitOpenCodeCommand,
+  type OpenCodeEvent,
+} from "../lib/opencode";
 import { authoringModeEnabled, usableRuntimeLlmOptions, webConfig, type RuntimeConfigContract } from "../lib/config";
 import { calculateProjectCostMetrics, resolveProjectComponentInstances } from "../lib/project-cost-metrics";
 import { useFormaAuth } from "../lib/forma-auth";
@@ -63,7 +70,6 @@ import ConversationMessageList, {
 } from "./forma-workspace/conversation-message-list";
 import HostedChatMaintenance, {
   AUTHORING_MODE_ACTIVE_MESSAGE,
-  AUTHORING_MODE_HANDOFF_MESSAGE,
   AuthoringModeBanner,
   HOSTED_CHAT_MAINTENANCE_MESSAGE,
 } from "./forma-workspace/hosted-chat-maintenance";
@@ -237,6 +243,7 @@ type ActiveGenerationRun = {
   projectId?: string | null;
   chatId: string;
   assistantMessageId: string | null;
+  openCodeSessionId?: string | null;
   cancelled: boolean;
 };
 
@@ -1794,6 +1801,7 @@ export function FormaWorkspace({
   });
   const [formaDevMode, setFormaDevMode] = useState(false);
   const [authoringMode, setAuthoringMode] = useState(false);
+  const [openCodeConnectorId, setOpenCodeConnectorId] = useState<string | null>(null);
   const [generateProductImage, setGenerateProductImage] = useState(false);
   const [generationWorkflow, setGenerationWorkflow] = useState(DEFAULT_WORKFLOW_ID);
   const [generationWorkflows, setGenerationWorkflows] = useState<GenerationWorkflowOption[]>(defaultGenerationWorkflows);
@@ -1824,6 +1832,9 @@ export function FormaWorkspace({
   const pipelineStepsLastRequestedWorkflowRef = useRef<string | null>(null);
   const recoveryJobMissesRef = useRef(new Map<string, { misses: number; retryAfter: number }>());
   const activeGenerationRef = useRef<ActiveGenerationRun | null>(null);
+  const openCodeSessionsRef = useRef<Record<string, string>>({});
+  const openCodeCursorsRef = useRef<Record<string, number>>({});
+  const openCodePollTimersRef = useRef<Record<string, number>>({});
   const visibleChatSourceProjects = myProjectHistory;
   const visibleChatSourceItems = useMemo(
     () => authRequired
@@ -1934,7 +1945,7 @@ export function FormaWorkspace({
       ? generationInputValidation.message
       : null);
   const hostedChatReadOnly = !hostedChatEnabled;
-  const chatReadOnly = hostedChatReadOnly || authoringMode;
+  const chatReadOnly = hostedChatReadOnly && !authoringMode;
   const chatUnavailableReason = hostedChatReadOnly
     ? HOSTED_CHAT_MAINTENANCE_MESSAGE
     : authoringMode
@@ -2841,6 +2852,11 @@ export function FormaWorkspace({
         setHostedChatEnabled(config.deployment.hosted_chat_enabled);
       }
       setAuthoringMode(authoringModeEnabled(config));
+      setOpenCodeConnectorId(
+        typeof config.deployment?.opencode_connector_id === "string" && config.deployment.opencode_connector_id.trim()
+          ? config.deployment.opencode_connector_id.trim()
+          : null,
+      );
       setFormaDevMode(config.forma_dev_mode === true);
       const activeLlms = usableRuntimeLlmOptions(config);
       const selectedLlm = config.generation.selected_llm;
@@ -3305,6 +3321,7 @@ export function FormaWorkspace({
       jobId: null,
       chatId,
       assistantMessageId: null,
+      openCodeSessionId: null,
       cancelled: false,
     };
     activeGenerationRef.current = run;
@@ -3446,7 +3463,12 @@ export function FormaWorkspace({
         ? "Build stopped. Your project brief is preserved."
         : "Generation stopped. You can send another message whenever you're ready.",
     );
-    if (run.kind === "context-build" && run.projectId && run.planId) {
+    if (authoringMode && run.openCodeSessionId) {
+      delete openCodeSessionsRef.current[run.chatId];
+      void generationRequestHeaders()
+        .then((headers) => cancelOpenCodeSession(API_URL, headers, run.openCodeSessionId || ""))
+        .catch(() => undefined);
+    } else if (run.kind === "context-build" && run.projectId && run.planId) {
       void cancelContextBuild(run.projectId, run.planId);
     } else if (run.jobId) {
       void cancelGenerationJob(run.jobId);
@@ -3754,11 +3776,30 @@ export function FormaWorkspace({
   }, [activeChatId, chatMessageIdentityKey(chatMessages), hostedChatEnabled]);
 
   const submitGatherContext = async (answer?: string) => {
-    if (!requireHostedChatEnabled()) return;
     if (authoringMode) {
-      setGenerationInputNotice(AUTHORING_MODE_ACTIVE_MESSAGE);
+      if (selectedImage) {
+        setGenerationInputNotice("Image attachments are not available in OpenCode authoring yet.");
+        return;
+      }
+      const text = (answer ?? prompt).trim();
+      if (!text || !openCodeConnectorId) {
+        setGenerationInputNotice(openCodeConnectorId ? "Describe the hardware project you want OpenCode to author." : "OpenCode authoring is not configured for this deployment.");
+        return;
+      }
+      const requestChatId = activeChatId || newBuildChatId();
+      setActiveChatId(requestChatId);
+      rememberChatItem({ chatId: requestChatId, title: text, projectId: "", createdAt: chatTimestamp(), projectCount: 0 });
+      syncChatRoute(requestChatId);
+      const userMessageId = appendChatMessage({ id: newChatMessageId(), role: "user", content: text, status: "idle" });
+      appendThreadMessage(requestChatId, { id: userMessageId, role: "user", content: text, status: "idle" });
+      const assistantMessageId = appendChatMessage({ id: newChatMessageId(), role: "assistant", content: "Sending to OpenCode…", status: "loading" });
+      appendThreadMessage(requestChatId, { id: assistantMessageId, role: "assistant", content: "Sending to OpenCode…", status: "loading" });
+      setPrompt("");
+      setGenerationInputNotice(null);
+      void submitOpenCodeTurn({ chatId: requestChatId, message: text, assistantMessageId });
       return;
     }
+    if (!requireHostedChatEnabled()) return;
     if (contextSubmitting || activeGenerationRef.current) return;
     if (!(await requireSignedInForGeneration())) return;
 
@@ -4396,30 +4437,59 @@ export function FormaWorkspace({
 
   const handleProjectChatGenerate = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (!requireHostedChatEnabled()) return;
     if (authoringMode) {
       const handoffProjectId = currentProjectId;
       const handoffMessage = projectChatInput.trim();
-      if (!handoffProjectId || !projectIR || !handoffMessage) return;
+      if (!handoffProjectId || !projectIR || !handoffMessage || !openCodeConnectorId) {
+        if (!openCodeConnectorId) setGenerationInputNotice("OpenCode authoring is not configured for this deployment.");
+        return;
+      }
       const sourceChatId = currentProjectChatId || activeChatId || newBuildChatId();
       setActiveChatId(sourceChatId);
-      appendThreadMessage(sourceChatId, {
+      const userMessageId = appendThreadMessage(sourceChatId, {
         role: "user",
         content: handoffMessage,
         status: "idle",
         projectId: handoffProjectId,
       });
-      appendThreadMessage(sourceChatId, {
+      const assistantMessageId = appendThreadMessage(sourceChatId, {
         role: "assistant",
-        content: AUTHORING_MODE_HANDOFF_MESSAGE,
-        status: "handed-off",
+        content: "Sending to OpenCode…",
+        status: "loading",
         projectId: handoffProjectId,
       });
       setProjectChatInput("");
       setGenerationInputNotice(null);
-      checkServerStatus();
+      if (sourceChatId === activeChatId) {
+        setChatMessages((current) => [
+          ...current,
+          {
+            id: userMessageId,
+            role: "user",
+            content: handoffMessage,
+            status: "idle",
+            projectId: handoffProjectId,
+            timestamp: chatTimestamp(),
+          },
+          {
+            id: assistantMessageId,
+            role: "assistant",
+            content: "Sending to OpenCode…",
+            status: "loading",
+            projectId: handoffProjectId,
+            timestamp: chatTimestamp(),
+          },
+        ]);
+      }
+      void submitOpenCodeTurn({
+        chatId: sourceChatId,
+        message: handoffMessage,
+        projectId: handoffProjectId,
+        assistantMessageId,
+      });
       return;
     }
+    if (!requireHostedChatEnabled()) return;
     if (activeGenerationRef.current) return;
     if (!(await requireSignedInForGeneration())) return;
     if (!currentUserOwnsProject) {
@@ -4654,6 +4724,144 @@ export function FormaWorkspace({
       if (!signal?.aborted) {
         setIsLoading(false);
       }
+    }
+  };
+
+  const openCodeEventPatch = (event: OpenCodeEvent): Partial<ChatMessage> => {
+    if (event.kind === "assistant_message" && event.message) {
+      return { content: event.message, status: "loading" };
+    }
+    if (event.kind === "completed") {
+      return {
+        content: "OpenCode finished authoring this project.",
+        status: "success",
+        projectId: event.project_id,
+      };
+    }
+    if (event.kind === "failed") {
+      return {
+        content: event.error?.message || "OpenCode could not complete this project change.",
+        status: "error",
+        projectId: event.project_id,
+      };
+    }
+    if (event.kind === "cancelled") {
+      return { content: "OpenCode authoring was stopped.", status: "cancelled", projectId: event.project_id };
+    }
+    if (event.kind === "connector_unavailable") {
+      return { content: "The local OpenCode connector is unavailable. Start it and try again.", status: "error" };
+    }
+    if (event.kind === "validating") return { content: "OpenCode is validating the project.", status: "loading" };
+    if (event.kind === "working" || event.kind === "progress" || event.kind === "queued") {
+      return { content: "OpenCode is authoring this project.", status: "loading" };
+    }
+    return {};
+  };
+
+  const pollOpenCodeTurn = (turn: {
+    chatId: string;
+    sessionId: string;
+    assistantMessageId: string;
+    run: ActiveGenerationRun;
+  }) => {
+    const poll = async () => {
+      if (turn.run.cancelled || turn.run.controller.signal.aborted) return;
+      try {
+        const page = await listOpenCodeEvents(
+          API_URL,
+          await generationRequestHeaders(),
+          turn.sessionId,
+          openCodeCursorsRef.current[turn.sessionId] || 0,
+        );
+        openCodeCursorsRef.current[turn.sessionId] = page.next_cursor;
+        let terminalEvent: OpenCodeEvent | null = null;
+        for (const event of page.events) {
+          if (event.session_id !== turn.sessionId) continue;
+          const patch = openCodeEventPatch(event);
+          updateThreadMessage(turn.chatId, turn.assistantMessageId, patch);
+          if (activeChatId === turn.chatId) updateChatMessage(turn.assistantMessageId, patch);
+          if (["completed", "failed", "cancelled", "connector_unavailable"].includes(event.kind)) terminalEvent = event;
+        }
+        if (terminalEvent) {
+          delete openCodePollTimersRef.current[turn.sessionId];
+          if (terminalEvent.kind === "cancelled") delete openCodeSessionsRef.current[turn.chatId];
+          if (terminalEvent.kind === "completed") {
+            rememberChatItem({
+              chatId: turn.chatId,
+              title: projectTitle || "OpenCode project",
+              projectId: terminalEvent.project_id,
+              createdAt: chatTimestamp(),
+              projectCount: 1,
+            });
+            void loadOldProject(terminalEvent.project_id, { syncRoute: false, tab: "chat", hydrateChat: true });
+            refreshProjectAndChatLists();
+          }
+          finishGenerationRun(turn.run);
+          return;
+        }
+        openCodePollTimersRef.current[turn.sessionId] = window.setTimeout(poll, 1500);
+      } catch (error) {
+        if (turn.run.cancelled || turn.run.controller.signal.aborted) return;
+        setGenerationInputNotice(error instanceof Error ? error.message : "OpenCode events could not be loaded.");
+        openCodePollTimersRef.current[turn.sessionId] = window.setTimeout(poll, 3000);
+      }
+    };
+    void poll();
+  };
+
+  const submitOpenCodeTurn = async ({
+    chatId,
+    message,
+    projectId,
+    assistantMessageId,
+  }: {
+    chatId: string;
+    message: string;
+    projectId?: string | null;
+    assistantMessageId: string;
+  }) => {
+    if (!openCodeConnectorId) {
+      const error = "OpenCode authoring is not configured for this deployment.";
+      updateChatMessage(assistantMessageId, { content: error, status: "error" });
+      updateThreadMessage(chatId, assistantMessageId, { content: error, status: "error" });
+      setGenerationInputNotice(error);
+      return;
+    }
+    const run = beginGenerationRun(projectId ? "project-chat" : "chat", chatId);
+    run.assistantMessageId = assistantMessageId;
+    try {
+      const headers = await generationRequestHeaders();
+      let session = openCodeSessionsRef.current[chatId];
+      let sessionProjectId = projectId || null;
+      if (!session) {
+        const created = await createOpenCodeSession(API_URL, headers, openCodeConnectorId, projectId);
+        session = created.session_id;
+        sessionProjectId = created.project_id;
+        openCodeSessionsRef.current[chatId] = session;
+        openCodeCursorsRef.current[session] = 0;
+        run.openCodeSessionId = session;
+        contextProjectIdsRef.current[chatId] = created.project_id;
+        rememberChatItem({
+          chatId,
+          title: projectTitle || message,
+          projectId: created.project_id,
+          createdAt: chatTimestamp(),
+          projectCount: 1,
+        });
+      }
+      run.projectId = sessionProjectId;
+      run.openCodeSessionId = session;
+      const command = await submitOpenCodeCommand(API_URL, headers, session, message);
+      run.jobId = command.command_id;
+      setActiveGeneration({ kind: run.kind, jobId: command.command_id });
+      setGenerationInputNotice("Sent to OpenCode. Live authoring status will appear here.");
+      pollOpenCodeTurn({ chatId, sessionId: session, assistantMessageId, run });
+    } catch (error) {
+      const messageText = error instanceof Error ? error.message : "OpenCode could not accept this request.";
+      updateChatMessage(assistantMessageId, { content: messageText, status: "error" });
+      updateThreadMessage(chatId, assistantMessageId, { content: messageText, status: "error" });
+      finishGenerationRun(run);
+      setGenerationInputNotice(messageText);
     }
   };
 
@@ -5356,7 +5564,7 @@ export function FormaWorkspace({
             onNewChat={startNewProjectChat}
             newChatDisabled={newChatDisabled}
             newChatDisabledReason={chatUnavailableReason}
-            readOnly={hostedChatReadOnly}
+             readOnly={chatReadOnly || authoringMode}
             onOpenChat={openChatItem}
             onRenameChat={renameSidebarChat}
             onPinChat={togglePinnedChat}
@@ -5379,7 +5587,7 @@ export function FormaWorkspace({
             onNewChat={startNewProjectChat}
             newChatDisabled={newChatDisabled}
             newChatDisabledReason={chatUnavailableReason}
-            readOnly={hostedChatReadOnly}
+             readOnly={chatReadOnly || authoringMode}
             onOpenChat={openChatItem}
             onRenameChat={renameSidebarChat}
             onPinChat={togglePinnedChat}
@@ -5428,9 +5636,9 @@ export function FormaWorkspace({
             chats={chatListItems}
             activeChatId={null}
             onNewChat={startNewProjectChat}
-            newChatDisabled={newChatDisabled}
-            newChatDisabledReason={chatUnavailableReason}
-            readOnly={hostedChatReadOnly}
+             newChatDisabled={newChatDisabled}
+             newChatDisabledReason={chatUnavailableReason}
+             readOnly={chatReadOnly || authoringMode}
             onOpenChat={openChatItem}
             onRenameChat={renameSidebarChat}
             onPinChat={togglePinnedChat}
@@ -5451,9 +5659,9 @@ export function FormaWorkspace({
             chats={chatListItems}
             activeChatId={null}
             onNewChat={startNewProjectChat}
-            newChatDisabled={newChatDisabled}
-            newChatDisabledReason={chatUnavailableReason}
-            readOnly={hostedChatReadOnly}
+             newChatDisabled={newChatDisabled}
+             newChatDisabledReason={chatUnavailableReason}
+             readOnly={chatReadOnly || authoringMode}
             onOpenChat={openChatItem}
             onRenameChat={renameSidebarChat}
             onPinChat={togglePinnedChat}
@@ -5502,11 +5710,11 @@ export function FormaWorkspace({
             onToggle={() => setSidebarCollapsed((value) => !value)}
             onHome={goHome}
             chats={chatListItems}
-            activeChatId={activeChatId}
+             activeChatId={activeChatId}
             onNewChat={startNewProjectChat}
             newChatDisabled={newChatDisabled}
             newChatDisabledReason={chatUnavailableReason}
-            readOnly={hostedChatReadOnly}
+             readOnly={chatReadOnly || authoringMode}
             onOpenChat={openChatItem}
             onRenameChat={renameSidebarChat}
             onPinChat={togglePinnedChat}
@@ -5525,11 +5733,11 @@ export function FormaWorkspace({
             onToggle={() => setSidebarCollapsed((value) => !value)}
             onHome={goHome}
             chats={chatListItems}
-            activeChatId={activeChatId}
+             activeChatId={activeChatId}
             onNewChat={startNewProjectChat}
             newChatDisabled={newChatDisabled}
             newChatDisabledReason={chatUnavailableReason}
-            readOnly={hostedChatReadOnly}
+             readOnly={chatReadOnly || authoringMode}
             onOpenChat={openChatItem}
             onRenameChat={renameSidebarChat}
             onPinChat={togglePinnedChat}
@@ -5564,7 +5772,7 @@ export function FormaWorkspace({
               title={(
                 <EditableWorkspaceTitle
                   value={activeSidebarChatItem?.title || NEW_PROJECT_TITLE}
-                  canEdit={hostedChatEnabled}
+                   canEdit={hostedChatEnabled && !authoringMode}
                   label="Chat title"
                   onCommit={(title) => {
                     if (activeChatId) {
@@ -5694,14 +5902,14 @@ export function FormaWorkspace({
           ) : (
             <HomeChatView
               started={activeSidebarChatStarted}
-              readOnly={hostedChatReadOnly}
+              readOnly={chatReadOnly}
               authoringActive={authoringMode}
               conversationKey={activeChatId || "new-chat"}
               workspaceTitle={
                 activeSidebarChatStarted ? (
                   <EditableWorkspaceTitle
                     value={activeSidebarChatItem?.title || NEW_PROJECT_TITLE}
-                    canEdit={hostedChatEnabled}
+                     canEdit={hostedChatEnabled && !authoringMode}
                     label="Chat title"
                     onCommit={(title) => {
                       if (activeChatId) {
@@ -5722,8 +5930,8 @@ export function FormaWorkspace({
                     <ChatProjectArtifact
                       projectId={currentProjectId}
                       projectTitle={projectTitle}
-                      canEdit={hostedChatEnabled && currentUserOwnsProject}
-                      onRenameTitle={hostedChatEnabled && currentUserOwnsProject ? (title) => { void commitOwnedWorkspaceTitle(title); } : undefined}
+                       canEdit={hostedChatEnabled && !authoringMode && currentUserOwnsProject}
+                       onRenameTitle={hostedChatEnabled && !authoringMode && currentUserOwnsProject ? (title) => { void commitOwnedWorkspaceTitle(title); } : undefined}
                       namespaceTabs={visibleWorkspaceTabs}
                       activeNamespace={activeWorkspaceTab.id}
                       onNamespaceChange={setActiveTab}
@@ -5752,7 +5960,7 @@ export function FormaWorkspace({
               onSelectContextSuggestion={(suggestion) => {
                 void submitGatherContext(suggestion);
               }}
-              isLoading={hostedChatEnabled && (contextSubmitting || Boolean(activeGeneration || pendingContextBuildMessage || resettingBuildMessageId))}
+               isLoading={(hostedChatEnabled || authoringMode) && (contextSubmitting || Boolean(activeGeneration || pendingContextBuildMessage || resettingBuildMessageId))}
               generationReady
               needsGenerationProvider={false}
               needsImageProvider={false}
@@ -5764,7 +5972,7 @@ export function FormaWorkspace({
                 setGenerationInputNotice(null);
                 setPrompt(value);
               }}
-              generationActive={hostedChatEnabled && Boolean(activeGeneration || pendingContextBuildMessage)}
+               generationActive={(hostedChatEnabled || authoringMode) && Boolean(activeGeneration || pendingContextBuildMessage)}
               onStop={() => {
                 if (activeGenerationRef.current) stopActiveGeneration();
                 else if (pendingContextBuildMessage) stopContextBuildMessage(pendingContextBuildMessage);
@@ -5810,11 +6018,11 @@ export function FormaWorkspace({
           onToggle={() => setSidebarCollapsed((value) => !value)}
           onHome={goHome}
           chats={chatListItems}
-          activeChatId={activeSidebarChatId}
+           activeChatId={activeSidebarChatId}
           onNewChat={startNewProjectChat}
           newChatDisabled={newChatDisabled}
           newChatDisabledReason={chatUnavailableReason}
-          readOnly={hostedChatReadOnly}
+                 readOnly={hostedChatReadOnly || authoringMode}
           onOpenChat={openChatItem}
           onRenameChat={renameSidebarChat}
           onPinChat={togglePinnedChat}
@@ -5837,7 +6045,7 @@ export function FormaWorkspace({
           onNewChat={startNewProjectChat}
           newChatDisabled={newChatDisabled}
           newChatDisabledReason={chatUnavailableReason}
-          readOnly={hostedChatReadOnly}
+           readOnly={chatReadOnly || authoringMode}
           onOpenChat={openChatItem}
           onRenameChat={renameSidebarChat}
           onPinChat={togglePinnedChat}
@@ -5867,8 +6075,8 @@ export function FormaWorkspace({
                 projectId={currentProjectId}
                 projectTitle={projectTitle}
                 owned={currentUserOwnsProject}
-                readOnly={hostedChatReadOnly}
-                onRenameTitle={hostedChatEnabled && currentUserOwnsProject ? (title) => { void commitOwnedWorkspaceTitle(title); } : undefined}
+                readOnly={hostedChatReadOnly || authoringMode}
+                 onRenameTitle={hostedChatEnabled && !authoringMode && currentUserOwnsProject ? (title) => { void commitOwnedWorkspaceTitle(title); } : undefined}
                 namespaceTabs={visibleWorkspaceTabs}
                 activeNamespace={activeWorkspaceTab.id}
                 onNamespaceChange={setActiveTab}
@@ -5880,22 +6088,22 @@ export function FormaWorkspace({
                 projectId={currentProjectId}
                 chatId={currentProjectChatId}
                 projectTitle={projectTitle}
-                onRenameTitle={hostedChatEnabled && currentUserOwnsProject ? (title) => { void commitOwnedWorkspaceTitle(title); } : undefined}
+                 onRenameTitle={hostedChatEnabled && !authoringMode && currentUserOwnsProject ? (title) => { void commitOwnedWorkspaceTitle(title); } : undefined}
                 messages={currentProjectChatMessages}
                 renderPipelineProgress={renderConversationPipelineProgress}
                 input={projectChatInput}
                 setInput={setProjectChatInput}
                 onSubmit={handleProjectChatGenerate}
-                isLoading={hostedChatEnabled && isLoading}
-                canStop={hostedChatEnabled && activeGeneration?.kind === "project-chat"}
+                 isLoading={(hostedChatEnabled || authoringMode) && isLoading}
+                 canStop={(hostedChatEnabled || authoringMode) && activeGeneration?.kind === "project-chat"}
                 onStop={stopActiveGeneration}
                 canRetryFailedBuild={hostedChatEnabled && Boolean(retryableProjectBuildMessage)}
                 retryingFailedBuild={hostedChatEnabled && resettingBuildMessageId === retryableProjectBuildMessage?.id}
                 onRetryFailedBuild={() => {
                   if (retryableProjectBuildMessage) void resetFailedContextBuild(retryableProjectBuildMessage);
                 }}
-                canChat={hostedChatEnabled && currentUserOwnsProject}
-                readOnly={hostedChatReadOnly}
+                 canChat={(hostedChatEnabled || authoringMode) && currentUserOwnsProject}
+                 readOnly={chatReadOnly}
                 authoringActive={authoringMode}
                 namespaceTabs={visibleWorkspaceTabs}
                 activeNamespace={activeWorkspaceTab.id}
@@ -7356,8 +7564,9 @@ function ChatWorkspace({
                   messages={messages}
                   renderPipelineProgress={renderPipelineProgress}
                   variant="project"
-                  emptyMessage="This chat has no project messages yet."
-                  isLoading={readOnly ? false : isLoading}
+                   emptyMessage="This chat has no project messages yet."
+                   isLoading={readOnly ? false : isLoading}
+                   assistantLabel={authoringActive ? "OpenCode" : "Forma"}
                 />
                 <div ref={endRef} />
                 <ChatProjectArtifact

--- a/apps/web/app/forma-workspace/conversation-message-list.tsx
+++ b/apps/web/app/forma-workspace/conversation-message-list.tsx
@@ -46,6 +46,7 @@ export default function ConversationMessageList({
   canBuildNow = false,
   buildNowLoading = false,
   onBuildNow,
+  assistantLabel = "Forma",
 }: {
   messages: ConversationMessage[];
   renderPipelineProgress: (message: ConversationMessage) => ReactNode;
@@ -56,6 +57,7 @@ export default function ConversationMessageList({
   canBuildNow?: boolean;
   buildNowLoading?: boolean;
   onBuildNow?: () => void;
+  assistantLabel?: string;
 }) {
   const latestChoiceMessageId = onSelectContextSuggestion
     ? [...messages]
@@ -110,7 +112,7 @@ export default function ConversationMessageList({
             ) : (
               <Cpu className="h-3.5 w-3.5 text-zinc-400" />
             )}
-            <span>{isUser ? "You" : isSystem ? "Context" : "Forma"}</span>
+            <span>{isUser ? "You" : isSystem ? "Context" : assistantLabel}</span>
             <span className="text-zinc-700">·</span>
             <span suppressHydrationWarning>{formatTimestamp(message.timestamp)}</span>
             <CopyButton

--- a/apps/web/app/forma-workspace/home-chat-view.tsx
+++ b/apps/web/app/forma-workspace/home-chat-view.tsx
@@ -164,6 +164,7 @@ export default function HomeChatView({
               renderPipelineProgress={renderPipelineProgress}
               onSelectContextSuggestion={readOnly ? undefined : onSelectContextSuggestion}
               isLoading={readOnly ? false : isLoading}
+              assistantLabel={authoringActive ? "OpenCode" : "Forma"}
               canBuildNow={readOnly ? false : canBuildNow}
               buildNowLoading={readOnly ? false : buildNowLoading}
               onBuildNow={readOnly ? undefined : onBuildNow}

--- a/apps/web/lib/config/runtime.ts
+++ b/apps/web/lib/config/runtime.ts
@@ -42,6 +42,7 @@ export type RuntimeConfigContract = {
   deployment?: {
     hosted_chat_enabled?: boolean;
     authoring_mode_enabled?: boolean;
+    opencode_connector_id?: string | null;
   };
   video?: {
     generation?: { configured?: boolean; reason?: string | null };

--- a/apps/web/lib/opencode.ts
+++ b/apps/web/lib/opencode.ts
@@ -1,0 +1,175 @@
+export type OpenCodeSession = {
+  session_id: string;
+  connector_id: string;
+  project_id: string;
+  owner_user_id: string;
+  status: "active" | "cancelled" | "completed";
+};
+
+export type OpenCodeCommand = {
+  command_id: string;
+  session_id: string;
+  project_id: string;
+  operation: "project_message" | "compile_project" | "validate_project";
+  status: "queued" | "leased" | "running" | "succeeded" | "failed" | "cancelled";
+};
+
+export type OpenCodeEvent = {
+  event_id: string;
+  sequence: number;
+  session_id: string;
+  project_id: string;
+  kind: "assistant_message" | "queued" | "working" | "validating" | "completed" | "failed" | "cancelled" | "connector_unavailable" | "progress";
+  status: OpenCodeCommand["status"] | null;
+  message: string | null;
+  revision_id: string | null;
+  error: { code: string; message: string; correlation_id: string } | null;
+  created_at: string;
+};
+
+type OpenCodeEventPage = {
+  events: OpenCodeEvent[];
+  next_cursor: number;
+};
+
+function record(value: unknown): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("OpenCode returned an invalid response.");
+  }
+  return value as Record<string, unknown>;
+}
+
+function stringField(value: Record<string, unknown>, name: string): string {
+  if (typeof value[name] !== "string" || !value[name]) throw new Error("OpenCode returned an invalid response.");
+  return value[name];
+}
+
+function nullableStringField(value: Record<string, unknown>, name: string): string | null {
+  if (value[name] !== null && typeof value[name] !== "string") throw new Error("OpenCode returned an invalid response.");
+  return (value[name] as string | null | undefined) ?? null;
+}
+
+function parseSession(value: unknown): OpenCodeSession {
+  const item = record(value);
+  const status = stringField(item, "status");
+  if (status !== "active" && status !== "cancelled" && status !== "completed") throw new Error("OpenCode returned an invalid session status.");
+  return {
+    session_id: stringField(item, "session_id"),
+    connector_id: stringField(item, "connector_id"),
+    project_id: stringField(item, "project_id"),
+    owner_user_id: stringField(item, "owner_user_id"),
+    status,
+  };
+}
+
+function parseCommand(value: unknown): OpenCodeCommand {
+  const item = record(value);
+  const operation = stringField(item, "operation");
+  const status = stringField(item, "status");
+  if (!["project_message", "compile_project", "validate_project"].includes(operation)) throw new Error("OpenCode returned an invalid command operation.");
+  if (!["queued", "leased", "running", "succeeded", "failed", "cancelled"].includes(status)) throw new Error("OpenCode returned an invalid command status.");
+  return {
+    command_id: stringField(item, "command_id"),
+    session_id: stringField(item, "session_id"),
+    project_id: stringField(item, "project_id"),
+    operation: operation as OpenCodeCommand["operation"],
+    status: status as OpenCodeCommand["status"],
+  };
+}
+
+function parseEvent(value: unknown): OpenCodeEvent {
+  const item = record(value);
+  const kind = stringField(item, "kind");
+  if (!["assistant_message", "queued", "working", "validating", "completed", "failed", "cancelled", "connector_unavailable", "progress"].includes(kind)) {
+    throw new Error("OpenCode returned an invalid event kind.");
+  }
+  const status = item.status === null || item.status === undefined ? null : stringField(item, "status");
+  if (status !== null && !["queued", "leased", "running", "succeeded", "failed", "cancelled"].includes(status)) throw new Error("OpenCode returned an invalid event status.");
+  const errorValue = item.error === null || item.error === undefined ? null : record(item.error);
+  return {
+    event_id: stringField(item, "event_id"),
+    sequence: Number(item.sequence),
+    session_id: stringField(item, "session_id"),
+    project_id: stringField(item, "project_id"),
+    kind: kind as OpenCodeEvent["kind"],
+    status: status as OpenCodeEvent["status"],
+    message: nullableStringField(item, "message"),
+    revision_id: nullableStringField(item, "revision_id"),
+    error: errorValue
+      ? {
+          code: stringField(errorValue, "code"),
+          message: stringField(errorValue, "message"),
+          correlation_id: stringField(errorValue, "correlation_id"),
+        }
+      : null,
+    created_at: stringField(item, "created_at"),
+  };
+}
+
+async function responseJson(response: Response): Promise<unknown> {
+  if (!response.ok) {
+    const body = await response.json().catch(() => null) as unknown;
+    const detail = body && typeof body === "object" && body !== null && "detail" in body ? (body as { detail?: unknown }).detail : null;
+    const message = detail && typeof detail === "object" && detail !== null && "message" in detail
+      ? (detail as { message?: unknown }).message
+      : null;
+    throw new Error(typeof message === "string" ? message : "OpenCode request failed.");
+  }
+  return response.json();
+}
+
+export async function createOpenCodeSession(
+  apiUrl: string,
+  headers: Record<string, string>,
+  connectorId: string,
+  projectId?: string | null,
+): Promise<OpenCodeSession> {
+  const response = await fetch(`${apiUrl}/opencode/sessions`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ connector_id: connectorId, ...(projectId ? { project_id: projectId } : {}) }),
+  });
+  return parseSession(await responseJson(response));
+}
+
+export async function submitOpenCodeCommand(
+  apiUrl: string,
+  headers: Record<string, string>,
+  sessionId: string,
+  message: string,
+): Promise<OpenCodeCommand> {
+  const response = await fetch(`${apiUrl}/opencode/sessions/${encodeURIComponent(sessionId)}/commands`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ message, idempotency_key: `web-${crypto.randomUUID()}` }),
+  });
+  return parseCommand(await responseJson(response));
+}
+
+export async function listOpenCodeEvents(
+  apiUrl: string,
+  headers: Record<string, string>,
+  sessionId: string,
+  cursor: number,
+): Promise<OpenCodeEventPage> {
+  const response = await fetch(`${apiUrl}/opencode/sessions/${encodeURIComponent(sessionId)}/events?cursor=${cursor}&limit=100`, {
+    headers,
+    cache: "no-store",
+  });
+  const value = record(await responseJson(response));
+  const events = value.events;
+  if (!Array.isArray(events) || !Number.isInteger(Number(value.next_cursor))) throw new Error("OpenCode returned an invalid event page.");
+  return { events: events.map(parseEvent), next_cursor: Number(value.next_cursor) };
+}
+
+export async function cancelOpenCodeSession(
+  apiUrl: string,
+  headers: Record<string, string>,
+  sessionId: string,
+): Promise<void> {
+  const response = await fetch(`${apiUrl}/opencode/sessions/${encodeURIComponent(sessionId)}/cancel`, {
+    method: "POST",
+    headers,
+  });
+  await responseJson(response);
+}

--- a/forma_core/config/runtime.py
+++ b/forma_core/config/runtime.py
@@ -171,21 +171,22 @@ def deployment_runtime_config(
     state = runtime_state()
     deployment_enabled = state["deployment_mode"] == "hosted"
     live_generation_enabled = bool(llm_config.get("live_generation_enabled"))
-    config = {
+    contract = {
         "enabled": deployment_enabled,
         "mode": state["deployment_mode"],
         "development_mode": state["development_mode"],
         "hosted_chat_enabled": hosted_chat_enabled(),
         "authoring_mode_enabled": authoring_mode_enabled(),
+        "opencode_connector_id": (config.get("FORMA_OPENCODE_CONNECTOR_ID") or "").strip() or None,
         "alpha_generation_gate_active": deployment_enabled and not live_generation_enabled,
         "generation_available": (not deployment_enabled) or live_generation_enabled,
     }
     if signup_storage:
-        config["signup_storage"] = signup_storage
+        contract["signup_storage"] = signup_storage
     reason = generation_unavailable_reason(llm_config)
     if reason:
-        config["generation_unavailable_reason"] = reason
-    return config
+        contract["generation_unavailable_reason"] = reason
+    return contract
 
 
 def _runtime_value(llm_config: Dict[str, Any], key: str) -> Any:

--- a/forma_core/database.py
+++ b/forma_core/database.py
@@ -1440,6 +1440,15 @@ def get_latest_project_revision(project_id: str, owner_user_id: str) -> ProjectR
     return ProjectStateService(_DATABASE_REPOSITORY).get_latest(project_id, owner_user_id)
 
 
+def get_project_revision_by_source_job(
+    project_id: str,
+    owner_user_id: str,
+    source_job_id: str,
+) -> Optional[ProjectRevision]:
+    """Return an existing revision for an idempotent worker/source delivery."""
+    return ProjectStateService(_DATABASE_REPOSITORY).get_by_source_job(project_id, owner_user_id, source_job_id)
+
+
 def list_latest_project_revisions(owner_user_id: str) -> List[ProjectRevision]:
     """List each owned project's latest immutable canonical revision."""
 

--- a/forma_core/opencode/__init__.py
+++ b/forma_core/opencode/__init__.py
@@ -1,0 +1,25 @@
+"""Typed contracts and persistence helpers for the hosted OpenCode bridge."""
+
+from forma_core.opencode.models import (
+    ConnectorCommand,
+    ConnectorEventInput,
+    CreateSessionRequest,
+    OpenCodeCommandStatus,
+    OpenCodeEventKind,
+    OpenCodeOperation,
+    OpenCodeSessionStatus,
+    PublicEvent,
+    SubmitCommandRequest,
+)
+
+__all__ = [
+    "ConnectorCommand",
+    "ConnectorEventInput",
+    "CreateSessionRequest",
+    "OpenCodeCommandStatus",
+    "OpenCodeEventKind",
+    "OpenCodeOperation",
+    "OpenCodeSessionStatus",
+    "PublicEvent",
+    "SubmitCommandRequest",
+]

--- a/forma_core/opencode/capabilities.py
+++ b/forma_core/opencode/capabilities.py
@@ -1,0 +1,117 @@
+"""Short-lived, session-scoped HMAC capabilities for connector calls."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+import time
+from dataclasses import dataclass
+from typing import FrozenSet
+
+from forma_core.config import config
+
+
+class CapabilityError(PermissionError):
+    """The connector capability is invalid, expired, or out of scope."""
+
+
+@dataclass(frozen=True, slots=True)
+class ConnectorCapability:
+    connector_id: str
+    session_id: str
+    project_id: str
+    owner_user_id: str
+    expires_at: int
+    nonce: str
+    scopes: FrozenSet[str]
+
+
+def _secret() -> bytes:
+    value = (config.get("FORMA_OPENCODE_CAPABILITY_SECRET") or config.get("FORMA_OPENCODE_CONNECTOR_SECRET") or "").strip()
+    if len(value) < 32:
+        raise CapabilityError("OpenCode connector capability signing is not configured.")
+    return value.encode("utf-8")
+
+
+def issue_capability(
+    *,
+    connector_id: str,
+    session_id: str,
+    project_id: str,
+    owner_user_id: str,
+    scopes: FrozenSet[str],
+    ttl_seconds: int = 300,
+) -> str:
+    expires_at = int(time.time()) + max(30, min(ttl_seconds, 900))
+    payload = {
+        "connector_id": connector_id,
+        "session_id": session_id,
+        "project_id": project_id,
+        "owner_user_id": owner_user_id,
+        "expires_at": expires_at,
+        "nonce": secrets.token_urlsafe(18),
+        "scopes": sorted(scopes),
+    }
+    encoded = _encode(payload)
+    signature = hmac.new(_secret(), encoded, hashlib.sha256).digest()
+    return f"{encoded.decode('ascii')}.{_b64encode(signature)}"
+
+
+def verify_capability(
+    token: str,
+    *,
+    connector_id: str | None = None,
+    session_id: str | None = None,
+    project_id: str | None = None,
+    owner_user_id: str | None = None,
+    scope: str | None = None,
+) -> ConnectorCapability:
+    try:
+        encoded_text, supplied_signature = token.split(".", 1)
+        encoded = encoded_text.encode("ascii")
+        expected_signature = hmac.new(_secret(), encoded, hashlib.sha256).digest()
+        actual_signature = base64.urlsafe_b64decode(supplied_signature + "=" * (-len(supplied_signature) % 4))
+        if _b64encode(actual_signature) != supplied_signature or not hmac.compare_digest(actual_signature, expected_signature):
+            raise CapabilityError("The connector capability is invalid.")
+        payload_bytes = base64.urlsafe_b64decode(encoded + b"=" * (-len(encoded) % 4))
+        payload = json.loads(payload_bytes.decode("utf-8"))
+        capability = ConnectorCapability(
+            connector_id=str(payload["connector_id"]),
+            session_id=str(payload["session_id"]),
+            project_id=str(payload["project_id"]),
+            owner_user_id=str(payload["owner_user_id"]),
+            expires_at=int(payload["expires_at"]),
+            nonce=str(payload["nonce"]),
+            scopes=frozenset(str(item) for item in payload["scopes"]),
+        )
+    except CapabilityError:
+        raise
+    except (ValueError, KeyError, TypeError, json.JSONDecodeError, UnicodeError) as exc:
+        raise CapabilityError("The connector capability is invalid.") from exc
+
+    if capability.expires_at < int(time.time()):
+        raise CapabilityError("The connector capability has expired.")
+    if connector_id is not None and capability.connector_id != connector_id:
+        raise CapabilityError("The connector capability is outside its connector scope.")
+    if session_id is not None and capability.session_id != session_id:
+        raise CapabilityError("The connector capability is outside its session scope.")
+    if project_id is not None and capability.project_id != project_id:
+        raise CapabilityError("The connector capability is outside its project scope.")
+    if owner_user_id is not None and capability.owner_user_id != owner_user_id:
+        raise CapabilityError("The connector capability is outside its owner scope.")
+    if scope is not None and scope not in capability.scopes:
+        raise CapabilityError("The connector capability does not grant this operation.")
+    return capability
+
+
+def _b64encode(value: bytes) -> str:
+    return base64.urlsafe_b64encode(value).decode("ascii").rstrip("=")
+
+
+def _encode(payload: dict[str, object]) -> bytes:
+    return base64.urlsafe_b64encode(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).rstrip(b"=")

--- a/forma_core/opencode/models.py
+++ b/forma_core/opencode/models.py
@@ -1,0 +1,268 @@
+"""Explicit protocol models for the hosted OpenCode project agent."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+from typing import Literal
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from forma_core.workspaces.projects.models import HardwareIR, ValidationIssue
+
+
+class OpenCodeSessionStatus(str, Enum):
+    ACTIVE = "active"
+    CANCELLED = "cancelled"
+    COMPLETED = "completed"
+
+
+class OpenCodeCommandStatus(str, Enum):
+    QUEUED = "queued"
+    LEASED = "leased"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+class OpenCodeOperation(str, Enum):
+    PROJECT_MESSAGE = "project_message"
+    COMPILE_PROJECT = "compile_project"
+    VALIDATE_PROJECT = "validate_project"
+
+
+class OpenCodeEventKind(str, Enum):
+    ASSISTANT_MESSAGE = "assistant_message"
+    QUEUED = "queued"
+    WORKING = "working"
+    VALIDATING = "validating"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    CONNECTOR_UNAVAILABLE = "connector_unavailable"
+    PROGRESS = "progress"
+
+
+class ValidationSummary(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    is_valid: bool
+    critical_count: int = Field(default=0, ge=0)
+    warning_count: int = Field(default=0, ge=0)
+
+
+class ProjectValidation(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    is_valid: bool
+    issues: tuple[ValidationIssue, ...] = ()
+
+
+class PublicError(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    code: str = Field(min_length=1, max_length=80)
+    message: str = Field(min_length=1, max_length=300)
+    correlation_id: str = Field(min_length=1, max_length=100)
+
+
+class PublicEvent(BaseModel):
+    """The only event shape that may cross the browser gateway."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    event_id: str = Field(min_length=1, max_length=100)
+    sequence: int = Field(ge=1)
+    session_id: str
+    project_id: UUID
+    kind: OpenCodeEventKind
+    status: OpenCodeCommandStatus | None = None
+    message: str | None = Field(default=None, max_length=2000)
+    revision_id: str | None = None
+    validation: ValidationSummary | None = None
+    artifact_ids: tuple[str, ...] = ()
+    error: PublicError | None = None
+    created_at: datetime
+
+
+class CreateSessionRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    connector_id: str = Field(min_length=1, max_length=120)
+    project_id: UUID | None = None
+    idempotency_key: str | None = Field(default=None, min_length=1, max_length=200)
+
+
+class SubmitCommandRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    message: str = Field(min_length=1, max_length=12_000)
+    idempotency_key: str = Field(min_length=1, max_length=200)
+
+    @field_validator("message")
+    @classmethod
+    def normalize_message(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("message must not be blank")
+        return normalized
+
+
+class SessionResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: str
+    connector_id: str
+    project_id: UUID
+    owner_user_id: str
+    status: OpenCodeSessionStatus
+    created_at: datetime
+    updated_at: datetime
+
+
+class CommandResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    command_id: str
+    session_id: str
+    project_id: UUID
+    operation: OpenCodeOperation
+    status: OpenCodeCommandStatus
+    attempt_count: int = Field(ge=0)
+    created_at: datetime
+    updated_at: datetime
+
+
+class ConnectorCommand(BaseModel):
+    """A leased command returned to the trusted mini-PC connector."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    command_id: str
+    session_id: str
+    connector_id: str
+    owner_user_id: str
+    project_id: UUID
+    operation: OpenCodeOperation
+    message: str | None = None
+    attempt_count: int = Field(ge=1)
+    lease_expires_at: datetime
+    lease_token: str = Field(min_length=1)
+
+
+class ConnectorSession(BaseModel):
+    """A session the authenticated connector is allowed to poll."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    session_id: str
+    connector_id: str
+    project_id: UUID
+
+
+class ConnectorSessionPage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    sessions: tuple[ConnectorSession, ...]
+
+
+class ConnectorCapabilityResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    capability: str = Field(min_length=1)
+
+
+class ConnectorEventInput(BaseModel):
+    """Allowlisted connector fields; all internal OpenCode fields are ignored."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    event_id: str = Field(min_length=1, max_length=100)
+    kind: str = Field(min_length=1, max_length=80)
+    message: str | None = Field(default=None, max_length=10_000)
+    status: OpenCodeCommandStatus | None = None
+    project_id: UUID | None = None
+    revision_id: str | None = Field(default=None, max_length=200)
+    validation: ValidationSummary | None = None
+    artifact_ids: tuple[str, ...] = Field(default_factory=tuple, max_length=20)
+    error_code: str | None = Field(default=None, max_length=80)
+    error_message: str | None = Field(default=None, max_length=300)
+    correlation_id: str | None = Field(default=None, max_length=100)
+
+
+class ConnectorHeartbeat(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lease_token: str = Field(min_length=1)
+
+
+class ConnectorLeaseResponse(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    command_id: str
+    status: OpenCodeCommandStatus
+    lease_expires_at: datetime
+
+
+class ConnectorCompletion(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    lease_token: str = Field(min_length=1)
+    status: Literal[OpenCodeCommandStatus.SUCCEEDED, OpenCodeCommandStatus.FAILED, OpenCodeCommandStatus.CANCELLED]
+
+
+class McpToolArguments(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    project_ir: HardwareIR | None = None
+
+
+class McpRequestParams(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    name: str | None = None
+    arguments: McpToolArguments = Field(default_factory=McpToolArguments)
+
+
+class McpJsonRpcRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    jsonrpc: Literal["2.0"]
+    id: str | int | None = None
+    method: str
+    params: McpRequestParams = Field(default_factory=McpRequestParams)
+
+
+class ProjectToolResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    project_id: UUID
+    revision_id: str | None = None
+    project_ir: HardwareIR
+    validation: ProjectValidation
+    mermaid_code: str
+    svg_schematic: str
+
+
+class ProjectScopeResult(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    project_id: UUID
+    owner_user_id: str
+    created: bool
+
+
+class EventPage(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    events: tuple[PublicEvent, ...]
+    next_cursor: int
+
+
+class ConnectorCapabilityRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    connector_id: str = Field(min_length=1, max_length=120)
+    session_id: str = Field(min_length=1, max_length=120)

--- a/forma_core/opencode/persistence.py
+++ b/forma_core/opencode/persistence.py
@@ -1,0 +1,59 @@
+"""SQLAlchemy rows for the durable OpenCode connector protocol."""
+
+from sqlalchemy import Column, Integer, String, Text, UniqueConstraint
+
+from forma_core.persistence.models import Base
+
+
+class DBOpenCodeSession(Base):
+    __tablename__ = "opencode_sessions"
+
+    session_id = Column(String, primary_key=True)
+    connector_id = Column(String, index=True, nullable=False)
+    owner_user_id = Column(String, index=True, nullable=False)
+    project_id = Column(String, index=True, nullable=False)
+    status = Column(String, index=True, nullable=False)
+    capability_nonce = Column(String, nullable=False)
+    created_at = Column(String, nullable=False)
+    updated_at = Column(String, index=True, nullable=False)
+    last_heartbeat_at = Column(String, nullable=True)
+    next_event_sequence = Column(Integer, nullable=False, default=1)
+
+
+class DBOpenCodeCommand(Base):
+    __tablename__ = "opencode_commands"
+    __table_args__ = (
+        UniqueConstraint("session_id", "idempotency_key", name="uq_opencode_commands_idempotency"),
+    )
+
+    command_id = Column(String, primary_key=True)
+    session_id = Column(String, index=True, nullable=False)
+    connector_id = Column(String, index=True, nullable=False)
+    owner_user_id = Column(String, index=True, nullable=False)
+    project_id = Column(String, index=True, nullable=False)
+    operation = Column(String, nullable=False)
+    idempotency_key = Column(String, nullable=False)
+    status = Column(String, index=True, nullable=False)
+    message_digest = Column(String, nullable=False)
+    attempt_count = Column(Integer, nullable=False, default=0)
+    lease_expires_at = Column(String, nullable=True)
+    lease_token_hash = Column(String, nullable=True)
+    created_at = Column(String, index=True, nullable=False)
+    updated_at = Column(String, nullable=False)
+    completed_at = Column(String, nullable=True)
+
+
+class DBOpenCodeEvent(Base):
+    __tablename__ = "opencode_events"
+    __table_args__ = (
+        UniqueConstraint("session_id", "event_id", name="uq_opencode_events_event_id"),
+        UniqueConstraint("session_id", "sequence", name="uq_opencode_events_sequence"),
+    )
+
+    event_id = Column(String, primary_key=True)
+    session_id = Column(String, index=True, nullable=False)
+    owner_user_id = Column(String, index=True, nullable=False)
+    project_id = Column(String, index=True, nullable=False)
+    sequence = Column(Integer, nullable=False)
+    event_json = Column(Text, nullable=False)
+    created_at = Column(String, index=True, nullable=False)

--- a/forma_core/opencode/public_events.py
+++ b/forma_core/opencode/public_events.py
@@ -1,0 +1,79 @@
+"""Project untrusted connector activity into a small public event contract."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime, timezone
+from uuid import UUID
+
+from forma_core.opencode.models import (
+    ConnectorEventInput,
+    OpenCodeCommandStatus,
+    OpenCodeEventKind,
+    PublicError,
+    PublicEvent,
+)
+
+
+_SECRET_PATTERN = re.compile(r"(?i)(?:api[_ -]?key|token|password|secret)\s*[:=]\s*\S+")
+_PATH_PATTERN = re.compile(r"(?:[A-Za-z]:[\\/]|/Users/|/home/|/tmp/|\\\\|\.{1,2}[\\/])")
+_INTERNAL_PATTERN = re.compile(r"(?i)(?:^|\s)(?:diff|patch|shell|command|tool|reasoning|traceback|exception)\s*[:=]")
+_PUBLIC_KINDS = {kind.value for kind in OpenCodeEventKind}
+_ERROR_MESSAGES = {
+    "connector_unavailable": "The OpenCode connector is unavailable.",
+    "command_failed": "The OpenCode project command failed.",
+    "validation_failed": "The project failed Forma validation.",
+}
+
+
+def project_public_event(
+    event: ConnectorEventInput,
+    *,
+    sequence: int,
+    session_id: str,
+    project_id: UUID,
+    created_at: datetime | None = None,
+) -> PublicEvent:
+    kind = event.kind.strip().lower()
+    if kind not in _PUBLIC_KINDS:
+        kind = OpenCodeEventKind.PROGRESS.value
+    safe_message = _safe_message(event.message) if kind == OpenCodeEventKind.ASSISTANT_MESSAGE.value else None
+    error = _public_error(event) if kind == OpenCodeEventKind.FAILED.value else None
+    if kind == OpenCodeEventKind.FAILED.value and error is None:
+        error = PublicError(
+            code="command_failed",
+            message=_ERROR_MESSAGES["command_failed"],
+            correlation_id=event.correlation_id or f"event_{event.event_id}",
+        )
+    return PublicEvent(
+        event_id=event.event_id,
+        sequence=sequence,
+        session_id=session_id,
+        project_id=project_id,
+        kind=OpenCodeEventKind(kind),
+        status=event.status,
+        message=safe_message,
+        revision_id=event.revision_id if kind == OpenCodeEventKind.COMPLETED.value else None,
+        validation=event.validation if kind in {OpenCodeEventKind.COMPLETED.value, OpenCodeEventKind.VALIDATING.value} else None,
+        artifact_ids=event.artifact_ids if kind == OpenCodeEventKind.COMPLETED.value else (),
+        error=error,
+        created_at=created_at or datetime.now(timezone.utc),
+    )
+
+
+def _safe_message(value: str | None) -> str | None:
+    if not value:
+        return None
+    if _PATH_PATTERN.search(value) or _INTERNAL_PATTERN.search(value):
+        return "The OpenCode connector is working on the project."
+    redacted = _SECRET_PATTERN.sub("[redacted]", value).strip()
+    return redacted[:2000] if redacted else None
+
+
+def _public_error(event: ConnectorEventInput) -> PublicError:
+    code = event.error_code if event.error_code in _ERROR_MESSAGES else "command_failed"
+    return PublicError(
+        code=code,
+        message=_ERROR_MESSAGES.get(code, "The OpenCode project command failed."),
+        correlation_id=event.correlation_id or f"event_{event.event_id}",
+    )

--- a/forma_core/opencode/schema.py
+++ b/forma_core/opencode/schema.py
@@ -1,0 +1,28 @@
+"""Schema contracts for the hosted OpenCode bridge."""
+
+from forma_core.persistence.base import TableContract
+
+
+OPENCODE_TABLE_CONTRACTS = (
+    TableContract(
+        "opencode_sessions",
+        (
+            "session_id", "connector_id", "owner_user_id", "project_id", "status", "capability_nonce",
+            "created_at", "updated_at", "last_heartbeat_at", "next_event_sequence",
+        ),
+    ),
+    TableContract(
+        "opencode_commands",
+        (
+            "command_id", "session_id", "connector_id", "owner_user_id", "project_id", "operation",
+            "idempotency_key", "status", "message_digest", "attempt_count", "lease_expires_at",
+            "lease_token_hash", "created_at", "updated_at", "completed_at",
+        ),
+    ),
+    TableContract(
+        "opencode_events",
+        (
+            "event_id", "session_id", "owner_user_id", "project_id", "sequence", "event_json", "created_at",
+        ),
+    ),
+)

--- a/forma_core/opencode/store.py
+++ b/forma_core/opencode/store.py
@@ -1,0 +1,531 @@
+"""Durable storage for OpenCode sessions, leased commands, and public events."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+import threading
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from forma_core.database import get_database_provider
+from forma_core.opencode.models import (
+    ConnectorCommand,
+    OpenCodeCommandStatus,
+    OpenCodeOperation,
+    OpenCodeSessionStatus,
+    PublicEvent,
+)
+from forma_core.persistence.providers import SQLiteProvider, SupabaseProvider, create_sqlite_provider
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _timestamp(value: datetime | None = None) -> str:
+    return (value or _now()).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+@dataclass(frozen=True, slots=True)
+class StoredSession:
+    session_id: str
+    connector_id: str
+    owner_user_id: str
+    project_id: str
+    status: OpenCodeSessionStatus
+    capability_nonce: str
+    created_at: str
+    updated_at: str
+    last_heartbeat_at: str | None
+    next_event_sequence: int
+
+    def as_record(self) -> dict[str, object]:
+        return {
+            "session_id": self.session_id,
+            "connector_id": self.connector_id,
+            "owner_user_id": self.owner_user_id,
+            "project_id": self.project_id,
+            "status": self.status.value,
+            "capability_nonce": self.capability_nonce,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "last_heartbeat_at": self.last_heartbeat_at,
+            "next_event_sequence": self.next_event_sequence,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class StoredCommand:
+    command_id: str
+    session_id: str
+    connector_id: str
+    owner_user_id: str
+    project_id: str
+    operation: OpenCodeOperation
+    idempotency_key: str
+    status: OpenCodeCommandStatus
+    message_digest: str
+    attempt_count: int
+    lease_expires_at: str | None
+    lease_token_hash: str | None
+    created_at: str
+    updated_at: str
+    completed_at: str | None
+
+    def as_record(self) -> dict[str, object]:
+        return {
+            "command_id": self.command_id,
+            "session_id": self.session_id,
+            "connector_id": self.connector_id,
+            "owner_user_id": self.owner_user_id,
+            "project_id": self.project_id,
+            "operation": self.operation.value,
+            "idempotency_key": self.idempotency_key,
+            "status": self.status.value,
+            "message_digest": self.message_digest,
+            "attempt_count": self.attempt_count,
+            "lease_expires_at": self.lease_expires_at,
+            "lease_token_hash": self.lease_token_hash,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "completed_at": self.completed_at,
+        }
+
+
+class OpenCodeStore:
+    """Use the configured primary provider; standalone SQLite is test-friendly."""
+
+    def __init__(self, db_path: str | None = None, provider: Any = None) -> None:
+        self._provider = provider
+        self._standalone = db_path is not None
+        self._db_path = db_path
+        self._lock = threading.RLock()
+        self._initialized = False
+        self._messages: dict[str, str] = {}
+
+    def _ensure_provider(self) -> Any:
+        if self._provider is None:
+            if self._standalone:
+                database_url = "sqlite:///:memory:" if self._db_path == ":memory:" else f"sqlite:///{self._db_path}"
+                self._provider = create_sqlite_provider(
+                    source="OpenCode test/store path",
+                    url=database_url,
+                    import_legacy_jobs=False,
+                )
+            else:
+                self._provider = get_database_provider()
+        if not self._initialized:
+            self._provider.initialize()
+            self._initialized = True
+        return self._provider
+
+    @property
+    def provider(self) -> Any:
+        return self._ensure_provider()
+
+    def close(self) -> None:
+        if self._standalone and isinstance(self._provider, SQLiteProvider):
+            self._provider.dispose()
+
+    def create_session(self, *, session_id: str, connector_id: str, owner_user_id: str, project_id: str) -> StoredSession:
+        now = _timestamp()
+        session = StoredSession(
+            session_id=session_id,
+            connector_id=connector_id,
+            owner_user_id=owner_user_id,
+            project_id=project_id,
+            status=OpenCodeSessionStatus.ACTIVE,
+            capability_nonce=secrets.token_urlsafe(18),
+            created_at=now,
+            updated_at=now,
+            last_heartbeat_at=None,
+            next_event_sequence=1,
+        )
+        provider = self._ensure_provider()
+        if isinstance(provider, SupabaseProvider):
+            provider.client.table("opencode_sessions").insert(session.as_record()).execute()
+            return session
+        with self._connection() as connection:
+            connection.execute(
+                "INSERT INTO opencode_sessions "
+                "(session_id, connector_id, owner_user_id, project_id, status, capability_nonce, created_at, "
+                "updated_at, last_heartbeat_at, next_event_sequence) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                tuple(session.as_record().values()),
+            )
+        return session
+
+    def get_session(self, session_id: str) -> StoredSession | None:
+        provider = self._ensure_provider()
+        if isinstance(provider, SupabaseProvider):
+            rows = provider.client.table("opencode_sessions").select("*").eq("session_id", session_id).limit(1).execute().data or []
+            return _session_from_record(rows[0]) if rows else None
+        with closing(provider.connect_dbapi()) as connection:
+            row = connection.execute("SELECT * FROM opencode_sessions WHERE session_id = ?", (session_id,)).fetchone()
+        return _session_from_record(dict(row)) if row else None
+
+    def touch_session(self, session_id: str) -> None:
+        now = _timestamp()
+        provider = self._ensure_provider()
+        if isinstance(provider, SupabaseProvider):
+            provider.client.table("opencode_sessions").update({"last_heartbeat_at": now, "updated_at": now}).eq("session_id", session_id).execute()
+            return
+        with self._connection() as connection:
+            connection.execute("UPDATE opencode_sessions SET last_heartbeat_at = ?, updated_at = ? WHERE session_id = ?", (now, now, session_id))
+
+    def create_command(
+        self,
+        *,
+        command_id: str,
+        session: StoredSession,
+        operation: OpenCodeOperation,
+        idempotency_key: str,
+        message: str,
+    ) -> StoredCommand:
+        existing = self.find_command(session.session_id, idempotency_key)
+        digest = hashlib.sha256(message.encode("utf-8")).hexdigest()
+        if existing:
+            if existing.message_digest != digest:
+                raise ValueError("The command idempotency key was already used with another message.")
+            self._messages.setdefault(existing.command_id, message)
+            return existing
+        now = _timestamp()
+        command = StoredCommand(
+            command_id=command_id,
+            session_id=session.session_id,
+            connector_id=session.connector_id,
+            owner_user_id=session.owner_user_id,
+            project_id=session.project_id,
+            operation=operation,
+            idempotency_key=idempotency_key,
+            status=OpenCodeCommandStatus.QUEUED,
+            message_digest=digest,
+            attempt_count=0,
+            lease_expires_at=None,
+            lease_token_hash=None,
+            created_at=now,
+            updated_at=now,
+            completed_at=None,
+        )
+        provider = self._ensure_provider()
+        if isinstance(provider, SupabaseProvider):
+            provider.client.table("opencode_commands").insert(command.as_record()).execute()
+        else:
+            with self._connection() as connection:
+                connection.execute(
+                    "INSERT INTO opencode_commands "
+                    "(command_id, session_id, connector_id, owner_user_id, project_id, operation, idempotency_key, "
+                    "status, message_digest, attempt_count, lease_expires_at, lease_token_hash, created_at, updated_at, completed_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    tuple(command.as_record().values()),
+                )
+        self._messages[command_id] = message
+        return command
+
+    def find_command(self, session_id: str, idempotency_key: str) -> StoredCommand | None:
+        provider = self._ensure_provider()
+        if isinstance(provider, SupabaseProvider):
+            rows = (
+                provider.client.table("opencode_commands")
+                .select("*")
+                .eq("session_id", session_id)
+                .eq("idempotency_key", idempotency_key)
+                .limit(1)
+                .execute()
+                .data
+                or []
+            )
+            return _command_from_record(rows[0]) if rows else None
+        with closing(provider.connect_dbapi()) as connection:
+            row = connection.execute(
+                "SELECT * FROM opencode_commands WHERE session_id = ? AND idempotency_key = ?",
+                (session_id, idempotency_key),
+            ).fetchone()
+        return _command_from_record(dict(row)) if row else None
+
+    def get_command(self, command_id: str) -> StoredCommand | None:
+        provider = self._ensure_provider()
+        if isinstance(provider, SupabaseProvider):
+            rows = provider.client.table("opencode_commands").select("*").eq("command_id", command_id).limit(1).execute().data or []
+            return _command_from_record(rows[0]) if rows else None
+        with closing(provider.connect_dbapi()) as connection:
+            row = connection.execute("SELECT * FROM opencode_commands WHERE command_id = ?", (command_id,)).fetchone()
+        return _command_from_record(dict(row)) if row else None
+
+    def list_connector_sessions(self, connector_id: str) -> list[StoredSession]:
+        provider = self._ensure_provider()
+        if isinstance(provider, SupabaseProvider):
+            rows = (
+                provider.client.table("opencode_sessions")
+                .select("*")
+                .eq("connector_id", connector_id)
+                .eq("status", OpenCodeSessionStatus.ACTIVE.value)
+                .order("created_at")
+                .execute()
+                .data
+                or []
+            )
+            return [_session_from_record(row) for row in rows]
+        with closing(provider.connect_dbapi()) as connection:
+            rows = connection.execute(
+                "SELECT * FROM opencode_sessions WHERE connector_id = ? AND status = ? ORDER BY created_at",
+                (connector_id, OpenCodeSessionStatus.ACTIVE.value),
+            ).fetchall()
+        return [_session_from_record(dict(row)) for row in rows]
+
+    def claim_next(self, *, connector_id: str, session_id: str, lease_seconds: int = 60) -> ConnectorCommand | None:
+        now = _now()
+        now_text = _timestamp(now)
+        expiry = _timestamp(now + timedelta(seconds=max(15, min(lease_seconds, 300))))
+        lease_token = secrets.token_urlsafe(24)
+        lease_hash = hashlib.sha256(lease_token.encode("utf-8")).hexdigest()
+        provider = self._ensure_provider()
+        if isinstance(provider, SupabaseProvider):
+            rows = (
+                provider.client.table("opencode_commands")
+                .select("*")
+                .eq("connector_id", connector_id)
+                .eq("session_id", session_id)
+                .in_("status", [
+                    OpenCodeCommandStatus.QUEUED.value,
+                    OpenCodeCommandStatus.LEASED.value,
+                    OpenCodeCommandStatus.RUNNING.value,
+                ])
+                .order("created_at")
+                .limit(50)
+                .execute()
+                .data
+                or []
+            )
+            for row in rows:
+                current_status = str(row.get("status") or "")
+                if current_status == OpenCodeCommandStatus.QUEUED.value:
+                    eligible = True
+                else:
+                    lease_expires_at = _parse_timestamp(row.get("lease_expires_at"))
+                    eligible = lease_expires_at is not None and lease_expires_at <= now
+                if not eligible:
+                    continue
+                updated = (
+                    provider.client.table("opencode_commands")
+                    .update({"status": OpenCodeCommandStatus.LEASED.value, "attempt_count": int(row.get("attempt_count") or 0) + 1,
+                             "lease_expires_at": expiry, "lease_token_hash": lease_hash, "updated_at": now_text})
+                    .eq("command_id", row["command_id"])
+                    .eq("status", current_status)
+                    .select("*")
+                    .execute()
+                    .data
+                    or []
+                )
+                if updated:
+                    return _connector_command(_command_from_record(updated[0]), lease_token, self._messages.get(str(row["command_id"])))
+            return None
+        with self._connection(begin_immediate=True) as connection:
+            row = connection.execute(
+                "SELECT * FROM opencode_commands WHERE connector_id = ? AND session_id = ? AND "
+                "(status = 'queued' OR (status IN ('leased', 'running') AND lease_expires_at <= ?)) "
+                "ORDER BY created_at LIMIT 1",
+                (connector_id, session_id, now_text),
+            ).fetchone()
+            if row is None:
+                return None
+            record = dict(row)
+            attempt_count = int(record["attempt_count"] or 0) + 1
+            connection.execute(
+                "UPDATE opencode_commands SET status = ?, attempt_count = ?, lease_expires_at = ?, "
+                "lease_token_hash = ?, updated_at = ? WHERE command_id = ?",
+                (OpenCodeCommandStatus.LEASED.value, attempt_count, expiry, lease_hash, now_text, record["command_id"]),
+            )
+            record.update(status=OpenCodeCommandStatus.LEASED.value, attempt_count=attempt_count,
+                          lease_expires_at=expiry, lease_token_hash=lease_hash, updated_at=now_text)
+        return _connector_command(_command_from_record(record), lease_token, self._messages.get(str(record["command_id"])))
+
+    def heartbeat(self, command: StoredCommand, lease_token: str) -> StoredCommand:
+        self._require_lease(command, lease_token)
+        now = _timestamp()
+        current_expiry = _parse_timestamp(command.lease_expires_at) or _now()
+        expiry = _timestamp(max(_now() + timedelta(seconds=60), current_expiry + timedelta(seconds=1)))
+        provider = self._ensure_provider()
+        if isinstance(provider, SupabaseProvider):
+            provider.client.table("opencode_commands").update({"status": OpenCodeCommandStatus.RUNNING.value, "lease_expires_at": expiry, "updated_at": now}).eq("command_id", command.command_id).eq("lease_token_hash", command.lease_token_hash).execute()
+            provider.client.table("opencode_sessions").update({"last_heartbeat_at": now, "updated_at": now}).eq("session_id", command.session_id).execute()
+        else:
+            with self._connection() as connection:
+                connection.execute("UPDATE opencode_commands SET status = ?, lease_expires_at = ?, updated_at = ? WHERE command_id = ? AND lease_token_hash = ?", (OpenCodeCommandStatus.RUNNING.value, expiry, now, command.command_id, command.lease_token_hash))
+                connection.execute("UPDATE opencode_sessions SET last_heartbeat_at = ?, updated_at = ? WHERE session_id = ?", (now, now, command.session_id))
+        return self.get_command(command.command_id) or command
+
+    def complete(self, command: StoredCommand, lease_token: str, status: OpenCodeCommandStatus) -> StoredCommand:
+        if status not in {OpenCodeCommandStatus.SUCCEEDED, OpenCodeCommandStatus.FAILED, OpenCodeCommandStatus.CANCELLED}:
+            raise ValueError("A connector may only complete a command with a terminal status.")
+        if command.status in {OpenCodeCommandStatus.SUCCEEDED, OpenCodeCommandStatus.FAILED, OpenCodeCommandStatus.CANCELLED}:
+            if command.status == status:
+                return command
+            raise PermissionError("The command has already reached another terminal status.")
+        self._require_lease(command, lease_token)
+        now = _timestamp()
+        values = {"status": status.value, "completed_at": now, "updated_at": now, "lease_token_hash": None, "lease_expires_at": None}
+        provider = self._ensure_provider()
+        if isinstance(provider, SupabaseProvider):
+            provider.client.table("opencode_commands").update(values).eq("command_id", command.command_id).eq("lease_token_hash", command.lease_token_hash).execute()
+        else:
+            with self._connection() as connection:
+                connection.execute("UPDATE opencode_commands SET status = ?, completed_at = ?, updated_at = ?, lease_token_hash = NULL, lease_expires_at = NULL WHERE command_id = ? AND lease_token_hash = ?", (status.value, now, now, command.command_id, command.lease_token_hash))
+        return self.get_command(command.command_id) or command
+
+    def validate_lease(self, command: StoredCommand, lease_token: str) -> None:
+        """Validate an event's lease without changing command state."""
+        self._require_lease(command, lease_token)
+
+    def cancel_command(self, command: StoredCommand) -> StoredCommand:
+        if command.status in {OpenCodeCommandStatus.SUCCEEDED, OpenCodeCommandStatus.FAILED, OpenCodeCommandStatus.CANCELLED}:
+            return command
+        now = _timestamp()
+        values = (OpenCodeCommandStatus.CANCELLED.value, now, now, command.command_id)
+        provider = self._ensure_provider()
+        if isinstance(provider, SupabaseProvider):
+            provider.client.table("opencode_commands").update({"status": values[0], "completed_at": now, "updated_at": now, "lease_token_hash": None, "lease_expires_at": None}).eq("command_id", command.command_id).execute()
+        else:
+            with self._connection() as connection:
+                connection.execute("UPDATE opencode_commands SET status = ?, completed_at = ?, updated_at = ?, lease_token_hash = NULL, lease_expires_at = NULL WHERE command_id = ?", values)
+        return self.get_command(command.command_id) or command
+
+    def cancel_session_commands(self, session_id: str) -> None:
+        provider = self._ensure_provider()
+        terminal = {
+            OpenCodeCommandStatus.SUCCEEDED.value,
+            OpenCodeCommandStatus.FAILED.value,
+            OpenCodeCommandStatus.CANCELLED.value,
+        }
+        if isinstance(provider, SupabaseProvider):
+            rows = provider.client.table("opencode_commands").select("command_id, status").eq("session_id", session_id).execute().data or []
+            command_ids = [str(row["command_id"]) for row in rows if str(row.get("status") or "") not in terminal]
+        else:
+            with closing(provider.connect_dbapi()) as connection:
+                rows = connection.execute("SELECT command_id FROM opencode_commands WHERE session_id = ? AND status NOT IN (?, ?, ?)", (session_id, *terminal)).fetchall()
+            command_ids = [str(row["command_id"]) for row in rows]
+        for command_id in command_ids:
+            command = self.get_command(command_id)
+            if command is not None:
+                self.cancel_command(command)
+
+    def add_event(self, event: PublicEvent) -> PublicEvent:
+        provider = self._ensure_provider()
+        payload = json.dumps(event.model_dump(mode="json"), separators=(",", ":"))
+        if isinstance(provider, SupabaseProvider):
+            existing = provider.client.table("opencode_events").select("event_json").eq("event_id", event.event_id).limit(1).execute().data or []
+            if existing:
+                return PublicEvent.model_validate(existing[0]["event_json"])
+            session = self.get_session(event.session_id)
+            if session is None:
+                raise ValueError("OpenCode session not found.")
+            provider.client.table("opencode_events").insert({"event_id": event.event_id, "session_id": event.session_id, "owner_user_id": session.owner_user_id, "project_id": str(event.project_id), "sequence": event.sequence, "event_json": event.model_dump(mode="json"), "created_at": _timestamp(event.created_at)}).execute()
+            return event
+        with self._connection() as connection:
+            existing = connection.execute("SELECT event_json FROM opencode_events WHERE event_id = ?", (event.event_id,)).fetchone()
+            if existing:
+                return PublicEvent.model_validate(json.loads(existing["event_json"]))
+            session = connection.execute("SELECT owner_user_id FROM opencode_sessions WHERE session_id = ?", (event.session_id,)).fetchone()
+            if session is None:
+                raise ValueError("OpenCode session not found.")
+            connection.execute("INSERT INTO opencode_events (event_id, session_id, owner_user_id, project_id, sequence, event_json, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)", (event.event_id, event.session_id, session["owner_user_id"], str(event.project_id), event.sequence, payload, _timestamp(event.created_at)))
+            connection.execute("UPDATE opencode_sessions SET next_event_sequence = MAX(next_event_sequence, ?), updated_at = ? WHERE session_id = ?", (event.sequence + 1, _timestamp(), event.session_id))
+        return event
+
+    def next_event_sequence(self, session_id: str) -> int:
+        session = self.get_session(session_id)
+        if session is None:
+            raise ValueError("OpenCode session not found.")
+        return session.next_event_sequence
+
+    def list_events(self, session_id: str, after: int, limit: int) -> list[PublicEvent]:
+        provider = self._ensure_provider()
+        if isinstance(provider, SupabaseProvider):
+            rows = provider.client.table("opencode_events").select("event_json").eq("session_id", session_id).gt("sequence", after).order("sequence").limit(limit).execute().data or []
+            return [PublicEvent.model_validate(row["event_json"]) for row in rows]
+        with closing(provider.connect_dbapi()) as connection:
+            rows = connection.execute("SELECT event_json FROM opencode_events WHERE session_id = ? AND sequence > ? ORDER BY sequence LIMIT ?", (session_id, after, limit)).fetchall()
+        return [PublicEvent.model_validate(json.loads(row["event_json"])) for row in rows]
+
+    def _require_lease(self, command: StoredCommand, lease_token: str) -> None:
+        digest = hashlib.sha256(lease_token.encode("utf-8")).hexdigest()
+        if not command.lease_token_hash or not secrets.compare_digest(digest, command.lease_token_hash):
+            raise PermissionError("The command lease is invalid or has expired.")
+        expiry = _parse_timestamp(command.lease_expires_at)
+        if expiry is None or expiry <= _now():
+            raise PermissionError("The command lease is invalid or has expired.")
+
+    def _connection(self, *, begin_immediate: bool = False) -> Any:
+        provider = self._ensure_provider()
+        if not isinstance(provider, SQLiteProvider):
+            raise TypeError("A SQLite connection was requested from a non-SQLite OpenCode provider.")
+        connection = provider.connect_dbapi()
+        if begin_immediate:
+            self._lock.acquire()
+            connection.execute("BEGIN IMMEDIATE")
+            return _LockedConnection(connection, self._lock, pre_acquired=True)
+        return _LockedConnection(connection, self._lock, pre_acquired=False)
+
+
+class _LockedConnection:
+    def __init__(self, connection: Any, lock: threading.RLock, *, pre_acquired: bool) -> None:
+        self.connection = connection
+        self.lock = lock
+        self.pre_acquired = pre_acquired
+
+    def __enter__(self) -> Any:
+        if not self.pre_acquired:
+            self.lock.acquire()
+        return self.connection
+
+    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        try:
+            if exc_type is None:
+                self.connection.commit()
+            else:
+                self.connection.rollback()
+            self.connection.close()
+        finally:
+            self.lock.release()
+
+
+def _session_from_record(record: dict[str, Any]) -> StoredSession:
+    return StoredSession(
+        session_id=str(record["session_id"]), connector_id=str(record["connector_id"]), owner_user_id=str(record["owner_user_id"]),
+        project_id=str(record["project_id"]), status=OpenCodeSessionStatus(str(record["status"])), capability_nonce=str(record["capability_nonce"]),
+        created_at=str(record["created_at"]), updated_at=str(record["updated_at"]), last_heartbeat_at=record.get("last_heartbeat_at"),
+        next_event_sequence=int(record.get("next_event_sequence") or 1),
+    )
+
+
+def _command_from_record(record: dict[str, Any]) -> StoredCommand:
+    return StoredCommand(
+        command_id=str(record["command_id"]), session_id=str(record["session_id"]), connector_id=str(record["connector_id"]),
+        owner_user_id=str(record["owner_user_id"]), project_id=str(record["project_id"]), operation=OpenCodeOperation(str(record["operation"])),
+        idempotency_key=str(record["idempotency_key"]), status=OpenCodeCommandStatus(str(record["status"])), message_digest=str(record["message_digest"]),
+        attempt_count=int(record.get("attempt_count") or 0), lease_expires_at=record.get("lease_expires_at"), lease_token_hash=record.get("lease_token_hash"),
+        created_at=str(record["created_at"]), updated_at=str(record["updated_at"]), completed_at=record.get("completed_at"),
+    )
+
+
+def _connector_command(command: StoredCommand, lease_token: str, message: str | None) -> ConnectorCommand:
+    return ConnectorCommand(
+        command_id=command.command_id, session_id=command.session_id, connector_id=command.connector_id,
+        owner_user_id=command.owner_user_id, project_id=command.project_id, operation=command.operation,
+        message=message, attempt_count=command.attempt_count, lease_expires_at=_parse_timestamp(command.lease_expires_at) or _now(),
+        lease_token=lease_token,
+    )

--- a/forma_core/persistence/providers/sqlite.py
+++ b/forma_core/persistence/providers/sqlite.py
@@ -34,6 +34,11 @@ class SQLiteProvider(DatabaseProvider):
 
     def initialize(self) -> None:
         from forma_core.jobs.persistence import DBA2AJob  # noqa: F401
+        from forma_core.opencode.persistence import (  # noqa: F401
+            DBOpenCodeCommand,
+            DBOpenCodeEvent,
+            DBOpenCodeSession,
+        )
         from forma_core.persistence.migrations import migrate_sqlite_schema
         from forma_core.persistence.models import Base
 

--- a/forma_core/persistence/schema.py
+++ b/forma_core/persistence/schema.py
@@ -4,6 +4,7 @@ from typing import Tuple
 
 from forma_core.jobs.schema import JOB_TABLE_CONTRACT
 from forma_core.persistence.base import TableContract
+from forma_core.opencode.schema import OPENCODE_TABLE_CONTRACTS
 
 # This is the schema surface used through both the local SQLite provider and
 # the hosted Supabase provider. A Supabase startup projection checks columns as
@@ -146,6 +147,7 @@ APPLICATION_SCHEMA: Tuple[TableContract, ...] = (
         ("id", "chat_id", "owner_user_id", "title", "messages", "created_at", "updated_at"),
     ),
     JOB_TABLE_CONTRACT,
+    *OPENCODE_TABLE_CONTRACTS,
     TableContract(
         "alpha_signups",
         ("id", "name", "email", "organization", "additional_info", "source", "metadata_json", "created_at"),

--- a/supabase/migrations/20260908000200_opencode_bridge.sql
+++ b/supabase/migrations/20260908000200_opencode_bridge.sql
@@ -1,0 +1,55 @@
+-- Durable hosted OpenCode connector protocol. Raw prompts and internal agent
+-- events are intentionally not stored in these tables.
+
+create table if not exists public.opencode_sessions (
+  session_id text primary key,
+  connector_id text not null,
+  owner_user_id text not null,
+  project_id text not null,
+  status text not null,
+  capability_nonce text not null,
+  created_at text not null,
+  updated_at text not null,
+  last_heartbeat_at text,
+  next_event_sequence integer not null default 1
+);
+
+create index if not exists idx_opencode_sessions_owner
+  on public.opencode_sessions (owner_user_id);
+
+create table if not exists public.opencode_commands (
+  command_id text primary key,
+  session_id text not null references public.opencode_sessions(session_id) on delete cascade,
+  connector_id text not null,
+  owner_user_id text not null,
+  project_id text not null,
+  operation text not null,
+  idempotency_key text not null,
+  status text not null,
+  message_digest text not null,
+  attempt_count integer not null default 0,
+  lease_expires_at text,
+  lease_token_hash text,
+  created_at text not null,
+  updated_at text not null,
+  completed_at text,
+  unique (session_id, idempotency_key)
+);
+
+create index if not exists idx_opencode_commands_queue
+  on public.opencode_commands (connector_id, status, created_at);
+
+create table if not exists public.opencode_events (
+  event_id text primary key,
+  session_id text not null references public.opencode_sessions(session_id) on delete cascade,
+  owner_user_id text not null,
+  project_id text not null,
+  sequence integer not null,
+  event_json jsonb not null,
+  created_at text not null,
+  unique (session_id, event_id),
+  unique (session_id, sequence)
+);
+
+create index if not exists idx_opencode_events_session_sequence
+  on public.opencode_events (session_id, sequence);

--- a/tests/opencode/test_bridge.py
+++ b/tests/opencode/test_bridge.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import unittest
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+from fastapi import HTTPException
+
+from apps.api.auth import UserContext, require_opencode_authoring_access
+from apps.api.opencode_api import _require_owned_project
+from apps.api.opencode_mcp import handle_opencode_mcp_json_rpc, opencode_mcp_tools
+from forma_core.opencode.capabilities import CapabilityError, issue_capability, verify_capability
+from forma_core.opencode.models import ConnectorEventInput, McpJsonRpcRequest, OpenCodeCommandStatus, OpenCodeEventKind, OpenCodeOperation
+from forma_core.opencode.public_events import project_public_event
+from forma_core.opencode.store import OpenCodeStore
+
+
+class OpenCodeBridgeTests(unittest.IsolatedAsyncioTestCase):
+    def test_allowed_email_is_server_derived_and_exact(self) -> None:
+        user = UserContext(provider="clerk", subject="user_1", owner_user_id="user_1", is_authenticated=True, is_admin=True)
+        with patch.dict(os.environ, {"FORMA_DEPLOYMENT_MODE": "hosted", "FORMA_AUTH_MODE": "clerk", "FORMA_OPENCODE_ALLOWED_EMAILS": "isayahculbertson@gmail.com"}, clear=True), patch("apps.api.auth.require_user_context", new=AsyncMock(return_value=user)), patch("apps.api.auth.clerk_user_email", return_value="isayahculbertson@gmail.com"):
+            resolved = asyncio.run(require_opencode_authoring_access(object()))
+        self.assertEqual("user_1", resolved.owner_user_id)
+
+    def test_allowlist_defaults_to_deny_and_service_identity_cannot_bypass(self) -> None:
+        service = UserContext(provider="mcp-api-key", subject="mcp-service", owner_user_id=None, is_authenticated=True, is_admin=True)
+        with patch.dict(os.environ, {"FORMA_DEPLOYMENT_MODE": "hosted", "FORMA_AUTH_MODE": "clerk"}, clear=True), patch("apps.api.auth.require_user_context", new=AsyncMock(return_value=service)):
+            with self.assertRaises(HTTPException) as denied:
+                asyncio.run(require_opencode_authoring_access(object()))
+        self.assertEqual(403, denied.exception.status_code)
+        self.assertEqual("opencode_clerk_required", denied.exception.detail["code"])
+
+    def test_project_scope_rejects_a_foreign_owner_before_session_use(self) -> None:
+        with patch("apps.api.opencode_api.get_project_identity", return_value={"owner_user_id": "another-user", "status": "active"}):
+            with self.assertRaises(HTTPException) as denied:
+                _require_owned_project(str(uuid4()), "user_a")
+        self.assertEqual(404, denied.exception.status_code)
+        self.assertEqual("opencode_project_not_found", denied.exception.detail["code"])
+
+    def test_capability_rejects_cross_session_and_tampering(self) -> None:
+        with patch.dict(os.environ, {"FORMA_OPENCODE_CAPABILITY_SECRET": "s" * 32}, clear=True):
+            token = issue_capability(connector_id="mini", session_id="session_a", project_id="project_a", owner_user_id="user_a", scopes=frozenset({"poll"}))
+            self.assertEqual("user_a", verify_capability(token, session_id="session_a", project_id="project_a", scope="poll").owner_user_id)
+            with self.assertRaises(CapabilityError):
+                verify_capability(token, session_id="session_b", scope="poll")
+            with self.assertRaises(CapabilityError):
+                verify_capability(token[:-1] + ("A" if token[-1] != "A" else "B"), session_id="session_a", scope="poll")
+
+    def test_event_projection_removes_internal_payloads_and_raw_errors(self) -> None:
+        project_id = uuid4()
+        event = ConnectorEventInput.model_validate({
+            "event_id": "evt_1",
+            "kind": "assistant_message",
+            "message": "diff: C:\\secret\\project\\main.py api_key=sk-secret",
+            "tool_call": {"command": "cat C:\\secret"},
+            "reasoning": "hidden reasoning",
+            "raw_exception": "provider token=secret",
+        })
+        public = project_public_event(event, sequence=1, session_id="session", project_id=project_id)
+        serialized = str(public.model_dump(mode="json"))
+        self.assertNotIn("secret\\project", serialized)
+        self.assertNotIn("sk-secret", serialized)
+        self.assertNotIn("tool_call", serialized)
+        self.assertIsNone(public.error)
+        self.assertEqual(OpenCodeEventKind.ASSISTANT_MESSAGE, public.kind)
+
+    def test_restricted_mcp_surface_excludes_forbidden_tools(self) -> None:
+        names = {str(tool["name"]) for tool in opencode_mcp_tools()}
+        self.assertEqual({
+            "forma.opencode.create_project",
+            "forma.opencode.read_project",
+            "forma.opencode.update_project",
+            "forma.opencode.compile_project",
+            "forma.opencode.validate_project",
+        }, names)
+        with patch.dict(os.environ, {"FORMA_OPENCODE_CAPABILITY_SECRET": "s" * 32}, clear=True):
+            from forma_core.opencode.capabilities import ConnectorCapability
+            capability = ConnectorCapability("mini", "session", str(uuid4()), "user", int(datetime.now(timezone.utc).timestamp()) + 60, "nonce", frozenset({"mcp"}))
+            response = asyncio.run(handle_opencode_mcp_json_rpc(McpJsonRpcRequest.model_validate({"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "forma.generate_project", "arguments": {}}}), capability))
+        self.assertEqual("authorization_required", response["error"]["data"]["code"])
+
+    def test_store_is_idempotent_leased_and_cursorable(self) -> None:
+        project_id = str(uuid4())
+        store = OpenCodeStore(":memory:")
+        try:
+            session = store.create_session(session_id="session", connector_id="mini", owner_user_id="user", project_id=project_id)
+            first = store.create_command(command_id="command", session=session, operation=OpenCodeOperation.PROJECT_MESSAGE, idempotency_key="same", message="build")
+            duplicate = store.create_command(command_id="other", session=session, operation=OpenCodeOperation.PROJECT_MESSAGE, idempotency_key="same", message="build")
+            self.assertEqual(first.command_id, duplicate.command_id)
+            claimed = store.claim_next(connector_id="mini", session_id="session")
+            self.assertIsNotNone(claimed)
+            assert claimed is not None
+            self.assertEqual("build", claimed.message)
+            public = project_public_event(ConnectorEventInput(event_id="event", kind="working"), sequence=1, session_id="session", project_id=UUID(project_id))
+            store.add_event(public)
+            self.assertEqual(1, len(store.list_events("session", 0, 10)))
+        finally:
+            store.close()
+
+    def test_store_is_session_scoped_renews_leases_and_completes_idempotently(self) -> None:
+        first_project_id = str(uuid4())
+        second_project_id = str(uuid4())
+        store = OpenCodeStore(":memory:")
+        try:
+            first_session = store.create_session(session_id="session_a", connector_id="mini", owner_user_id="user", project_id=first_project_id)
+            second_session = store.create_session(session_id="session_b", connector_id="mini", owner_user_id="user", project_id=second_project_id)
+            store.create_command(command_id="command_a", session=first_session, operation=OpenCodeOperation.PROJECT_MESSAGE, idempotency_key="a", message="first")
+            store.create_command(command_id="command_b", session=second_session, operation=OpenCodeOperation.PROJECT_MESSAGE, idempotency_key="b", message="second")
+            claimed = store.claim_next(connector_id="mini", session_id="session_a")
+            self.assertIsNotNone(claimed)
+            assert claimed is not None
+            self.assertEqual("command_a", claimed.command_id)
+            stored = store.get_command(claimed.command_id)
+            self.assertIsNotNone(stored)
+            assert stored is not None
+            old_expiry = stored.lease_expires_at
+            renewed = store.heartbeat(stored, claimed.lease_token)
+            self.assertNotEqual(old_expiry, renewed.lease_expires_at)
+            completed = store.complete(renewed, claimed.lease_token, OpenCodeCommandStatus.SUCCEEDED)
+            self.assertEqual(OpenCodeCommandStatus.SUCCEEDED, completed.status)
+            self.assertEqual(completed, store.complete(completed, "not-needed-after-terminal", OpenCodeCommandStatus.SUCCEEDED))
+            self.assertIsNotNone(store.claim_next(connector_id="mini", session_id="session_b"))
+        finally:
+            store.close()


### PR DESCRIPTION
## Summary
Adds the hosted OpenCode authoring bridge and connects the workspace UI to session-scoped OpenCode execution.

## Includes
- Durable sessions, leased commands, heartbeats, cancellation, completion, and sanitized public events
- Clerk primary-email allowlist and server-derived project ownership
- Restricted project-only MCP tools with typed JSON-RPC models
- Workspace UI submission, event polling, and completed-project hydration
- Supabase migration, SQLite support, runtime configuration, and focused tests

## Validation
- Forma OpenCode tests: 8/8
- Runtime tests: 16/16
- Frontend ESLint and TypeScript checks
- Python compileall and diff checks

Tracks #454, #455, #456, #457, #458, and #459.