### PR TITLE
fix(opencode): preserve completion failure codes

### DIFF
--- a/apps/api/opencode_api.py
+++ b/apps/api/opencode_api.py
@@ -258,7 +258,7 @@ def complete_opencode_command(
             event_id=f"{command.command_id}:terminal",
             kind=terminal_kind,
             status=request.status,
-            error_code="command_failed" if request.status == OpenCodeCommandStatus.FAILED else None,
+            error_code=request.error_code if request.status == OpenCodeCommandStatus.FAILED else None,
         ),
     )
     return _command_response(updated)

--- a/forma_core/opencode/models.py
+++ b/forma_core/opencode/models.py
@@ -211,6 +211,7 @@ class ConnectorCompletion(BaseModel):
 
     lease_token: str = Field(min_length=1)
     status: Literal[OpenCodeCommandStatus.SUCCEEDED, OpenCodeCommandStatus.FAILED, OpenCodeCommandStatus.CANCELLED]
+    error_code: str | None = Field(default=None, max_length=80)
 
 
 class McpToolArguments(BaseModel):


### PR DESCRIPTION
## Summary
- carry the connector's safe local HTTP error code through completion payloads
- preserve that code in the idempotent terminal-event fallback
- keep response bodies and sensitive details out of public events

## Verification
- py -3 -m unittest tests.opencode.test_bridge
- py -3 -m py_compile forma_core/opencode/models.py apps/api/opencode_api.py
- git diff --check