### PR TITLE
fix(opencode): tolerate stale user settings for allowlisted access

### DIFF
--- a/apps/api/main.py
+++ b/apps/api/main.py
@@ -395,6 +395,20 @@ def _resolved_client_runtime_config(
     return llm_config, contract
 
 
+def _runtime_config_settings(user: Optional[UserContext]) -> Optional[ResolvedIntegrationSettings]:
+    """Keep the allowlisted OpenCode surface available when stale BYOK data is unreadable."""
+    try:
+        return _resolve_user_integrations(user)
+    except RuntimeError as exc:
+        if not has_opencode_authoring_access(user):
+            raise
+        logger.warning(
+            "OpenCode allowlisted runtime config is using deployment defaults after user settings failed: %s",
+            exc,
+        )
+        return None
+
+
 def _resolve_user_integrations(user: Optional[UserContext]) -> ResolvedIntegrationSettings:
     """Snapshot provider settings for this request without mutating the process environment."""
     if user is None or user.provider == "local":
@@ -643,8 +657,8 @@ def debug_config_endpoint(
 @app.get("/runtime/config")
 def runtime_config_endpoint(user: UserContext = Depends(optional_user_context)):
     """Return the canonical, credential-safe runtime contract for this user."""
-    settings = _resolve_user_integrations(user)
     try:
+        settings = _runtime_config_settings(user)
         _, contract = _resolved_client_runtime_config(settings, user)
         return contract
     except LLMProviderConfigError as e:

--- a/tests/opencode/test_bridge.py
+++ b/tests/opencode/test_bridge.py
@@ -10,6 +10,7 @@ from uuid import UUID, uuid4
 from fastapi import HTTPException
 
 from apps.api.auth import UserContext, has_opencode_authoring_access, require_opencode_authoring_access
+from apps.api.main import _runtime_config_settings
 from apps.api.opencode_api import _require_owned_project
 from apps.api.opencode_mcp import handle_opencode_mcp_json_rpc, opencode_mcp_tools
 from forma_core.opencode.capabilities import CapabilityError, issue_capability, verify_capability
@@ -42,6 +43,19 @@ class OpenCodeBridgeTests(unittest.IsolatedAsyncioTestCase):
         ):
             self.assertTrue(has_opencode_authoring_access(allowed))
             self.assertFalse(has_opencode_authoring_access(denied))
+
+    def test_allowlisted_runtime_config_falls_back_when_user_settings_are_unreadable(self) -> None:
+        user = UserContext(provider="clerk", subject="user_1", owner_user_id="user_1", is_authenticated=True, is_admin=False)
+        with patch("apps.api.main._resolve_user_integrations", side_effect=RuntimeError("key mismatch")), patch(
+            "apps.api.main.has_opencode_authoring_access", return_value=True,
+        ):
+            self.assertIsNone(_runtime_config_settings(user))
+
+        with patch("apps.api.main._resolve_user_integrations", side_effect=RuntimeError("key mismatch")), patch(
+            "apps.api.main.has_opencode_authoring_access", return_value=False,
+        ):
+            with self.assertRaises(RuntimeError):
+                _runtime_config_settings(user)
 
     def test_project_scope_rejects_a_foreign_owner_before_session_use(self) -> None:
         with patch("apps.api.opencode_api.get_project_identity", return_value={"owner_user_id": "another-user", "status": "active"}):


### PR DESCRIPTION
## Summary
- keep the allowlisted OpenCode runtime contract available when stale Supabase BYOK data cannot be decrypted
- preserve fail-closed behavior for non-allowlisted users
- add regression coverage for both paths

## Production configuration
- replaced the invalid literal [SENSITIVE] FORMA_USER_SECRETS_KEY value with a fresh server-only secret

## Verification
- python -m unittest tests.opencode.test_bridge tests.providers.test_runtime_contract
- python -m compileall -q apps forma_core tests/opencode tests/providers
