### PR TITLE
fix(opencode): cancel malformed connector commands

### DIFF
--- a/forma_core/opencode/store.py
+++ b/forma_core/opencode/store.py
@@ -341,7 +341,11 @@ class OpenCodeStore:
                 )
                 if updated:
                     updated_command = _command_from_record(updated[0])
-                    return _connector_command(updated_command, lease_token, self._command_message(updated_command))
+                    message = self._command_message(updated_command)
+                    if message is None:
+                        self.cancel_command(updated_command)
+                        continue
+                    return _connector_command(updated_command, lease_token, message)
             return None
         with self._connection(begin_immediate=True) as connection:
             row = connection.execute(
@@ -362,7 +366,11 @@ class OpenCodeStore:
             record.update(status=OpenCodeCommandStatus.LEASED.value, attempt_count=attempt_count,
                           lease_expires_at=expiry, lease_token_hash=lease_hash, updated_at=now_text)
         command = _command_from_record(record)
-        return _connector_command(command, lease_token, self._command_message(command))
+        message = self._command_message(command)
+        if message is None:
+            self.cancel_command(command)
+            return self.claim_next(connector_id=connector_id, session_id=session_id, lease_seconds=lease_seconds)
+        return _connector_command(command, lease_token, message)
 
     def heartbeat(self, command: StoredCommand, lease_token: str) -> StoredCommand:
         self._require_lease(command, lease_token)

--- a/tests/opencode/test_bridge.py
+++ b/tests/opencode/test_bridge.py
@@ -161,3 +161,24 @@ class OpenCodeBridgeTests(unittest.IsolatedAsyncioTestCase):
                 self.assertIsNotNone(store.claim_next(connector_id="mini", session_id="session_b"))
             finally:
                 store.close()
+
+    def test_store_cancels_claimed_command_without_message(self) -> None:
+        project_id = str(uuid4())
+        with patch.dict(os.environ, {"FORMA_USER_SECRETS_KEY": "test-key"}, clear=False):
+            store = OpenCodeStore(":memory:")
+            try:
+                session = store.create_session(session_id="session", connector_id="mini", owner_user_id="user", project_id=project_id)
+                store.create_command(command_id="invalid", session=session, operation=OpenCodeOperation.PROJECT_MESSAGE, idempotency_key="invalid", message="build")
+                with store._connection() as connection:
+                    connection.execute(
+                        "UPDATE opencode_commands SET message_ciphertext = NULL, message_key_id = NULL WHERE command_id = ?",
+                        ("invalid",),
+                    )
+
+                self.assertIsNone(store.claim_next(connector_id="mini", session_id="session"))
+                command = store.get_command("invalid")
+                self.assertIsNotNone(command)
+                assert command is not None
+                self.assertEqual(OpenCodeCommandStatus.CANCELLED, command.status)
+            finally:
+                store.close()


### PR DESCRIPTION
## Summary
- cancel leased connector commands that have no decryptable message
- prevent malformed queued commands from retrying forever
- add SQLite regression coverage

## Verification
- python -m pytest tests/opencode/test_bridge.py -q