### PR TITLE
feat(opencode): gate authoring by allowlisted user

### DIFF
--- a/apps/api/auth.py
+++ b/apps/api/auth.py
@@ -243,6 +243,14 @@ def opencode_allowed_emails() -> frozenset[str]:
     return frozenset(email.strip().lower() for email in _csv_env("FORMA_OPENCODE_ALLOWED_EMAILS") if "@" in email)
 
 
+def has_opencode_authoring_access(user: Optional[UserContext]) -> bool:
+    """Return whether this authenticated Clerk user is on the OpenCode allowlist."""
+    if user is None or user.provider != "clerk" or not user.owner_user_id:
+        return False
+    email = clerk_user_email(user.owner_user_id)
+    return bool(email and email.strip().lower() in opencode_allowed_emails())
+
+
 async def require_opencode_authoring_access(request: Request) -> UserContext:
     """Require a hosted Clerk user whose primary email is explicitly allowed.
 
@@ -265,8 +273,7 @@ async def require_opencode_authoring_access(request: Request) -> UserContext:
             status_code=status.HTTP_403_FORBIDDEN,
             detail=_opencode_auth_error("opencode_clerk_required", "A Clerk user session is required."),
         )
-    email = clerk_user_email(context.owner_user_id)
-    if not email or email.strip().lower() not in opencode_allowed_emails():
+    if not has_opencode_authoring_access(context):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=_opencode_auth_error("opencode_email_not_allowed", "This account is not enabled for hosted OpenCode."),

--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -174,6 +174,7 @@ from apps.api.auth import (
     require_a2a_websocket_context,
     clerk_user_profile,
     deployed_auth_required,
+    has_opencode_authoring_access,
     optional_user_context,
     require_admin_user_context,
     require_mcp_user_context,
@@ -373,7 +374,10 @@ def _deployment_runtime_config(llm_config: Dict[str, Any]) -> Dict[str, Any]:
     return deployment_runtime_config(llm_config, signup_storage=get_database_config()["client"])
 
 
-def _resolved_client_runtime_config(settings: Optional[ResolvedIntegrationSettings] = None) -> tuple[Dict[str, Any], Dict[str, Any]]:
+def _resolved_client_runtime_config(
+    settings: Optional[ResolvedIntegrationSettings] = None,
+    user: Optional[UserContext] = None,
+) -> tuple[Dict[str, Any], Dict[str, Any]]:
     llm_config = HardwarePipelineOrchestrator(settings=settings).get_debug_config()
     image_config = get_image_output_debug_config(settings=settings)
     contract = resolve_runtime_contract(
@@ -382,6 +386,7 @@ def _resolved_client_runtime_config(settings: Optional[ResolvedIntegrationSettin
         workflows=list_workflows(),
         signup_storage=get_database_config()["client"],
         settings=settings,
+        authoring_access=has_opencode_authoring_access(user),
     )
     contract["video"] = {
         "generation": GMICloudProvider(settings=settings).get_debug_config(),
@@ -640,7 +645,7 @@ def runtime_config_endpoint(user: UserContext = Depends(optional_user_context)):
     """Return the canonical, credential-safe runtime contract for this user."""
     settings = _resolve_user_integrations(user)
     try:
-        _, contract = _resolved_client_runtime_config(settings)
+        _, contract = _resolved_client_runtime_config(settings, user)
         return contract
     except LLMProviderConfigError as e:
         correlation_id = new_error_correlation_id()

--- a/apps/web/lib/config/runtime.ts
+++ b/apps/web/lib/config/runtime.ts
@@ -42,6 +42,7 @@ export type RuntimeConfigContract = {
   deployment?: {
     hosted_chat_enabled?: boolean;
     authoring_mode_enabled?: boolean;
+    authoring_access?: boolean;
     opencode_connector_id?: string | null;
   };
   video?: {
@@ -57,5 +58,5 @@ export function usableRuntimeLlmOptions(contract: RuntimeConfigContract): Genera
 }
 
 export function authoringModeEnabled(contract: RuntimeConfigContract): boolean {
-  return contract.deployment?.authoring_mode_enabled === true;
+  return contract.deployment?.authoring_mode_enabled === true && contract.deployment?.authoring_access === true;
 }

--- a/apps/web/test/runtime-config.test.ts
+++ b/apps/web/test/runtime-config.test.ts
@@ -100,8 +100,15 @@ test("authoring mode is disabled unless the backend explicitly enables it", () =
 test("the runtime contract surfaces an enabled authoring mode", () => {
   const enabled = authoringModeEnabled({
     ...contract(),
-    deployment: { authoring_mode_enabled: true },
+    deployment: { authoring_mode_enabled: true, authoring_access: true },
   });
 
   assert.equal(enabled, true);
+});
+
+test("authoring mode stays disabled for authenticated users without backend access", () => {
+  assert.equal(authoringModeEnabled({
+    ...contract(),
+    deployment: { authoring_mode_enabled: true, authoring_access: false },
+  }), false);
 });

--- a/forma_core/config/contract.py
+++ b/forma_core/config/contract.py
@@ -112,6 +112,7 @@ def resolve_runtime_contract(
     workflows: Optional[list[Dict[str, Any]]] = None,
     signup_storage: Optional[str] = None,
     settings: Optional[Mapping[str, str]] = None,
+    authoring_access: bool = False,
 ) -> Dict[str, Any]:
     """Resolve all client-facing generation decisions from the active environment."""
     resolved_llm_config = llm_config or HardwarePipelineOrchestrator(settings=settings).get_debug_config()
@@ -133,7 +134,11 @@ def resolve_runtime_contract(
             else str(resolved_workflows[0].get("id") or "default")
         )
 
-    deployment = deployment_runtime_config(resolved_llm_config, signup_storage=signup_storage)
+    deployment = deployment_runtime_config(
+        resolved_llm_config,
+        signup_storage=signup_storage,
+        authoring_access=authoring_access,
+    )
     llm_ready = bool(resolved_llm_config.get("live_generation_enabled"))
     llm_reason = resolved_llm_config.get("validation_error")
     image_reason = resolved_image.get("reason")

--- a/forma_core/config/runtime.py
+++ b/forma_core/config/runtime.py
@@ -167,6 +167,7 @@ def deployment_runtime_config(
     llm_config: Dict[str, Any],
     *,
     signup_storage: Optional[str] = None,
+    authoring_access: bool = False,
 ) -> Dict[str, Any]:
     state = runtime_state()
     deployment_enabled = state["deployment_mode"] == "hosted"
@@ -177,6 +178,7 @@ def deployment_runtime_config(
         "development_mode": state["development_mode"],
         "hosted_chat_enabled": hosted_chat_enabled(),
         "authoring_mode_enabled": authoring_mode_enabled(),
+        "authoring_access": authoring_access,
         "opencode_connector_id": (config.get("FORMA_OPENCODE_CONNECTOR_ID") or "").strip() or None,
         "alpha_generation_gate_active": deployment_enabled and not live_generation_enabled,
         "generation_available": (not deployment_enabled) or live_generation_enabled,

--- a/tests/opencode/test_bridge.py
+++ b/tests/opencode/test_bridge.py
@@ -9,7 +9,7 @@ from uuid import UUID, uuid4
 
 from fastapi import HTTPException
 
-from apps.api.auth import UserContext, require_opencode_authoring_access
+from apps.api.auth import UserContext, has_opencode_authoring_access, require_opencode_authoring_access
 from apps.api.opencode_api import _require_owned_project
 from apps.api.opencode_mcp import handle_opencode_mcp_json_rpc, opencode_mcp_tools
 from forma_core.opencode.capabilities import CapabilityError, issue_capability, verify_capability
@@ -32,6 +32,16 @@ class OpenCodeBridgeTests(unittest.IsolatedAsyncioTestCase):
                 asyncio.run(require_opencode_authoring_access(object()))
         self.assertEqual(403, denied.exception.status_code)
         self.assertEqual("opencode_clerk_required", denied.exception.detail["code"])
+
+    def test_runtime_authoring_access_is_limited_to_the_exact_allowlisted_email(self) -> None:
+        allowed = UserContext(provider="clerk", subject="user_1", owner_user_id="user_1", is_authenticated=True, is_admin=False)
+        denied = UserContext(provider="clerk", subject="user_2", owner_user_id="user_2", is_authenticated=True, is_admin=False)
+        with patch.dict(os.environ, {"FORMA_OPENCODE_ALLOWED_EMAILS": "isayahculbertson@gmail.com"}, clear=True), patch(
+            "apps.api.auth.clerk_user_email",
+            side_effect=lambda user_id: "isayahculbertson@gmail.com" if user_id == "user_1" else "someone-else@example.com",
+        ):
+            self.assertTrue(has_opencode_authoring_access(allowed))
+            self.assertFalse(has_opencode_authoring_access(denied))
 
     def test_project_scope_rejects_a_foreign_owner_before_session_use(self) -> None:
         with patch("apps.api.opencode_api.get_project_identity", return_value={"owner_user_id": "another-user", "status": "active"}):

--- a/tests/providers/test_runtime_contract.py
+++ b/tests/providers/test_runtime_contract.py
@@ -41,6 +41,7 @@ class RuntimeContractTests(unittest.TestCase):
         self.assertFalse(contract["provider_setup"]["required"])
         self.assertTrue(contract["deployment"]["hosted_chat_enabled"])
         self.assertFalse(contract["deployment"]["authoring_mode_enabled"])
+        self.assertFalse(contract["deployment"]["authoring_access"])
         self.assertEqual(
             ("cloudflare", "@cf/google/gemma-4-26b-a4b-it"),
             (
@@ -96,8 +97,9 @@ class RuntimeContractTests(unittest.TestCase):
 
         self.assertFalse(contract["deployment"]["hosted_chat_enabled"])
         self.assertFalse(contract["deployment"]["authoring_mode_enabled"])
+        self.assertFalse(contract["deployment"]["authoring_access"])
 
-    def test_authoring_mode_surfaces_in_the_runtime_contract(self) -> None:
+    def test_authoring_mode_surfaces_in_the_runtime_contract_without_granting_user_access(self) -> None:
         with patch.dict(os.environ, {"FORMA_AUTHORING_MODE_ENABLED": "true"}, clear=True):
             contract = resolve_runtime_contract(
                 llm_config={"live_generation_enabled": False, "validation_error": "Unavailable."},
@@ -106,6 +108,7 @@ class RuntimeContractTests(unittest.TestCase):
             )
 
         self.assertTrue(contract["deployment"]["authoring_mode_enabled"])
+        self.assertFalse(contract["deployment"]["authoring_access"])
 
     def test_config_can_select_catalog_as_the_default_workflow(self) -> None:
         with patch.dict(os.environ, {"FORMA_DEFAULT_GENERATION_WORKFLOW": "default"}, clear=True):


### PR DESCRIPTION
## Summary
- expose credential-safe per-user OpenCode authoring access in the runtime contract
- enable authoring UI only when the authenticated Clerk email is exactly allowlisted
- keep hosted chat maintenance enabled for all other users
- add backend and frontend coverage for allowed and denied access

## Verification
- python -m unittest tests.providers.test_runtime_contract tests.opencode.test_bridge
- npm exec --yes --package=tsx tsx -- --test test/runtime-config.test.ts (from apps/web)
- npm run lint (from apps/web)
- npx tsc --noEmit (from apps/web)
- python -m compileall -q apps forma_core tests/opencode tests/providers
