### PR TITLE
fix(opencode): persist encrypted connector messages

### DIFF
--- a/forma_core/opencode/persistence.py
+++ b/forma_core/opencode/persistence.py
@@ -35,6 +35,8 @@ class DBOpenCodeCommand(Base):
     idempotency_key = Column(String, nullable=False)
     status = Column(String, index=True, nullable=False)
     message_digest = Column(String, nullable=False)
+    message_ciphertext = Column(Text, nullable=True)
+    message_key_id = Column(String, nullable=True)
     attempt_count = Column(Integer, nullable=False, default=0)
     lease_expires_at = Column(String, nullable=True)
     lease_token_hash = Column(String, nullable=True)

--- a/forma_core/opencode/schema.py
+++ b/forma_core/opencode/schema.py
@@ -15,7 +15,7 @@ OPENCODE_TABLE_CONTRACTS = (
         "opencode_commands",
         (
             "command_id", "session_id", "connector_id", "owner_user_id", "project_id", "operation",
-            "idempotency_key", "status", "message_digest", "attempt_count", "lease_expires_at",
+            "idempotency_key", "status", "message_digest", "message_ciphertext", "message_key_id", "attempt_count", "lease_expires_at",
             "lease_token_hash", "created_at", "updated_at", "completed_at",
         ),
     ),

--- a/forma_core/opencode/store.py
+++ b/forma_core/opencode/store.py
@@ -20,6 +20,7 @@ from forma_core.opencode.models import (
     PublicEvent,
 )
 from forma_core.persistence.providers import SQLiteProvider, SupabaseProvider, create_sqlite_provider
+from forma_core.user_integrations import decrypt_user_secret_text, encrypt_user_secret_text
 
 
 def _now() -> datetime:
@@ -80,6 +81,8 @@ class StoredCommand:
     idempotency_key: str
     status: OpenCodeCommandStatus
     message_digest: str
+    message_ciphertext: str | None
+    message_key_id: str | None
     attempt_count: int
     lease_expires_at: str | None
     lease_token_hash: str | None
@@ -98,6 +101,8 @@ class StoredCommand:
             "idempotency_key": self.idempotency_key,
             "status": self.status.value,
             "message_digest": self.message_digest,
+            "message_ciphertext": self.message_ciphertext,
+            "message_key_id": self.message_key_id,
             "attempt_count": self.attempt_count,
             "lease_expires_at": self.lease_expires_at,
             "lease_token_hash": self.lease_token_hash,
@@ -116,7 +121,6 @@ class OpenCodeStore:
         self._db_path = db_path
         self._lock = threading.RLock()
         self._initialized = False
-        self._messages: dict[str, str] = {}
 
     def _ensure_provider(self) -> Any:
         if self._provider is None:
@@ -201,9 +205,12 @@ class OpenCodeStore:
         if existing:
             if existing.message_digest != digest:
                 raise ValueError("The command idempotency key was already used with another message.")
-            self._messages.setdefault(existing.command_id, message)
+            if existing.message_ciphertext is None or existing.message_key_id is None:
+                ciphertext, key_id = encrypt_user_secret_text(message)
+                self._update_command_message(existing.command_id, ciphertext, key_id)
             return existing
         now = _timestamp()
+        ciphertext, key_id = encrypt_user_secret_text(message)
         command = StoredCommand(
             command_id=command_id,
             session_id=session.session_id,
@@ -214,6 +221,8 @@ class OpenCodeStore:
             idempotency_key=idempotency_key,
             status=OpenCodeCommandStatus.QUEUED,
             message_digest=digest,
+            message_ciphertext=ciphertext,
+            message_key_id=key_id,
             attempt_count=0,
             lease_expires_at=None,
             lease_token_hash=None,
@@ -229,11 +238,10 @@ class OpenCodeStore:
                 connection.execute(
                     "INSERT INTO opencode_commands "
                     "(command_id, session_id, connector_id, owner_user_id, project_id, operation, idempotency_key, "
-                    "status, message_digest, attempt_count, lease_expires_at, lease_token_hash, created_at, updated_at, completed_at) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                     "status, message_digest, message_ciphertext, message_key_id, attempt_count, lease_expires_at, lease_token_hash, created_at, updated_at, completed_at) "
+                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     tuple(command.as_record().values()),
                 )
-        self._messages[command_id] = message
         return command
 
     def find_command(self, session_id: str, idempotency_key: str) -> StoredCommand | None:
