### PR TITLE
fix(opencode): preserve UI chat lifecycle and project identity

### DIFF
--- a/apps/api/opencode_api.py
+++ b/apps/api/opencode_api.py
@@ -326,15 +326,12 @@ def _store_event(session: StoredSession, event: ConnectorEventInput) -> PublicEv
 
 
 def _record_connector_unavailable_if_stale(session: StoredSession) -> None:
-    heartbeat = session.last_heartbeat_at
-    if heartbeat:
-        normalized = heartbeat[:-1] + "+00:00" if heartbeat.endswith("Z") else heartbeat
-        try:
-            age = (datetime.now(timezone.utc) - datetime.fromisoformat(normalized).astimezone(timezone.utc)).total_seconds()
-        except ValueError:
-            age = 0
-    else:
-        age = 10**9
+    last_seen = session.last_heartbeat_at or session.created_at
+    normalized = last_seen[:-1] + "+00:00" if last_seen.endswith("Z") else last_seen
+    try:
+        age = (datetime.now(timezone.utc) - datetime.fromisoformat(normalized).astimezone(timezone.utc)).total_seconds()
+    except ValueError:
+        age = 0
     if age < 120 or session.status != OpenCodeSessionStatus.ACTIVE:
         return
     _store_event(

--- a/apps/web/app/forma-workspace.tsx
+++ b/apps/web/app/forma-workspace.tsx
@@ -16,8 +16,10 @@ import {
   cancelOpenCodeSession,
   createOpenCodeSession,
   listOpenCodeEvents,
+  reduceOpenCodeTurn,
   submitOpenCodeCommand,
-  type OpenCodeEvent,
+  type OpenCodeSession,
+  type OpenCodeTurnState,
 } from "../lib/opencode";
 import { authoringModeEnabled, usableRuntimeLlmOptions, webConfig, type RuntimeConfigContract } from "../lib/config";
 import { calculateProjectCostMetrics, resolveProjectComponentInstances } from "../lib/project-cost-metrics";
@@ -1832,9 +1834,13 @@ export function FormaWorkspace({
   const pipelineStepsLastRequestedWorkflowRef = useRef<string | null>(null);
   const recoveryJobMissesRef = useRef(new Map<string, { misses: number; retryAfter: number }>());
   const activeGenerationRef = useRef<ActiveGenerationRun | null>(null);
-  const openCodeSessionsRef = useRef<Record<string, string>>({});
+  const openCodeSessionsRef = useRef<Record<string, OpenCodeSession>>({});
   const openCodeCursorsRef = useRef<Record<string, number>>({});
   const openCodePollTimersRef = useRef<Record<string, number>>({});
+  const activeChatIdRef = useRef(activeChatId);
+  useLayoutEffect(() => {
+    activeChatIdRef.current = activeChatId;
+  }, [activeChatId]);
   const visibleChatSourceProjects = myProjectHistory;
   const visibleChatSourceItems = useMemo(
     () => authRequired
@@ -1990,9 +1996,9 @@ export function FormaWorkspace({
     );
   };
 
-  const ensureChatThread = (projectId: string | null, ir: any, sourcePrompt?: string | null) => {
+  const ensureChatThread = (projectId: string | null, ir: any, sourcePrompt?: string | null, routedChatId?: string) => {
     if (!projectId) return;
-    const chatId = chatIdFromIR(ir) || projectId;
+    const chatId = routedChatId || chatIdFromIR(ir) || projectId;
     setActiveChatId(chatId);
     setChatThreads((current) => {
       if (current[chatId]?.length) return current;
@@ -2604,7 +2610,7 @@ export function FormaWorkspace({
   };
 
   const goHome = () => {
-    if (!hostedChatEnabled) {
+    if (chatReadOnly) {
       setChatRouteTransition(null);
       setProjectIR(null);
       setActiveTab("overview");
@@ -2622,7 +2628,7 @@ export function FormaWorkspace({
   };
 
   const startNewProjectChat = () => {
-    if (!requireHostedChatEnabled()) return;
+    if (!authoringMode && !requireHostedChatEnabled()) return;
     if (homeView === "chat" && !currentRouteProjectId && !currentProjectChatHasStarted()) return;
     const nextChatId = resetToNewProjectChat();
     router.push(chatRoute(nextChatId));
@@ -4694,30 +4700,43 @@ export function FormaWorkspace({
 
   const loadOldProject = async (
     projectId: string,
-    options: { syncRoute?: boolean; signal?: AbortSignal; tab?: string | null; hydrateChat?: boolean } = {}
+    options: { syncRoute?: boolean; signal?: AbortSignal; tab?: string | null; hydrateChat?: boolean; chatId?: string; retryTransient?: boolean } = {}
   ): Promise<boolean> => {
     if (options.signal?.aborted) return false;
 
     const shouldSyncRoute = options.syncRoute ?? true;
     const signal = options.signal;
-    setIsLoading(true);
+    const isVisibleChat = () => !options.chatId || activeChatIdRef.current === options.chatId;
+    if (isVisibleChat()) setIsLoading(true);
     try {
-      const res = await fetch(`${API_URL}/projects/${encodeURIComponent(projectId)}`, {
-        signal,
-        headers: await optionalAuthHeaders(),
-      });
-      if (!res.ok) return false;
+      let res: Response | undefined;
+      const attempts = options.retryTransient ? 3 : 1;
+      for (let attempt = 0; attempt < attempts; attempt += 1) {
+        try {
+          res = await fetch(`${API_URL}/projects/${encodeURIComponent(projectId)}`, {
+            signal,
+            headers: await optionalAuthHeaders(),
+          });
+        } catch (error) {
+          if (signal?.aborted || attempt === attempts - 1) throw error;
+        }
+        if (res && res.status !== 429 && res.status < 500) break;
+        if (attempt < attempts - 1) await new Promise((resolve) => window.setTimeout(resolve, 500 * (attempt + 1)));
+      }
+      if (!res?.ok) return false;
 
       const data = await res.json();
       if (signal?.aborted) return false;
 
       const ir = withProjectResponseMetadata(data.project_ir, data);
-      setProjectIR(ir);
-      if (options.hydrateChat && canChatWithProjectIR(ir)) {
-        ensureChatThread(projectId, ir, data.prompt);
+      if (isVisibleChat()) {
+        setProjectIR(ir);
+        if (options.hydrateChat && canChatWithProjectIR(ir)) {
+          ensureChatThread(projectId, ir, data.prompt, options.chatId);
+        }
+        setActiveTab(normalizeTab(options.tab || "") || "overview");
+        if (shouldSyncRoute) syncProjectRoute(projectId);
       }
-      setActiveTab(normalizeTab(options.tab || "") || "overview");
-      if (shouldSyncRoute) syncProjectRoute(projectId);
       return true;
     } catch (error) {
       const errorName = error instanceof Error ? error.name : "";
@@ -4726,49 +4745,25 @@ export function FormaWorkspace({
       }
       return false;
     } finally {
-      if (!signal?.aborted) {
+      if (!signal?.aborted && isVisibleChat()) {
         setIsLoading(false);
       }
     }
   };
 
-  const openCodeEventPatch = (event: OpenCodeEvent): Partial<ChatMessage> => {
-    if (event.kind === "assistant_message" && event.message) {
-      return { content: event.message, status: "loading" };
-    }
-    if (event.kind === "completed") {
-      return {
-        content: "OpenCode finished authoring this project.",
-        status: "success",
-        projectId: event.project_id,
-      };
-    }
-    if (event.kind === "failed") {
-      return {
-        content: event.error?.message || "OpenCode could not complete this project change.",
-        status: "error",
-        projectId: event.project_id,
-      };
-    }
-    if (event.kind === "cancelled") {
-      return { content: "OpenCode authoring was stopped.", status: "cancelled", projectId: event.project_id };
-    }
-    if (event.kind === "connector_unavailable") {
-      return { content: "The local OpenCode connector is unavailable. Start it and try again.", status: "error" };
-    }
-    if (event.kind === "validating") return { content: "OpenCode is validating the project.", status: "loading" };
-    if (event.kind === "working" || event.kind === "progress" || event.kind === "queued") {
-      return { content: "OpenCode is authoring this project.", status: "loading" };
-    }
-    return {};
-  };
-
   const pollOpenCodeTurn = (turn: {
     chatId: string;
     sessionId: string;
+    commandId: string;
     assistantMessageId: string;
     run: ActiveGenerationRun;
   }) => {
+    let state: OpenCodeTurnState = {
+      assistantMessage: null,
+      content: "Waiting for OpenCode.",
+      status: "loading",
+      terminalEvent: null,
+    };
     const poll = async () => {
       if (turn.run.cancelled || turn.run.controller.signal.aborted) return;
       try {
@@ -4778,29 +4773,45 @@ export function FormaWorkspace({
           turn.sessionId,
           openCodeCursorsRef.current[turn.sessionId] || 0,
         );
+        if (turn.run.cancelled || turn.run.controller.signal.aborted) return;
         openCodeCursorsRef.current[turn.sessionId] = page.next_cursor;
-        let terminalEvent: OpenCodeEvent | null = null;
         for (const event of page.events) {
           if (event.session_id !== turn.sessionId) continue;
-          const patch = openCodeEventPatch(event);
-          updateThreadMessage(turn.chatId, turn.assistantMessageId, patch);
-          if (activeChatId === turn.chatId) updateChatMessage(turn.assistantMessageId, patch);
-          if (["completed", "failed", "cancelled", "connector_unavailable"].includes(event.kind)) terminalEvent = event;
+          state = reduceOpenCodeTurn(state, event, turn.commandId);
         }
+        const patch = { content: state.content, status: state.status };
+        updateThreadMessage(turn.chatId, turn.assistantMessageId, patch);
+        if (activeChatIdRef.current === turn.chatId) updateChatMessage(turn.assistantMessageId, patch);
+        const terminalEvent = state.terminalEvent;
         if (terminalEvent) {
           delete openCodePollTimersRef.current[turn.sessionId];
           if (terminalEvent.kind === "cancelled") delete openCodeSessionsRef.current[turn.chatId];
           if (terminalEvent.kind === "completed") {
-            rememberChatItem({
+            // A successful conversation need not create a project. Probe before linking it.
+            const projectLoaded = await loadOldProject(terminalEvent.project_id, {
+              syncRoute: false,
+              tab: "chat",
+              signal: turn.run.controller.signal,
               chatId: turn.chatId,
-              title: projectTitle || "OpenCode project",
-              projectId: terminalEvent.project_id,
-              createdAt: chatTimestamp(),
-              projectCount: 1,
+              retryTransient: true,
             });
-            void loadOldProject(terminalEvent.project_id, { syncRoute: false, tab: "chat", hydrateChat: true });
-            refreshProjectAndChatLists();
+            if (turn.run.cancelled || turn.run.controller.signal.aborted) return;
+            if (projectLoaded) {
+              contextProjectIdsRef.current[turn.chatId] = terminalEvent.project_id;
+              rememberChatItem({
+                chatId: turn.chatId,
+                title: projectTitle || "OpenCode project",
+                projectId: terminalEvent.project_id,
+                createdAt: chatTimestamp(),
+                projectCount: 1,
+              });
+              const projectPatch = { ...patch, projectId: terminalEvent.project_id };
+              updateThreadMessage(turn.chatId, turn.assistantMessageId, projectPatch);
+              if (activeChatIdRef.current === turn.chatId) updateChatMessage(turn.assistantMessageId, projectPatch);
+              refreshProjectAndChatLists();
+            }
           }
+          if (activeChatIdRef.current === turn.chatId) setGenerationInputNotice(null);
           finishGenerationRun(turn.run);
           return;
         }
@@ -4837,30 +4848,18 @@ export function FormaWorkspace({
     try {
       const headers = await generationRequestHeaders();
       let session = openCodeSessionsRef.current[chatId];
-      let sessionProjectId = projectId || null;
       if (!session) {
-        const created = await createOpenCodeSession(API_URL, headers, openCodeConnectorId, projectId);
-        session = created.session_id;
-        sessionProjectId = created.project_id;
+        session = await createOpenCodeSession(API_URL, headers, openCodeConnectorId, projectId);
         openCodeSessionsRef.current[chatId] = session;
-        openCodeCursorsRef.current[session] = 0;
-        run.openCodeSessionId = session;
-        contextProjectIdsRef.current[chatId] = created.project_id;
-        rememberChatItem({
-          chatId,
-          title: projectTitle || message,
-          projectId: created.project_id,
-          createdAt: chatTimestamp(),
-          projectCount: 1,
-        });
+        openCodeCursorsRef.current[session.session_id] = 0;
       }
-      run.projectId = sessionProjectId;
-      run.openCodeSessionId = session;
-      const command = await submitOpenCodeCommand(API_URL, headers, session, message);
+      run.projectId = session.project_id;
+      run.openCodeSessionId = session.session_id;
+      const command = await submitOpenCodeCommand(API_URL, headers, session.session_id, message);
       run.jobId = command.command_id;
       setActiveGeneration({ kind: run.kind, jobId: command.command_id });
       setGenerationInputNotice("Sent to OpenCode. Live authoring status will appear here.");
-      pollOpenCodeTurn({ chatId, sessionId: session, assistantMessageId, run });
+      pollOpenCodeTurn({ chatId, sessionId: session.session_id, commandId: command.command_id, assistantMessageId, run });
     } catch (error) {
       const messageText = error instanceof Error ? error.message : "OpenCode could not accept this request.";
       updateChatMessage(assistantMessageId, { content: messageText, status: "error" });
@@ -4894,7 +4893,7 @@ export function FormaWorkspace({
         const ir = withProjectResponseMetadata(data.project_ir, data);
         setProjectIR(ir);
         if (canChatWithProjectIR(ir)) {
-          ensureChatThread(inlineChatProjectId, ir, data.prompt);
+          ensureChatThread(inlineChatProjectId, ir, data.prompt, currentRouteChatId ? safeDecodeChatId(currentRouteChatId) : undefined);
         }
         setActiveTab("overview");
       } catch (error) {
@@ -5049,6 +5048,7 @@ export function FormaWorkspace({
       signal: controller.signal,
       tab: "chat",
       hydrateChat: true,
+      chatId,
     }).then((loaded) => {
       if (controller.signal.aborted) return;
       if (loaded) {
@@ -5207,7 +5207,7 @@ export function FormaWorkspace({
     ? (chatIdFromIR(projectIR) || currentProjectId)
     : null;
   const currentProjectChatId = projectIR
-    ? routedProjectId ? null : (ownerProjectChatId || activeChatId)
+    ? routedProjectId ? null : (routedChatId || ownerProjectChatId || activeChatId)
     : activeChatId;
   const currentProjectChatMessages = useMemo(
     () => currentProjectChatId ? chatThreads[currentProjectChatId] || [] : [],

--- a/apps/web/e2e/opencode-chat.spec.ts
+++ b/apps/web/e2e/opencode-chat.spec.ts
@@ -1,0 +1,396 @@
+import { expect, test, type Route } from "@playwright/test";
+import type { RuntimeConfigContract } from "../lib/config";
+import type { OpenCodeCommand, OpenCodeEvent, OpenCodeSession } from "../lib/opencode";
+
+const projectId = "746df932-f4ed-49a4-a36e-5a50a22aa918";
+const sessionId = "session-opencode-chat";
+const commandIds = ["command-first-turn", "command-second-turn"];
+const answers = ["Hello from OpenCode.", "Still here in the same OpenCode session."];
+const publishedProject = {
+  project_id: projectId,
+  chat_id: "839aeb42-31d5-4b74-91f8-a93bc3a17db6",
+  can_chat: true,
+  prompt: "hi",
+  project_ir: {
+    overview: {
+      title: "USB-powered status monitor",
+      description: "A minimal low-voltage status monitor using an ESP32 development board.",
+      difficulty: "Beginner",
+      estimated_cost: 5,
+      category: "Monitoring",
+    },
+    components: [{
+      ref_des: "U1",
+      part_number: "ESP32-DevKitC",
+      name: "ESP32 development board",
+      category: "Microcontroller",
+      quantity: 1,
+      unit_price: 5,
+      rationale: "Provides USB power and an onboard controller for the status monitor.",
+      pins: [],
+    }],
+    connections: [],
+    nets: [],
+    assembly: [],
+    constraints: ["Power from 5V USB only."],
+    validation: { critical: [], warning: [], info: [] },
+    // Identity is supplied by the GET envelope, as consumed by withProjectResponseMetadata.
+    assembly_metadata: { workflow: "default", source_prompt: "hi" },
+  },
+};
+
+const runtimeConfig: RuntimeConfigContract = {
+  contract_version: 1,
+  authority: "backend",
+  forma_dev_mode: false,
+  generation: {
+    ready: true,
+    available: true,
+    reason: null,
+    selected_llm: null,
+    llm_options: [],
+  },
+  images: {
+    enabled: false,
+    configured: false,
+    request_capable: false,
+    provider: null,
+    model: null,
+    generate_by_default: false,
+    reason: null,
+  },
+  workflow: {
+    default_id: "default",
+    options: [{ id: "default", label: "Default", description: "Local OpenCode authoring" }],
+  },
+  provider_setup: { required: false, llm_required: false, image_required: false },
+  deployment: {
+    hosted_chat_enabled: false,
+    authoring_mode_enabled: true,
+    authoring_access: true,
+    opencode_connector_id: "mini-pc-1",
+  },
+  video: {
+    generation: { configured: false, reason: null },
+    self_correction: { configured: false, reason: null },
+  },
+};
+
+function event(
+  sequence: number,
+  kind: OpenCodeEvent["kind"],
+  overrides: Partial<OpenCodeEvent> = {},
+): OpenCodeEvent {
+  return {
+    event_id: `event-${sequence}`,
+    sequence,
+    session_id: sessionId,
+    project_id: projectId,
+    kind,
+    status: null,
+    message: null,
+    revision_id: null,
+    error: null,
+    created_at: "2026-09-12T12:00:00Z",
+    ...overrides,
+  };
+}
+
+// FORMA_AUTH_MODE=local must be supplied to the local web server, not mocked in the browser.
+test.use({ serviceWorkers: "block" });
+
+for (const projectPublished of [false, true]) test(`OpenCode chat survives connector recovery with a ${projectPublished ? "published" : "unpublished"} project, reuses its session, and starts a new chat`, async ({ page, baseURL }) => {
+  test.setTimeout(180_000);
+  const appOrigin = new URL(baseURL!).origin;
+  expect(["localhost", "127.0.0.1", "[::1]"]).toContain(new URL(appOrigin).hostname);
+
+  const unexpectedRequests: string[] = [];
+  const pageErrors: string[] = [];
+  const configErrors: string[] = [];
+  const sessionRequests: unknown[] = [];
+  const commandRequests: { path: string; body: unknown }[] = [];
+  const polls: { turn: number; cursor: number }[] = [];
+  const completedTurns: number[] = [];
+  const projectProbes: { turn: number; afterCompletion: boolean }[] = [];
+  const projectResponseStatuses: number[] = [];
+  let originalChatUrl = "";
+  let releaseProgress!: () => void;
+  let releaseCompletion!: () => void;
+  const progressGate = new Promise<void>((resolve) => { releaseProgress = resolve; });
+  const completionGate = new Promise<void>((resolve) => { releaseCompletion = resolve; });
+
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+  page.on("console", (message) => {
+    if (message.type() === "error" && message.text().includes("Error fetching runtime config")) {
+      configErrors.push(message.text());
+    }
+  });
+
+  // Only local app assets/navigation may escape the mocks. Unknown backends fail closed.
+  await page.route("**/*", async (route) => {
+    const url = new URL(route.request().url());
+    if (url.origin === appOrigin && !/^\/api(?:\/|$)/.test(url.pathname)) {
+      await route.continue();
+      return;
+    }
+    unexpectedRequests.push(`${route.request().method()} ${url.href}`);
+    await route.abort("blockedbyclient");
+  });
+
+  const mockBackend = async (route: Route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const path = url.pathname.replace(/^\/api(?=\/|$)/, "") || "/";
+    const method = request.method();
+
+    if (method === "OPTIONS") {
+      await route.fulfill({ status: 204 });
+      return;
+    }
+    if (method === "GET" && path === "/runtime/config") {
+      await route.fulfill({ json: runtimeConfig });
+      return;
+    }
+    if (method === "GET" && path === "/") {
+      await route.fulfill({ json: { status: "ok" } });
+      return;
+    }
+    if (method === "GET" && ["/projects", "/my/projects"].includes(path)) {
+      await route.fulfill({ json: {
+        items: [], total: 0, has_more: false,
+        limit: Number(url.searchParams.get("limit") || 6),
+        offset: Number(url.searchParams.get("offset") || 0),
+      } });
+      return;
+    }
+    if (method === "GET" && ["/chats", "/a2a/jobs", "/example-project-object-jobs"].includes(path)) {
+      await route.fulfill({ json: [] });
+      return;
+    }
+    if (method === "GET" && path === "/admin/session") {
+      await route.fulfill({ json: { is_admin: false } });
+      return;
+    }
+    if (method === "GET" && path === "/pipeline/steps") {
+      await route.fulfill({ json: { steps: [] } });
+      return;
+    }
+    if (method === "GET" && path === "/video/models") {
+      await route.fulfill({ json: { models: [], generation_configured: false } });
+      return;
+    }
+    if (method === "POST" && path === "/opencode/sessions") {
+      sessionRequests.push(request.postDataJSON());
+      const session: OpenCodeSession = {
+        session_id: sessionId,
+        connector_id: "mini-pc-1",
+        project_id: projectId,
+        owner_user_id: "local-user",
+        status: "active",
+      };
+      await route.fulfill({ json: session });
+      return;
+    }
+    if (method === "POST" && path === `/opencode/sessions/${sessionId}/commands`) {
+      commandRequests.push({ path, body: request.postDataJSON() });
+      const command: OpenCodeCommand = {
+        command_id: commandIds[commandRequests.length - 1],
+        session_id: sessionId,
+        project_id: projectId,
+        operation: "project_message",
+        status: "queued",
+      };
+      await route.fulfill({ json: command });
+      return;
+    }
+    if (method === "GET" && path === `/opencode/sessions/${sessionId}/events`) {
+      const cursor = Number(url.searchParams.get("cursor"));
+      const turn = commandRequests.length;
+      polls.push({ turn, cursor });
+      let events: OpenCodeEvent[] = [];
+      if (turn === 1 && cursor === 0) {
+        events = [event(1, "connector_unavailable", {
+          event_id: `connector_unavailable_${sessionId}`,
+          message: "Waiting for the local OpenCode connector.",
+        })];
+      } else if (turn === 1 && cursor === 1) {
+        await progressGate;
+        events = [event(2, "queued", { status: "queued" }), event(3, "working", { status: "running" })];
+      } else if ((turn === 1 && cursor === 3) || (turn === 2 && cursor === 5)) {
+        if (turn === 1) await completionGate;
+        const sequence = turn === 1 ? 4 : 6;
+        // The canonical terminal event shares the page with the answer but has no message.
+        events = [
+          event(sequence, "assistant_message", { message: answers[turn - 1] }),
+          event(sequence + 1, "completed", {
+            event_id: `${commandIds[turn - 1]}:terminal`,
+            status: "succeeded",
+          }),
+        ];
+        completedTurns.push(turn);
+      }
+      await route.fulfill({ json: { events, next_cursor: events.at(-1)?.sequence ?? cursor } });
+      return;
+    }
+    if (method === "GET" && path === `/projects/${projectId}`) {
+      const turn = commandRequests.length;
+      projectProbes.push({ turn, afterCompletion: completedTurns.includes(turn) });
+      const status = !projectPublished ? 404 : projectProbes.length === 1 ? 503 : 200;
+      projectResponseStatuses.push(status);
+      await route.fulfill({
+        status,
+        json: status === 200 ? publishedProject : {
+          detail: status === 404 ? "Project not found" : "Project store temporarily unavailable",
+        },
+      });
+      return;
+    }
+
+    unexpectedRequests.push(`${method} ${url.href}`);
+    await route.fulfill({ status: 501, json: { detail: `Unmocked endpoint: ${method} ${path}` } });
+  };
+
+  await page.route("**/api/**", mockBackend);
+  await page.route(/^https?:\/\/(?:localhost|127\.0\.0\.1):8000(?:\/|$)/, mockBackend);
+  await page.clock.install();
+
+  try {
+    try {
+      await page.goto("/", { waitUntil: "domcontentloaded", timeout: 120_000 });
+    } catch (error) {
+      // Match the existing suite's workaround for a first Next dev compilation.
+      if (!String(error).includes("ERR_ABORTED")) throw error;
+      await page.goto("/", { waitUntil: "domcontentloaded", timeout: 120_000 });
+    }
+
+    const composer = page.getByPlaceholder("Describe the product, constraints, references, and outputs you need\u2026", { exact: true });
+    const followUpComposer = projectPublished ? page.getByRole("textbox", { name: /Describe a change to/ }) : composer;
+    const stop = page.getByRole("button", { name: "Stop generation", exact: true });
+    const missingProject = page.getByText(/no longer available in (?:the )?project database/i);
+    const projectLinks = page.locator(`a[href*="${projectId}"]`);
+    const projectOutput = page.getByRole("region", { name: "Project", exact: true });
+    const firstAnswer = page.getByRole("main").getByText(answers[0], { exact: true });
+    const secondAnswer = page.getByRole("main").getByText(answers[1], { exact: true });
+
+    await expect(page.getByRole("status", { name: "OpenCode is authoring this workspace.", exact: true })).toBeVisible();
+    await expect(composer).toBeVisible();
+
+    await test.step("keep polling after connector_unavailable without loading the reserved project", async () => {
+      await composer.fill("hi");
+      await composer.press("Enter");
+      await expect.poll(() => polls).toContainEqual({ turn: 1, cursor: 1 });
+      await expect(page).toHaveURL(/\/chat\/[^/?#]+$/);
+      originalChatUrl = page.url();
+      expect(new URL(originalChatUrl).pathname.split("/").at(-1)).not.toBe(publishedProject.chat_id);
+      await expect(stop).toBeVisible();
+      expect(sessionRequests).toEqual([{ connector_id: "mini-pc-1" }]);
+      expect(projectProbes).toEqual([]);
+      await expect(missingProject).toHaveCount(0);
+      await expect(projectLinks).toHaveCount(0);
+
+      releaseProgress();
+      await expect.poll(() => polls).toContainEqual({ turn: 1, cursor: 3 });
+      await expect(stop).toBeVisible();
+      expect(projectProbes).toEqual([]);
+      await expect(missingProject).toHaveCount(0);
+      await expect(projectLinks).toHaveCount(0);
+    });
+
+    await test.step(projectPublished
+      ? "preserve the answer and original chat URL after canonical completion and a 503 retry"
+      : "preserve the answer after canonical completion and exactly one 404 probe", async () => {
+      releaseCompletion();
+      await expect(firstAnswer).toBeVisible();
+      if (projectPublished) {
+        await expect.poll(() => projectResponseStatuses[0]).toBe(503);
+      } else {
+        await expect(stop).toHaveCount(0);
+        await expect.poll(() => projectProbes).toEqual([{ turn: 1, afterCompletion: true }]);
+      }
+
+      // Advance beyond the poll and hydration retry delays without a wall-clock sleep.
+      await page.clock.runFor(6_000);
+      await expect(stop).toHaveCount(0);
+      await expect(firstAnswer).toBeVisible();
+      await expect(firstAnswer).toHaveCount(1);
+      await expect(missingProject).toHaveCount(0);
+      await expect(page).toHaveURL(originalChatUrl);
+      if (projectPublished) {
+        await expect.poll(() => projectResponseStatuses.slice(0, 2)).toEqual([503, 200]);
+        await expect(projectOutput).toBeVisible();
+        await expect(projectOutput.getByRole("heading", { name: publishedProject.project_ir.overview.title, exact: true })).toBeVisible();
+        await expect(projectOutput.getByText(publishedProject.project_ir.overview.description, { exact: true })).toBeVisible();
+        // Successful publication may also trigger route/inline hydration GETs.
+        expect(projectProbes.every((probe) => probe.turn === 1 && probe.afterCompletion)).toBe(true);
+        expect(projectResponseStatuses.slice(1).every((status) => status === 200)).toBe(true);
+      } else {
+        await expect(projectLinks).toHaveCount(0);
+        await expect(projectOutput).toHaveCount(0);
+        expect(projectProbes).toEqual([{ turn: 1, afterCompletion: true }]);
+      }
+      expect(polls).toEqual([{ turn: 1, cursor: 0 }, { turn: 1, cursor: 1 }, { turn: 1, cursor: 3 }]);
+    });
+
+    await test.step("send a second turn in the same session and original UI chat", async () => {
+      await followUpComposer.fill("Are you still there?");
+      await followUpComposer.press("Enter");
+      await expect(secondAnswer).toBeVisible();
+      await expect(stop).toHaveCount(0);
+      if (projectPublished) {
+        await expect.poll(() => projectProbes).toContainEqual({ turn: 2, afterCompletion: true });
+      } else {
+        await expect.poll(() => projectProbes).toEqual([
+          { turn: 1, afterCompletion: true }, { turn: 2, afterCompletion: true },
+        ]);
+      }
+      await page.clock.runFor(6_000);
+      await expect(firstAnswer).toBeVisible();
+      await expect(firstAnswer).toHaveCount(1);
+      await expect(secondAnswer).toBeVisible();
+      await expect(secondAnswer).toHaveCount(1);
+      await expect(missingProject).toHaveCount(0);
+      await expect(page).toHaveURL(originalChatUrl);
+      if (projectPublished) {
+        await expect(projectOutput).toBeVisible();
+        await expect(projectOutput.getByRole("heading", { name: publishedProject.project_ir.overview.title, exact: true })).toBeVisible();
+        expect(projectProbes.every((probe) => probe.afterCompletion)).toBe(true);
+        expect(projectResponseStatuses.slice(1).every((status) => status === 200)).toBe(true);
+      } else {
+        await expect(projectLinks).toHaveCount(0);
+        expect(projectProbes).toHaveLength(2);
+      }
+      expect(sessionRequests).toEqual([{ connector_id: "mini-pc-1" }]);
+      expect(commandRequests).toEqual(["hi", "Are you still there?"].map((message) => ({
+        path: `/opencode/sessions/${sessionId}/commands`,
+        body: { message, idempotency_key: expect.stringMatching(/^web-.+/) },
+      })));
+      expect(polls).toEqual([
+        { turn: 1, cursor: 0 }, { turn: 1, cursor: 1 }, { turn: 1, cursor: 3 }, { turn: 2, cursor: 5 },
+      ]);
+    });
+
+    await test.step("New chat resets the rendered conversation with legacy hosted chat disabled", async () => {
+      const previousUrl = page.url();
+      const newChat = page.getByRole("button", { name: "New chat", exact: true }).filter({ visible: true });
+      await expect(newChat).toBeEnabled();
+      await followUpComposer.fill("Unsent draft");
+      await newChat.click();
+      await expect(page).not.toHaveURL(previousUrl);
+      await expect(composer).toHaveValue("");
+      await expect(firstAnswer).toHaveCount(0);
+      await expect(secondAnswer).toHaveCount(0);
+      await expect(newChat).toBeDisabled();
+      await expect(page.getByRole("status", { name: "Hosted chat maintenance", exact: true })).toHaveCount(0);
+      await expect(missingProject).toHaveCount(0);
+      await expect(projectLinks).toHaveCount(0);
+      await expect(projectOutput).toHaveCount(0);
+    });
+
+    expect(unexpectedRequests, "Every backend request must be mocked; no external requests may escape").toEqual([]);
+    expect(configErrors).toEqual([]);
+    expect(pageErrors).toEqual([]);
+  } finally {
+    releaseProgress();
+    releaseCompletion();
+  }
+});

--- a/apps/web/lib/opencode.ts
+++ b/apps/web/lib/opencode.ts
@@ -32,6 +32,47 @@ type OpenCodeEventPage = {
   next_cursor: number;
 };
 
+export type OpenCodeTurnState = {
+  assistantMessage: string | null;
+  content: string;
+  status: "loading" | "success" | "error" | "cancelled";
+  terminalEvent: OpenCodeEvent | null;
+};
+
+export function reduceOpenCodeTurn(
+  state: OpenCodeTurnState,
+  event: OpenCodeEvent,
+  commandId: string,
+): OpenCodeTurnState {
+  if (state.terminalEvent) return state;
+  if (event.kind === "connector_unavailable") {
+    return {
+      ...state,
+      content: state.assistantMessage || "Waiting for the OpenCode connector to reconnect. You can stop this request at any time.",
+    };
+  }
+  if (event.kind === "assistant_message" && event.message) {
+    return { ...state, assistantMessage: event.message, content: event.message };
+  }
+  if (event.kind === "completed" || event.kind === "failed" || event.kind === "cancelled") {
+    // A prior command's terminal event must not finish the current turn.
+    if (event.event_id !== `${commandId}:terminal` && event.event_id !== `cancelled_${event.session_id}`) return state;
+    const status = event.kind === "completed" ? "success" : event.kind === "failed" ? "error" : "cancelled";
+    const content = event.kind === "completed"
+      ? state.assistantMessage || "OpenCode finished responding."
+      : event.kind === "failed"
+        ? event.error?.message || "OpenCode could not complete this request."
+        : "OpenCode was stopped.";
+    return { ...state, content, status, terminalEvent: event };
+  }
+  return {
+    ...state,
+    content: state.assistantMessage || (event.kind === "validating"
+      ? "OpenCode is validating the project."
+      : "OpenCode is working on your request."),
+  };
+}
+
 function record(value: unknown): Record<string, unknown> {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     throw new Error("OpenCode returned an invalid response.");

--- a/apps/web/test/opencode-turn.test.ts
+++ b/apps/web/test/opencode-turn.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { reduceOpenCodeTurn, type OpenCodeEvent, type OpenCodeTurnState } from "../lib/opencode.ts";
+
+const initial: OpenCodeTurnState = {
+  content: "Waiting for OpenCode.",
+  assistantMessage: null,
+  status: "loading",
+  terminalEvent: null,
+};
+
+function event(kind: OpenCodeEvent["kind"], overrides: Partial<OpenCodeEvent> = {}): OpenCodeEvent {
+  return {
+    kind, event_id: "command:terminal", sequence: 1, session_id: "session",
+    project_id: "reserved-project", status: null, message: null, revision_id: null,
+    error: null, created_at: "2026-09-12T00:00:00Z", ...overrides,
+  };
+}
+
+test("connector unavailability is recoverable and never completes the turn", () => {
+  const waiting = reduceOpenCodeTurn(initial, event("connector_unavailable"), "command");
+  assert.equal(waiting.status, "loading");
+  assert.equal(waiting.terminalEvent, null);
+  assert.match(waiting.content, /reconnect/);
+  const working = reduceOpenCodeTurn(waiting, event("working"), "command");
+  assert.match(working.content, /working/);
+  assert.equal(working.terminalEvent, null);
+});
+
+test("assistant text survives progress, reconnect, and completion in the same event page", () => {
+  const events = [
+    event("assistant_message", { event_id: "answer", message: "Hello!" }),
+    event("progress"), event("connector_unavailable"), event("completed"),
+  ];
+  const result = events.reduce((state, next) => reduceOpenCodeTurn(state, next, "command"), initial);
+  assert.equal(result.content, "Hello!");
+  assert.equal(result.status, "success");
+  assert.equal(result.terminalEvent?.kind, "completed");
+  assert.equal("projectId" in result, false);
+});
+
+test("completion without an answer does not claim a project was created", () => {
+  const result = reduceOpenCodeTurn(initial, event("completed"), "command");
+  assert.equal(result.content, "OpenCode finished responding.");
+  assert.equal("projectId" in result, false);
+});
+
+test("late terminal events from a prior command do not stop the next turn", () => {
+  assert.equal(reduceOpenCodeTurn(initial, event("completed", { event_id: "prior:terminal" }), "command"), initial);
+});
+
+test("failure and cancellation finish without attaching the reserved project", () => {
+  for (const kind of ["failed", "cancelled"] as const) {
+    const result = reduceOpenCodeTurn(initial, event(kind), "command");
+    assert.equal(result.status, kind === "failed" ? "error" : "cancelled");
+    assert.equal(result.terminalEvent?.kind, kind);
+    assert.equal("projectId" in result, false);
+  }
+  const cancelled = reduceOpenCodeTurn(initial, event("cancelled", { event_id: "cancelled_session" }), "command");
+  assert.equal(cancelled.status, "cancelled");
+});
+
+test("historical availability events after completion do not erase success", () => {
+  const completed = reduceOpenCodeTurn(initial, event("completed"), "command");
+  assert.equal(reduceOpenCodeTurn(completed, event("connector_unavailable"), "command"), completed);
+});

--- a/tests/opencode/test_bridge.py
+++ b/tests/opencode/test_bridge.py
@@ -5,19 +5,19 @@ import os
 import tempfile
 import unittest
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 from uuid import UUID, uuid4
 
 from fastapi import HTTPException
 
 from apps.api.auth import UserContext, has_opencode_authoring_access, require_opencode_authoring_access
 from apps.api.main import _runtime_config_settings
-from apps.api.opencode_api import _require_owned_project
+from apps.api.opencode_api import _record_connector_unavailable_if_stale, _require_owned_project, list_opencode_events
 from apps.api.opencode_mcp import handle_opencode_mcp_json_rpc, opencode_mcp_tools
 from forma_core.opencode.capabilities import CapabilityError, issue_capability, verify_capability
-from forma_core.opencode.models import ConnectorEventInput, McpJsonRpcRequest, OpenCodeCommandStatus, OpenCodeEventKind, OpenCodeOperation
+from forma_core.opencode.models import ConnectorEventInput, McpJsonRpcRequest, OpenCodeCommandStatus, OpenCodeEventKind, OpenCodeOperation, OpenCodeSessionStatus
 from forma_core.opencode.public_events import project_public_event
-from forma_core.opencode.store import OpenCodeStore
+from forma_core.opencode.store import OpenCodeStore, StoredSession
 
 
 class OpenCodeBridgeTests(unittest.IsolatedAsyncioTestCase):
@@ -120,6 +120,59 @@ class OpenCodeBridgeTests(unittest.IsolatedAsyncioTestCase):
             capability = ConnectorCapability("mini", "session", str(uuid4()), "user", int(datetime.now(timezone.utc).timestamp()) + 60, "nonce", frozenset({"mcp"}))
             response = asyncio.run(handle_opencode_mcp_json_rpc(McpJsonRpcRequest.model_validate({"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "forma.generate_project", "arguments": {}}}), capability))
         self.assertEqual("authorization_required", response["error"]["data"]["code"])
+
+    def test_connector_unavailable_respects_session_freshness(self) -> None:
+        now = datetime(2026, 9, 12, 12, 0, tzinfo=timezone.utc)
+        fresh = "2026-09-12T11:58:00.000001Z"
+        boundary = "2026-09-12T11:58:00Z"
+        stale = "2026-09-12T11:00:00+00:00"
+        cases = (
+            ("new session", now.isoformat(), None, OpenCodeSessionStatus.ACTIVE, False),
+            ("missing heartbeat within grace", fresh, None, OpenCodeSessionStatus.ACTIVE, False),
+            ("missing heartbeat at boundary", boundary, None, OpenCodeSessionStatus.ACTIVE, True),
+            ("missing heartbeat past grace", stale, None, OpenCodeSessionStatus.ACTIVE, True),
+            ("old creation recent heartbeat", stale, fresh, OpenCodeSessionStatus.ACTIVE, False),
+            ("heartbeat at boundary", stale, boundary, OpenCodeSessionStatus.ACTIVE, True),
+            ("stale heartbeat", stale, stale, OpenCodeSessionStatus.ACTIVE, True),
+            ("malformed heartbeat", stale, "invalid", OpenCodeSessionStatus.ACTIVE, False),
+            ("malformed creation", "invalid", None, OpenCodeSessionStatus.ACTIVE, False),
+            ("cancelled without heartbeat", stale, None, OpenCodeSessionStatus.CANCELLED, False),
+            ("completed without heartbeat", stale, None, OpenCodeSessionStatus.COMPLETED, False),
+            ("cancelled stale heartbeat", stale, stale, OpenCodeSessionStatus.CANCELLED, False),
+            ("completed stale heartbeat", stale, stale, OpenCodeSessionStatus.COMPLETED, False),
+        )
+        for name, created_at, heartbeat, status, unavailable in cases:
+            with self.subTest(name=name):
+                session = StoredSession(
+                    session_id="session", connector_id="mini", owner_user_id="user", project_id=str(uuid4()),
+                    status=status, capability_nonce="nonce", created_at=created_at, updated_at=now.isoformat(),
+                    last_heartbeat_at=heartbeat, next_event_sequence=1,
+                )
+                with patch("apps.api.opencode_api.datetime", new=Mock(wraps=datetime)) as clock, patch("apps.api.opencode_api._store_event") as store_event:
+                    clock.now.return_value = now
+                    _record_connector_unavailable_if_stale(session)
+                if unavailable:
+                    store_event.assert_called_once_with(
+                        session,
+                        ConnectorEventInput(event_id="connector_unavailable_session", kind=OpenCodeEventKind.CONNECTOR_UNAVAILABLE.value),
+                    )
+                else:
+                    store_event.assert_not_called()
+
+    def test_list_events_for_new_session_does_not_record_connector_unavailable(self) -> None:
+        store = OpenCodeStore(":memory:")
+        try:
+            session = store.create_session(session_id="session", connector_id="mini", owner_user_id="user", project_id=str(uuid4()))
+            self.assertIsNone(session.last_heartbeat_at)
+            user = UserContext(provider="clerk", subject="user", owner_user_id="user", is_authenticated=True, is_admin=False)
+            with patch("apps.api.opencode_api.OPENCODE_STORE", new=store), patch("apps.api.opencode_api.datetime", new=Mock(wraps=datetime)) as clock:
+                clock.now.return_value = datetime.fromisoformat(session.created_at.replace("Z", "+00:00"))
+                page = list_opencode_events(session.session_id, cursor=0, limit=50, user=user)
+            self.assertEqual((), page.events)
+            self.assertEqual(0, page.next_cursor)
+            self.assertEqual([], store.list_events(session.session_id, 0, 50))
+        finally:
+            store.close()
 
     def test_store_is_idempotent_leased_and_cursorable(self) -> None:
         project_id = str(uuid4())


### PR DESCRIPTION
## Summary
- Give newly created OpenCode sessions the existing 120-second heartbeat grace period instead of immediately marking them unavailable.
- Keep the UI polling through temporary connector unavailability and preserve assistant text across progress and canonical completion events.
- Keep reserved project IDs separate from published projects. Probe project availability after completion and retry transient failures without showing a missing-project warning for ordinary conversation.
- Preserve the originating browser chat when project metadata contains another chat ID, reuse the OpenCode session for follow-up turns, and allow New Chat with legacy hosted chat disabled.

## Validation
- 14 backend tests passed: `.\.venv\Scripts\python.exe -m unittest discover -s tests/opencode -v`.
- 6 frontend unit tests passed: `node --test test/opencode-turn.test.ts` (from apps/web).
- 2 Chromium browser regressions passed: `npx playwright test e2e/opencode-chat.spec.ts --project=chromium --workers=1 --reporter=list`, with local auth and a local API URL.
- Browser tests mock backend responses and cover connector recovery, reply preservation, an unpublished project returning 404, a published project returning 503 then 200, session reuse, and New Chat.
- `npx tsc --noEmit --incremental false`, targeted ESLint, and `git diff --check origin/main...HEAD` passed.

## Deployment
The live UI is not changed by opening this PR. Deploy the frontend and the API changes after merge, including the mini-PC API checkout where applicable. No credentials or runtime configuration files are included.

## Revision
- Base: 3eeb83e1a0c3e23e9759ff8239b4135a149c762c
- Implementation: 6bdee16135f09d373b57dc6d77c6eb1f15d08083