### PR TITLE
fix(opencode): avoid concurrent Supabase HTTP/2 failures

### DIFF
--- a/forma_core/database.py
+++ b/forma_core/database.py
@@ -168,10 +168,15 @@ def _warn_ignored_database_urls() -> None:
 
 def _build_supabase_client(url: str, key: str):
     try:
+        import httpx
         from supabase import create_client
+        from supabase.lib.client_options import SyncClientOptions
     except ImportError as exc:
         raise RuntimeError("Supabase client is not installed. Run pip install -r apps/api/requirements.txt.") from exc
-    return create_client(url, key)
+    # The sync Supabase client enables HTTP/2 by default, but its httpcore stream
+    # bookkeeping is not safe when shared by FastAPI's concurrent worker threads.
+    http_client = httpx.Client(http2=False, follow_redirects=True, timeout=120)
+    return create_client(url, key, options=SyncClientOptions(httpx_client=http_client))
 
 
 def _select_database_config() -> tuple[DatabaseConfig, Any, Any]:

--- a/tests/persistence/test_persistence.py
+++ b/tests/persistence/test_persistence.py
@@ -162,6 +162,14 @@ class PersistenceArchitectureTests(unittest.TestCase):
         self.assertIn("remix_project_id", client.projections["project_remixes"])
         self.assertIn("project_id", client.projections["project_saves"])
 
+    def test_supabase_client_uses_http1_transport_for_concurrent_sync_requests(self) -> None:
+        with patch("supabase.create_client") as create_client, patch("httpx.Client") as http_client:
+            database._build_supabase_client("https://example.supabase.co", "secret")
+
+        http_client.assert_called_once_with(http2=False, follow_redirects=True, timeout=120)
+        options = create_client.call_args.kwargs["options"]
+        self.assertIs(options.httpx_client, http_client.return_value)
+
     def test_supabase_provider_propagates_original_readiness_error(self) -> None:
         failure = ConnectionError("[Errno 111] Connection refused")
         client = _SchemaClient(


### PR DESCRIPTION
## Summary
- configure the synchronous Supabase client to use pooled HTTP/1.1 instead of its default HTTP/2 transport
- add regression coverage for the transport configuration

The hosted backend logs showed concurrent OpenCode requests failing inside httpcore HTTP/2 stream bookkeeping (KeyError: 1025) and read timeouts.

## Verification
- .venv\\Scripts\\python.exe -m pytest tests/opencode tests/persistence/test_persistence.py -q
- 54 passed
- git diff --check origin/main...HEAD

The full suite was also run; it reported 810 passed, 2 skipped, and 6 unrelated existing/environment failures.