### PR TITLE
fix(opencode): resolve CLI allowlist identity

### DIFF
--- a/apps/api/auth.py
+++ b/apps/api/auth.py
@@ -247,11 +247,9 @@ def has_opencode_authoring_access(user: Optional[UserContext]) -> bool:
     """Return whether this authenticated user is on the OpenCode allowlist."""
     if user is None or user.provider not in {"clerk", "forma-cli"} or not user.owner_user_id:
         return False
-    email = (
-        clerk_user_email(user.owner_user_id)
-        if user.provider == "clerk"
-        else user.claims.get("email")
-    )
+    # CLI subjects are the original Clerk user IDs; resolve the email again
+    # server-side because older device tokens may not carry email claims.
+    email = clerk_user_email(user.owner_user_id)
     return bool(email and email.strip().lower() in opencode_allowed_emails())
 
 

--- a/tests/opencode/test_bridge.py
+++ b/tests/opencode/test_bridge.py
@@ -52,9 +52,11 @@ class OpenCodeBridgeTests(unittest.IsolatedAsyncioTestCase):
             owner_user_id="user_1",
             is_authenticated=True,
             is_admin=False,
-            claims={"email": "isayahculbertson@gmail.com"},
         )
-        with patch.dict(os.environ, {"FORMA_OPENCODE_ALLOWED_EMAILS": "isayahculbertson@gmail.com"}, clear=True):
+        with patch.dict(os.environ, {"FORMA_OPENCODE_ALLOWED_EMAILS": "isayahculbertson@gmail.com"}, clear=True), patch(
+            "apps.api.auth.clerk_user_email",
+            return_value="isayahculbertson@gmail.com",
+        ):
             self.assertTrue(has_opencode_authoring_access(user))
 
     def test_allowlisted_runtime_config_falls_back_when_user_settings_are_unreadable(self) -> None:


### PR DESCRIPTION
## Summary
- resolve the Clerk email server-side for Forma CLI OpenCode sessions
- support older CLI device tokens without embedded email claims
- preserve the exact allowlist and service-identity denial

## Verification
- py -3 -m unittest tests.opencode.test_bridge
- git diff --check