### PR TITLE
fix(opencode): expose local connection failures

### DIFF
--- a/apps/api/opencode_api.py
+++ b/apps/api/opencode_api.py
@@ -258,7 +258,7 @@ def complete_opencode_command(
             event_id=f"{command.command_id}:terminal",
             kind=terminal_kind,
             status=request.status,
-            error_code="command_failed" if request.status == OpenCodeCommandStatus.FAILED else None,
+            error_code=request.error_code if request.status == OpenCodeCommandStatus.FAILED else None,
         ),
     )
     return _command_response(updated)

--- a/forma_core/opencode/models.py
+++ b/forma_core/opencode/models.py
@@ -211,6 +211,7 @@ class ConnectorCompletion(BaseModel):
 
     lease_token: str = Field(min_length=1)
     status: Literal[OpenCodeCommandStatus.SUCCEEDED, OpenCodeCommandStatus.FAILED, OpenCodeCommandStatus.CANCELLED]
+    error_code: str | None = Field(default=None, max_length=80)
 
 
 class McpToolArguments(BaseModel):

--- a/forma_core/opencode/public_events.py
+++ b/forma_core/opencode/public_events.py
@@ -24,6 +24,7 @@ _ERROR_MESSAGES = {
     "command_failed": "The OpenCode project command failed.",
     "validation_failed": "The project failed Forma validation.",
 }
+_SAFE_WORKER_ERROR_PATTERN = re.compile(r"^opencode_(?:session_)?http_[45]\d{2}$")
 
 
 def project_public_event(
@@ -72,8 +73,13 @@ def _safe_message(value: str | None) -> str | None:
 
 def _public_error(event: ConnectorEventInput) -> PublicError:
     code = event.error_code if event.error_code in _ERROR_MESSAGES else "command_failed"
+    if event.error_code and _SAFE_WORKER_ERROR_PATTERN.fullmatch(event.error_code):
+        code = event.error_code
+        message = f"OpenCode local request failed (HTTP {event.error_code[-3:]})."
+    else:
+        message = _ERROR_MESSAGES.get(code, "The OpenCode project command failed.")
     return PublicError(
         code=code,
-        message=_ERROR_MESSAGES.get(code, "The OpenCode project command failed."),
+        message=message,
         correlation_id=event.correlation_id or f"event_{event.event_id}",
     )


### PR DESCRIPTION
## Summary
- expose a safe local OpenCode connection failure category in terminal events
- distinguish local reachability failures without exposing response bodies or secrets
- preserve generic handling for other failures

## Verification
- py -3 -m unittest tests.opencode.test_bridge
- py -3 -m py_compile forma_core/opencode/public_events.py
- git diff --check