### PR TITLE
fix(chat): recover authenticated chats after refresh

### DIFF
--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -4963,7 +4963,7 @@ export function FormaWorkspace({
     const controller = new AbortController();
     const chatId = routedChatId;
     const chatSourcesReady = chatIndexLoaded && chatHistoryLoaded;
-    const storedMessages = !authRequired || (chatSourcesReady && routedChatFound)
+    const storedMessages = !authRequired || chatSourcesReady
       ? readStoredChatThread(chatId, null, chatStorageScope)
       : [];
     setActiveChatId(chatId);
@@ -4978,6 +4978,23 @@ export function FormaWorkspace({
 
     if (!chatSourcesReady) {
       setChatRouteTransition({ chatId, title: "Opening chat", projectId: "", error: null });
+      return () => {
+        controller.abort();
+      };
+    }
+
+    if (!routedChatFound && chatSourcesReady && authRequired && chatHasStarted(storedMessages)) {
+      const recoveredTitle = chatTitleFromMessages(storedMessages);
+      const recoveredItem = {
+        chatId,
+        title: recoveredTitle,
+        projectId: "",
+        createdAt: chatTimestamp(),
+        projectCount: 0,
+      };
+      setSessionChatItems((current) => mergeChatListItems([recoveredItem], current));
+      persistChatThread(chatId, storedMessages, recoveredTitle);
+      setChatRouteTransition(null);
       return () => {
         controller.abort();
       };


### PR DESCRIPTION
## Summary
- recover started authenticated chat threads from identity-scoped local storage when the server chat index is missing the route ID
- recreate the chat record through the existing persistence path so it remains available after refresh
- keep unavailable handling for routes without recoverable local history

## Verification
- npm run lint from apps/web
- git diff --check