@@ -332,7 +340,8 @@ class OpenCodeStore:
                     or []
                 )
                 if updated:
-                    return _connector_command(_command_from_record(updated[0]), lease_token, self._messages.get(str(row["command_id"])))
+                    updated_command = _command_from_record(updated[0])
+                    return _connector_command(updated_command, lease_token, self._command_message(updated_command))
             return None
         with self._connection(begin_immediate=True) as connection:
             row = connection.execute(
@@ -352,7 +361,8 @@ class OpenCodeStore:
             )
             record.update(status=OpenCodeCommandStatus.LEASED.value, attempt_count=attempt_count,
                           lease_expires_at=expiry, lease_token_hash=lease_hash, updated_at=now_text)
-        return _connector_command(_command_from_record(record), lease_token, self._messages.get(str(record["command_id"])))
+        command = _command_from_record(record)
+        return _connector_command(command, lease_token, self._command_message(command))
 
     def heartbeat(self, command: StoredCommand, lease_token: str) -> StoredCommand:
         self._require_lease(command, lease_token)
@@ -469,6 +479,23 @@ class OpenCodeStore:
         if expiry is None or expiry <= _now():
             raise PermissionError("The command lease is invalid or has expired.")
 
+    def _command_message(self, command: StoredCommand) -> str | None:
+        if command.message_ciphertext is None or command.message_key_id is None:
+            return None
+        return decrypt_user_secret_text(command.message_ciphertext, command.message_key_id)
+
+    def _update_command_message(self, command_id: str, ciphertext: str, key_id: str) -> None:
+        provider = self._ensure_provider()
+        values = {"message_ciphertext": ciphertext, "message_key_id": key_id}
+        if isinstance(provider, SupabaseProvider):
+            provider.client.table("opencode_commands").update(values).eq("command_id", command_id).execute()
+            return
+        with self._connection() as connection:
+            connection.execute(
+                "UPDATE opencode_commands SET message_ciphertext = ?, message_key_id = ? WHERE command_id = ?",
+                (ciphertext, key_id, command_id),
+            )
+
     def _connection(self, *, begin_immediate: bool = False) -> Any:
         provider = self._ensure_provider()
         if not isinstance(provider, SQLiteProvider):
@@ -517,6 +544,7 @@ def _command_from_record(record: dict[str, Any]) -> StoredCommand:
         command_id=str(record["command_id"]), session_id=str(record["session_id"]), connector_id=str(record["connector_id"]),
         owner_user_id=str(record["owner_user_id"]), project_id=str(record["project_id"]), operation=OpenCodeOperation(str(record["operation"])),
         idempotency_key=str(record["idempotency_key"]), status=OpenCodeCommandStatus(str(record["status"])), message_digest=str(record["message_digest"]),
+        message_ciphertext=record.get("message_ciphertext"), message_key_id=record.get("message_key_id"),
         attempt_count=int(record.get("attempt_count") or 0), lease_expires_at=record.get("lease_expires_at"), lease_token_hash=record.get("lease_token_hash"),
         created_at=str(record["created_at"]), updated_at=str(record["updated_at"]), completed_at=record.get("completed_at"),
     )

--- a/forma_core/persistence/migrations.py
+++ b/forma_core/persistence/migrations.py
@@ -113,6 +113,15 @@ def migrate_sqlite_schema(engine: Engine, *, import_legacy_jobs: bool = True) ->
             text("CREATE INDEX IF NOT EXISTS ix_project_revisions_project_revision "
                  "ON project_revisions (project_id, revision DESC)")
         )
