### PR TITLE
fix(opencode): allow authorized CLI sessions

### DIFF
--- a/apps/api/auth.py
+++ b/apps/api/auth.py
@@ -244,18 +244,23 @@ def opencode_allowed_emails() -> frozenset[str]:
 
 
 def has_opencode_authoring_access(user: Optional[UserContext]) -> bool:
-    """Return whether this authenticated Clerk user is on the OpenCode allowlist."""
-    if user is None or user.provider != "clerk" or not user.owner_user_id:
+    """Return whether this authenticated user is on the OpenCode allowlist."""
+    if user is None or user.provider not in {"clerk", "forma-cli"} or not user.owner_user_id:
         return False
-    email = clerk_user_email(user.owner_user_id)
+    email = (
+        clerk_user_email(user.owner_user_id)
+        if user.provider == "clerk"
+        else user.claims.get("email")
+    )
     return bool(email and email.strip().lower() in opencode_allowed_emails())
 
 
 async def require_opencode_authoring_access(request: Request) -> UserContext:
-    """Require a hosted Clerk user whose primary email is explicitly allowed.
+    """Require a hosted Clerk or CLI user whose email is explicitly allowed.
 
-    This intentionally does not use admin status or either service API key. The
-    email is resolved from Clerk by the server, never accepted from the caller.
+    This intentionally does not use admin status or either service API key. For
+    CLI sessions, the email was captured from the Clerk-authenticated device
+    approval flow and stored server-side.
     """
     deployment = (config.get("FORMA_DEPLOYMENT_MODE") or "").strip().lower()
     try:
@@ -268,10 +273,10 @@ async def require_opencode_authoring_access(request: Request) -> UserContext:
             detail=_opencode_auth_error("opencode_hosted_only", "Hosted OpenCode access is unavailable."),
         )
     context = await require_user_context(request)
-    if context.provider != "clerk" or not context.owner_user_id:
+    if context.provider not in {"clerk", "forma-cli"} or not context.owner_user_id:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail=_opencode_auth_error("opencode_clerk_required", "A Clerk user session is required."),
+            detail=_opencode_auth_error("opencode_user_required", "A Clerk or Forma CLI user session is required."),
         )
     if not has_opencode_authoring_access(context):
         raise HTTPException(

--- a/tests/opencode/test_bridge.py
+++ b/tests/opencode/test_bridge.py
@@ -33,7 +33,7 @@ class OpenCodeBridgeTests(unittest.IsolatedAsyncioTestCase):
             with self.assertRaises(HTTPException) as denied:
                 asyncio.run(require_opencode_authoring_access(object()))
         self.assertEqual(403, denied.exception.status_code)
-        self.assertEqual("opencode_clerk_required", denied.exception.detail["code"])
+        self.assertEqual("opencode_user_required", denied.exception.detail["code"])
 
     def test_runtime_authoring_access_is_limited_to_the_exact_allowlisted_email(self) -> None:
         allowed = UserContext(provider="clerk", subject="user_1", owner_user_id="user_1", is_authenticated=True, is_admin=False)
@@ -44,6 +44,18 @@ class OpenCodeBridgeTests(unittest.IsolatedAsyncioTestCase):
         ):
             self.assertTrue(has_opencode_authoring_access(allowed))
             self.assertFalse(has_opencode_authoring_access(denied))
+
+    def test_allowlisted_cli_identity_can_use_runtime_authoring_access(self) -> None:
+        user = UserContext(
+            provider="forma-cli",
+            subject="user_1",
+            owner_user_id="user_1",
+            is_authenticated=True,
+            is_admin=False,
+            claims={"email": "isayahculbertson@gmail.com"},
+        )
+        with patch.dict(os.environ, {"FORMA_OPENCODE_ALLOWED_EMAILS": "isayahculbertson@gmail.com"}, clear=True):
+            self.assertTrue(has_opencode_authoring_access(user))
 
     def test_allowlisted_runtime_config_falls_back_when_user_settings_are_unreadable(self) -> None:
         user = UserContext(provider="clerk", subject="user_1", owner_user_id="user_1", is_authenticated=True, is_admin=False)


### PR DESCRIPTION
## Summary
- allow authenticated Forma CLI sessions to use hosted OpenCode
- reuse the exact server-side email allowlist used by Clerk sessions
- keep service identities and non-allowlisted users denied

## Verification
- py -3 -m unittest tests.opencode.test_bridge
- git diff --check