### PR TITLE
fix(opencode): expose local execution failures

### DIFF
--- a/forma_core/opencode/public_events.py
+++ b/forma_core/opencode/public_events.py
@@ -73,7 +73,10 @@ def _safe_message(value: str | None) -> str | None:
 
 def _public_error(event: ConnectorEventInput) -> PublicError:
     code = event.error_code if event.error_code in _ERROR_MESSAGES else "command_failed"
-    if event.error_code and _SAFE_WORKER_ERROR_PATTERN.fullmatch(event.error_code):
+    if event.error_code == "opencode_fetch_failed":
+        code = event.error_code
+        message = "The mini-PC could not reach its local OpenCode server."
+    elif event.error_code and _SAFE_WORKER_ERROR_PATTERN.fullmatch(event.error_code):
         code = event.error_code
         message = f"OpenCode local request failed (HTTP {event.error_code[-3:]})."
     else:


### PR DESCRIPTION
## Summary
- expose a safe local OpenCode connection failure category in terminal events
- distinguish local reachability failures without exposing response bodies or secrets
- preserve generic handling for other failures

## Verification
- py -3 -m unittest tests.opencode.test_bridge
- py -3 -m py_compile forma_core/opencode/public_events.py
- git diff --check