### PR TITLE
fix(opencode): stop polling idle sessions

### DIFF
--- a/apps/api/opencode_api.py
+++ b/apps/api/opencode_api.py
@@ -42,6 +42,7 @@ from forma_core.database import get_project_identity
 
 router = APIRouter(prefix="/opencode", tags=["opencode"])
 OPENCODE_STORE = OpenCodeStore()
+OPENCODE_SESSION_DISCOVERY_IDLE_SECONDS = 15 * 60
 
 
 @router.post("/sessions", response_model=SessionResponse, status_code=status.HTTP_201_CREATED)
@@ -154,7 +155,9 @@ def list_opencode_connector_sessions(
     bootstrap: str | None = Header(default=None, alias="X-Forma-OpenCode-Bootstrap"),
 ) -> ConnectorSessionPage:
     _require_connector_bootstrap(bootstrap)
-    sessions = OPENCODE_STORE.list_connector_sessions(connector_id.strip())
+    sessions = OPENCODE_STORE.list_connector_sessions(
+        connector_id.strip(), idle_after_seconds=OPENCODE_SESSION_DISCOVERY_IDLE_SECONDS,
+    )
     return ConnectorSessionPage(
         sessions=tuple(
             ConnectorSession(session_id=session.session_id, connector_id=session.connector_id, project_id=UUID(session.project_id))

--- a/forma_core/opencode/store.py
+++ b/forma_core/opencode/store.py
@@ -183,13 +183,21 @@ class OpenCodeStore:
         return _session_from_record(dict(row)) if row else None
 
     def touch_session(self, session_id: str) -> None:
+        provider = self._ensure_provider()
+        if isinstance(provider, SupabaseProvider):
+            provider.client.table("opencode_sessions").update({"last_heartbeat_at": _timestamp()}).eq("session_id", session_id).execute()
+            return
+        with self._connection() as connection:
+            connection.execute("UPDATE opencode_sessions SET last_heartbeat_at = ? WHERE session_id = ?", (_timestamp(), session_id))
+
+    def touch_session_activity(self, session_id: str) -> None:
         now = _timestamp()
         provider = self._ensure_provider()
         if isinstance(provider, SupabaseProvider):
-            provider.client.table("opencode_sessions").update({"last_heartbeat_at": now, "updated_at": now}).eq("session_id", session_id).execute()
+            provider.client.table("opencode_sessions").update({"updated_at": now}).eq("session_id", session_id).execute()
             return
         with self._connection() as connection:
-            connection.execute("UPDATE opencode_sessions SET last_heartbeat_at = ?, updated_at = ? WHERE session_id = ?", (now, now, session_id))
+            connection.execute("UPDATE opencode_sessions SET updated_at = ? WHERE session_id = ?", (now, session_id))
 
     def create_command(
         self,
@@ -208,6 +216,7 @@ class OpenCodeStore:
             if existing.message_ciphertext is None or existing.message_key_id is None:
                 ciphertext, key_id = encrypt_user_secret_text(message)
                 self._update_command_message(existing.command_id, ciphertext, key_id)
+            self.touch_session_activity(session.session_id)
             return existing
         now = _timestamp()
         ciphertext, key_id = encrypt_user_secret_text(message)
@@ -242,6 +251,7 @@ class OpenCodeStore:
                      "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     tuple(command.as_record().values()),
                 )
+        self.touch_session_activity(session.session_id)
         return command
 
     def find_command(self, session_id: str, idempotency_key: str) -> StoredCommand | None:
@@ -274,7 +284,8 @@ class OpenCodeStore:
             row = connection.execute("SELECT * FROM opencode_commands WHERE command_id = ?", (command_id,)).fetchone()
         return _command_from_record(dict(row)) if row else None
 
-    def list_connector_sessions(self, connector_id: str) -> list[StoredSession]:
+    def list_connector_sessions(self, connector_id: str, *, idle_after_seconds: int = 900) -> list[StoredSession]:
+        cutoff = _now() - timedelta(seconds=max(1, idle_after_seconds))
         provider = self._ensure_provider()
         if isinstance(provider, SupabaseProvider):
             rows = (
@@ -287,13 +298,15 @@ class OpenCodeStore:
                 .data
                 or []
             )
-            return [_session_from_record(row) for row in rows]
+            sessions = [_session_from_record(row) for row in rows]
+            return [session for session in sessions if (_parse_timestamp(session.updated_at) or cutoff) >= cutoff]
         with closing(provider.connect_dbapi()) as connection:
             rows = connection.execute(
                 "SELECT * FROM opencode_sessions WHERE connector_id = ? AND status = ? ORDER BY created_at",
                 (connector_id, OpenCodeSessionStatus.ACTIVE.value),
             ).fetchall()
-        return [_session_from_record(dict(row)) for row in rows]
+        sessions = [_session_from_record(dict(row)) for row in rows]
+        return [session for session in sessions if (_parse_timestamp(session.updated_at) or cutoff) >= cutoff]
 
     def claim_next(self, *, connector_id: str, session_id: str, lease_seconds: int = 60) -> ConnectorCommand | None:
         now = _now()

--- a/tests/opencode/test_bridge.py
+++ b/tests/opencode/test_bridge.py
@@ -202,6 +202,24 @@ class OpenCodeBridgeTests(unittest.IsolatedAsyncioTestCase):
             finally:
                 reopened.close()
 
+    def test_connector_session_discovery_excludes_idle_sessions_but_command_activity_reactivates_them(self) -> None:
+        now = datetime(2026, 9, 12, 12, 0, tzinfo=timezone.utc)
+        with patch("forma_core.opencode.store._now", return_value=now), patch.dict(os.environ, {"FORMA_USER_SECRETS_KEY": "test-key"}, clear=False):
+            store = OpenCodeStore(":memory:")
+            try:
+                idle = store.create_session(session_id="idle", connector_id="mini", owner_user_id="user", project_id=str(uuid4()))
+                active = store.create_session(session_id="active", connector_id="mini", owner_user_id="user", project_id=str(uuid4()))
+                with store._connection() as connection:
+                    connection.execute("UPDATE opencode_sessions SET updated_at = ? WHERE session_id = ?", ("2026-09-12T11:00:00Z", idle.session_id))
+                self.assertEqual([active.session_id], [session.session_id for session in store.list_connector_sessions("mini", idle_after_seconds=900)])
+                store.create_command(
+                    command_id="command", session=idle, operation=OpenCodeOperation.PROJECT_MESSAGE,
+                    idempotency_key="message", message="reactivate",
+                )
+                self.assertEqual({"idle", "active"}, {session.session_id for session in store.list_connector_sessions("mini", idle_after_seconds=900)})
+            finally:
+                store.close()
+
     def test_store_is_session_scoped_renews_leases_and_completes_idempotently(self) -> None:
         first_project_id = str(uuid4())
         second_project_id = str(uuid4())


### PR DESCRIPTION
## Summary
- Stop connector polling from refreshing user session activity.
- Refresh session activity only when a command is created or retried.
- Limit connector discovery to sessions active within the last 15 minutes.
- Preserve stale sessions for UI recovery while preventing abandoned-session polling.

## Verification
- 30 OpenCode tests passed.
- Base: 148f2b08805f7cc1bac2c3c7b639a62b2b834751
- Commit: d4001b92d99528fc408e9faae57e78117222816e