### PR TITLE
fix(opencode): unblock stalled chat hydration

### DIFF
--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -5056,6 +5056,23 @@ export function FormaWorkspace({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [routedChatId, currentRouteProjectId, routedChatFound, routedChatProjectId, inlineChatProjectId, chatIndexLoaded, chatHistoryLoaded, authRequired, isSignedIn, chatStorageScope]);
 
+  useEffect(() => {
+    if (!routedChatId || currentRouteProjectId || chatHistoryLoaded) return;
+    const chatId = routedChatId;
+    const timeoutId = window.setTimeout(() => {
+      setChatRouteTransition((current) => (
+        current?.chatId === chatId && !current.error
+          ? {
+              ...current,
+              title: "Chat unavailable",
+              error: "The chat workspace could not finish loading. Please return home and try again.",
+            }
+          : current
+      ));
+    }, 10000);
+    return () => window.clearTimeout(timeoutId);
+  }, [routedChatId, currentRouteProjectId, chatHistoryLoaded]);
+
   const findProjectForJob = (job: A2AJob) => {
     const projectId = job.result_summary?.project_id;
     if (projectId) {

--- a/forma_core/opencode/store.py
+++ b/forma_core/opencode/store.py
@@ -444,12 +444,15 @@ class OpenCodeStore:
                 session = self.get_session(event.session_id)
                 if session is None:
                     raise ValueError("OpenCode session not found.")
-                candidate = event.model_copy(update={"sequence": session.next_event_sequence})
+                latest = provider.client.table("opencode_events").select("sequence").eq("session_id", event.session_id).order("sequence", desc=True).limit(1).execute().data or []
+                latest_sequence = int(latest[0]["sequence"]) + 1 if latest else 1
+                candidate = event.model_copy(update={"sequence": max(session.next_event_sequence, latest_sequence)})
                 try:
                     provider.client.table("opencode_events").insert({"event_id": candidate.event_id, "session_id": candidate.session_id, "owner_user_id": session.owner_user_id, "project_id": str(candidate.project_id), "sequence": candidate.sequence, "event_json": candidate.model_dump(mode="json"), "created_at": _timestamp(candidate.created_at)}).execute()
+                    provider.client.table("opencode_sessions").update({"next_event_sequence": candidate.sequence + 1, "updated_at": _timestamp()}).eq("session_id", event.session_id).lt("next_event_sequence", candidate.sequence + 1).execute()
                     return candidate
                 except Exception as exc:
-                    if getattr(exc, "code", None) != "23505":
+                    if getattr(exc, "code", None) != "23505" and getattr(exc, "status_code", None) != 409:
                         raise
                     existing = provider.client.table("opencode_events").select("event_json").eq("event_id", event.event_id).limit(1).execute().data or []
                     if existing:

--- a/tests/opencode/test_bridge.py
+++ b/tests/opencode/test_bridge.py
@@ -131,6 +131,7 @@ class OpenCodeBridgeTests(unittest.IsolatedAsyncioTestCase):
                 public = project_public_event(ConnectorEventInput(event_id="event", kind="working"), sequence=1, session_id="session", project_id=UUID(project_id))
                 reopened.add_event(public)
                 self.assertEqual(1, len(reopened.list_events("session", 0, 10)))
+                self.assertEqual(2, reopened.next_event_sequence("session"))
             finally:
                 reopened.close()
 


### PR DESCRIPTION
## Summary
- Fail chat route hydration visibly instead of leaving users on an indefinite Opening chat screen
- Allocate Supabase event sequences from persisted events and advance the session watermark
- Treat Supabase HTTP 409 duplicate event inserts as idempotent

## Verification
- 
pm run lint
- 
px tsc --noEmit
- python -m pytest tests/opencode/test_bridge.py -q (10 passed)