+        opencode_columns = {
+            row[1]
+            for row in connection.exec_driver_sql("PRAGMA table_info(opencode_commands)").fetchall()
+        }
+        if opencode_columns:
+            if "message_ciphertext" not in opencode_columns:
+                connection.execute(text("ALTER TABLE opencode_commands ADD COLUMN message_ciphertext TEXT"))
+            if "message_key_id" not in opencode_columns:
+                connection.execute(text("ALTER TABLE opencode_commands ADD COLUMN message_key_id VARCHAR"))
         connection.exec_driver_sql("DROP VIEW IF EXISTS project_gallery_inventory")
         connection.exec_driver_sql(
             """

--- a/forma_core/user_integrations.py
+++ b/forma_core/user_integrations.py
@@ -8,6 +8,7 @@ from forma_core.config import config as env_config
 import re
 import hashlib
 import base64
+import secrets
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -1210,6 +1211,25 @@ def _decrypt_config(token: str) -> UserIntegrationConfig:
     return _decrypt_config_with_secret(token, _integration_encryption_secret())
 
 
+def encrypt_user_secret_text(value: str) -> tuple[str, str]:
+    """Encrypt short server-only payloads with the configured user secret key."""
+    secret = _integration_encryption_secret()
+    token = _fernet_for_secret(secret).encrypt(value.encode("utf-8"))
+    return token.decode("ascii"), _integration_encryption_key_id(secret)
+
+
+def decrypt_user_secret_text(token: str, key_id: str) -> str:
+    """Decrypt a payload and reject values encrypted with another configured key."""
+    secret = _integration_encryption_secret()
+    if not secrets.compare_digest(key_id, _integration_encryption_key_id(secret)):
+        raise RuntimeError("Stored secret text was encrypted with a different FORMA_USER_SECRETS_KEY.")
+    try:
+        plaintext = _fernet_for_secret(secret).decrypt(token.encode("ascii"))
+    except InvalidToken as exc:
+        raise RuntimeError("Stored secret text could not be decrypted with the configured key.") from exc
+    return plaintext.decode("utf-8")
+
+
 class EncryptedFileIntegrationStore(UserIntegrationStore):
     """Fernet-encrypted file storage for local workspace or user settings."""
 
@@ -2042,6 +2062,8 @@ __all__ = [
     "integration_status_payload",
     "list_integration_definitions",
     "mask_secret",
+    "encrypt_user_secret_text",
+    "decrypt_user_secret_text",
     "require_user_secrets_key",
     "user_integrations_path_for_user",
 ]

--- a/supabase/migrations/20260909000100_opencode_encrypted_command_messages.sql
+++ b/supabase/migrations/20260909000100_opencode_encrypted_command_messages.sql
@@ -1,0 +1,4 @@
+-- Store queued OpenCode prompts durably without exposing raw prompt text at rest.
+alter table public.opencode_commands
+  add column if not exists message_ciphertext text,
+  add column if not exists message_key_id text;

--- a/tests/opencode/test_bridge.py
+++ b/tests/opencode/test_bridge.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import tempfile
 import unittest
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, patch
@@ -108,44 +109,54 @@ class OpenCodeBridgeTests(unittest.IsolatedAsyncioTestCase):
 
     def test_store_is_idempotent_leased_and_cursorable(self) -> None:
         project_id = str(uuid4())
-        store = OpenCodeStore(":memory:")
-        try:
-            session = store.create_session(session_id="session", connector_id="mini", owner_user_id="user", project_id=project_id)
-            first = store.create_command(command_id="command", session=session, operation=OpenCodeOperation.PROJECT_MESSAGE, idempotency_key="same", message="build")
-            duplicate = store.create_command(command_id="other", session=session, operation=OpenCodeOperation.PROJECT_MESSAGE, idempotency_key="same", message="build")
-            self.assertEqual(first.command_id, duplicate.command_id)
-            claimed = store.claim_next(connector_id="mini", session_id="session")
-            self.assertIsNotNone(claimed)
-            assert claimed is not None
-            self.assertEqual("build", claimed.message)
-            public = project_public_event(ConnectorEventInput(event_id="event", kind="working"), sequence=1, session_id="session", project_id=UUID(project_id))
-            store.add_event(public)
-            self.assertEqual(1, len(store.list_events("session", 0, 10)))
-        finally:
-            store.close()
+        with tempfile.TemporaryDirectory() as directory, patch.dict(os.environ, {"FORMA_USER_SECRETS_KEY": "test-key"}, clear=False):
+            path = os.path.join(directory, "opencode.sqlite")
+            store = OpenCodeStore(path)
+            try:
+                session = store.create_session(session_id="session", connector_id="mini", owner_user_id="user", project_id=project_id)
+                first = store.create_command(command_id="command", session=session, operation=OpenCodeOperation.PROJECT_MESSAGE, idempotency_key="same", message="build")
+                duplicate = store.create_command(command_id="other", session=session, operation=OpenCodeOperation.PROJECT_MESSAGE, idempotency_key="same", message="build")
+                self.assertEqual(first.command_id, duplicate.command_id)
+                self.assertIsNotNone(first.message_ciphertext)
+                self.assertNotIn("build", str(first.message_ciphertext))
+            finally:
+                store.close()
+
+            reopened = OpenCodeStore(path)
+            try:
+                claimed = reopened.claim_next(connector_id="mini", session_id="session")
+                self.assertIsNotNone(claimed)
+                assert claimed is not None
+                self.assertEqual("build", claimed.message)
+                public = project_public_event(ConnectorEventInput(event_id="event", kind="working"), sequence=1, session_id="session", project_id=UUID(project_id))
+                reopened.add_event(public)
+                self.assertEqual(1, len(reopened.list_events("session", 0, 10)))
+            finally:
+                reopened.close()
 
     def test_store_is_session_scoped_renews_leases_and_completes_idempotently(self) -> None:
         first_project_id = str(uuid4())
         second_project_id = str(uuid4())
-        store = OpenCodeStore(":memory:")
-        try:
-            first_session = store.create_session(session_id="session_a", connector_id="mini", owner_user_id="user", project_id=first_project_id)
-            second_session = store.create_session(session_id="session_b", connector_id="mini", owner_user_id="user", project_id=second_project_id)
-            store.create_command(command_id="command_a", session=first_session, operation=OpenCodeOperation.PROJECT_MESSAGE, idempotency_key="a", message="first")
-            store.create_command(command_id="command_b", session=second_session, operation=OpenCodeOperation.PROJECT_MESSAGE, idempotency_key="b", message="second")
-            claimed = store.claim_next(connector_id="mini", session_id="session_a")
-            self.assertIsNotNone(claimed)
-            assert claimed is not None
-            self.assertEqual("command_a", claimed.command_id)
-            stored = store.get_command(claimed.command_id)
-            self.assertIsNotNone(stored)
-            assert stored is not None
-            old_expiry = stored.lease_expires_at
-            renewed = store.heartbeat(stored, claimed.lease_token)
-            self.assertNotEqual(old_expiry, renewed.lease_expires_at)
-            completed = store.complete(renewed, claimed.lease_token, OpenCodeCommandStatus.SUCCEEDED)
-            self.assertEqual(OpenCodeCommandStatus.SUCCEEDED, completed.status)
-            self.assertEqual(completed, store.complete(completed, "not-needed-after-terminal", OpenCodeCommandStatus.SUCCEEDED))
-            self.assertIsNotNone(store.claim_next(connector_id="mini", session_id="session_b"))
-        finally:
-            store.close()
+        with patch.dict(os.environ, {"FORMA_USER_SECRETS_KEY": "test-key"}, clear=False):
+            store = OpenCodeStore(":memory:")
+            try:
+                first_session = store.create_session(session_id="session_a", connector_id="mini", owner_user_id="user", project_id=first_project_id)
+                second_session = store.create_session(session_id="session_b", connector_id="mini", owner_user_id="user", project_id=second_project_id)
+                store.create_command(command_id="command_a", session=first_session, operation=OpenCodeOperation.PROJECT_MESSAGE, idempotency_key="a", message="first")
+                store.create_command(command_id="command_b", session=second_session, operation=OpenCodeOperation.PROJECT_MESSAGE, idempotency_key="b", message="second")
+                claimed = store.claim_next(connector_id="mini", session_id="session_a")
+                self.assertIsNotNone(claimed)
+                assert claimed is not None
+                self.assertEqual("command_a", claimed.command_id)
+                stored = store.get_command(claimed.command_id)
+                self.assertIsNotNone(stored)
+                assert stored is not None
+                old_expiry = stored.lease_expires_at
+                renewed = store.heartbeat(stored, claimed.lease_token)
+                self.assertNotEqual(old_expiry, renewed.lease_expires_at)
+                completed = store.complete(renewed, claimed.lease_token, OpenCodeCommandStatus.SUCCEEDED)
+                self.assertEqual(OpenCodeCommandStatus.SUCCEEDED, completed.status)
+                self.assertEqual(completed, store.complete(completed, "not-needed-after-terminal", OpenCodeCommandStatus.SUCCEEDED))
+                self.assertIsNotNone(store.claim_next(connector_id="mini", session_id="session_b"))
+            finally:
+                store.close()


### PR DESCRIPTION
## Summary
- persist hosted OpenCode command prompts as Fernet ciphertext
- decrypt only when a scoped connector leases a command
- add Supabase and SQLite schema upgrades
- cover cross-process recovery in bridge tests

## Tests
- python -m unittest tests.opencode.test_bridge -q
- python -m compileall -q forma_core/opencode forma_core/user_integrations.py apps/api/opencode_api.py

The unrelated working-tree change in forma_core/persistence/repositories/sqlite.py was intentionally excluded.